### PR TITLE
added missing command to 'Resetting the app' paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ DELETE FROM oc_appconfig WHERE appid = 'mail';
 DROP TABLE oc_mail_accounts;
 DROP TABLE oc_mail_aliases;
 DROP TABLE oc_mail_collected_addresses;
+DROP TABLE oc_mail_attachments;
 ```
 
 


### PR DESCRIPTION
added missing `DROP TABLE oc_mail_attachments;` command to the 'Resetting the app' paragraph.