### PR TITLE
use correct internal server version

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 	<dependencies>
 		<php min-version="5.4" max-version="7.0" />
 		<owncloud min-version="9.1" max-version="9.2" />
-		<nextcloud min-version="10" max-version="11" />
+		<nextcloud min-version="9.1" max-version="9.2" />
 	</dependencies>
 	<ocsid>169914</ocsid>
 </info>


### PR DESCRIPTION
Otherwise the app installation fails with

```
occ app:enable mail                                                                                                     

                                                                                                                                 
  [Exception]                                                                                                                    
  App "Mail" cannot be installed because the following dependencies are not fulfilled: Server version 10 or higher is required.  
```

I suspect PR https://github.com/nextcloud/server/pull/1940 caused this incompatibility. cc @LukasReschke 