### PR TITLE
add viewBox to app icon for proper scaling in Firefox

### DIFF
--- a/img/mail.svg
+++ b/img/mail.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="32" width="32" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<svg xmlns="http://www.w3.org/2000/svg" height="32" width="32" version="1.0" viewBox="0 0 32 32">
  <path fill="#FFF" d="m1.7778 6c-0.98491 0-1.7778 0.7935-1.7778 1.7784v16.446c0 0.985 0.79289 1.776 1.7778 1.776h28.444c0.985 0 1.778-0.791 1.778-1.776v-16.446c0-0.9849-0.793-1.7784-1.778-1.7784zm1.5 2.0562 12.167 12.167h1.0556l12.222-12.167 1.2222 1.2222-7.2778 7.3889 5.5 5.6111-1.2222 1.2222-5.6111-5.6111-4.0556 4.1111h-2.5556l-4.055-4.11-5.6114 5.666-1.2223-1.278 5.5556-5.611-7.3333-7.3886z"/>
 </svg>


### PR DESCRIPTION
Please review @MorrisJobke @juliushaertl @nextcloud/mail :)

You can test it by looking at the Mail app entry in the apps management. Before it was small, now it’s proper.