### PR TITLE
Add IMAP integration test framework

### DIFF
--- a/tests/Integration/Framework/ImapTest.php
+++ b/tests/Integration/Framework/ImapTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration\Framework;
+
+use Horde_Imap_Client_Fetch_Query;
+use Horde_Imap_Client_Ids;
+use Horde_Imap_Client_Socket;
+use Horde_Mail_Rfc822_Address;
+use Horde_Mime_Mail;
+use Horde_Mime_Part;
+
+trait ImapTest {
+
+	/**  @var Horde_Imap_Client_Socket */
+	private $client;
+
+	/** @var array<string> */
+	private $defaultMailboxes = [
+		'Drafts',
+		'INBOX',
+		'Junk',
+		'Sent',
+		'Trash',
+	];
+
+	/**
+	 * @return Horde_Imap_Client_Socket
+	 */
+	private function getTestClient() {
+		if (is_null($this->client)) {
+			$this->client = new Horde_Imap_Client_Socket([
+				'username' => 'user@domain.tld',
+				'password' => 'mypassword',
+				'hostspec' => 'localhost',
+				'port' => 993,
+				'secure' => 'ssl',
+			]);
+		}
+
+		return $this->client;
+	}
+
+	/**
+	 * Reset the testing account to empty default mailboxes and delete any
+	 * other mailboxes that have been created
+	 */
+	public function resetImapAccount() {
+		$client = $this->getTestClient();
+		$mailboxes = $this->listMailboxes($client);
+
+		foreach ($mailboxes as $mailbox) {
+			if (in_array($mailbox, $this->defaultMailboxes)) {
+				$this->emptyMailbox($client, $mailbox);
+			} else {
+				$this->deleteMailbox($client, $mailbox);
+			}
+		}
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	public function getMailboxes() {
+		$client = $this->getTestClient();
+
+		return $this->listMailboxes($client);
+	}
+
+	/**
+	 * @param Horde_Imap_Client_Socket $client
+	 * @return array<string>
+	 */
+	private function listMailboxes(Horde_Imap_Client_Socket $client) {
+		return array_map(function($mailbox) {
+			return $mailbox['mailbox'];
+		}, $client->listMailboxes('*'));
+	}
+
+	/**
+	 * @param string $mailbox
+	 */
+	public function createImapMailbox($mailbox) {
+		$client = $this->getTestClient();
+
+		$client->createMailbox($mailbox);
+	}
+
+	/**
+	 * @return MessageBuilder
+	 */
+	public function getMessageBuilder() {
+		return MessageBuilder::create();
+	}
+
+	/**
+	 * @param string $mailbox
+	 * @param SimpleMessage $message
+	 */
+	public function saveMessage($mailbox, SimpleMessage $message) {
+		$client = $this->getTestClient();
+
+		$headers = [
+			'From' => new Horde_Mail_Rfc822_Address($message->getFrom()),
+			'To' => new Horde_Mail_Rfc822_Address($message->getTo()),
+			'Cc' => new Horde_Mail_Rfc822_Address($message->getCc()),
+			'Bcc' => new Horde_Mail_Rfc822_Address($message->getBcc()),
+			'Subject' => $message->getSubject(),
+		];
+
+		$mail = new Horde_Mime_Mail();
+		$mail->addHeaders($headers);
+		$body = new Horde_Mime_Part();
+		$body->setType('text/plain');
+		$body->setContents($message->getBody());
+		$mail->setBasePart($body);
+
+		$raw = $mail->getRaw();
+		$data = stream_get_contents($raw);
+
+		$client->append($mailbox, [
+			[
+				'data' => $data,
+			]
+		]);
+	}
+
+	/**
+	 * @param Horde_Imap_Client_Socket $client
+	 * @param string $mailbox
+	 */
+	private function emptyMailbox(Horde_Imap_Client_Socket $client, $mailbox) {
+		$query = new Horde_Imap_Client_Fetch_Query();
+		$query->uid();
+		$ids = new Horde_Imap_Client_Ids($client->fetch($mailbox, $query)->ids());
+
+		$client->expunge($mailbox, [
+			'ids' => $ids,
+			'delete' => true,
+		]);
+	}
+
+	/**
+	 * @param Horde_Imap_Client_Socket $client
+	 * @param string $mailbox
+	 */
+	private function deleteMailbox(Horde_Imap_Client_Socket $client, $mailbox) {
+		$client->deleteMailbox($mailbox);
+	}
+
+	/**
+	 * @param int $number
+	 * @param string $mailbox
+	 */
+	public function assertMessageCount($number, $mailbox) {
+		$client = $this->getTestClient();
+
+		$query = new Horde_Imap_Client_Fetch_Query();
+		$query->uid();
+		$this->assertSame($number, $client->fetch($mailbox, $query)->count());
+	}
+
+}

--- a/tests/Integration/Framework/MessageBuilder.php
+++ b/tests/Integration/Framework/MessageBuilder.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration\Framework;
+
+class MessageBuilder {
+
+	/** @var string */
+	private $from;
+
+	/** @var string */
+	private $to;
+
+	/** @var string */
+	private $cc;
+
+	/** @var string */
+	private $bcc;
+
+	/** @var string */
+	private $date;
+
+	/** @var string */
+	private $subject;
+
+	/** @var string */
+	private $body;
+
+	/**
+	 * @return MessageBuilder
+	 */
+	public static function create() {
+		return new static;
+	}
+
+	/**
+	 * @param string $from
+	 * @return MessageBuilder
+	 */
+	public function from($from) {
+		$this->from = $from;
+		return $this;
+	}
+
+	/**
+	 * @param string $to
+	 * @return MessageBuilder
+	 */
+	public function to($to) {
+		$this->to = $to;
+		return $this;
+	}
+
+	/**
+	 * @param string $cc
+	 * @return MessageBuilder
+	 */
+	public function cc($cc) {
+		$this->cc = $cc;
+		return $this;
+	}
+
+	/**
+	 * @param string $bcc
+	 * @return MessageBuilder
+	 */
+	public function bcc($bcc) {
+		$this->bcc = $bcc;
+		return $this;
+	}
+
+	/**
+	 * @param string $date
+	 * @return MessageBuilder
+	 */
+	public function date($date) {
+		$this->date = $date;
+		return $this;
+	}
+
+	/**
+	 * @param string $subject
+	 * @return MessageBuilder
+	 */
+	public function subject($subject) {
+		$this->subject = $subject;
+		return $this;
+	}
+
+	/**
+	 * @param string $body
+	 * @return MessageBuilder
+	 */
+	public function body($body) {
+		$this->body = $body;
+		return $this;
+	}
+
+	public function finish() {
+		return new SimpleMessage($this->from, $this->to, $this->cc, $this->bcc, $this->date, $this->subject, $this->body);
+	}
+
+}

--- a/tests/Integration/Framework/SelfTest.php
+++ b/tests/Integration/Framework/SelfTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration\Framework;
+
+use OCA\Mail\Tests\Integration\TestCase;
+
+/**
+ * Tests the IMAP test framework functionality
+ */
+class SelfTest extends TestCase {
+
+	use ImapTest;
+
+	public function testResetAccount() {
+		$this->assertCount(5, $this->getMailboxes());
+		$this->createImapMailbox('folder1');
+		$this->assertCount(6, $this->getMailboxes());
+		$this->resetImapAccount();
+		$this->assertCount(5, $this->getMailboxes());
+	}
+
+	public function testMessageCapabilities() {
+		$mb = $this->getMessageBuilder();
+		$message = $mb->to('fritz@phantom.at')
+			->from('tom@turbo.at')
+			->subject('hello')
+			->body('hi!')
+			->finish();
+
+		$this->assertMessageCount(0, 'INBOX');
+		$this->saveMessage('INBOX', $message);
+		$this->assertMessageCount(1, 'INBOX');
+	}
+
+}

--- a/tests/Integration/Framework/SimpleMessage.php
+++ b/tests/Integration/Framework/SimpleMessage.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration\Framework;
+
+class SimpleMessage {
+
+	/** @var string */
+	private $from;
+
+	/** @var string */
+	private $to;
+
+	/** @var string */
+	private $cc;
+
+	/** @var string */
+	private $bcc;
+
+	/** @var string */
+	private $date;
+
+	/** @var string */
+	private $subject;
+
+	/** @var string */
+	private $body;
+
+	/**
+	 * @param string $from
+	 * @param string $to
+	 * @param string $cc
+	 * @param string $bcc
+	 * @param string $date
+	 * @param string $subject
+	 * @param string $body
+	 */
+	public function __construct($from, $to, $cc, $bcc, $date, $subject, $body) {
+		$this->from = $from;
+		$this->to = $to;
+		$this->cc = $cc;
+		$this->bcc = $bcc;
+		$this->date = $date;
+		$this->subject = $subject;
+		$this->body = $body;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getFrom() {
+		return $this->from;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getTo() {
+		return $this->to;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getCc() {
+		return $this->cc;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getBcc() {
+		return $this->bcc;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getDate() {
+		return $this->date;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getSubject() {
+		return $this->subject;
+	}
+
+	/**
+	 * @return string
+	 */
+	function getBody() {
+		return $this->body;
+	}
+
+}

--- a/tests/Integration/Service/FolderMapperIntegrationTest.php
+++ b/tests/Integration/Service/FolderMapperIntegrationTest.php
@@ -23,8 +23,8 @@ namespace OCA\Mail\Tests\Integration\Service;
 
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
+use OCA\Mail\Folder;
 use OCA\Mail\Service\FolderMapper;
-use OCP\Files\Folder;
 use PHPUnit_Framework_TestCase;
 
 class FolderMapperIntegrationTest extends PHPUnit_Framework_TestCase {

--- a/tests/Integration/Service/FolderMapperIntegrationTest.php
+++ b/tests/Integration/Service/FolderMapperIntegrationTest.php
@@ -19,15 +19,15 @@
  *
  */
 
-namespace OCA\Mail\Tests\Service;
+namespace OCA\Mail\Tests\Integration\Service;
 
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
-use OCA\Mail\Folder;
 use OCA\Mail\Service\FolderMapper;
-use Test\TestCase;
+use OCP\Files\Folder;
+use PHPUnit_Framework_TestCase;
 
-class FolderMapperIntegrationTest extends TestCase {
+class FolderMapperIntegrationTest extends PHPUnit_Framework_TestCase {
 
 	/** @var FolderMapper */
 	private $mapper;

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\Mail\Tests\Service;
+namespace OCA\Mail\Tests\Integration\Service;
 
 use OC;
 use OCA\Mail\Account;
@@ -27,10 +27,9 @@ use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
-use OCP\Security\ICrypto;
-use PHPUnit_Framework_TestCase;
+use OCA\Mail\Tests\Integration\TestCase;
 
-class MailTransmissionIntegrationTest extends PHPUnit_Framework_TestCase {
+class MailTransmissionIntegrationTest extends TestCase {
 
 	/** @var Account */
 	private $account;
@@ -61,7 +60,7 @@ class MailTransmissionIntegrationTest extends PHPUnit_Framework_TestCase {
 	public function testSendMail() {
 		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
 		$reply = new RepliedMessageData($this->account, null, null);
-		$this->transmission->sendMessage($message, $reply);
+		$this->transmission->sendMessage('ferdinand', $message, $reply);
 	}
 
 }

--- a/tests/Integration/TestCase.php
+++ b/tests/Integration/TestCase.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration;
+
+use OCA\Mail\Tests\Integration\Framework\ImapTest;
+use PHPUnit_Framework_TestCase;
+
+class TestCase extends PHPUnit_Framework_TestCase {
+
+	protected function setUp() {
+		parent::setUp();
+
+		// If it's an IMAP test, we reset the test account automatically
+		if (in_array(ImapTest::class, class_uses($this))) {
+			$this->resetImapAccount();
+		}
+	}
+
+}


### PR DESCRIPTION
Add a trait-based testing framework that automatically resets
the IMAP testing account before a test case is run to prevent
side effects and dependencies across different tests.
A simple self test was added to ensure the functionality works
as expected.
A new super class for integration tests was added which should
be used now instead of phpunit's class. This will allow to write
tests with less boilerplate code, as we can for example check
the usage of the IMAP test trait and reset accounts automatically.
This was inspired by the Laravel testing capabilities.