### PR TITLE
Add SMTP integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
   - composer self-update
   - make install-composer-deps
   - make start-imap-docker
+  - make start-smtp-docker
   - cd ..
   - git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b $CORE_BRANCH core
   - mv mail core/apps/

--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,20 @@ dev-setup: install-composer-deps install-npm-deps-dev
 
 start-imap-docker:
 	docker pull $(docker_image)
-	docker run --name="ocimaptest" -d \
-	-p 2525:25 -p 587:587 -p 993:993 \
+	docker run --name="ncimaptest" -d \
+	-p 993:993 \
 	-e POSTFIX_HOSTNAME=mail.domain.tld $(docker_image)
 
+start-smtp-docker:
+	docker pull catatnight/postfix
+	docker run --name="ncsmtptest" -d \
+	-e maildomain=domain.tld \
+	-e smtp_user=user@domain.tld:mypassword \
+	-p 2525:25 \
+	catatnight/postfix
+
 add-imap-account:
-	docker exec -it ocimaptest /opt/bin/useradd $(mail_user) $(mail_pwd)
+	docker exec -it ncimaptest /opt/bin/useradd $(mail_user) $(mail_pwd)
 
 update-composer: composer.phar
 	rm -f composer.lock

--- a/tests/integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/integration/Service/MailTransmissionIntegrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service;
+
+use OC;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailTransmission;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Model\NewMessageData;
+use OCA\Mail\Model\RepliedMessageData;
+use OCP\Security\ICrypto;
+use PHPUnit_Framework_TestCase;
+
+class MailTransmissionIntegrationTest extends PHPUnit_Framework_TestCase {
+
+	/** @var ICrypto */
+	private $crypo;
+	
+	/** @var IMailTransmission */
+	private $transmission;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->crypo = OC::$server->getCrypto();
+		$this->transmission = OC::$server->query(IMailTransmission::class);
+	}
+
+	public function testSendMail() {
+		$account = new Account(MailAccount::fromParams([
+			'email' => 'user@domain.tld',
+			'inboundHost' => 'localhost',
+			'inboundPort' => '993',
+			'inboundSslMode' => 'none',
+			'inboundUser' => 'user@domain.tld',
+			'inboundPassword' => $this->crypo->encrypt('mypassword'),
+			'outboundHost' => 'smtp.mailtrap.io',
+			'outboundPort' => '25',
+			'outboundSslMode' => 'none',
+			'outboundUser' => 'xxx',
+			'outboundPassword' => $this->crypo->encrypt('xxx'),
+		]));
+		$message = NewMessageData::fromRequest($account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
+		$reply = new RepliedMessageData($account, null, null);
+		$this->transmission->sendMessage($message, $reply);
+	}
+
+}

--- a/tests/integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/integration/Service/MailTransmissionIntegrationTest.php
@@ -32,35 +32,35 @@ use PHPUnit_Framework_TestCase;
 
 class MailTransmissionIntegrationTest extends PHPUnit_Framework_TestCase {
 
-	/** @var ICrypto */
-	private $crypo;
-	
+	/** @var Account */
+	private $account;
+
 	/** @var IMailTransmission */
 	private $transmission;
 
 	protected function setUp() {
 		parent::setUp();
 
-		$this->crypo = OC::$server->getCrypto();
+		$crypo = OC::$server->getCrypto();
+		$this->account = new Account(MailAccount::fromParams([
+				'email' => 'user@domain.tld',
+				'inboundHost' => 'localhost',
+				'inboundPort' => '993',
+				'inboundSslMode' => 'ssl',
+				'inboundUser' => 'user@domain.tld',
+				'inboundPassword' => $crypo->encrypt('mypassword'),
+				'outboundHost' => 'localhost',
+				'outboundPort' => '2525',
+				'outboundSslMode' => 'none',
+				'outboundUser' => 'user@domain.tld',
+				'outboundPassword' => $crypo->encrypt('mypassword'),
+		]));
 		$this->transmission = OC::$server->query(IMailTransmission::class);
 	}
 
 	public function testSendMail() {
-		$account = new Account(MailAccount::fromParams([
-			'email' => 'user@domain.tld',
-			'inboundHost' => 'localhost',
-			'inboundPort' => '993',
-			'inboundSslMode' => 'none',
-			'inboundUser' => 'user@domain.tld',
-			'inboundPassword' => $this->crypo->encrypt('mypassword'),
-			'outboundHost' => 'smtp.mailtrap.io',
-			'outboundPort' => '25',
-			'outboundSslMode' => 'none',
-			'outboundUser' => 'xxx',
-			'outboundPassword' => $this->crypo->encrypt('xxx'),
-		]));
-		$message = NewMessageData::fromRequest($account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
-		$reply = new RepliedMessageData($account, null, null);
+		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
+		$reply = new RepliedMessageData($this->account, null, null);
 		$this->transmission->sendMessage($message, $reply);
 	}
 


### PR DESCRIPTION
This adds a simple integration test for our mail transmission code. It's very basic now but can be extended to test more complex scenarios like attachments.

~~I'm waiting to get a free account on mailtrap so that we can easily test against a real SMTP server.~~ Let's use a local docker image instead.