### PR TITLE
replace deprecated getMock method with mock builder

### DIFF
--- a/tests/command/createaccounttest.php
+++ b/tests/command/createaccounttest.php
@@ -51,7 +51,7 @@ class CreateAccountTest extends PHPUnit_Framework_TestCase {
 		$this->service = $this->getMockBuilder('\OCA\Mail\Service\AccountService')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->crypto = $this->getMock('\OCP\Security\ICrypto');
+		$this->crypto = $this->getMockBuilder('\OCP\Security\ICrypto')->getMock();
 
 		$this->command = new CreateAccount($this->service, $this->crypto);
 	}

--- a/tests/controller/autoconfigcontrollertest.php
+++ b/tests/controller/autoconfigcontrollertest.php
@@ -30,7 +30,7 @@ class AutoConfigControllerTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->request = $this->getMock('OCP\IRequest');
+		$this->request = $this->getMockBuilder('OCP\IRequest')->getMock();
 		$this->service = $this->getMockBuilder('OCA\Mail\Service\AutoCompletion\AutoCompleteService')
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/controller/pagecontrollertest.php
+++ b/tests/controller/pagecontrollertest.php
@@ -58,8 +58,8 @@ class PageControllerTest extends TestCase {
 	}
 
 	public function testIndex() {
-		$account1 = $this->getMock('OCA\Mail\Service\IAccount');
-		$account2 = $this->getMock('OCA\Mail\Service\IAccount');
+		$account1 = $this->getMockBuilder('OCA\Mail\Service\IAccount')->getMock();
+		$account2 = $this->getMockBuilder('OCA\Mail\Service\IAccount')->getMock();
 
 		$this->accountService->expects($this->once())
 			->method('findByUserId')

--- a/tests/controller/proxycontrollertest.php
+++ b/tests/controller/proxycontrollertest.php
@@ -47,8 +47,8 @@ class ProxyControllerTest extends TestCase {
 		$this->session = $this->getMockBuilder('\OCP\ISession')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->clientService = $this->getMock('\OCP\Http\Client\IClientService');
-		$this->client = $this->getMock('\OCP\Http\Client\IClient');
+		$this->clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')->getMock();
+		$this->client = $this->getMockBuilder('\OCP\Http\Client\IClient')->getMock();
 		$this->clientService->expects($this->any())
 			->method('getClient')
 			->will($this->returnValue($this->client));

--- a/tests/service/loggertest.php
+++ b/tests/service/loggertest.php
@@ -34,7 +34,7 @@ class LoggerTest extends TestCase {
 	 */
 	public function testLoggerMethod($method, $param = '1') {
 
-		$baseLogger = $this->getMock('\OCP\ILogger');
+		$baseLogger = $this->getMockBuilder('\OCP\ILogger')->getMock();
 		$baseLogger->expects($this->once())
 			->method($method)
 			->with(


### PR DESCRIPTION
# Before
```
1) OCA\Mail\Tests\Command\CreateAccountTest::testName

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

2) OCA\Mail\Tests\Command\CreateAccountTest::testDescription

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

3) OCA\Mail\Tests\Command\CreateAccountTest::testArguments

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

4) AutoConfigControllerTest::testAutoComplete

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

5) PageControllerTest::testIndex

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

6) ProxyControllerTest::testRedirect with data set #0 ('http://nextcloud.com', false)

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

7) ProxyControllerTest::testRedirect with data set #1 ('https://nextcloud.com', false)

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

8) ProxyControllerTest::testRedirect with data set #2 ('http://example.com', true)

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

9) ProxyControllerTest::testRedirect with data set #3 ('https://example.com', true)

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

10) ProxyControllerTest::testRedirectInvalidUrl

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

11) ProxyControllerTest::testProxy

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

12) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #0 ('alert')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

13) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #1 ('warning')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

14) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #2 ('emergency')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

15) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #3 ('critical')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

16) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #4 ('error')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

17) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #5 ('notice')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

18) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #6 ('info')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

19) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #7 ('debug')

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

20) OCA\Mail\Tests\Service\LoggerTest::testLoggerMethod with data set #8 ('logException', Exception Object (...))

PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead
```

cc @nextcloud/mail @tahaalibra @nickvergessen @rullzer 