### PR TITLE
Remove unused Account::reconnect method

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -732,18 +732,6 @@ class Account implements IAccount {
 	}
 
 	/**
-	 * @throws Horde_Imap_Client_Exception
-	 */
-	public function reconnect() {
-		$this->mailboxes = null;
-		if ($this->client) {
-			$this->client->close();
-			$this->client = null;
-		}
-		$this->getImapConnection();
-	}
-
-	/**
 	 * @return array
 	 */
 	public function getConfiguration() {


### PR DESCRIPTION
Can't find a single reference to this method (actually it's the first time I see it in the code base), hence it can be removed safely.