### PR TITLE
fix ProxyController's response

### DIFF
--- a/lib/controller/proxycontroller.php
+++ b/lib/controller/proxycontroller.php
@@ -117,7 +117,8 @@ class ProxyController extends Controller {
 		$this->session->close();
 
 		$client = $this->clientService->newClient();
-		$content = $client->get($src);
+		$response = $client->get($src);
+		$content = $response->getBody();
 		return new ProxyDownloadResponse($content, $src, 'application/octet-stream');
 	}
 

--- a/tests/controller/proxycontrollertest.php
+++ b/tests/controller/proxycontrollertest.php
@@ -106,6 +106,7 @@ class ProxyControllerTest extends TestCase {
 
 	public function testProxy() {
 		$src = 'http://example.com';
+		$httpResponse = $this->getMockBuilder('\OCP\Http\Client\IResponse')->getMock();
 		$content = '🐵🐵🐵';
 
 		$this->session->expects($this->once())
@@ -117,6 +118,9 @@ class ProxyControllerTest extends TestCase {
 		$client->expects($this->once())
 			->method('get')
 			->with($src)
+			->will($this->returnValue($httpResponse));
+		$httpResponse->expects($this->once())
+			->method('getBody')
 			->will($this->returnValue($content));
 
 		$expected = new ProxyDownloadResponse($content, $src,


### PR DESCRIPTION
IResponse cannot be converted to string automatically, therefore we need to get the
body before we create the response object.

This fixes the bug where images of HTML messages do not load.

cc @Gomez @jancborchardt @eppfel @hechi this *should* be the last blocking issue for 0.6 :rocket: 