### PR TITLE
Fix error propagation in case messages cannot be loaded

### DIFF
--- a/js/service/messageservice.js
+++ b/js/service/messageservice.js
@@ -57,17 +57,20 @@ define(function(require) {
 			folderId: folder.get('id')
 		});
 
-		return Promise.resolve($.ajax(url, {
-			data: {
-				filter: options.filter
-			},
-			error: function(error, status) {
-				if (status !== 'abort') {
-					console.error('error loading messages', error);
-					throw new Error(error);
+		return new Promise(function(resolve, reject) {
+			$.ajax(url, {
+				data: {
+					filter: options.filter
+				},
+				success: resolve,
+				error: function(error, status) {
+					if (status !== 'abort') {
+						console.error('error loading messages', error, status);
+						reject(error);
+					}
 				}
-			}
-		})).then(function(messages) {
+			});
+		}).then(function(messages) {
 			var isSearching = options.filter !== '';
 			var collection = folder.messages;
 


### PR DESCRIPTION
For some reason messages cannot be loaded in my dev instance at the moment, so I discovered that we do not propagate this error correctly and the app gets stuck at the loading view, which is kinda misleading. Now a beautiful error view is displayed if one of the accounts fails to load 😁 