### PR TITLE
add Settings label to icon to make consistent with other apps

### DIFF
--- a/js/tests/integration/app_start_spec.js
+++ b/js/tests/integration/app_start_spec.js
@@ -46,7 +46,7 @@ define([
 					+ '		</ul>'
 					+ '		<div id="app-settings">'
 					+ '			<div id="app-settings-header">'
-					+ '				<button class="settings-button" data-apps-slide-toggle="#app-settings-content"></button>'
+					+ '				<button class="settings-button" data-apps-slide-toggle="#app-settings-content"><?php p($l->t("Settings"));?></button>'
 					+ '			</div>'
 					+ '			<div id="app-settings-content"></div>'
 					+ '		</div>'

--- a/templates/index.php
+++ b/templates/index.php
@@ -55,7 +55,7 @@ if ($_['debug']) {
 		<div id="app-settings">
 			<div id="app-settings-header">
 				<button class="settings-button"
-						data-apps-slide-toggle="#app-settings-content"></button>
+						data-apps-slide-toggle="#app-settings-content"><?php p($l->t('Settings'));?></button>
 			</div>
 			<div id="app-settings-content"></div>
 		</div>


### PR DESCRIPTION
Adds the word »Settings« to the gear icon in the bottom left so people know what it is. This is in place in other apps already and should be consistent. :)

Please review @nextcloud/mail 