### PR TITLE
Be lazy when fetching UserFolder

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -39,9 +39,11 @@ class Application extends App {
 			return $c->getServer()->getSession();
 		});
 
-		$user = $container->query("UserId");
 		$container->registerParameter("appName", "mail");
-		$container->registerParameter("userFolder", $container->getServer()->getUserFolder($user));
+		$container->registerService("userFolder", function ($c) use ($container) {
+			$user = $container->query("UserId");
+			return $container->getServer()->getUserFolder($user);
+		});
 		$container->registerParameter("testSmtp", $testSmtp);
 		$container->registerParameter("referrer", isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : null);
 		$container->registerParameter("hostname", Util::getServerHostName());


### PR DESCRIPTION
Since on a lot of requests the routes are loaded (and thus the
application is initialized) it is good to not be greedy. Now we only
fetch the user folder when one of the controllers is actually called.

Me and @LukasReschke found this while profiling some requests on a production instance.

CC: @ChristophWurst 