### PR TITLE
Fix background sync account selection

### DIFF
--- a/js/service/backgroundsyncservice.js
+++ b/js/service/backgroundsyncservice.js
@@ -37,7 +37,7 @@ define(function(require) {
 	function triggerNextSync() {
 		_timer = setTimeout(function() {
 			var account;
-			if (require('state').accounts.length === 0) {
+			if (require('state').accounts.length === 1) {
 				account = _accounts.first();
 			} else {
 				account = _accounts.get(-1);

--- a/js/service/backgroundsyncservice.js
+++ b/js/service/backgroundsyncservice.js
@@ -37,7 +37,10 @@ define(function(require) {
 	function triggerNextSync() {
 		_timer = setTimeout(function() {
 			var account;
-			if (require('state').accounts.length === 1) {
+			if (require('state').accounts.length === 0) {
+				// Nothing to do right now, just re-trigger the sync event
+				triggerNextSync();
+			} else if (require('state').accounts.length === 1) {
 				account = _accounts.first();
 			} else {
 				account = _accounts.get(-1);


### PR DESCRIPTION
If only a single account is used, the number of accounts equals
1 and not 0.