### PR TITLE
adjust travis test matrix to server 5.4,5.5 drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ sudo: required
 dist: trusty
 language: php
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - 7
+  - 7.0
 
 addons:
   apt:
@@ -99,12 +97,12 @@ script:
 
 matrix:
   include:
-    - php: 5.4
+    - php: 7.0
       env: "DB=mysql TEST_JS=TRUE"
-    - php: 7
+    - php: 7.0
       env: "DB=pgsql PHP_COVERAGE=TRUE"
     - php: 5.4
       env: "DB=mysql CORE_BRANCH=stable9 PACKAGE=TRUE"
-    - php: 5.4
+    - php: 5.5
       env: "DB=mysql CORE_BRANCH=stable10"
   fast_finish: true


### PR DESCRIPTION
fixes CI errors caused by the recent drop of PHP 5.4 and 5.5. See https://travis-ci.org/nextcloud/mail/builds/156724478 for an example