### PR TITLE
use detachChildView instead of reset

### DIFF
--- a/js/views/appview.js
+++ b/js/views/appview.js
@@ -221,7 +221,7 @@ define(function(require) {
 		showSidebarLoading: function() {
 			$('#app-navigation').addClass('icon-loading');
 			if (this.navigation.getChildView('accounts')) {
-				this.navigation.getChildView('accounts').reset();
+				this.navigation.detachChildView('accounts');
 			}
 		},
 		showSidebarAccounts: function() {


### PR DESCRIPTION
This caused a js error and stalled user interface when creating the first account.