### PR TITLE
Fix encoding of saved messages

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -218,7 +218,7 @@ class Account implements IAccount {
 
 		// Save the message in the sent folder
 		$sentFolder = $this->getSentFolder();
-		$raw = $mail->getRaw(false);
+		$raw = stream_get_contents($mail->getRaw());
 		$uid = $sentFolder->saveMessage($raw, [
 			Horde_Imap_Client::FLAG_SEEN
 		]);
@@ -261,7 +261,7 @@ class Account implements IAccount {
 		$mail->send($transport, false, false);
 		// save the message in the drafts folder
 		$draftsFolder = $this->getDraftsFolder();
-		$raw = $mail->getRaw(false);
+		$raw = stream_get_contents($mail->getRaw());
 		$newUid = $draftsFolder->saveDraft($raw);
 
 		// delete old version if one exists


### PR DESCRIPTION
Apparently horde libs use a different encoding when a message
is serialized to a string depending on whether a stream is
used or not.
Before, drafts and sent messages were stored with a wrong encoding,
although the message sent was correctly encoded.

To test this, just send out a new message containing special chars like `>` or `ä`.

This fixes a regression caused by https://github.com/nextcloud/mail/pull/476.

@jancborchardt this is *exactly* the issue that you observed during the conf when we debugged another issue. Please test so that we can release this fix ASAP.