### PR TITLE
Add more unit tests for the autoconfig logic

### DIFF
--- a/lib/Service/AutoConfig/ConnectivityTester.php
+++ b/lib/Service/AutoConfig/ConnectivityTester.php
@@ -18,13 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\Mail\Service\AutoConfig;
 
 use OCA\Mail\Service\Logger;
 
 class ConnectivityTester {
 
-	const CONNECTION_TIMEOUT = 10;
+	const CONNECTION_TIMEOUT = 5;
 
 	/** @var Logger */
 	protected $logger;
@@ -43,7 +44,7 @@ class ConnectivityTester {
 	 */
 	public function canConnect($url, $port) {
 		$this->logger->debug("attempting to connect to <$url> on port <$port>");
-		$fp = fsockopen($url, $port, $error, $errorstr, self::CONNECTION_TIMEOUT);
+		$fp = @fsockopen($url, $port, $error, $errorstr, self::CONNECTION_TIMEOUT);
 		if (is_resource($fp)) {
 			fclose($fp);
 			$this->logger->debug("connection to <$url> on port <$port> established");

--- a/lib/Service/AutoConfig/SmtpServerDetector.php
+++ b/lib/Service/AutoConfig/SmtpServerDetector.php
@@ -46,9 +46,15 @@ class SmtpServerDetector {
 		$this->testSmtp = $testSmtp;
 	}
 
+	/**
+	 * @param MailAccount $account
+	 * @param string $email
+	 * @param string $password
+	 * @return bool
+	 */
 	public function detect(MailAccount $account, $email, $password) {
 		if ($this->testSmtp === false) {
-			return;
+			return true;
 		}
 
 		// splitting the email address into user and host part
@@ -61,20 +67,18 @@ class SmtpServerDetector {
 		$mxHosts = $this->mxRecord->query($host);
 		if ($mxHosts) {
 			foreach ($mxHosts as $mxHost) {
-				$result = $this->smtpConnectivityTester->test($account, $mxHost,
-					[$user, $email], $password);
+				$result = $this->smtpConnectivityTester->test($account, $mxHost, [$user, $email], $password);
 				if ($result) {
-					return;
+					return true;
 				}
 			}
 		}
 
 		/*
-		 * IMAP login with full email address as user
+		 * SMTP login with full email address as user
 		 * works for a lot of providers (e.g. Google Mail)
 		 */
-		$this->smtpConnectivityTester->test($account, $host, [$user, $email],
-			$password, true);
+		return $this->smtpConnectivityTester->test($account, $host, [$user, $email], $password, true);
 	}
 
 }

--- a/tests/Service/Autoconfig/ConnectivityTesterTest.php
+++ b/tests/Service/Autoconfig/ConnectivityTesterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service\Autoconfig;
+
+use OCA\Mail\Service\AutoConfig\ConnectivityTester;
+use OCA\Mail\Service\Logger;
+use OpenCloud\Common\Log\Logger as Logger2;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+class ConnectivityTesterTest extends PHPUnit_Framework_TestCase {
+
+	/** @var Logger2|PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
+	/** @var ConnectivityTester */
+	private $tester;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->logger = $this->createMock(Logger::class);
+
+		$this->tester = new ConnectivityTester($this->logger);
+	}
+
+	public function testCanConnect() {
+		$canConnect = $this->tester->canConnect('wikipedia.org', 80);
+
+		$this->assertTrue($canConnect);
+	}
+
+	public function testCanNotConnect() {
+		$before = microtime(true);
+		$canConnect = $this->tester->canConnect('wikipedia.org', 90);
+		$after = microtime(true);
+
+		$this->assertFalse($canConnect);
+		$this->assertLessThan(15, $after - $before);
+	}
+
+	public function testCanNotConnectToNonexistentDomain() {
+		$before = microtime(true);
+		$canConnect = $this->tester->canConnect('thisdomaindoesnotexist', 90);
+		$after = microtime(true);
+
+		$this->assertFalse($canConnect);
+		$this->assertLessThan(15, $after - $before);
+	}
+
+}

--- a/tests/Service/Autoconfig/ImapConnectorTest.php
+++ b/tests/Service/Autoconfig/ImapConnectorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service\Autoconfig;
+
+use Horde_Imap_Client_Exception;
+use OC;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AutoConfig\ImapConnector;
+use OCA\Mail\Service\Logger;
+use OCP\Security\ICrypto;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+class ImapConnectorTest extends PHPUnit_Framework_TestCase {
+
+	/** @var ICrypto */
+	private $crypto;
+
+	/** @var Logger|PHPUnit_Framework_MockObject_MockObject */
+	private $logger;
+
+	/** @var ImapConnector */
+	private $connector;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->crypto = OC::$server->getCrypto();
+		$this->logger = $this->createMock(Logger::class);
+
+		$this->connector = new ImapConnector($this->crypto, $this->logger, 'christopher');
+	}
+
+	public function testSuccessfulConnection() {
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$name = 'User';
+		$host = 'localhost';
+		$port = '993';
+		$ssl = 'ssl';
+		$user = 'user@domain.tld';
+
+		$account = $this->connector->connect($email, $password, $name, $host, $port, $ssl, $user);
+
+		$this->assertInstanceOf(MailAccount::class, $account);
+	}
+
+	/**
+	 * The password is wrong
+	 */
+	public function testFailingConnection() {
+		$email = 'user@domain.tld';
+		$password = 'notmypassword';
+		$name = 'User';
+		$host = 'localhost';
+		$port = '993';
+		$ssl = 'ssl';
+		$user = 'user@domain.tld';
+		$this->expectException(Horde_Imap_Client_Exception::class);
+
+		$this->connector->connect($email, $password, $name, $host, $port, $ssl, $user);
+
+		$this->fail('should not have been reached');
+	}
+
+}

--- a/tests/Service/Autoconfig/ImapServerDetectorTest.php
+++ b/tests/Service/Autoconfig/ImapServerDetectorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service\Autoconfig;
+
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AutoConfig\ImapConnectivityTester;
+use OCA\Mail\Service\AutoConfig\ImapServerDetector;
+use OCA\Mail\Service\AutoConfig\MxRecord;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+class ImapServerDetectorTest extends PHPUnit_Framework_TestCase {
+
+	/** @var MxRecord|PHPUnit_Framework_MockObject_MockObject */
+	private $mxRecord;
+
+	/** @var ImapConnectivityTester|PHPUnit_Framework_MockObject_MockObject */
+	private $imapConnectivityTester;
+
+	/** @var ImapServerDetector */
+	private $detector;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mxRecord = $this->createMock(MxRecord::class);
+		$this->imapConnectivityTester = $this->createMock(ImapConnectivityTester::class);
+
+		$this->detector = new ImapServerDetector($this->mxRecord, $this->imapConnectivityTester);
+	}
+
+	public function testDetectNo() {
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$name = 'User';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(['mx.domain.tld']);
+		$this->imapConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($email), $this->equalTo('mx.domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn($this->createMock(MailAccount::class));
+
+		$account = $this->detector->detect($email, $password, $name);
+
+		$this->assertNotNull($account);
+		$this->assertInstanceOf(MailAccount::class, $account);
+	}
+
+	public function testDetectNoMxRecordsFound() {
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$name = 'User';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(false);
+		$this->imapConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($email), $this->equalTo('domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn($this->createMock(MailAccount::class));
+
+		$account = $this->detector->detect($email, $password, $name);
+
+		$this->assertNotNull($account);
+		$this->assertInstanceOf(MailAccount::class, $account);
+	}
+
+	public function testDetectNoMxRecordsFoundAndFallbackFails() {
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$name = 'User';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(false);
+		$this->imapConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($email), $this->equalTo('domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn(null);
+
+		$account = $this->detector->detect($email, $password, $name);
+
+		$this->assertNull($account);
+	}
+
+}

--- a/tests/Service/Autoconfig/MxRecordTest.php
+++ b/tests/Service/Autoconfig/MxRecordTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service\Autoconfig;
+
+use OCA\Mail\Service\AutoConfig\MxRecord;
+use OCA\Mail\Service\Logger;
+use PHPUnit_Framework_TestCase;
+
+class MxRecordTest extends PHPUnit_Framework_TestCase {
+
+	/** @var MxRecord */
+	private $record;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$logger = $this->createMock(Logger::class);
+		$this->record = new MxRecord($logger);
+	}
+
+	public function testQuery() {
+		$records = $this->record->query('nextcloud.com');
+
+		$this->assertInternalType('array', $records);
+		$this->assertNotEmpty($records);
+	}
+
+	public function testQueryNoRecord() {
+		$records = $this->record->query('example.com');
+
+		$this->assertFalse($records);
+	}
+
+}

--- a/tests/Service/Autoconfig/SmtpServerDetectorTest.php
+++ b/tests/Service/Autoconfig/SmtpServerDetectorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Service\Autoconfig;
+
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AutoConfig\MxRecord;
+use OCA\Mail\Service\AutoConfig\SmtpConnectivityTester;
+use OCA\Mail\Service\AutoConfig\SmtpServerDetector;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+
+class SmtpServerDetectorTest extends PHPUnit_Framework_TestCase {
+
+	/** @var MxRecord|PHPUnit_Framework_MockObject_MockObject */
+	private $mxRecord;
+
+	/** @var SmtpConnectivityTester|PHPUnit_Framework_MockObject_MockObject */
+	private $smtpConnectivityTester;
+
+	/** @var SmtpServerDetector */
+	private $detector;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mxRecord = $this->createMock(MxRecord::class);
+		$this->smtpConnectivityTester = $this->createMock(SmtpConnectivityTester::class);
+
+		$this->detector = new SmtpServerDetector($this->mxRecord, $this->smtpConnectivityTester, true);
+	}
+
+	public function testDetectNo() {
+		$account = $this->createMock(MailAccount::class);
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(['mx.domain.tld']);
+		$this->smtpConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($account), $this->equalTo('mx.domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn($this->createMock(MailAccount::class));
+
+		$result = $this->detector->detect($account, $email, $password);
+
+		$this->assertTrue($result);
+	}
+
+	public function testDetectNoMxRecordsFound() {
+		$account = $this->createMock(MailAccount::class);
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(false);
+		$this->smtpConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($account), $this->equalTo('domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn(true);
+
+		$result = $this->detector->detect($account, $email, $password);
+
+		$this->assertTrue($result);
+	}
+
+	public function testDetectNoMxRecordsFoundAndFallbackFails() {
+		$account = $this->createMock(MailAccount::class);
+		$email = 'user@domain.tld';
+		$password = 'mypassword';
+		$this->mxRecord->expects($this->once())
+			->method('query')
+			->with($this->equalTo('domain.tld'))
+			->willReturn(false);
+		$this->smtpConnectivityTester->expects($this->once())
+			->method('test')
+			->with($this->equalTo($account), $this->equalTo('domain.tld'), $this->equalTo(['user', 'user@domain.tld']))
+			->willReturn(false);
+
+		$result = $this->detector->detect($account, $email, $password);
+
+		$this->assertFalse($result);
+	}
+
+}


### PR DESCRIPTION
As part of my long-time goal to reach a higher testing coverage, I took a closer look at https://scrutinizer-ci.com/g/nextcloud/mail/code-structure/master/code-coverage/lib/Service/AutoConfig/ and tested the simple classes. Some of the tests aren't 100% pure unit tests as they connect to external resources, but still better than no unit tests.