### PR TITLE
Fix Folder::jsonSerialize warning due to undefined index

### DIFF
--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -158,7 +158,7 @@ class Folder implements JsonSerializable {
 			'accountId' => $this->account->getId(),
 			'name' => $this->getDisplayName(),
 			'specialRole' => null, // TODO
-			'unseen' => $this->status['unseen'],
+			'unseen' => isset($this->status['unseen']) ? $this->status['unseen'] : 0,
 			'total' => isset($this->status['messages']) ? (int) $this->status['messages'] : 0,
 			'isEmpty' => isset($this->status['messages']) ? 0 >= (int) $this->status['messages'] : true,
 			'noSelect' => in_array('\noselect', $this->attributes),

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -159,8 +159,8 @@ class Folder implements JsonSerializable {
 			'name' => $this->getDisplayName(),
 			'specialRole' => null, // TODO
 			'unseen' => $this->status['unseen'],
-			'total' => $this->status['messages'],
-			'isEmpty' => 0 >= (int) $this->status['messages'],
+			'total' => isset($this->status['messages']) ? (int) $this->status['messages'] : 0,
+			'isEmpty' => isset($this->status['messages']) ? 0 >= (int) $this->status['messages'] : true,
 			'noSelect' => in_array('\noselect', $this->attributes),
 			'attributes' => $this->attributes,
 			'delimiter' => $this->delimiter,


### PR DESCRIPTION
This makes the serialization a bit more error tolerant as in status
values not being set does not result in PHP errors anymore but fall
back to sensible default values.

I cannot reproduce https://github.com/nextcloud/mail/pull/326#issuecomment-308420686 but this should fix it.