### PR TITLE
Fix adding a new account

### DIFF
--- a/js/service/accountservice.js
+++ b/js/service/accountservice.js
@@ -64,7 +64,17 @@ define(function(require) {
 			return Promise.resolve(accounts);
 		}
 
-		return Promise.resolve(accounts.fetch());
+		return new Promise(function(resolve, reject) {
+			accounts.fetch({
+				success: function() {
+					// fetch resolves the Promise with the raw data returned by
+					// the ajax call. Since we want the Backbone models, we have
+					// to 'convert' the response here.
+					resolve(accounts);
+				},
+				error: reject
+			});
+		});
 	}
 
 	function getAccountEntities() {


### PR DESCRIPTION
Apparently Backbone.Collection.fetch resolves its promise with
the raw data returned by the ajax call. Since the consuming code
relied on getting proper Account models, it failed when a new
account was added. This fix 'converts' the promise so that it
resolves with a collection of Account models.

Found while working on https://github.com/nextcloud/mail/pull/298.

Fixes https://github.com/nextcloud/mail/issues/320