### PR TITLE
Add more CSRF checks

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -100,7 +100,6 @@ class AccountsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 *
 	 * @return JSONResponse
 	 */

--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -51,7 +51,6 @@ class AliasesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @param int $accountId
 	 * @return Alias[]
 	 */
@@ -61,7 +60,6 @@ class AliasesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 */
 	public function show() {
 		$response = new JSONResponse();
@@ -71,7 +69,6 @@ class AliasesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 */
 	public function update() {
 		$response = new JSONResponse();
@@ -81,7 +78,6 @@ class AliasesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @param int $id
 	 * @return Alias[]
 	 */
@@ -91,7 +87,6 @@ class AliasesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @param int $accountId
 	 * @param string $alias
 	 * @param string $aliasName

--- a/lib/Controller/FoldersController.php
+++ b/lib/Controller/FoldersController.php
@@ -62,7 +62,6 @@ class FoldersController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @param int $accountId
 	 * @return JSONResponse
 	 */
@@ -80,7 +79,6 @@ class FoldersController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @param int $accountId
 	 * @param string $folderId
 	 * @param string $syncToken
@@ -99,7 +97,6 @@ class FoldersController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 */
 	public function show() {
 		$response = new JSONResponse();

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -115,7 +115,6 @@ class MessagesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 *
 	 * @param int $accountId
 	 * @param string $folderId
@@ -295,7 +294,6 @@ class MessagesController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 *
 	 * @param int $accountId
 	 * @param string $folderId


### PR DESCRIPTION
I've removed the `@NoCSRFRequired` from routes that are access by AJAX calls. Those should automatically send the CSRF token.

@LukasReschke please take a quick look.