### PR TITLE
Fix active message selection

### DIFF
--- a/js/views/messagesview.js
+++ b/js/views/messagesview.js
@@ -85,9 +85,9 @@ define(function(require) {
 		 * @param {Message} message
 		 */
 		setActiveMessage: function(message) {
-			if (this.currentMessage !== null) {
-				this.currentMessage.set('active', false);
-			}
+			this.collection.forEach(function(message) {
+				message.set('active', false);
+			});
 
 			this.currentMessage = message;
 			if (message !== null) {


### PR DESCRIPTION
The state that determines whether a messages is actively shown
or not is stored as a property of the message object. Since
we now use the very same message data in the unified inbox
as in specific ones, a message marked as being active kept its
state when the users switched to the unified inbox. Now all states
are reset to ensure we only have one active message.

Steps to reproduce the bug:
* configure more than one account
* load the app
* go to a specific inbox and select a message (ideally not the first one)
* go to the unified inbox and see the very same message is still marked as being active, although the first one in the list is actually opened/active

Fixes https://github.com/nextcloud/mail/issues/466

cc @s-rosenfeld