### PR TITLE
Re-add message on the client if it cannot be deleted

### DIFF
--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -384,6 +384,9 @@ define(function(require) {
 				defer.resolve();
 			},
 			error: function() {
+				// Add the message to the collection again
+				folder.addMessage(message);
+
 				defer.reject();
 			}
 		});

--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -32,6 +32,7 @@ define(function(require) {
 	Radio.message.reply('flag', flagMessage);
 	Radio.message.reply('send', sendMessage);
 	Radio.message.reply('draft', saveDraft);
+	Radio.message.reply('delete', deleteMessage);
 
 	/**
 	 * @param {Account} account
@@ -355,6 +356,38 @@ define(function(require) {
 			};
 			$.ajax(url, data);
 		}
+		return defer.promise();
+	}
+
+	/**
+	 * @param {Account} account
+	 * @param {Folder} folder
+	 * @param {Message} message
+	 * @returns {Deferred}
+	 */
+	function deleteMessage(account, folder, message) {
+		var defer = $.Deferred();
+
+		var url = OC.generateUrl('apps/mail/accounts/{accountId}/folders/{folderId}/messages/{messageId}', {
+			accountId: require('state').currentAccount.get('accountId'),
+			folderId: require('state').currentFolder.get('id'),
+			messageId: message.get('id')
+		});
+		$.ajax(url, {
+			data: {},
+			type: 'DELETE',
+			success: function() {
+				var cache = require('cache');
+				var state = require('state');
+				cache.removeMessage(state.currentAccount, state.currentFolder, message.get('id'));
+
+				defer.resolve();
+			},
+			error: function() {
+				defer.reject();
+			}
+		});
+
 		return defer.promise();
 	}
 });

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -15,7 +15,6 @@ define(function(require) {
 	var _ = require('underscore');
 	var Handlebars = require('handlebars');
 	var Marionette = require('marionette');
-	var OC = require('OC');
 	var Radio = require('radio');
 	var MessageTemplate = require('text!templates/message-list-item.html');
 
@@ -118,23 +117,12 @@ define(function(require) {
 			});
 
 			// really delete the message
-			$.ajax(
-					OC.generateUrl('apps/mail/accounts/{accountId}/folders/{folderId}/messages/{messageId}',
-							{
-								accountId: require('state').currentAccount.get('accountId'),
-								folderId: require('state').currentFolder.get('id'),
-								messageId: thisModel.id
-							}), {
-				data: {},
-				type: 'DELETE',
-				success: function() {
-					var cache = require('cache');
-					var state = require('state');
-					cache.removeMessage(state.currentAccount, state.currentFolder, thisModel.id);
-				},
-				error: function() {
-					Radio.ui.trigger('error:show', t('mail', 'Error while deleting message.'));
-				}
+			var account = require('state').currentAccount;
+			var deleting = Radio.message.request('delete', account, folder, this.model);
+
+			$.when(deleting).fail(function() {
+				// TODO: move to controller
+				Radio.ui.trigger('error:show', t('mail', 'Error while deleting message.'));
 			});
 		}
 	});

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -123,6 +123,10 @@ define(function(require) {
 			$.when(deleting).fail(function() {
 				// TODO: move to controller
 				Radio.ui.trigger('error:show', t('mail', 'Error while deleting message.'));
+
+				// Restore counter
+				count = folder.get('total');
+				folder.set('total', count + 1);
 			});
 		}
 	});

--- a/js/views/messagesview.js
+++ b/js/views/messagesview.js
@@ -21,6 +21,7 @@ define(function(require) {
 	'use strict';
 
 	var $ = require('jquery');
+	var _ = require('underscore');
 	var Backbone = require('backbone');
 	var Handlebars = require('handlebars');
 	var Radio = require('radio');
@@ -40,7 +41,10 @@ define(function(require) {
 		loadingMore: false,
 		reloaded: false,
 		events: {
-			'wheel': 'onScroll',
+			wheel: 'onScroll'
+		},
+		collectionEvents: {
+			update: 'render'
 		},
 		initialize: function(options) {
 			this.searchQuery = options.searchQuery;


### PR DESCRIPTION
To prevent inconstencies on the client, we should re-add a deleted message if it cannot be deleted.

Example: you're disconnected from your nc server temporarily. With this PR you can delete the message later. On master, the message disappeared from the list, but will come back with the next reload.

TODO
- [x] reset folder properties (e.g. total, unseen counter)