### PR TITLE
Making IMAP and SMTP timeouts configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ You can enable IMAP and SMTP backend logging. A horde_imap.log for IMAP and hord
 'app.mail.smtplog.enabled' => true
 ```
 
+### Timeouts:
+Depending on your mail host, it may be necessary to increase your IMAP and/or SMTP timeout settings. Currently IMAP defaults to 20 seconds and SMTP defaults to 2 seconds. They can be changed with.
+
+#### IMAP timeout:
+```php
+'app.mail.imap.timeout' => 20
+```
+#### SMTP timeout:
+```php
+'app.mail.smtp.timeout' => 2
+```
 ### Use php-mail for mail sending
 You can use the php mail function to send mails. This is needed for some webhosters (1&1 (1und1)):
 ```php

--- a/lib/account.php
+++ b/lib/account.php
@@ -139,7 +139,7 @@ class Account implements IAccount {
 				'hostspec' => $host,
 				'port' => $port,
 				'secure' => $ssl_mode,
-				'timeout' => 20,
+				'timeout' => $this->config->getSystemValue('app.mail.imap.timeout', 20),
 			];
 			if ($this->config->getSystemValue('app.mail.imaplog.enabled', false)) {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
@@ -388,7 +388,7 @@ class Account implements IAccount {
 			'port' => $this->account->getOutboundPort(),
 			'username' => $this->account->getOutboundUser(),
 			'secure' => $this->convertSslMode($this->account->getOutboundSslMode()),
-			'timeout' => 2
+			'timeout' => $this->config->getSystemValue('app.mail.smtp.timeout', 2)
 		];
 		if ($this->config->getSystemValue('app.mail.smtplog.enabled', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';

--- a/lib/account.php
+++ b/lib/account.php
@@ -139,7 +139,7 @@ class Account implements IAccount {
 				'hostspec' => $host,
 				'port' => $port,
 				'secure' => $ssl_mode,
-				'timeout' => $this->config->getSystemValue('app.mail.imap.timeout', 20),
+				'timeout' => (int) $this->config->getSystemValue('app.mail.imap.timeout', 20),
 			];
 			if ($this->config->getSystemValue('app.mail.imaplog.enabled', false)) {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
@@ -388,7 +388,7 @@ class Account implements IAccount {
 			'port' => $this->account->getOutboundPort(),
 			'username' => $this->account->getOutboundUser(),
 			'secure' => $this->convertSslMode($this->account->getOutboundSslMode()),
-			'timeout' => $this->config->getSystemValue('app.mail.smtp.timeout', 2)
+			'timeout' => (int) $this->config->getSystemValue('app.mail.smtp.timeout', 2)
 		];
 		if ($this->config->getSystemValue('app.mail.smtplog.enabled', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';


### PR DESCRIPTION
I was testing mail with GoDaddy as the mail host. Its SMTP server doesn't respond until long after the 2 seconds currently hard-coded into Nextcloud mail. This was resulted in Nextcloud mail timing out on the SMTP setup phase.

I decided rather than changing a hard-coded value that I should make it configurable instead.