### PR TITLE
Remove noreferrer from links in HTML messages

### DIFF
--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -56,6 +56,8 @@ class ProxyController extends Controller {
 	 * @param IURLGenerator $urlGenerator
 	 * @param ISession $session
 	 * @param IClientService $clientService
+	 * @param string $referrer
+	 * @param string $hostname
 	 */
 	public function __construct($appName, IRequest $request,
 		IURLGenerator $urlGenerator, ISession $session,	IClientService $clientService, $referrer, $hostname) {

--- a/lib/Service/HtmlPurify/TransformHTMLLinks.php
+++ b/lib/Service/HtmlPurify/TransformHTMLLinks.php
@@ -53,7 +53,7 @@ class TransformHTMLLinks extends HTMLPurifier_AttrTransform {
 
 		// XXX Kind of inefficient
 		$attr['target'] = '_blank';
-		$attr['rel'] = 'noopener noreferrer';
+		$attr['rel'] = 'noopener';
 
 		return $attr;
 	}


### PR DESCRIPTION
This brings back automatic redirection.
Fixes https://github.com/nextcloud/mail/issues/250

cc @LukasReschke