### PR TITLE
Fix selection of next message in unified inbox

### DIFF
--- a/js/controller/foldercontroller.js
+++ b/js/controller/foldercontroller.js
@@ -245,7 +245,7 @@ define(function(require) {
 
 		if (require('state').currentMessage && require('state').currentMessage.get('id') === message.id) {
 			if (nextMessage) {
-				Radio.message.trigger('load', message.folder.account, message.folder, nextMessage);
+				Radio.message.trigger('load', nextMessage.folder.account, nextMessage.folder, nextMessage);
 			}
 		}
 


### PR DESCRIPTION
If the user deletes a message in the unified inbox, the next (previous)
message is selected automatically. In case that message actually is part
of a different one than the deleted one an error was shown because the
new message could not be loaded. This happened because the wrong account
and folder objects were passed to the 'load' event.

Fixes https://github.com/nextcloud/mail/issues/465