### PR TITLE
do not unnecessarily re-render views

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -27,7 +27,6 @@ define(function(require) {
 
 	var $ = require('jquery');
 	var Backbone = require('backbone');
-	var Handlebars = require('handlebars');
 	var Marionette = require('marionette');
 	var OC = require('OC');
 	var AppView = require('views/appview');
@@ -47,13 +46,6 @@ define(function(require) {
 	require('service/folderservice');
 	require('service/messageservice');
 	require('service/aliasesservice');
-
-	// Set marionette defaults
-	Marionette.TemplateCache.prototype.compileTemplate = function(rawTemplate) {
-		return Handlebars.compile(rawTemplate);
-	};
-	Marionette.ItemView.prototype.modelEvents = {change: 'render'};
-	Marionette.CompositeView.prototype.modelEvents = {change: 'render'};
 
 	var Mail = Marionette.Application.extend({
 		registerProtocolHandler: function() {

--- a/js/views/folder.js
+++ b/js/views/folder.js
@@ -43,6 +43,9 @@ define(function(require) {
 			'click .collapse': 'collapseFolder',
 			'click .folder': 'loadFolder'
 		},
+		modelEvents: {
+			change: 'render'
+		},
 		collapseFolder: function(e) {
 			e.preventDefault();
 			this.model.toggleOpen();

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -29,6 +29,9 @@ define(function(require) {
 			'click .mail-message-header': 'openMessage',
 			'click .star': 'toggleMessageStar'
 		},
+		modelEvents: {
+			change: 'render'
+		},
 		onRender: function() {
 			// Get rid of that pesky wrapping-div.
 			// Assumes 1 child element present in template.


### PR DESCRIPTION
This improves performance and is necessary for #81.

@nextcloud/mail @jancborchardt please test this patch. As far as I tested only two views needed adjustment, all other either don't have any model changes that need propagation or are collection views, which are automatically rendered by Marionette already.

I also removed the `TemplateCache` *hack* because we always create a handlebars template manually now.