### PR TITLE
Update autosize to a recent version and load it as module

### DIFF
--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -60,10 +60,6 @@ $.fn.tooltip = function() {
 
 };
 
-$.fn.autosize = function() {
-
-};
-
 $.fn.droppable = function() {
 
 };

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -14,6 +14,7 @@ define(function(require) {
 	var Marionette = require('backbone.marionette');
 	var $ = require('jquery');
 	var _ = require('underscore');
+	var autosize = require('autosize');
 	var OC = require('OC');
 	var Radio = require('radio');
 	var Attachments = require('models/attachments');
@@ -154,7 +155,7 @@ define(function(require) {
 		setAutoSize: function(state) {
 			if (state === true) {
 				if (!this.autosized) {
-					this.$('textarea').autosize({append: '\n\n'});
+					autosize(this.$('textarea'), {append: '\n\n'});
 					this.autosized = true;
 				}
 				this.$('.message-body').trigger('autosize.resize');

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack": "^3.5.5"
   },
   "dependencies": {
-    "autosize": "1.18.13",
+    "autosize": "^4.0.0",
     "backbone": "^1.3.3",
     "backbone.babysitter": "^0.1.12",
     "backbone.marionette": "^3.0.0",

--- a/templates/index.php
+++ b/templates/index.php
@@ -25,7 +25,6 @@
  */
 style('mail', 'mail');
 style('mail', 'mobile');
-script('mail', '../node_modules/autosize/build/jquery.autosize');
 script('mail', 'searchproxy');
 script('mail', 'build/build');
 ?>


### PR DESCRIPTION
Newer versions of autosize are independent of jQuery and can be loaded
as a proper module. Hence we don't have to include it in the template
and save another request per page load