### PR TITLE
line up attachment button with send button

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -424,6 +424,7 @@
 
 .message-composer {
 	margin: 0;
+	margin-bottom: 10px; /* line up with the send button */
 	z-index: 100;
 }
 #reply-composer .message-composer {


### PR DESCRIPTION
Open the »New message« window, write a long message (so the main view scrolls) and you’ll notice the bottom buttons not being aligned:
![capture du 2016-12-17 03-50-04](https://cloud.githubusercontent.com/assets/925062/21502778/a9832cae-cc52-11e6-983b-c4bd2ad623c8.png)

This is fixed now:
![capture du 2016-12-17 03-49-50](https://cloud.githubusercontent.com/assets/925062/21502779/a987cd22-cc52-11e6-80ad-dae7e9a62431.png)

Please review @nextcloud/designers ;)