### PR TITLE
Add earlier loading feedback

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -102,7 +102,7 @@ define(function(require) {
 		this.view = new AppView();
 		Cache.init();
 
-		Radio.ui.trigger('content:loading');
+		Radio.ui.trigger('content:loading', t('mail', 'Loading accounts …'));
 
 		this.registerProtocolHandler();
 		this.requestNotificationPermissions();

--- a/js/tests/integration/app_start_spec.js
+++ b/js/tests/integration/app_start_spec.js
@@ -81,7 +81,7 @@ define([
 			Mail.start();
 
 			expect(Cache.init).toHaveBeenCalled();
-			expect(Radio.ui.trigger).toHaveBeenCalledWith('content:loading');
+			expect(Radio.ui.trigger).toHaveBeenCalledWith('content:loading', 'Loading accounts …');
 
 			var accounts = new AccountCollection([
 				{


### PR DESCRIPTION
In terms of UX, I like to know what the app is doing, thus
IMO it makes sense to tell the user we're loading their accounts.

From a technical perspective, I know that the app's js has started
executing. This is useful for debugging where you didn't know
whether the page was still loading or the app was already started.

If you have any suggestions for a better wording, let me know :)