### PR TITLE
Remove wrong abstraction in IAccount and use impl instead

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -321,6 +321,7 @@ class AccountsController extends Controller {
 
 		// create transport and save message
 		try {
+			/* @var $account Account */
 			$newUID = $account->saveDraft($message, $uid);
 		} catch (Horde_Exception $ex) {
 			$this->logger->error('Saving draft failed: ' . $ex->getMessage());

--- a/lib/Service/IAccount.php
+++ b/lib/Service/IAccount.php
@@ -43,19 +43,6 @@ interface IAccount extends JsonSerializable {
 	public function getEmail();
 
 	/**
-	 * @param IMessage $message
-	 * @param int|null $draftUID
-	 */
-	public function sendMessage(IMessage $message, $draftUID);
-
-	/**
-	 * @param IMessage $message
-	 * @param int|null $previousUID
-	 * @return int
-	 */
-	public function saveDraft(IMessage $message, $previousUID);
-
-	/**
 	 * @param string $folderId
 	 * @param int $messageId
 	 */

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -66,7 +66,7 @@ class MailTransmission implements IMailTransmission {
 	/**
 	 * Send a new message or reply to an existing one
 	 *
-	 * @param srting $userId
+	 * @param string $userId
 	 * @param NewMessageData $messageData
 	 * @param RepliedMessageData $replyData
 	 * @param Alias|null $alias

--- a/lib/Service/UnifiedAccount.php
+++ b/lib/Service/UnifiedAccount.php
@@ -143,23 +143,6 @@ class UnifiedAccount implements IAccount {
 	}
 
 	/**
-	 * @param IMessage $message
-	 * @param int|null $draftUID
-	 */
-	public function sendMessage(IMessage $message, $draftUID) {
-		throw new Exception('Not implemented');
-	}
-
-	/**
-	 * @param IMessage $message
-	 * @param int|null $previousUID
-	 * @return int
-	 */
-	public function saveDraft(IMessage $message, $previousUID) {
-		throw new Exception('Not implemented');
-	}
-
-	/**
 	 * @param string $folderId
 	 * @param string $messageId
 	 */


### PR DESCRIPTION
This removes a minor flaw in our OOP design. Those two methods are only implemented for a specific account, hence they shouldn't be part of the interface. In fact, the mail transmission logic even assumed to get an instance of `Account` and the impl in `UnifiedAccount` would throw an exception anyway.

Found while digging into the drafts code for https://github.com/nextcloud/mail/issues/9.