### PR TITLE
add text to email account menu

### DIFF
--- a/js/templates/account.html
+++ b/js/templates/account.html
@@ -10,11 +10,21 @@
 	</ul>
 </div>
 
-<div class="app-navigation-entry-menu">
-	<ul>
-		<li><button class="icon-rename svg" title="{{ t 'Settings' }}"></button></li>
-		<li><button class="icon-delete svg" title="{{ t 'Delete account' }}"></button></li>
-	</ul>
+<div class="app-navigation-entry-menu popovermenu bubble menu">
+    <ul>
+        <li>
+            <a href="#" class="menuitem action action-settings permanent" data-action="Settings">
+                <span class="icon icon-rename"></span>
+                <span>{{ t 'Settings' }}</span>
+            </a>
+        </li>
+        <li>
+            <a href="#" class="menuitem action action-delete permanent" data-action="Delete">
+                <span class="icon icon-delete"></span>
+                <span>{{ t 'Delete account' }}</span>
+            </a>
+        </li>
+    </ul>
 </div>
 {{/if}}
 

--- a/js/views/accountview.js
+++ b/js/views/accountview.js
@@ -41,9 +41,9 @@ define(function(require) {
 		},
 		ui: {
 			email: '.mail-account-email',
-			menu: 'div.app-navigation-entry-menu',
-			deleteButton: 'button[class^="icon-delete"]',
-			settingsButton: 'button[class^="icon-rename"]'
+			menu: '.app-navigation-entry-menu',
+			settingsButton: '.action-settings',
+			deleteButton: '.action-delete'
 		},
 		className: 'navigation-account',
 		menuShown: false,
@@ -66,7 +66,7 @@ define(function(require) {
 		onDelete: function(e) {
 			e.stopPropagation();
 
-			this.getUI('deleteButton').removeClass('icon-delete').addClass('icon-loading-small');
+			this.getUI('deleteButton').find('.icon-delete').removeClass('icon-delete').addClass('icon-loading-small');
 
 			var account = this.model;
 


### PR DESCRIPTION
Check out the 3-dot menu of the mail account :) now has text next to the icons like all other menus in Nextcloud.
![capture du 2017-03-27 20-42-08](https://cloud.githubusercontent.com/assets/925062/24417853/4c90a654-13ea-11e7-8f84-128722c84ba8.png)


Please review @nextcloud/mail @nextcloud/designers 