### PR TITLE
Add integration test for replacing an existing draft

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -44,8 +44,8 @@ use Horde_Mail_Transport_Mail;
 use Horde_Mail_Transport_Null;
 use Horde_Mail_Transport_Smtphorde;
 use Horde_Mime_Headers_Date;
+use Horde_Mime_Headers_MessageId;
 use Horde_Mime_Mail;
-use Horde_Mime_Part;
 use OC;
 use OCA\Mail\Cache\Cache;
 use OCA\Mail\Db\Alias;
@@ -168,9 +168,9 @@ class Account implements IAccount {
 	 * @param string $mailBox
 	 * @return Mailbox
 	 */
-	public function createMailbox($mailBox) {
+	public function createMailbox($mailBox, $opts = []) {
 		$conn = $this->getImapConnection();
-		$conn->createMailbox($mailBox);
+		$conn->createMailbox($mailBox, $opts);
 		$this->mailboxes = null;
 
 		return $this->getMailbox($mailBox);
@@ -251,6 +251,7 @@ class Account implements IAccount {
 		$mail = new Horde_Mime_Mail();
 		$mail->addHeaders($headers);
 		$mail->setBody($message->getContent());
+		$mail->addHeaderOb(Horde_Mime_Headers_MessageId::create());
 
 		// "Send" the message
 		$transport = new Horde_Mail_Transport_Null();
@@ -413,9 +414,8 @@ class Account implements IAccount {
 		$draftsFolder = $this->getSpecialFolder('drafts', true);
 		if (count($draftsFolder) === 0) {
 			// drafts folder does not exist - let's create one
-			$conn = $this->getImapConnection();
 			// TODO: also search for translated drafts mailboxes
-			$conn->createMailbox('Drafts', [
+			$this->createMailbox('Drafts', [
 				'special_use' => ['drafts'],
 			]);
 			return $this->guessBestMailBox($this->listMailboxes('Drafts'));
@@ -441,9 +441,8 @@ class Account implements IAccount {
 		$sentFolders = $this->getSpecialFolder('sent', true);
 		if (count($sentFolders) === 0) {
 			//sent folder does not exist - let's create one
-			$conn = $this->getImapConnection();
 			//TODO: also search for translated sent mailboxes
-			$conn->createMailbox('Sent', [
+			$this->createMailbox('Sent', [
 				'special_use' => ['sent'],
 			]);
 			return $this->guessBestMailBox($this->listMailboxes('Sent'));

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -122,4 +122,13 @@ class MailTransmissionIntegrationTest extends TestCase {
 		$this->assertMessageContent('Drafts', $uid, 'hello there');
 	}
 
+	public function testReplaceDraft() {
+		$message1 = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello t', []);
+		$uid = $this->transmission->saveDraft($message1);
+		$message2 = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
+		$this->transmission->saveDraft($message2, $uid);
+
+		$this->assertMessageCount(1, 'Drafts');
+	}
+
 }


### PR DESCRIPTION
Yet another little integration test to cover more of our features. I even found a little issue that caused wrongly cached mailboxes when we created a new drafts/sent folder. Now the cache is cleared and the current list of mailboxes is fetched from the server.