### PR TITLE
init.js is the main/entry module now

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -11,7 +11,7 @@
 ({
 	baseUrl: '../js',
 	mainConfigFile: '../js/require_config.js',
-	name: 'app',
+	name: 'init',
 	out: '../js/mail.min.js',
 	insertRequire: [
 		'init',


### PR DESCRIPTION
fixes https://github.com/nextcloud/mail/issues/207.
Probably caused by https://github.com/nextcloud/mail/pull/126.

@jancborchardt @tahaalibra @nextcloud/mail please test

Steps to reproduce:
1. set up app
2. run 'make optimize-js'
3. disable debug mode
4. view app in the browser
