### PR TITLE
Fix the account selected as reply account

### DIFF
--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -579,7 +579,7 @@ define(function(require) {
 				});
 			}
 			if (alias) {
-				$('.mail-account').val(alias.id);
+				this.$('.mail-account').val(alias.id);
 			}
 		}
 	});


### PR DESCRIPTION
The code to determine the right account was already in place,
but it used a global jQuery selector. Since the view has not
been attached to the DOM at that point, the selector doesn't
select anything and the line of code has no effect.

Fixes https://github.com/nextcloud/mail/issues/10