### PR TITLE
Use a common base class for all tests

### DIFF
--- a/tests/Controller/FoldersControllerTest.php
+++ b/tests/Controller/FoldersControllerTest.php
@@ -28,12 +28,12 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Controller\FoldersController;
 use OCA\Mail\Folder;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Tests\TestCase;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
 
 class FoldersControllerTest extends TestCase {
 

--- a/tests/Db/AliasMapperTest.php
+++ b/tests/Db/AliasMapperTest.php
@@ -21,8 +21,9 @@
 
 namespace OCA\Mail\Db;
 
+use OC;
+use OCA\Mail\Tests\TestCase;
 use OCP\IDBConnection;
-use Test\TestCase;
 
 /**
  * Class AliasMapperTest
@@ -32,28 +33,26 @@ use Test\TestCase;
  * @package OCA\Mail\Db
  */
 class AliasMapperTest extends TestCase {
-	/**
-	 * @var AliasMapper
-	 */
+
+	/** @var AliasMapper */
 	private $mapper;
-	/**
-	 * @var IDBConnection
-	 */
+
+	/** @var IDBConnection */
 	private $db;
-	/**
-	 * @var Alias
-	 */
+
+	/** @var Alias */
 	private $alias;
+
 	/**
 	 * Initialize Mapper
 	 */
-	public function setup(){
+	public function setup() {
 		parent::setUp();
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = OC::$server->getDatabaseConnection();
 		$this->mapper = new AliasMapper($this->db);
 	}
 
-	public function testFind(){
+	public function testFind() {
 		$accountMapper = new MailAccountMapper($this->db);
 		$account = new MailAccount();
 		$account->setName('Peter Parker');
@@ -81,19 +80,19 @@ class AliasMapperTest extends TestCase {
 
 		$this->assertEquals(
 			[
-				'accountId' => $this->alias->getAccountId(),
-				'name' => $this->alias->getName(),
-				'alias' => $this->alias->getAlias(),
-				'id' => $this->alias->getId()
-			],
-			[
-				'accountId' => $result->getAccountId(),
-				'name' => $result->getName(),
-				'alias' => $result->getAlias(),
-				'id' => $result->getId()
+			'accountId' => $this->alias->getAccountId(),
+			'name' => $this->alias->getName(),
+			'alias' => $this->alias->getAlias(),
+			'id' => $this->alias->getId()
+			], [
+			'accountId' => $result->getAccountId(),
+			'name' => $result->getName(),
+			'alias' => $result->getAlias(),
+			'id' => $result->getId()
 			]
 		);
 	}
+
 	protected function tearDown() {
 		parent::tearDown();
 
@@ -108,4 +107,5 @@ class AliasMapperTest extends TestCase {
 			$stmt->execute(['user12345']);
 		}
 	}
+
 }

--- a/tests/Db/CollectedAddressMapperTest.php
+++ b/tests/Db/CollectedAddressMapperTest.php
@@ -22,9 +22,11 @@
 
 namespace OCA\Mail\Tests\Db;
 
-use OCA\Mail\Db\CollectedAddressMapper;
+use OC;
 use OCA\Mail\Db\CollectedAddress;
-use Test\TestCase;
+use OCA\Mail\Db\CollectedAddressMapper;
+use OCA\Mail\Tests\TestCase;
+use OCP\IDBConnection;
 
 /**
  * Class CollectedAddressMapperTest
@@ -35,8 +37,10 @@ use Test\TestCase;
  */
 class CollectedAddressMapperTest extends TestCase {
 
-	/** @var \OCP\IDBConnection */
+	/** @var IDBConnection */
 	private $db;
+
+	/** @var string */
 	private $userId = 'testuser';
 
 	/** @var CollectedAddressMapper */
@@ -54,7 +58,7 @@ class CollectedAddressMapperTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = OC::$server->getDatabaseConnection();
 		$this->mapper = new CollectedAddressMapper($this->db);
 
 		$this->address1 = new CollectedAddress();
@@ -119,8 +123,8 @@ class CollectedAddressMapperTest extends TestCase {
 
 	public function matchingData() {
 		return [
-				['user1@example.com', ['user1@example.com']],
-				['examp', ['user1@example.com', 'user2@example.com']],
+			['user1@example.com', ['user1@example.com']],
+			['examp', ['user1@example.com', 'user2@example.com']],
 		];
 	}
 
@@ -142,8 +146,8 @@ class CollectedAddressMapperTest extends TestCase {
 
 	public function existsData() {
 		return [
-				['user1@example.com', true],
-				['user3@example.com', false],
+			['user1@example.com', true],
+			['user3@example.com', false],
 		];
 	}
 

--- a/tests/Db/MailAccountMapperTest.php
+++ b/tests/Db/MailAccountMapperTest.php
@@ -21,9 +21,9 @@
 
 namespace OCA\Mail\Db;
 
-
+use OC;
+use OCA\Mail\Tests\TestCase;
 use OCP\IDBConnection;
-use Test\TestCase;
 
 /**
  * Class MailAccountMapperTest
@@ -54,7 +54,7 @@ class MailAccountMapperTest extends TestCase {
 	 */
 	public function setup(){
 		parent::setUp();
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = OC::$server->getDatabaseConnection();
 		$this->mapper = new MailAccountMapper($this->db);
 
 		$this->account = new MailAccount();

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -25,7 +25,6 @@ use Horde_Imap_Client_Mailbox;
 use OCA\Mail\Account;
 use OCA\Mail\Folder;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
 
 class FolderTest extends TestCase {
 

--- a/tests/SearchFolderTest.php
+++ b/tests/SearchFolderTest.php
@@ -24,7 +24,6 @@ namespace OCA\Mail\Tests;
 use Horde_Imap_Client_Mailbox;
 use OCA\Mail\Account;
 use OCA\Mail\SearchFolder;
-use Test\TestCase;
 
 class SearchFolderTest extends TestCase {
 

--- a/tests/Service/FolderMapperTest.php
+++ b/tests/Service/FolderMapperTest.php
@@ -28,7 +28,7 @@ use OCA\Mail\Account;
 use OCA\Mail\Folder;
 use OCA\Mail\SearchFolder;
 use OCA\Mail\Service\FolderMapper;
-use Test\TestCase;
+use OCA\Mail\Tests\TestCase;
 
 class FolderMapperTest extends TestCase {
 

--- a/tests/Service/FolderNameTranslatorTest.php
+++ b/tests/Service/FolderNameTranslatorTest.php
@@ -22,11 +22,10 @@
 namespace OCA\Mail\Tests\Service;
 
 use OCA\Mail\Folder;
-use OCA\Mail\SearchFolder;
 use OCA\Mail\Service\FolderNameTranslator;
+use OCA\Mail\Tests\TestCase;
 use OCP\IL10N;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
 
 class FolderNameTranslatorTest extends TestCase {
 

--- a/tests/Service/IMAP/IMAPClientFactoryTest.php
+++ b/tests/Service/IMAP/IMAPClientFactoryTest.php
@@ -26,11 +26,11 @@ use OC;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Service\IMAP\IMAPClientFactory;
+use OCA\Mail\Tests\TestCase;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 use PHPUnit_Framework_MockObject_MockObject;
-use Test\TestCase;
 
 class IMAPClientFactoryTest extends TestCase {
 

--- a/tests/Service/MailManagerTest.php
+++ b/tests/Service/MailManagerTest.php
@@ -27,8 +27,8 @@ use OCA\Mail\Service\FolderMapper;
 use OCA\Mail\Service\FolderNameTranslator;
 use OCA\Mail\Service\IMAP\IMAPClientFactory;
 use OCA\Mail\Service\MailManager;
+use OCA\Mail\Tests\TestCase;
 use OCP\Files\Folder;
-use Test\TestCase;
 
 class MailManagerTest extends TestCase {
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,20 +19,10 @@
  *
  */
 
-namespace OCA\Mail\Tests\Integration;
+namespace OCA\Mail\Tests;
 
-use OCA\Mail\Tests\Integration\Framework\ImapTest;
-use OCA\Mail\Tests\TestCase as Base;
+use PHPUnit_Framework_TestCase;
 
-class TestCase extends Base {
-
-	protected function setUp() {
-		parent::setUp();
-
-		// If it's an IMAP test, we reset the test account automatically
-		if (in_array(ImapTest::class, class_uses($this))) {
-			$this->resetImapAccount();
-		}
-	}
+abstract class TestCase extends PHPUnit_Framework_TestCase {
 
 }


### PR DESCRIPTION
This will easy the migration to a newer phpunit (the class is now namespaced) and furthermore we don't rely on Nextcloud server code.