### PR TITLE
decouple and recactor account deletion for es6-promises

### DIFF
--- a/js/service/accountservice.js
+++ b/js/service/accountservice.js
@@ -1,3 +1,5 @@
+/* global Promise */
+
 /**
  * Mail
  *
@@ -17,6 +19,7 @@ define(function(require) {
 
 	Radio.account.reply('create', createAccount);
 	Radio.account.reply('entities', getAccountEntities);
+	Radio.account.reply('delete', deleteAccount);
 
 	function createAccount(config) {
 		return new Promise(function(resolve, reject) {
@@ -68,6 +71,23 @@ define(function(require) {
 					}
 				});
 			}
+		});
+	}
+
+	/**
+	 * @param {Account} account
+	 * @returns {Promise}
+	 */
+	function deleteAccount(account) {
+		var url = OC.generateUrl('/apps/mail/accounts/{accountId}', {
+			accountId: account.get('accountId')
+		});
+
+		return Promise.resolve($.ajax(url, {
+			type: 'DELETE'
+		})).then(function() {
+			// Delete cached message lists
+			require('cache').removeAccount(account);
 		});
 	}
 

--- a/js/views/accountview.js
+++ b/js/views/accountview.js
@@ -70,20 +70,12 @@ define(function(require) {
 
 			var account = this.model;
 
-			$.ajax(OC.generateUrl('/apps/mail/accounts/{accountId}'), {
-				data: {accountId: account.get('accountId')},
-				type: 'DELETE',
-				success: function() {
-					// Delete cached message lists
-					require('cache').removeAccount(account);
-
-					// reload the complete page
-					// TODO should only reload the app nav/content
-					window.location.reload();
-				},
-				error: function() {
-					OC.Notification.show(t('mail', 'Error while deleting account.'));
-				}
+			Radio.account.request('delete', account).then(function() {
+				// reload the complete page
+				// TODO should only reload the app nav/content
+				window.location.reload();
+			}, function() {
+				OC.Notification.show(t('mail', 'Error while deleting account.'));
 			});
 		},
 		onClick: function(e) {

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -34,6 +34,7 @@ use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Model\Message;
 use OCA\Mail\Model\ReplyMessage;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\AliasesService;
 use OCA\Mail\Service\AutoCompletion\AddressCollector;
 use OCA\Mail\Service\AutoConfig\AutoConfig;
 use OCA\Mail\Service\Logger;
@@ -48,7 +49,6 @@ use OCP\Files\Folder;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
-use OCA\Mail\Service\AliasesService;
 
 class AccountsController extends Controller {
 
@@ -160,16 +160,15 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $accountId
+	 * @param int $id
 	 * @return JSONResponse
 	 */
-	public function destroy($accountId) {
+	public function destroy($id) {
 		try {
-			$this->accountService->delete($this->currentUserId, $accountId);
-
+			$this->accountService->delete($this->currentUserId, $id);
 			return new JSONResponse();
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse();
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 	}
 

--- a/tests/Controller/AccountsControllerTest.php
+++ b/tests/Controller/AccountsControllerTest.php
@@ -171,7 +171,7 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 
 		$response = $this->controller->destroy($this->accountId);
 
-		$expectedResponse = new JSONResponse();
+		$expectedResponse = new JSONResponse([], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 


### PR DESCRIPTION
Following our usual architecture, I've moved the ajax call from the view to the account service. Additionally, I've migrated this call to use an es6 promise.