### PR TITLE
Remove quotes from contact integration repient label

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -65,11 +65,10 @@ class ContactsIntegration {
 
 			// loop through all email addresses of this contact
 			foreach ($email as $e) {
-				$displayName = "\"$fn\" <$e>";
 				$receivers[] = [
 					'id' => $id,
-					'label' => $displayName,
-					'value' => $displayName,
+					'label' => "$fn ($e)",
+					'value' => "\"$fn\" <$e>",
 					'photo' => $photo,
 				];
 			}

--- a/tests/Service/ContactsIntegrationTest.php
+++ b/tests/Service/ContactsIntegrationTest.php
@@ -87,19 +87,19 @@ class ContactsIntegrationTest extends PHPUnit_Framework_TestCase {
 		$expected = [
 			[
 				'id' => 1,
-				'label' => '"Jonathan Frakes" <jonathan@frakes.com>',
+				'label' => 'Jonathan Frakes (jonathan@frakes.com)',
 				'value' => '"Jonathan Frakes" <jonathan@frakes.com>',
 				'photo' => null,
 			],
 			[
 				'id' => 2,
-				'label' => '"John Doe" <john@doe.info>',
+				'label' => 'John Doe (john@doe.info)',
 				'value' => '"John Doe" <john@doe.info>',
 				'photo' => null,
 			],
 			[
 				'id' => 2,
-				'label' => '"John Doe" <doe@john.info>',
+				'label' => 'John Doe (doe@john.info)',
 				'value' => '"John Doe" <doe@john.info>',
 				'photo' => null,
 			],


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/pull/151#issuecomment-261396530 (only suggested recipients from the address book)

Now the proper avatar is shown instead of ":
![bildschirmfoto von 2016-12-03 16-59-32](https://cloud.githubusercontent.com/assets/1374172/20860597/04e5988c-b97c-11e6-903f-837b8b7d5ebb.png)

cc @jancborchardt @skjnldsv :-)