### PR TITLE
Fix dovecot sieve special folder

### DIFF
--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -45,6 +45,11 @@ class FolderMapper {
 
 		$folders = [];
 		foreach ($mailboxes as $mailbox) {
+			if ($mailbox['mailbox']->utf8 === 'dovecot.sieve') {
+				// This is a special folder that must not be shown
+				continue;
+			}
+
 			$folder = new Folder($account, $mailbox['mailbox'], $mailbox['attributes'], $mailbox['delimiter']);
 
 			if ($folder->isSearchable()) {


### PR DESCRIPTION
Dovecot/sieve seems to create a special 'dovecot.sieve' folder as soon
as a filter is configured. This folder, however, must not be queried
(e.g.) for a sync token. This patch makes sure that this special folder
is simply ignored. Thus it's also not shown in the UI.

Fixes https://github.com/nextcloud/mail/issues/475

@digdug3 thanks a lot for providing an account on your mail server. This helped a lot 🚀 