### PR TITLE
show text too when a loading spinner is used

### DIFF
--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -125,7 +125,9 @@ define(function(require) {
 	 */
 	function showFolder(account, folder) {
 		Radio.ui.trigger('search:set', '');
-		Radio.ui.trigger('content:loading');
+		Radio.ui.trigger('content:loading', t('mail', 'Loading {folder}', {
+			folder: folder.get('name')
+		}));
 		loadFolderMessages(account, folder, false);
 
 		// Save current folder

--- a/js/views/foldercontent.js
+++ b/js/views/foldercontent.js
@@ -145,8 +145,10 @@ define(function(require) {
 				}
 			}
 		},
-		onMessageLoading: function() {
-			this.message.show(new LoadingView());
+		onMessageLoading: function(text) {
+			this.message.show(new LoadingView({
+				text: text
+			}));
 		},
 		onKeyUp: function(event, key) {
 			var message;


### PR DESCRIPTION
@jancborchardt how about providing feedback about *what* we are loading?

As a user, I'd like to know what the software does. This makes the application state more clear. However, this would be different to other Nextcloud UIs (e.g. files and other community apps)…