### PR TITLE
Refactor message transmission logic

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -105,11 +105,10 @@ class Account implements IAccount {
 	}
 
 	/**
-	 * @param Alias $alias
+	 * @param Alias|null $alias
 	 * @return void
 	 */
 	public function setAlias($alias) {
-		$this->alias = new Alias();
 		$this->alias = $alias;
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,7 +23,9 @@
 namespace OCA\Mail\AppInfo;
 
 use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Service\MailManager;
+use OCA\Mail\Service\MailTransmission;
 use OCP\AppFramework\App;
 use OCP\Util;
 
@@ -42,6 +44,7 @@ class Application extends App {
 		$testSmtp = $transport === 'smtp';
 
 		$container->registerAlias(IMailManager::class, MailManager::class);
+		$container->registerAlias(IMailTransmission::class, MailTransmission::class);
 		$container->registerService('OCP\ISession', function ($c) {
 			return $c->getServer()->getSession();
 		});

--- a/lib/Contracts/IMailTransmission.php
+++ b/lib/Contracts/IMailTransmission.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Contracts;
+
+use OCA\Mail\Db\Alias;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
+
+interface IMailTransmission {
+
+	public function sendMessage(NewMessageData $message, RepliedMessageData $reply, Alias $alias = null, $draftUID = null);
+}

--- a/lib/Contracts/IMailTransmission.php
+++ b/lib/Contracts/IMailTransmission.php
@@ -27,5 +27,13 @@ use OCA\Mail\Model\RepliedMessageData;
 
 interface IMailTransmission {
 
+	/**
+	 * Send a new message or reply to an existing one
+	 *
+	 * @param NewMessageData $message
+	 * @param RepliedMessageData $reply
+	 * @param Alias|null $alias
+	 * @param int|null $draftUID
+	 */
 	public function sendMessage(NewMessageData $message, RepliedMessageData $reply, Alias $alias = null, $draftUID = null);
 }

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -263,14 +263,6 @@ class AccountsController extends Controller {
 		$aliasId) {
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 		$alias = $aliasId ? $this->aliasesService->find($aliasId, $this->currentUserId) : null;
-		if ($account instanceof UnifiedAccount) {
-			list($account, $folderId, $messageId) = $account->resolve($messageId);
-		}
-		if (!$account instanceof Account) {
-			return new JSONResponse(
-				['message' => 'Invalid account'], Http::STATUS_BAD_REQUEST
-			);
-		}
 
 		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
 		$repliedMessageData = new RepliedMessageData($account, $folderId, $messageId);

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -28,14 +28,14 @@ namespace OCA\Mail\Controller;
 
 use Exception;
 use Horde_Exception;
-use Horde_Imap_Client;
 use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Model\Message;
-use OCA\Mail\Model\ReplyMessage;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AliasesService;
-use OCA\Mail\Service\AutoCompletion\AddressCollector;
 use OCA\Mail\Service\AutoConfig\AutoConfig;
 use OCA\Mail\Service\Logger;
 use OCA\Mail\Service\UnifiedAccount;
@@ -44,8 +44,6 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\Response;
-use OCP\Files\File;
-use OCP\Files\Folder;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Security\ICrypto;
@@ -61,9 +59,6 @@ class AccountsController extends Controller {
 	/** @var AutoConfig */
 	private $autoConfig;
 
-	/** @var Folder */
-	private $userFolder;
-
 	/** @var Logger */
 	private $logger;
 
@@ -73,18 +68,17 @@ class AccountsController extends Controller {
 	/** @var ICrypto */
 	private $crypto;
 
-	/** @var AddressCollector  */
-	private $addressCollector;
-
 	/** @var AliasesService  */
 	private $aliasesService;
+
+	/** @var IMailTransmission */
+	private $mailTransmission;
 
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param AccountService $accountService
 	 * @param $UserId
-	 * @param $userFolder
 	 * @param AutoConfig $autoConfig
 	 * @param Logger $logger
 	 * @param IL10N $l10n
@@ -94,24 +88,22 @@ class AccountsController extends Controller {
 		IRequest $request,
 		AccountService $accountService,
 		$UserId,
-		$userFolder,
 		AutoConfig $autoConfig,
 		Logger $logger,
 		IL10N $l10n,
 		ICrypto $crypto,
-		AddressCollector $addressCollector,
-		AliasesService $aliasesService
+		AliasesService $aliasesService,
+		IMailTransmission $mailTransmission
 	) {
 		parent::__construct($appName, $request);
 		$this->accountService = $accountService;
 		$this->currentUserId = $UserId;
-		$this->userFolder = $userFolder;
 		$this->autoConfig = $autoConfig;
 		$this->logger = $logger;
 		$this->l10n = $l10n;
 		$this->crypto = $crypto;
-		$this->addressCollector = $addressCollector;
 		$this->aliasesService = $aliasesService;
+		$this->mailTransmission = $mailTransmission;
 	}
 
 	/**
@@ -263,12 +255,12 @@ class AccountsController extends Controller {
 	 * @param string $cc
 	 * @param string $bcc
 	 * @param int $draftUID
-	 * @param string $messageId
+	 * @param int $messageId
 	 * @param mixed $attachments
 	 * @return JSONResponse
 	 */
-	public function send($accountId, $folderId, $subject, $body, $to, $cc,
-		$bcc, $draftUID, $messageId, $attachments, $aliasId) {
+	public function send($accountId, $folderId, $subject, $body, $to, $cc, $bcc, $draftUID, $messageId, $attachments,
+		$aliasId) {
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 		$alias = $aliasId ? $this->aliasesService->find($aliasId, $this->currentUserId) : null;
 		if ($account instanceof UnifiedAccount) {
@@ -276,78 +268,20 @@ class AccountsController extends Controller {
 		}
 		if (!$account instanceof Account) {
 			return new JSONResponse(
-				['message' => 'Invalid account'],
-				Http::STATUS_BAD_REQUEST
+				['message' => 'Invalid account'], Http::STATUS_BAD_REQUEST
 			);
 		}
 
-		$mailbox = null;
-		if (!is_null($folderId) && !is_null($messageId)) {
-			// Reply
-			$message = $account->newReplyMessage();
-
-			$mailbox = $account->getMailbox(base64_decode($folderId));
-			$repliedMessage = $mailbox->getMessage($messageId);
-
-			if (is_null($subject)) {
-				// No subject set – use the original one
-				$message->setSubject($repliedMessage->getSubject());
-			} else {
-				$message->setSubject($subject);
-			}
-
-			if (is_null($to)) {
-				$message->setTo(Message::parseAddressList($repliedMessage->getToList()));
-			} else {
-				$message->setTo(Message::parseAddressList($to));
-			}
-
-			$message->setRepliedMessage($repliedMessage);
-		} else {
-			// New message
-			$message = $account->newMessage();
-			$message->setTo(Message::parseAddressList($to));
-			$message->setSubject($subject ? : '');
-		}
-
-		$account->setAlias($alias);
-		$message->setFrom($alias ? $alias->alias : $account->getEMailAddress());
-		$message->setCC(Message::parseAddressList($cc));
-		$message->setBcc(Message::parseAddressList($bcc));
-		$message->setContent($body);
-
-		if (is_array($attachments)) {
-			foreach($attachments as $attachment) {
-				$fileName = $attachment['fileName'];
-				if ($this->userFolder->nodeExists($fileName)) {
-					$f = $this->userFolder->get($fileName);
-					if ($f instanceof File) {
-						$message->addAttachmentFromFiles($f);
-					}
-				}
-			}
-		}
+		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
+		$repliedMessageData = new RepliedMessageData($account, $folderId, $messageId);
 
 		try {
-			$account->sendMessage($message, $draftUID);
-
-			// in case of reply we flag the message as answered
-			if ($message instanceof ReplyMessage) {
-				$mailbox->setMessageFlag($messageId, Horde_Imap_Client::FLAG_ANSWERED, true);
-			}
-
-			// Collect mail addresses
-			try {
-				$addresses = array_merge($message->getToList(), $message->getCCList(), $message->getBCCList());
-				$this->addressCollector->addAddresses($addresses);
-			} catch (Exception $e) {
-				$this->logger->error("Error while collecting mail addresses: " . $e->getMessage());
-			}
+			$this->mailTransmission->sendMessage($messageData, $repliedMessageData, $alias, $draftUID);
 		} catch (Horde_Exception $ex) {
 			$this->logger->error('Sending mail failed: ' . $ex->getMessage());
-			return new JSONResponse(
-				array('message' => $ex->getMessage()),
-				Http::STATUS_INTERNAL_SERVER_ERROR
+			return new JSONResponse([
+				'message' => $ex->getMessage()
+				], Http::STATUS_INTERNAL_SERVER_ERROR
 			);
 		}
 

--- a/lib/Db/AliasMapper.php
+++ b/lib/Db/AliasMapper.php
@@ -27,7 +27,7 @@ class AliasMapper extends Mapper {
 	/**
 	 * @param int $aliasId
 	 * @param string $currentUserId
-	 * @return Alias[]
+	 * @return Alias
 	 */
 	public function find($aliasId, $currentUserId) {
 		$sql = 'select *PREFIX*mail_aliases.* from *PREFIX*mail_aliases join *PREFIX*mail_accounts on *PREFIX*mail_aliases.account_id = *PREFIX*mail_accounts.id where *PREFIX*mail_accounts.user_id = ? and *PREFIX*mail_aliases.id=?';

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -23,7 +23,6 @@ namespace OCA\Mail\Model;
 
 use Horde_Mail_Rfc822_List;
 use OCA\Mail\Account;
-use OCA\Mail\Service\IAccount;
 
 /**
  * Simple data class that wraps the request data of a new message or reply
@@ -71,10 +70,20 @@ class NewMessageData {
 		$this->attachments = $attachments;
 	}
 
-	public static function fromRequest(IAccount $account, $to, $cc, $bcc, $subject, $body, $attachments) {
-		$toArray = is_null($to) ? [] : Message::parseAddressList($to);
-		$ccArray = is_null($cc) ? [] : Message::parseAddressList($cc);
-		$bccArray = is_null($bcc) ? [] : Message::parseAddressList($bcc);
+	/**
+	 * @param Account $account
+	 * @param string|null $to
+	 * @param string|null $cc
+	 * @param string|null $bcc
+	 * @param string $subject
+	 * @param string $body
+	 * @param array|null $attachments
+	 * @return NewMessageData
+	 */
+	public static function fromRequest(Account $account, $to, $cc, $bcc, $subject, $body, $attachments) {
+		$toArray = is_null($to) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($to);
+		$ccArray = is_null($cc) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($cc);
+		$bccArray = is_null($bcc) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($bcc);
 		$attchmentsArray = is_null($attachments) ? [] : $attachments;
 
 		return new NewMessageData($account, $toArray, $ccArray, $bccArray, $subject, $body, $attchmentsArray);

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Model;
+
+use Horde_Mail_Rfc822_List;
+use OCA\Mail\Account;
+use OCA\Mail\Service\IAccount;
+
+/**
+ * Simple data class that wraps the request data of a new message or reply
+ */
+class NewMessageData {
+
+	/** @var Account */
+	private $account;
+
+	/** @var Horde_Mail_Rfc822_List */
+	private $to;
+
+	/** @var Horde_Mail_Rfc822_List */
+	private $cc;
+
+	/** @var Horde_Mail_Rfc822_List */
+	private $bcc;
+
+	/** @var string */
+	private $subject;
+
+	/** @var string */
+	private $body;
+
+	/** @var array */
+	private $attachments;
+
+	/**
+	 * @param Account $account
+	 * @param Horde_Mail_Rfc822_List $to
+	 * @param Horde_Mail_Rfc822_List $cc
+	 * @param Horde_Mail_Rfc822_List $bcc
+	 * @param string $subject
+	 * @param string $body
+	 * @param array $attachments
+	 */
+	public function __construct(Account $account, Horde_Mail_Rfc822_List $to, Horde_Mail_Rfc822_List $cc,
+		Horde_Mail_Rfc822_List $bcc, $subject, $body, array $attachments) {
+		$this->account = $account;
+		$this->to = $to;
+		$this->cc = $cc;
+		$this->bcc = $bcc;
+		$this->subject = $subject;
+		$this->body = $body;
+		$this->attachments = $attachments;
+	}
+
+	public static function fromRequest(IAccount $account, $to, $cc, $bcc, $subject, $body, $attachments) {
+		$toArray = is_null($to) ? [] : Message::parseAddressList($to);
+		$ccArray = is_null($cc) ? [] : Message::parseAddressList($cc);
+		$bccArray = is_null($bcc) ? [] : Message::parseAddressList($bcc);
+		$attchmentsArray = is_null($attachments) ? [] : $attachments;
+
+		return new NewMessageData($account, $toArray, $ccArray, $bccArray, $subject, $body, $attchmentsArray);
+	}
+
+	/**
+	 * @return Account
+	 */
+	public function getAccount() {
+		return $this->account;
+	}
+
+	/**
+	 * @return Horde_Mail_Rfc822_List
+	 */
+	public function getTo() {
+		return $this->to;
+	}
+
+	/**
+	 * @return Horde_Mail_Rfc822_List
+	 */
+	public function getCc() {
+		return $this->cc;
+	}
+
+	/**
+	 * @return Horde_Mail_Rfc822_List
+	 */
+	public function getBcc() {
+		return $this->bcc;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSubject() {
+		return $this->subject;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getBody() {
+		return $this->body;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getAttachments() {
+		return $this->attachments;
+	}
+
+}

--- a/lib/Model/RepliedMessageData.php
+++ b/lib/Model/RepliedMessageData.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Model;
+
+use OCA\Mail\Service\IAccount;
+
+/**
+ * An immutable DTO that holds information about a message that is replied to
+ */
+class RepliedMessageData {
+
+	/** @var IAccount */
+	private $account;
+
+	/** @var string|null */
+	private $folderId;
+
+	/** @var int|null */
+	private $id;
+
+	/**
+	 * @param IAccount $account
+	 * @param string|null $folderId
+	 * @param int|null $id
+	 */
+	public function __construct(IAccount $account, $folderId, $id) {
+		$this->account = $account;
+		$this->folderId = $folderId;
+		$this->id = $id;
+	}
+
+	/**
+	 * @return IAccount
+	 */
+	public function getAccount() {
+		return $this->account;
+	}
+
+	/**
+	 * @return string|null
+	 */
+	public function getFolderId() {
+		return $this->folderId;
+	}
+
+	/**
+	 * @return int|null
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isReply() {
+		return !is_null($this->folderId) && !is_null($this->id);
+	}
+
+}

--- a/lib/Service/AliasesService.php
+++ b/lib/Service/AliasesService.php
@@ -48,7 +48,7 @@ class AliasesService {
 	/**
 	 * @param int $aliasId
 	 * @param String $currentUserId
-	 * @return Alias[]
+	 * @return Alias
 	 */
 	public function find($aliasId, $currentUserId) {
 		return $this->mapper->find($aliasId, $currentUserId);

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -44,12 +44,25 @@ class MailTransmission implements IMailTransmission {
 	/** @var Folder */
 	private $userFolder;
 
+	/**
+	 * @param AddressCollector $addressCollector
+	 * @param Folder $userFolder
+	 * @param Logger $logger
+	 */
 	public function __construct(AddressCollector $addressCollector, $userFolder, Logger $logger) {
 		$this->addressCollector = $addressCollector;
 		$this->userFolder = $userFolder;
 		$this->logger = $logger;
 	}
 
+	/**
+	 * Send a new message or reply to an existing one
+	 *
+	 * @param NewMessageData $message
+	 * @param RepliedMessageData $reply
+	 * @param Alias|null $alias
+	 * @param int|null $draftUID
+	 */
 	public function sendMessage(NewMessageData $messageData, RepliedMessageData $replyData, Alias $alias = null,
 		$draftUID = null) {
 		$account = $messageData->getAccount();

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -58,8 +58,8 @@ class MailTransmission implements IMailTransmission {
 	/**
 	 * Send a new message or reply to an existing one
 	 *
-	 * @param NewMessageData $message
-	 * @param RepliedMessageData $reply
+	 * @param NewMessageData $messageData
+	 * @param RepliedMessageData $replyData
 	 * @param Alias|null $alias
 	 * @param int|null $draftUID
 	 */

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Service;
+
+use Exception;
+use Horde_Imap_Client;
+use OC\Files\Node\File;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailTransmission;
+use OCA\Mail\Db\Alias;
+use OCA\Mail\Model\IMessage;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
+use OCA\Mail\Service\AutoCompletion\AddressCollector;
+use OCP\Files\Folder;
+
+class MailTransmission implements IMailTransmission {
+
+	/** @var Logger */
+	private $logger;
+
+	/** @var AddressCollector  */
+	private $addressCollector;
+
+	/** @var Folder */
+	private $userFolder;
+
+	public function __construct(AddressCollector $addressCollector, $userFolder, Logger $logger) {
+		$this->addressCollector = $addressCollector;
+		$this->userFolder = $userFolder;
+		$this->logger = $logger;
+	}
+
+	public function sendMessage(NewMessageData $messageData, RepliedMessageData $replyData, Alias $alias = null,
+		$draftUID = null) {
+		$account = $messageData->getAccount();
+
+		if ($replyData->isReply()) {
+			$message = $this->buildReplyMessage($account, $messageData, $replyData);
+		} else {
+			$message = $this->buildNewMessage($account, $messageData);
+		}
+
+		$account->setAlias($alias);
+		$message->setFrom($alias ? $alias->alias : $account->getEMailAddress());
+		$message->setCC($messageData->getCc());
+		$message->setBcc($messageData->getBcc());
+		$message->setContent($messageData->getBody());
+		$this->handleAttachments($messageData, $message);
+
+		$account->sendMessage($message, $draftUID);
+
+		if ($replyData->isReply()) {
+			$this->flagRepliedMessage($account, $replyData);
+		}
+
+		$this->collectMailAddresses($message);
+	}
+
+	/**
+	 * @param Account $account
+	 * @param RepliedMessageData $replyData
+	 * @return IMessage
+	 */
+	private function buildReplyMessage(Account $account, NewMessageData $messageData, RepliedMessageData $replyData) {
+		// Reply
+		$message = $account->newReplyMessage();
+
+		$mailbox = $account->getMailbox(base64_decode($replyData->getFolderId()));
+		$repliedMessage = $mailbox->getMessage($replyData->getId());
+
+		if (is_null($messageData->getSubject())) {
+			// No subject set – use the original one
+			$message->setSubject($repliedMessage->getSubject());
+		} else {
+			$message->setSubject($messageData->getSubject());
+		}
+
+		// TODO: old code used
+		// $message->setTo(Message::parseAddressList($repliedMessage->getToList()));
+		// when $to was null. Needs investigation whether that is needed or even makes sense.
+		$message->setTo($messageData->getTo());
+		$message->setRepliedMessage($repliedMessage);
+
+		return $message;
+	}
+
+	/**
+	 * @param Account $account
+	 * @param NewMessageData $messageData
+	 * @return IMessage
+	 */
+	private function buildNewMessage(Account $account, NewMessageData $messageData) {
+		// New message
+		$message = $account->newMessage();
+		$message->setTo($messageData->getTo());
+		$message->setSubject($messageData->getSubject() ?: '');
+
+		return $message;
+	}
+
+	/**
+	 * @param Account $account
+	 * @param RepliedMessageData $replyData
+	 */
+	private function flagRepliedMessage(Account $account, RepliedMessageData $replyData) {
+		$mailbox = $account->getMailbox(base64_decode($replyData->getFolderId()));
+		$mailbox->setMessageFlag($replyData->getId(), Horde_Imap_Client::FLAG_ANSWERED, true);
+	}
+
+	/**
+	 * @param NewMessageData $messageData
+	 * @param IMessage $message
+	 */
+	private function handleAttachments(NewMessageData $messageData, IMessage $message) {
+		foreach ($messageData->getAttachments() as $attachment) {
+			$file = $this->handleCloudAttachment($attachment);
+			if (!is_null($file)) {
+				$message->addAttachmentFromFiles($file);
+			}
+		}
+	}
+
+	/**
+	 * @param array $attachment
+	 * @return File|null
+	 */
+	private function handleCloudAttachment(array $attachment) {
+		if (!isset($attachment['fileName'])) {
+			$this->logger->warning('ignoring cloud attachment because its fileName is unknown');
+			return null;
+		}
+
+		$fileName = $attachment['fileName'];
+		if (!$this->userFolder->nodeExists($fileName)) {
+			$this->logger->warning('ignoring cloud attachment because the node does not exist');
+			return null;
+		}
+
+		$file = $this->userFolder->get($fileName);
+		if (!$file instanceof File) {
+			$this->logger->warning('ignoring cloud attachment because the node is not a file');
+			return null;
+		}
+
+		return $file;
+	}
+
+	/**
+	 * @param IMessage $message
+	 */
+	private function collectMailAddresses($message) {
+		try {
+			$addresses = array_merge($message->getToList(), $message->getCCList(), $message->getBCCList());
+			$this->addressCollector->addAddresses($addresses);
+		} catch (Exception $e) {
+			$this->logger->error("Error while collecting mail addresses: " . $e->getMessage());
+		}
+	}
+
+}

--- a/tests/Controller/AccountsControllerTest.php
+++ b/tests/Controller/AccountsControllerTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
@@ -23,75 +22,88 @@
 
 namespace OCA\Mail\Tests\Controller;
 
-use Exception;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Controller\AccountsController;
 use OCA\Mail\Model\Message;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\AliasesService;
+use OCA\Mail\Service\AutoConfig\AutoConfig;
+use OCA\Mail\Service\Logger;
+use OCA\Mail\Service\UnifiedAccount;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IL10N;
+use OCP\IRequest;
+use OCP\Security\ICrypto;
+use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 
 class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 
+	/** @var string */
 	private $appName;
+
+	/** @var IRequest|PHPUnit_Framework_MockObject_MockObject */
 	private $request;
+
+	/** @var AccountService|PHPUnit_Framework_MockObject_MockObject */
 	private $accountService;
+
+	/** @var string */
 	private $userId;
-	private $userFolder;
+
+	/** @var AutoConfig|PHPUnit_Framework_MockObject_MockObject */
 	private $autoConfig;
+
+	/** @var Logger|PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
+
+	/** @var IL10N|PHPUnit_Framework_MockObject_MockObject */
 	private $l10n;
+
+	/** @var ICrypto|PHPUnit_Framework_MockObject_MockObject */
 	private $crypto;
-	private $collector;
+
+	/** @var AccountsController */
 	private $controller;
+
+	/** @var int */
 	private $accountId;
+
+	/** @var Account|PHPUnit_Framework_MockObject_MockObject */
 	private $account;
+
+	/** @var UnifiedAccount|PHPUnit_Framework_MockObject_MockObject */
 	private $unifiedAccount;
+
+	/** @var AliasesService|PHPUnit_Framework_MockObject_MockObject */
 	private $aliasesService;
+
+	/** @var IMailTransmission|PHPUnit_Framework_MockObject_MockObject */
+	private $transmission;
 
 	protected function setUp() {
 		parent::setUp();
 
 		$this->appName = 'mail';
-		$this->request = $this->getMockBuilder('\OCP\IRequest')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->accountService = $this->getMockBuilder('\OCA\Mail\Service\AccountService')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
 		$this->userId = 'manfred';
-		$this->userFolder = $this->getMockBuilder('\OCP\Files\Folder')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->autoConfig = $this->getMockBuilder('\OCA\Mail\Service\AutoConfig\AutoConfig')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->logger = $this->getMockBuilder('\OCA\Mail\Service\Logger')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->crypto = $this->getMockBuilder('\OCP\Security\ICrypto')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->collector = $this->getMockBuilder('\OCA\Mail\Service\AutoCompletion\AddressCollector')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->aliasesService = $this->getMockBuilder('\OCA\Mail\Service\AliasesService')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->autoConfig = $this->createMock(AutoConfig::class);
+		$this->logger = $this->createMock(Logger::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->aliasesService = $this->createMock(AliasesService::class);
+		$this->transmission = $this->createMock(IMailTransmission::class);
 
-		$this->controller = new AccountsController($this->appName, $this->request,
-			$this->accountService, $this->userId, $this->userFolder, $this->autoConfig,
-			$this->logger, $this->l10n, $this->crypto, $this->collector, $this->aliasesService);
-
-		$this->account = $this->getMockBuilder('\OCA\Mail\Account')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->unifiedAccount = $this->getMockBuilder('\OCA\Mail\Service\UnifiedAccount')
-			->disableOriginalConstructor()
-			->getMock();
+		$this->controller = new AccountsController($this->appName, $this->request, $this->accountService, $this->userId,
+			$this->autoConfig, $this->logger, $this->l10n, $this->crypto, $this->aliasesService, $this->transmission);
+		$this->account = $this->createMock(Account::class);
+		$this->unifiedAccount = $this->createMock(UnifiedAccount::class);
 		$this->accountId = 123;
 	}
 
@@ -99,8 +111,8 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 		$this->account->expects($this->once())
 			->method('getConfiguration')
 			->will($this->returnValue([
-				'accountId' => 123,
-			]));
+					'accountId' => 123,
+		]));
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
 			->with($this->equalTo($this->userId))
@@ -185,15 +197,14 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 			->will($this->returnValue(135));
 		$this->autoConfig->expects($this->once())
 			->method('createAutoDetected')
-			->with($this->equalTo($email), $this->equalTo($password),
-				$this->equalTo($accountName))
+			->with($this->equalTo($email), $this->equalTo($password), $this->equalTo($accountName))
 			->will($this->returnValue($this->account));
 		$this->accountService->expects($this->once())
 			->method('save')
 			->with($this->equalTo($this->account));
 
-		$response = $this->controller->create($accountName, $email, $password, null,
-			null, null, null, null, null, null, null, null, null, true);
+		$response = $this->controller->create($accountName, $email, $password, null, null, null, null, null, null, null, null,
+			null, null, true);
 
 		$expectedResponse = new JSONResponse([
 			'data' => [
@@ -210,15 +221,14 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 
 		$this->autoConfig->expects($this->once())
 			->method('createAutoDetected')
-			->with($this->equalTo($email), $this->equalTo($password),
-				$this->equalTo($accountName))
+			->with($this->equalTo($email), $this->equalTo($password), $this->equalTo($accountName))
 			->will($this->returnValue(null));
 		$this->l10n->expects($this->once())
 			->method('t')
 			->will($this->returnValue('fail'));
 
-		$response = $this->controller->create($accountName, $email, $password, null,
-			null, null, null, null, null, null, null, null, null, true);
+		$response = $this->controller->create($accountName, $email, $password, null, null, null, null, null, null, null, null,
+			null, null, true);
 
 		$expectedResponse = new JSONResponse([
 			'message' => 'fail',
@@ -226,138 +236,58 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($expectedResponse, $response);
 	}
 
-	public function newMessageDataProvider() {
-		return [
-			[false, false, false],
-			[true, false, false],
-			[false, true, false],
-			[true, true, true],
-		];
-	}
-
-	/**
-	 * @dataProvider newMessageDataProvider
-	 */
-	public function testSend($isUnifiedInbox, $isReply, $addressCollectorError) {
-		$account = $isUnifiedInbox ? $this->unifiedAccount : $this->account;
-		$folderId = base64_encode('My folder');
-		$subject = 'Hello';
-		$body = 'Hi!';
-		$from = 'test@example.com';
-		$to = 'user1@example.com';
-		$cc = '"user2" <user2@example.com>, user3@example.com';
-		$bcc = 'user4@example.com';
-		$draftUID = 45;
-		$messageId = $isReply ? 123 : null;
-		$attachmentName = 'kitten.png';
-		$attachments = [
-			[
-				'fileName' => $attachmentName
-			],
-		];
-		$aliasId = null;
-
+	public function testSendNewMessage() {
+		$account = $this->createMock(Account::class);
 		$this->accountService->expects($this->once())
 			->method('find')
-			->with($this->userId, $this->accountId)
-			->will($this->returnValue($account));
-		if ($isUnifiedInbox) {
-			$this->unifiedAccount->expects($this->once())
-				->method('resolve')
-				->with($messageId)
-				->will($this->returnValue([$this->account, $folderId, $messageId]));
-		}
-
-		if ($isReply) {
-			$message = $this->getMockBuilder('OCA\Mail\Model\ReplyMessage')
-				->disableOriginalConstructor()
-				->getMock();
-			$this->account->expects($this->once())
-				->method('newReplyMessage')
-				->will($this->returnValue($message));
-			$mailbox = $this->getMockBuilder('OCA\Mail\Service\IMailBox')
-				->disableOriginalConstructor()
-				->getMock();
-			$this->account->expects($this->once())
-				->method('getMailbox')
-				->with(base64_decode($folderId))
-				->will($this->returnValue($mailbox));
-			$reply = new Message();
-			$mailbox->expects($this->once())
-				->method('getMessage')
-				->with($messageId)
-				->will($this->returnValue($reply));
-			$message->expects($this->once())
-				->method('setRepliedMessage')
-				->with($reply);
-		} else {
-			$message = $this->getMockBuilder('OCA\Mail\Model\Message')
-				->disableOriginalConstructor()
-				->getMock();
-			$this->account->expects($this->once())
-				->method('newMessage')
-				->will($this->returnValue($message));
-		}
-
-		$message->expects($this->once())
-			->method('setTo')
-			->with(Message::parseAddressList($to));
-		$message->expects($this->once())
-			->method('setSubject')
-			->with($subject);
-		$message->expects($this->once())
-			->method('setFrom')
-			->with($from);
-		$message->expects($this->once())
-			->method('setCC')
-			->with(Message::parseAddressList($cc));
-		$message->expects($this->once())
-			->method('setBcc')
-			->with(Message::parseAddressList($bcc));
-		$message->expects($this->once())
-			->method('setContent')
-			->with($body);
-		$message->expects($this->once())
-			->method('getToList')
-			->willReturn([]);
-		$message->expects($this->once())
-			->method('getCCList')
-			->willReturn([]);
-		$message->expects($this->once())
-			->method('getBCCList')
-			->willReturn([]);
-
-		$this->account->expects($this->once())
-			->method('getEMailAddress')
-			->will($this->returnValue($from));
-		$this->account->expects($this->once())
+			->willReturn($account);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', []);
+		$replyData = new RepliedMessageData($account, null, null);
+		$this->transmission->expects($this->once())
 			->method('sendMessage')
-			->with($message, $draftUID);
-		$this->userFolder->expects($this->at(0))
-			->method('nodeExists')
-			->with($attachmentName)
-			->will($this->returnValue(true));
-		$file = $this->getMockBuilder('OCP\Files\File')
-			->disableOriginalConstructor()
-			->getMock();
-		$this->userFolder->expects($this->once())
-			->method('get')
-			->with($attachmentName)
-			->will($this->returnValue($file));
-		if ($addressCollectorError) {
-			$this->collector->expects($this->once())
-				->method('addAddresses')
-				->will($this->throwException(new Exception('some error')));
-		} else {
-			$this->collector->expects($this->once())
-				->method('addAddresses');
-		}
-
+			->with($messageData, $replyData, null, null);
 		$expected = new JSONResponse();
-		$actual = $this->controller->send($this->accountId, $folderId, $subject,
-			$body, $to, $cc, $bcc, $draftUID, $messageId, $attachments, $aliasId);
 
-		$this->assertEquals($expected, $actual);
+		$resp = $this->controller->send(13, null, 'sub', 'bod', 'to@d.com', '', '', null, null, [], null);
+
+		$this->assertEquals($expected, $resp);
+	}
+
+	public function testSendingError() {
+		$account = $this->createMock(Account::class);
+		$this->accountService->expects($this->once())
+			->method('find')
+			->willReturn($account);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', []);
+		$replyData = new RepliedMessageData($account, null, null);
+		$this->transmission->expects($this->once())
+			->method('sendMessage')
+			->with($messageData, $replyData, null, null)
+			->willThrowException(new \Horde_Exception('error'));
+		$expected = new JSONResponse(['message' => 'error'], 500);
+
+		$resp = $this->controller->send(13, null, 'sub', 'bod', 'to@d.com', '', '', null, null, [], null);
+
+		$this->assertEquals($expected, $resp);
+	}
+
+	public function testSendReply() {
+		$account = $this->createMock(Account::class);
+		$folderId = base64_encode('INBOX');
+		$messageId = 1234;
+		$this->accountService->expects($this->once())
+			->method('find')
+			->willReturn($account);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', []);
+		$replyData = new RepliedMessageData($account, $folderId, $messageId);
+		$this->transmission->expects($this->once())
+			->method('sendMessage')
+			->with($messageData, $replyData, null, null);
+		$expected = new JSONResponse();
+
+		$resp = $this->controller->send(13, $folderId, 'sub', 'bod', 'to@d.com', '', '', null, $messageId, [], null);
+
+		$this->assertEquals($expected, $resp);
 	}
 
 	public function draftDataProvider() {
@@ -430,8 +360,7 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 		$expected = new JSONResponse([
 			'uid' => $newUID,
 		]);
-		$actual = $this->controller->draft($this->accountId, $subject, $body, $to,
-			$cc, $bcc, $uid, $messageId);
+		$actual = $this->controller->draft($this->accountId, $subject, $body, $to, $cc, $bcc, $uid, $messageId);
 
 		$this->assertEquals($expected, $actual);
 	}

--- a/tests/Model/NewMessageDataTest.php
+++ b/tests/Model/NewMessageDataTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Model;
+
+use Horde_Mail_Rfc822_List;
+use OCA\Mail\Account;
+use OCA\Mail\Model\NewMessageData;
+use PHPUnit_Framework_TestCase;
+
+class NewMessageDataTest extends PHPUnit_Framework_TestCase {
+
+	public function testConstructionFromSimpleRequestData() {
+		$account = $this->createMock(Account::class);
+		$to = '"Test" <test@domain.com>';
+		$cc = '';
+		$bcc = '';
+		$subject = 'Hello';
+		$body = 'Hi!';
+		$attachments = null;
+		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
+
+		$this->assertEquals($account, $messageData->getAccount());
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getTo());
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getCc());
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getBcc());
+		$this->assertEquals('Hello', $messageData->getSubject());
+		$this->assertEquals('Hi!', $messageData->getBody());
+		$this->assertEquals([], $messageData->getAttachments());
+	}
+
+	public function testConstructionFromComplexRequestData() {
+		$account = $this->createMock(Account::class);
+		$to = '"Test" <test@domain.com>, test2@domain.de';
+		$cc = 'test2@domain.at';
+		$bcc = '"Test3" <test3@domain.net>';
+		$subject = 'Hello';
+		$body = 'Hi!';
+		$attachments = null;
+		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
+
+		$this->assertEquals($account, $messageData->getAccount());
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getTo());
+		$this->assertEquals(['test@domain.com', 'test2@domain.de'], $messageData->getTo()->bare_addresses);
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getCc());
+		$this->assertEquals(['test2@domain.at'], $messageData->getCc()->bare_addresses);
+		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getBcc());
+		$this->assertEquals(['test3@domain.net'], $messageData->getBcc()->bare_addresses);
+		$this->assertEquals('Hello', $messageData->getSubject());
+		$this->assertEquals('Hi!', $messageData->getBody());
+		$this->assertEquals([], $messageData->getAttachments());
+	}
+
+}

--- a/tests/Model/RepliedMessageTest.php
+++ b/tests/Model/RepliedMessageTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Model;
+
+use OCA\Mail\Model\RepliedMessageData;
+use OCA\Mail\Service\IAccount;
+use PHPUnit_Framework_TestCase;
+
+class RepliedMessageTest extends PHPUnit_Framework_TestCase {
+
+	public function testGetAccount() {
+		$account = $this->createMock(IAccount::class);
+		$data = new RepliedMessageData($account, null, null);
+
+		$this->assertEquals($account, $data->getAccount());
+	}
+
+	public function testGetFolderId() {
+		$account = $this->createMock(IAccount::class);
+		$folderId = base64_encode('INBOX');
+		$data = new RepliedMessageData($account, $folderId, null);
+
+		$this->assertEquals($folderId, $data->getFolderId());
+	}
+
+	public function testGetId() {
+		$account = $this->createMock(IAccount::class);
+		$messageId = 12;
+		$data = new RepliedMessageData($account, null, $messageId);
+
+		$this->assertEquals($messageId, $data->getId());
+	}
+
+	public function testIsReply() {
+		$account = $this->createMock(IAccount::class);
+		$folderId = base64_encode('INBOX');
+		$messageId = 12;
+		$data = new RepliedMessageData($account, $folderId, $messageId);
+
+		$this->assertTrue($data->isReply());
+	}
+
+	public function testIsNoReply() {
+		$account = $this->createMock(IAccount::class);
+		$data = new RepliedMessageData($account, null, null);
+
+		$this->assertFalse($data->isReply());
+	}
+
+}

--- a/tests/Service/MailTransmissionTest.php
+++ b/tests/Service/MailTransmissionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service;
+
+use Horde_Imap_Client;
+use OC\Files\Node\File;
+use OCA\Mail\Account;
+use OCA\Mail\Db\Alias;
+use OCA\Mail\Mailbox;
+use OCA\Mail\Model\IMessage;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
+use OCA\Mail\Model\ReplyMessage;
+use OCA\Mail\Service\AutoCompletion\AddressCollector;
+use OCA\Mail\Service\Logger;
+use OCA\Mail\Service\MailTransmission;
+use OCP\Files\Folder;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+class MailTransmissionTest extends PHPUnit_Framework_TestCase {
+
+	/** @var AddressCollector|PHPUnit_Framework_MockObject_MockObject */
+	private $addressCollector;
+
+	/** @var Folder|PHPUnit_Framework_MockObject_MockObject */
+	private $userFolder;
+
+	/** @var Logger|PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
+	/** @var MailTransmission */
+	private $transmission;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->addressCollector = $this->createMock(AddressCollector::class);
+		$this->userFolder = $this->createMock(Folder::class);
+		$this->logger = $this->createMock(Logger::class);
+
+		$this->transmission = new MailTransmission($this->addressCollector, $this->userFolder, $this->logger);
+	}
+
+	public function testSendNewMessage() {
+		$account = $this->createMock(Account::class);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', null);
+		$replyData = new RepliedMessageData($account, null, null);
+		$message = $this->createMock(IMessage::class);
+		$account->expects($this->once())
+			->method('newMessage')
+			->willReturn($message);
+		$account->expects($this->once())
+			->method('sendMessage')
+			->with($message, null);
+
+		$this->transmission->sendMessage($messageData, $replyData);
+	}
+
+	public function testSendMessageAndDeleteDraft() {
+		$account = $this->createMock(Account::class);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', null);
+		$replyData = new RepliedMessageData($account, null, null);
+		$message = $this->createMock(IMessage::class);
+		$account->expects($this->once())
+			->method('newMessage')
+			->willReturn($message);
+		$account->expects($this->once())
+			->method('sendMessage')
+			->with($message, 123);
+
+		$this->transmission->sendMessage($messageData, $replyData, null, 123);
+	}
+
+	public function testSendMessageFromAlias() {
+		$account = $this->createMock(Account::class);
+		$alias = $this->createMock(Alias::class);
+		$alias->alias = 'a@d.com';
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', null);
+		$replyData = new RepliedMessageData($account, null, null);
+		$message = $this->createMock(IMessage::class);
+		$account->expects($this->once())
+			->method('newMessage')
+			->willReturn($message);
+		$account->expects($this->once())
+			->method('sendMessage')
+			->with($message, null);
+		$account->expects($this->once())
+			->method('setAlias')
+			->with($alias);
+		$message->expects($this->once())
+			->method('setFrom')
+			->with($this->equalTo('a@d.com'));
+
+		$this->transmission->sendMessage($messageData, $replyData, $alias);
+	}
+
+	public function testSendNewMessageWithCloudAttachments() {
+		$account = $this->createMock(Account::class);
+		$attachmenst = [
+			[
+				'fileName' => 'cat.jpg',
+			],
+			[
+				'fileName' => 'dog.jpg',
+			],
+			[] // add an invalid one too
+		];
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', $attachmenst);
+		$replyData = new RepliedMessageData($account, null, null);
+		$message = $this->createMock(IMessage::class);
+		$account->expects($this->once())
+			->method('newMessage')
+			->willReturn($message);
+		$account->expects($this->once())
+			->method('sendMessage')
+			->with($message, null);
+		$this->userFolder->expects($this->exactly(2))
+			->method('nodeExists')
+			->willReturnMap([
+				['cat.jpg', true],
+				['dog.jpg', false],
+		]);
+		$node = $this->createMock(File::class);
+		$this->userFolder->expects($this->once())
+			->method('get')
+			->with('cat.jpg')
+			->willReturn($node);
+		$message->expects($this->once())
+			->method('addAttachmentFromFiles')
+			->with($node);
+
+		$this->transmission->sendMessage($messageData, $replyData);
+	}
+
+	public function testReplyToAnExistingMessage() {
+		$account = $this->createMock(Account::class);
+		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', null);
+		$folderId = base64_encode('INBOX');
+		$repliedMessageId = 321;
+		$replyData = new RepliedMessageData($account, $folderId, $repliedMessageId);
+		$message = $this->createMock(ReplyMessage::class);
+		$account->expects($this->once())
+			->method('newReplyMessage')
+			->willReturn($message);
+		$mailbox = $this->createMock(Mailbox::class);
+		$account->expects($this->exactly(2)) // once to get the orignal message and once to flag it
+			->method('getMailbox')
+			->with(base64_decode($folderId))
+			->willReturn($mailbox);
+		$repliedMessage = $this->createMock(IMessage::class);
+		$mailbox->expects($this->once())
+			->method('getMessage')
+			->with($repliedMessageId)
+			->willReturn($repliedMessage);
+		$message->expects($this->once())
+			->method('setRepliedMessage')
+			->with($repliedMessage);
+		$account->expects($this->once())
+			->method('sendMessage')
+			->with($message, null);
+		$mailbox->expects($this->once())
+			->method('setMessageFlag')
+			->with($repliedMessageId, Horde_Imap_Client::FLAG_ANSWERED, true);
+
+		$this->transmission->sendMessage($messageData, $replyData);
+	}
+
+}


### PR DESCRIPTION
* Move sending logic from controller into its own serivce
* Create service contract/interface to decouple HTTP controller from service implementation
* Decompose logic into multiple small, readable methods
* Wrap data in immutable data classes/objects to prevent long parameter lists and easy testing
* Add basic unit tests that cover the main code paths

TODO:
- [x] manual testing of various use cases
  - [x] send new message
  - [x] reply to a message
  - [x] attach files on a new message
  - [x] attach files on an existing messageb
- [x] AccountController tests