### PR TITLE
Safari color dot position fix

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -225,6 +225,13 @@
 	left: 15px;
 	top: -12px;
 }
+/* color dot position fix for Safari */
+@media not all and (min-resolution:.001dpcm) { @media
+{
+.mail-account-color {
+        top: 2px;
+}
+}}
 
 .mail-message-account-color {
 	position: absolute;


### PR DESCRIPTION
Using Safari Browser (mac) the color-dot is not aligned with email address in navigation side bar
This css patch corrects dot alignment only for Safari browsers
![Image of Yaktocat](https://i.imgur.com/BBHB7TW.png)