### PR TITLE
Fix wrong method being using to add message to a folder

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -131,7 +131,7 @@ define(function(require) {
 						if (State.currentAccount === changedAccount &&
 							State.currentFolder.get('id') === changes.id) {
 							_.each(changes.messages, function(msg) {
-								State.currentFolder.addMessages(msg);
+								State.currentFolder.addMessage(msg);
 							});
 							var messages = new MessageCollection(changes.messages).slice(0);
 							Radio.message.trigger('fetch:bodies', changedAccount, changedFolder, messages);


### PR DESCRIPTION
This bug prevent the background checker from adding new incoming messages to the folder's message list.

cc @nextcloud/mail @hechi 