### PR TITLE
Update changelog for 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.6.2 – 2016-12-10
+## 0.6.2 – 2016-12-12
 ### Added
 - Various autocompletion enhancements
 - Support for CSP nonces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,35 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.6.0 – 2016-10-10
+## 0.6.2 – 2016-12-10
+### Added
+- Various autocompletion enhancements
+- Support for CSP nonces
+- Many small enhancements in the user interface
+- Updated info.xml for the new app store
+- Timestamps are updated automatically
+
+### Changed
+- Sent folder is now shown in the collapsed folder list
+- PSR-4 naming of source files
+- The mail notification is not closed after 5sec anymore
+- Collected mail addresses are now sanitized and split into name and address
+- Update to Marionette 3
+- Removed client-side message list cache
+- Updated documentation (developer, shortcuts)
+- Messages that cannot be deleted are added back to the list
+
+### Fixed
+- FTP url filtering in HTML mails
+- Noopener attribute for external links
+- Downloading attachments does no longer abort other connections
+
+## 0.6.1 – 2016-12-05
+### Added
+- Nextcloud 11 compatibility
+  [#196](https://github.com/nextcloud/mail/pull/196) @MorrisJobke
+
+## 0.6.0 – 2016-09-20
 ### Added
 - Alias support
   [#1523](https://github.com/owncloud/mail/pull/1523) @tahaalibra

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Mail</name>
 	<summary>IMAP web client</summary>
 	<description>Easy to use email client which connects to your mail server via IMAP and SMTP.</description>
-	<version>0.6.1</version>
+	<version>0.6.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Jan-Christoph Borchardt</author>


### PR DESCRIPTION
Everything in 0.6.1 was moved to 0.6.2 because we had to release a NC11 compatible version and I chose it to be 0.6.1.
Therefore, I now increased the version number for master and added all relevant changes that were made in this milestone. If no blocking issues are found in the next few days (I'm using the nightly build to verify in production), I will push it to the app store. Again, we did not release anything for three months, although we've learned from the past that smaller and more regular releases are easier to handle. I'd like to get back to that strategy and release more often now.

cc @Gomez @jancborchardt @nextcloud/mail 