### PR TITLE
Remove the broken //IGNORE option

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -594,8 +594,10 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$data = $fetch->getBodyPart($partNo);
 
 		$p->setContents($data);
-		
-		return mb_convert_encoding($p->getContents(), 'UTF-8', $p->getCharset());
+		$data = $p->getContents();
+
+		$data = mb_convert_encoding($data, 'UTF-8', $p->getCharset());
+		return $data;
 	}
 
 	public function getContent() {

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -596,7 +596,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$p->setContents($data);
 		$data = $p->getContents();
 
-		$data = iconv($p->getCharset(), 'utf-8//IGNORE', $data);
+		$data = iconv($p->getCharset(), 'utf-8', $data);
 		return $data;
 	}
 


### PR DESCRIPTION
In the latest versions of iconv, the //IGNORE options is broken.

Instead of filtering out all invalid characters, it will silently fail and return an empty string. The result of this is that the user cannot see the body of the email.

This has already been reported in issue #243 