### PR TITLE
move mail address select triangle back next to address

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -19,7 +19,7 @@
 }
 
 .mail-account {
-	width: 100%;
+	max-width: 100%;
 	height: 44px;
 	padding-left: 30px;
 	background-color: transparent;


### PR DESCRIPTION
As requested by @irgendwie ;D

The downward-pointing triangle of the »from« selector was a bit strange, so the select is simply now as wide as the value to have the triangle directly next to it.
