### PR TITLE
show a loading spinner while loading folders

### DIFF
--- a/js/templates/loading.html
+++ b/js/templates/loading.html
@@ -3,4 +3,6 @@
 	<a class="icon-loading"></a>
 	<h2>{{{ hint }}}</h2>
 </div>
+{{else}}
+<div class="container icon-loading"></div>
 {{/if}}


### PR DESCRIPTION
fixes the bug where no loading spinner was shown while switching to a folder that has not been loaded yet and therefore no cached version is shown. That was especially annoying on mobile browsers.

@jancborchardt  I think you noticed that too

cc @nextcloud/mail 