### PR TITLE
enable server-side cache by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,6 @@ You can enable IMAP and SMTP backend logging. A horde_imap.log for IMAP and hord
 'app.mail.smtplog.enabled' => true
 ```
 
-### Server-side caching
-Mailbox messages and accounts can be cached on the Nextcloud server to reduce mail server load:
-This requires a valid memcache to be configured
-```php
-'app.mail.server-side-cache.enabled' => true
-```
-
 ### Use php-mail for mail sending
 You can use the php mail function to send mails. This is needed for some webhosters (1&1 (1und1)):
 ```php

--- a/lib/account.php
+++ b/lib/account.php
@@ -144,7 +144,7 @@ class Account implements IAccount {
 			if ($this->config->getSystemValue('app.mail.imaplog.enabled', false)) {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
 			}
-			if ($this->config->getSystemValue('app.mail.server-side-cache.enabled', false)) {
+			if ($this->config->getSystemValue('app.mail.server-side-cache.enabled', true)) {
 				if ($this->memcacheFactory->isAvailable()) {
 					$params['cache'] = [
 						'backend' => new Cache(array(


### PR DESCRIPTION
I have had it enabled in production for ages and have never seen any issues with it. Therefore I'd like to enable it for everyone, by default :rocket: 