### PR TITLE
Always treat the search mailbox as top level folder

### DIFF
--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -79,7 +79,7 @@ class FolderMapper {
 		}
 
 		$top = array_filter($indexedFolders, function(Folder $folder) {
-			return is_null($this->getParentId($folder));
+			return $folder instanceof SearchFolder || is_null($this->getParentId($folder));
 		});
 
 		foreach ($indexedFolders as $folder) {


### PR DESCRIPTION
If the account's delimiter was `.` then the search inbox was shown as subfolder of the inbox. 

Fixes https://github.com/nextcloud/mail/issues/528