### PR TITLE
fix client-side account order

### DIFF
--- a/js/models/accountcollection.js
+++ b/js/models/accountcollection.js
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @copyright Christoph Wurst 2015
+ * @copyright Christoph Wurst 2015, 2016
  */
 
 define(function(require) {
@@ -22,7 +22,7 @@ define(function(require) {
 		model: Account,
 		url: OC.generateUrl('apps/mail/accounts'),
 		comparator: function(account) {
-			return account.get('id');
+			return account.get('accountId');
 		}
 	});
 


### PR DESCRIPTION
fixes the following bug
* configure first acount
* configure second account

Then the account order was: account1, unified account, account2

Now it is: unified account, account1, account2

cc @nextcloud/mail 