### PR TITLE
Add avatars and placeholders to the recipient autocomplete widget

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -470,6 +470,9 @@ input.bcc {
 	border-top: none;
 	border-radius: 0;
 }
+.mail-recipient-autocomplete .avatar {
+	display: inline-block;
+}
 textarea.message-body {
 	margin: 0;
 	border-top: none;

--- a/css/mail.css
+++ b/css/mail.css
@@ -389,6 +389,16 @@
 	right: -10px;
 }
 
+/* autocomplete list */
+.ui-autocomplete .ui-menu-item a.mail-recipient-autocomplete {
+	display: flex;
+	align-content: center;
+	align-items: center;
+}
+.ui-autocomplete .ui-menu-item a.mail-recipient-autocomplete span {
+	margin-left: 10px;
+}
+
 /* editor */
 #mail-new-message-fixed {
 	z-index: 111; /* navigation menu is 110 ;-) */
@@ -469,9 +479,6 @@ input.bcc {
 	margin: 0;
 	border-top: none;
 	border-radius: 0;
-}
-.mail-recipient-autocomplete .avatar {
-	display: inline-block;
 }
 textarea.message-body {
 	margin: 0;

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -488,7 +488,7 @@ define(function(require) {
 						$row.append($placeholder);
 					}
 
-					$row.append($('<span>').html(item.value));
+					$row.append($('<span>').text(item.value));
 
 					$item.append($row);
 					$item.appendTo($ul);

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -473,14 +473,15 @@ define(function(require) {
 						this.value = terms.join(', ');
 						return false;
 					}
-				}).data('ui-autocomplete')._renderItem = function ($ul, item) {
+				}).data('ui-autocomplete')._renderItem = function($ul, item) {
 					var $item = $('<li/>');
 					var $row = $('<a/>');
 
 					$row.addClass('mail-recipient-autocomplete');
 
-					if (prevUID === item['id']) {
-						var $placeholder = $('<div/>');
+					var $placeholder;
+					if (prevUID === item.id) {
+						$placeholder = $('<div/>');
 						$placeholder.addClass('avatar');
 						$row.append($placeholder);
 					} else if (item.photo && item.photo !== null) {
@@ -491,13 +492,13 @@ define(function(require) {
 						$avatar.attr('src', item.photo);
 						$row.append($avatar);
 					} else {
-						var $placeholder = $('<div/>');
+						$placeholder = $('<div/>');
 						$placeholder.imageplaceholder(item.value);
 						$placeholder.addClass('avatar');
 						$row.append($placeholder);
 					}
 
-					prevUID = item['id'];
+					prevUID = item.id;
 
 					$row.append($('<span>').text(item.value));
 

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -479,7 +479,7 @@ define(function(require) {
 
 					$row.addClass('mail-recipient-autocomplete');
 
-					if (prevUID == item['id']) {
+					if (prevUID === item['id']) {
 						var $placeholder = $('<div/>');
 						$placeholder.addClass('avatar');
 						$row.append($placeholder);

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -468,7 +468,32 @@ define(function(require) {
 						this.value = terms.join(', ');
 						return false;
 					}
-				});
+				}).data('ui-autocomplete')._renderItem = function ($ul, item) {
+					var $item = $('<li/>');
+					var $row = $('<a/>');
+
+					$row.addClass('mail-recipient-autocomplete');
+
+					if (item.photo && item.photo !== null) {
+						var $avatar = $('<img/>');
+						$avatar.addClass('avatar');
+						$avatar.height('32px');
+						$avatar.width('32px');
+						$avatar.attr('src', item.photo);
+						$row.append($avatar);
+					} else {
+						var $placeholder = $('<div/>');
+						$placeholder.imageplaceholder(item.value);
+						$placeholder.addClass('avatar');
+						$row.append($placeholder);
+					}
+
+					$row.append($('<span>').html(item.value));
+
+					$item.append($row);
+					$item.appendTo($ul);
+					return $item;
+				};
 			}
 		},
 		buildAliases: function() {

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -433,6 +433,8 @@ define(function(require) {
 			if (!elem.data('autocomplete')) {
 				// If the autocomplete wasn't called yet:
 				// don't navigate away from the field on tab when selecting an item
+				var prevUID = false;
+
 				elem.bind('keydown', function(event) {
 					if (event.keyCode === $.ui.keyCode.TAB &&
 						typeof elem.data('autocomplete') !== 'undefined' &&
@@ -451,7 +453,10 @@ define(function(require) {
 						// custom minLength
 						var term = extractLast(this.value);
 						return term.length >= 2;
-
+					},
+					response: function() {
+						// Reset prevUid
+						prevUID = false;
 					},
 					focus: function() {
 						// prevent value inserted on focus
@@ -474,7 +479,11 @@ define(function(require) {
 
 					$row.addClass('mail-recipient-autocomplete');
 
-					if (item.photo && item.photo !== null) {
+					if (prevUID == item['id']) {
+						var $placeholder = $('<div/>');
+						$placeholder.addClass('avatar');
+						$row.append($placeholder);
+					} else if (item.photo && item.photo !== null) {
 						var $avatar = $('<img/>');
 						$avatar.addClass('avatar');
 						$avatar.height('32px');
@@ -487,6 +496,8 @@ define(function(require) {
 						$placeholder.addClass('avatar');
 						$row.append($placeholder);
 					}
+
+					prevUID = item['id'];
 
 					$row.append($('<span>').text(item.value));
 

--- a/lib/service/contactsintegration.php
+++ b/lib/service/contactsintegration.php
@@ -52,7 +52,7 @@ class ContactsIntegration {
 		$result = $this->contactsManager->search($term, ['FN', 'EMAIL']);
 		$receivers = [];
 		foreach ($result as $r) {
-			$id = $r['id'];
+			$id = $r['UID'];
 			$fn = $r['FN'];
 			if (!isset($r['EMAIL'])) {
 				continue;

--- a/lib/service/contactsintegration.php
+++ b/lib/service/contactsintegration.php
@@ -61,6 +61,7 @@ class ContactsIntegration {
 			if (!is_array($email)) {
 				$email = [$email];
 			}
+			$photo = isset($r['PHOTO']) ? $this->getPhotoUri($r['PHOTO']) : null;
 
 			// loop through all email addresses of this contact
 			foreach ($email as $e) {
@@ -68,7 +69,8 @@ class ContactsIntegration {
 				$receivers[] = [
 					'id' => $id,
 					'label' => $displayName,
-					'value' => $displayName
+					'value' => $displayName,
+					'photo' => $photo,
 				];
 			}
 		}
@@ -82,20 +84,23 @@ class ContactsIntegration {
 	 */
 	public function getPhoto($email) {
 		$result = $this->contactsManager->search($email, ['EMAIL']);
-		$uriPrefix = 'VALUE=uri:';
 		if (count($result) > 0) {
 			if (isset($result[0]['PHOTO'])) {
-				$s = $result[0]['PHOTO'];
-				if (substr($s, 0, strlen($uriPrefix)) === $uriPrefix) {
-					return substr($s, strpos($s, 'http'));
-				} else {
-					// ignore contacts >= 1.0 binary images
-					// TODO: fix
-					return null;
-				}
+				return $this->getPhotoUri($result[0]['PHOTO']);
 			}
 		}
 		return null;
+	}
+
+	private function getPhotoUri($raw) {
+		$uriPrefix = 'VALUE=uri:';
+		if (substr($raw, 0, strlen($uriPrefix)) === $uriPrefix) {
+			return substr($raw, strpos($raw, 'http'));
+		} else {
+			// ignore contacts >= 1.0 binary images
+			// TODO: fix
+			return null;
+		}
 	}
 
 }

--- a/tests/service/contactsintegrationtest.php
+++ b/tests/service/contactsintegrationtest.php
@@ -53,13 +53,13 @@ class ContactsIntegrationTest extends TestCase {
 		$searchResult = [
 			[
 				// Simple match
-				'id' => 1,
+				'UID' => 1,
 				'FN' => 'Jonathan Frakes',
 				'EMAIL' => 'jonathan@frakes.com',
 			],
 			[
 				// Array of addresses
-				'id' => 2,
+				'UID' => 2,
 				'FN' => 'John Doe',
 				'EMAIL' => [
 					'john@doe.info',
@@ -67,8 +67,8 @@ class ContactsIntegrationTest extends TestCase {
 				],
 			],
 			[
-				// Johann Struass II didn't have a email address ;-)
-				'id' => 3,
+				// Johann Strauss II didn't have a email address ;-)
+				'UID' => 3,
 				'FN' => 'Johann Strauss II',
 			]
 		];
@@ -86,16 +86,19 @@ class ContactsIntegrationTest extends TestCase {
 				'id' => 1,
 				'label' => '"Jonathan Frakes" <jonathan@frakes.com>',
 				'value' => '"Jonathan Frakes" <jonathan@frakes.com>',
+				'photo' => null,
 			],
 			[
 				'id' => 2,
 				'label' => '"John Doe" <john@doe.info>',
 				'value' => '"John Doe" <john@doe.info>',
+				'photo' => null,
 			],
 			[
 				'id' => 2,
 				'label' => '"John Doe" <doe@john.info>',
 				'value' => '"John Doe" <doe@john.info>',
+				'photo' => null,
 			],
 		];
 		$actual = $this->contactsIntegration->getMatchingRecipient($term);


### PR DESCRIPTION
cc @jancborchardt @eppfel since we talked about that at the conf

would be great if a CSS ninja could fix the design a bit (e.g. some padding, fix vertical alignment and remove ugly background color/image). @skjnldsv maybe 😉 

![bildschirmfoto von 2016-10-06 22-09-32](https://cloud.githubusercontent.com/assets/1374172/19168790/18f16b4a-8c12-11e6-8107-b4e3091f8915.png)
