### PR TITLE
Fix drafts cleanup mechanism

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -291,7 +291,7 @@ class AccountsController extends Controller {
 		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, []);
 
 		try {
-			$newUID = $this->mailTransmission->saveDraft($messageData, $messageId);
+			$newUID = $this->mailTransmission->saveDraft($messageData, $uid);
 			return new JSONResponse([
 				'uid' => $newUID,
 			]);


### PR DESCRIPTION
The wrong id was passed into the drafts service method, hence old messages
weren't actually cleaned up.