### PR TITLE
Change to full path for nightly upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ script:
   - if [[ "$PACKAGE" = "TRUE" ]]; then make appstore; fi
 
   # Upload the nightly to ftp server
-  - if [[ "$NIGHTLY" = "TRUE" ]]; then curl --ftp-create-dirs -T build/artifacts/appstore/mail.tar.gz -u $FTP_LOGIN:$FTP_PW ftp://upload.portknox.de/htdocs/mail/nextcloud_mail_nightly_build_$(date +%Y-%m-%d).tar.gz; fi
+  - if [[ "$NIGHTLY" = "TRUE" ]]; then curl --ftp-create-dirs -T /home/travis/build/nextcloud/core/apps/mail/build/artifacts/mail.tar.gz -u $FTP_LOGIN:$FTP_PW ftp://upload.portknox.de/htdocs/mail/nextcloud_mail_nightly_build_$(date +%Y-%m-%d).tar.gz; fi
 
 matrix:
   include:


### PR DESCRIPTION
The tar -C "path" changes the dir before the upload. This adds a full path to curl to upload the tar.gz.

