### PR TITLE
Fix CSS to avoid collision with nextcloud server 'date' class.

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -326,7 +326,7 @@
 
 .mail-message-summary-from,
 .mail-message-summary-subject,
-.date {
+.mail-message-summary .date {
 	display: inline-block;
 	padding: 12px;
 	white-space: nowrap;
@@ -347,7 +347,7 @@
 	margin-left: 37px;
 }
 
-.date {
+.mail-message-summary .date {
 	position: absolute;
 	right: 0;
 	top: 0;


### PR DESCRIPTION
Fix for issue #369.

Using the `.date` collided with the nextcloud css and made it impossible to close the `OC.dialogs.filepicker`.
Changed the css selection from `.date` to `.mail-message-summary .date` to select only the needed date.

I used the selection 

> .mail-message-summary .date

but maybe 

> mail-message-header > .date

 makes more sense ?
