### PR TITLE
Add missing border in overview

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -276,6 +276,7 @@
 	height: 100%;
 	overflow-x: hidden;
 	overflow-y: auto;
+	border-right: 1px solid #ebebeb;
 }
 #mail-message-list-loading {
 	position: fixed;


### PR DESCRIPTION
In the overview is the right border missing (see screenshot please).

Before:
![before](https://cloud.githubusercontent.com/assets/1473674/25619156/252992e4-2f4a-11e7-9d44-1760f5ace070.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/1473674/25619160/28cf19b4-2f4a-11e7-9b21-bc79e482c22e.PNG)
