### PR TITLE
Use another IMAP docker image that allows more connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ source_dir=$(build_dir)/source
 sign_dir=$(build_dir)/sign
 package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
-docker_image=christophwurst/owncloud-mail-test-docker
+docker_image=christophwurst/nextcloud-mail-test-docker
 mail_user=user@domain.tld
 mail_pwd=mypassword
 


### PR DESCRIPTION
Since CI builds of #326 failed and I could reproduce this locally,
it turned out that running single tests or tests of a single directory
was no problem. However, executing all tests at once led to failing
IMAP connections. Apparently an increased number of allowed IMAP
connections fixes the problem (locally).