### PR TITLE
Client side unified inbox folder

### DIFF
--- a/js/models/account.js
+++ b/js/models/account.js
@@ -21,7 +21,8 @@ define(function(require) {
 	 */
 	var Account = Backbone.Model.extend({
 		defaults: {
-			aliases: []
+			aliases: [],
+			specialFolders: []
 		},
 		idAttribute: 'accountId',
 		url: function() {

--- a/js/service/accountservice.js
+++ b/js/service/accountservice.js
@@ -71,8 +71,7 @@ define(function(require) {
 		return loadAccountData().then(function(accounts) {
 			require('cache').cleanUp(accounts);
 
-			// TODO: accounts.length > 1
-			if (true) {
+			if (accounts.length > 1) {
 				accounts.add({
 					accountId: -1
 				}, {

--- a/js/service/accountservice.js
+++ b/js/service/accountservice.js
@@ -44,33 +44,43 @@ define(function(require) {
 		});
 	}
 
-	function getAccountEntities() {
+	/**
+	 * @private
+	 * @returns {Promise}
+	 */
+	function loadAccountData() {
 		var $serialized = $('#serialized-accounts');
 		var accounts = require('state').accounts;
 
-		return new Promise(function(resolve, reject) {
-			if ($serialized.val() !== '') {
-				var serialized = $serialized.val();
-				var serialzedAccounts = JSON.parse(atob(serialized));
+		if ($serialized.val() !== '') {
+			var serialized = $serialized.val();
+			var serialzedAccounts = JSON.parse(atob(serialized));
 
-				accounts.reset();
-				for (var i = 0; i < serialzedAccounts.length; i++) {
-					accounts.add(serialzedAccounts[i]);
-				}
-				resolve(accounts);
+			accounts.reset();
+			for (var i = 0; i < serialzedAccounts.length; i++) {
+				accounts.add(serialzedAccounts[i]);
+			}
+			$serialized.val('');
+			return Promise.resolve(accounts);
+		}
 
-				$serialized.val('');
-			} else {
-				accounts.fetch({
-					success: function(accounts) {
-						require('cache').cleanUp(accounts);
-						resolve(accounts);
-					},
-					error: function() {
-						reject();
-					}
+		return Promise.resolve(accounts.fetch());
+	}
+
+	function getAccountEntities() {
+		return loadAccountData().then(function(accounts) {
+			require('cache').cleanUp(accounts);
+
+			// TODO: accounts.length > 1
+			if (true) {
+				accounts.add({
+					accountId: -1
+				}, {
+					at: 0
 				});
 			}
+
+			return accounts;
 		});
 	}
 

--- a/js/service/folderservice.js
+++ b/js/service/folderservice.js
@@ -20,6 +20,20 @@ define(function(require) {
 
 	Radio.folder.reply('entities', getFolderEntities);
 
+	function buildUnifiedInbox(account) {
+		account.addFolder({
+			id: btoa('all-inboxes'),
+			name: t('mail', 'All inboxes'),
+			specialRole: 'inbox',
+			isEmpty: false,
+			accountId: -1,
+			noSelect: false,
+			delimiter: '.'
+		});
+
+		return Promise.resolve(account.folders);
+	}
+
 	/**
 	 * @param {Account} account
 	 * @returns {Promise}
@@ -28,6 +42,10 @@ define(function(require) {
 		var url = OC.generateUrl('apps/mail/accounts/{id}/folders', {
 			id: account.get('accountId')
 		});
+
+		if (account.id === -1) {
+			return buildUnifiedInbox(account);
+		}
 
 		return Promise.resolve($.get(url))
 			.then(function(data) {

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -61,10 +61,6 @@ class AccountService {
 			$accounts = array_map(function($a) {
 				return new Account($a);
 			}, $accounts);
-			if (count($accounts) > 1) {
-				$unifiedAccount = $this->buildUnifiedAccount($currentUserId);
-				$accounts = array_merge([$unifiedAccount], $accounts);
-			}
 			$this->accounts = $accounts;
 		}
 

--- a/tests/Service/AccoutServiceTest.php
+++ b/tests/Service/AccoutServiceTest.php
@@ -57,35 +57,18 @@ class AccountServiceTest extends PHPUnit_Framework_TestCase {
 		$this->mapper->expects($this->once())
 			->method('findByUserId')
 			->with($this->user)
-			->will($this->returnValue([$this->account1]));
-
-		$expected = [
-			new Account($this->account1)
-		];
-		$actual = $this->service->findByUserId($this->user);
-
-		$this->assertEquals($expected, $actual);
-	}
-
-	public function testFindByUserIdUnifiedInbox() {
-		$this->mapper->expects($this->once())
-			->method('findByUserId')
-			->with($this->user)
 			->will($this->returnValue([
 					$this->account1,
 					$this->account2,
 		]));
 
 		$expected = [
-			null,
 			new Account($this->account1),
 			new Account($this->account2),
 		];
 		$actual = $this->service->findByUserId($this->user);
 
-		$this->assertCount(3, $actual);
-		$this->assertEquals($expected[1], $actual[1]);
-		$this->assertEquals($expected[2], $actual[2]);
+		$this->assertEquals($expected, $actual);
 	}
 
 	public function testFind() {


### PR DESCRIPTION
This is the small refactoring I need for https://github.com/nextcloud/mail/pull/271 so that the server does not have to list the unified account anymore.

This does
* add the unified account on the client automatically (if there's more than one account)
* add the unified inbox to the unified account on the client side. This actually saves us one ajax request, so that can be seen as little performance improvement :-)

I did not find any issues with this. @nextcloud/mail please give it a quick test too :-)