### PR TITLE
prevent stacking of Aw, Wg, Fwd just like Re

### DIFF
--- a/lib/Model/ReplyMessage.php
+++ b/lib/Model/ReplyMessage.php
@@ -26,6 +26,14 @@ class ReplyMessage extends Message {
 		// prevent 'Re: Re:' stacking
 		if (strcasecmp(substr($subject, 0, 4), 'Re: ') === 0) {
 			parent::setSubject($subject);
+		} else if (strcasecmp(substr($subject, 0, 4), 'Aw: ') === 0) {
+			parent::setSubject($subject);
+		} else if (strcasecmp(substr($subject, 0, 4), 'Wg: ') === 0) {
+			parent::setSubject($subject);
+		} else if (strcasecmp(substr($subject, 0, 4), 'Fw: ') === 0) {
+			parent::setSubject($subject);
+		} else if (strcasecmp(substr($subject, 0, 5), 'Fwd: ') === 0) {
+			parent::setSubject($subject);
 		} else {
 			parent::setSubject("Re: $subject");
 		}

--- a/tests/Model/ReplyMessageTest.php
+++ b/tests/Model/ReplyMessageTest.php
@@ -57,4 +57,76 @@ class ReplyMessageTest extends MessageTest {
 		$this->assertSame($subject, $this->message->getSubject());
 	}
 
+	public function testSubjectAwStacking() {
+		$subject = 'Aw: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectAwCaseStacking() {
+		$subject = 'AW: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectWgStacking() {
+		$subject = 'Wg: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectWgCaseStacking() {
+		$subject = 'WG: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectFwStacking() {
+		$subject = 'Fw: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectFwCaseStacking() {
+		$subject = 'FW: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectFwdStacking() {
+		$subject = 'Fwd: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
+	public function testSubjectFwdCaseStacking() {
+		$subject = 'FWD: test message';
+
+		$this->message->setSubject($subject);
+
+		// Subject shouldn't change
+		$this->assertSame($subject, $this->message->getSubject());
+	}
+
 }


### PR DESCRIPTION
We already prevent Re: stacking (repeating the same reply prefix in the subject), so this does the same for very common other prefixes.

Please review @nextcloud/mail 