### PR TITLE
don't close the mail notifcation programmatically

### DIFF
--- a/js/tests/util_notificationhandler_spec.js
+++ b/js/tests/util_notificationhandler_spec.js
@@ -92,22 +92,5 @@ define([
 			expect(Radio.navigation.trigger).not.toHaveBeenCalled();
 			expect(notification.onclick).not.toBe(undefined);
 		});
-
-		it('should close the notification after 5 seconds', function() {
-			window.Notification = getNotificationMock();
-			spyOn(Radio.navigation, 'trigger');
-
-			NotificationHandler.showNotification('a', 'b');
-
-			// A new notification should have been created
-			expect(notification).not.toBe(undefined);
-
-			spyOn(notification, 'close');
-			expect(notification.close).not.toHaveBeenCalled();
-			jasmine.clock().tick(2000);
-			expect(notification.close).not.toHaveBeenCalled();
-			jasmine.clock().tick(3100);
-			expect(notification.close).toHaveBeenCalled();
-		});
 	});
 });

--- a/js/util/notificationhandler.js
+++ b/js/util/notificationhandler.js
@@ -58,9 +58,6 @@ define(function(require) {
 			Radio.navigation.trigger('folder', account.get('accountId'), folder.get('id'), false);
 			window.focus();
 		};
-		setTimeout(function() {
-			notification.close();
-		}, 5000);
 	}
 
 	function showMailNotification(email, folder) {


### PR DESCRIPTION
I always found it quite annoying to see the notification vanish when I slowly moved the cursor onto it because the 5sec elapsed. My OS (Linux + Gnome) hides the notification automatically after a few seconds if I don't react to it.

Can some1 with an other OS or display manager test this too?
