### PR TITLE
Add OCP files as composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
 		"pear-pear.horde.org/Horde_Smtp": "^1.9.5@stable",
 		"cerdic/css-tidy": "v1.5.5",
 		"ezyang/htmlpurifier": "4.9.3",
-		"kwi/urllinker": "dev-default",
-		"christophwurst/nextcloud": "^12.0.0"
+		"kwi/urllinker": "dev-default"
 	},
 	"require-dev": {
+		"christophwurst/nextcloud": "^12.0.0",
 		"phpunit/phpunit": "^5.7"
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,6 @@
 		{
 			"type": "pear",
 			"url": "https://pear.horde.org"
-		},
-		{
-			"type": "vcs",
-			"url": "https://github.com/ChristophWurst/nextcloud_composer"
 		}
 	],
 	"require": {
@@ -26,7 +22,7 @@
 		"cerdic/css-tidy": "v1.5.5",
 		"ezyang/htmlpurifier": "4.9.3",
 		"kwi/urllinker": "dev-default",
-		"christophwurst/nextcloud": "dev-stable12"
+		"christophwurst/nextcloud": "^12.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,10 @@
 		{
 			"type": "pear",
 			"url": "https://pear.horde.org"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/ChristophWurst/nextcloud_composer"
 		}
 	],
 	"require": {
@@ -21,7 +25,8 @@
 		"pear-pear.horde.org/Horde_Smtp": "^1.9.5@stable",
 		"cerdic/css-tidy": "v1.5.5",
 		"ezyang/htmlpurifier": "4.9.3",
-		"kwi/urllinker": "dev-default"
+		"kwi/urllinker": "dev-default",
+		"christophwurst/nextcloud": "dev-stable12"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ca19ae439144321766a08522f8d45ab",
+    "content-hash": "28522020e1dcad59038ae96380ca6d6e",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -38,36 +38,6 @@
             ],
             "description": "CSSTidy is a CSS minifier",
             "time": "2015-11-28T21:47:43+00:00"
-        },
-        {
-            "name": "christophwurst/nextcloud",
-            "version": "12.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/2b85ca1531926e8475e3c40f47be28b51580fcb6",
-                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6",
-                "shasum": ""
-            },
-            "type": "library",
-            "license": [
-                "AGPLv3"
-            ],
-            "authors": [
-                {
-                    "name": "Christoph Wurst",
-                    "email": "christoph@winzerhof-wurst.at"
-                }
-            ],
-            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
-            "support": {
-                "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
-            },
-            "time": "2017-09-20T09:46:46+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -802,6 +772,36 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "christophwurst/nextcloud",
+            "version": "12.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
+                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/2b85ca1531926e8475e3c40f47be28b51580fcb6",
+                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6",
+                "shasum": ""
+            },
+            "type": "library",
+            "license": [
+                "AGPLv3"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Wurst",
+                    "email": "christoph@winzerhof-wurst.at"
+                }
+            ],
+            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "support": {
+                "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
+            },
+            "time": "2017-09-20T09:46:46+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "58191087d15849c68ffc4fc6e29f5a83",
+    "content-hash": "9ca7a6d0f35833b3ff1afbca19b54cbb",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -38,6 +38,36 @@
             ],
             "description": "CSSTidy is a CSS minifier",
             "time": "2015-11-28T21:47:43+00:00"
+        },
+        {
+            "name": "christophwurst/nextcloud",
+            "version": "dev-stable12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
+                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/2b85ca1531926e8475e3c40f47be28b51580fcb6",
+                "reference": "2b85ca1531926e8475e3c40f47be28b51580fcb6",
+                "shasum": ""
+            },
+            "type": "library",
+            "license": [
+                "AGPLv3"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Wurst",
+                    "email": "christoph@winzerhof-wurst.at"
+                }
+            ],
+            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
+            "support": {
+                "source": "https://github.com/ChristophWurst/nextcloud_composer/tree/master"
+            },
+            "time": "2017-09-20T09:46:46+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -2101,7 +2131,8 @@
         "pear-pear.horde.org/horde_text_flowed": 0,
         "pear-pear.horde.org/horde_util": 0,
         "pear-pear.horde.org/horde_smtp": 0,
-        "kwi/urllinker": 20
+        "kwi/urllinker": 20,
+        "christophwurst/nextcloud": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ca7a6d0f35833b3ff1afbca19b54cbb",
+    "content-hash": "1ca19ae439144321766a08522f8d45ab",
     "packages": [
         {
             "name": "cerdic/css-tidy",
@@ -41,7 +41,7 @@
         },
         {
             "name": "christophwurst/nextcloud",
-            "version": "dev-stable12",
+            "version": "12.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
@@ -2131,8 +2131,7 @@
         "pear-pear.horde.org/horde_text_flowed": 0,
         "pear-pear.horde.org/horde_util": 0,
         "pear-pear.horde.org/horde_smtp": 0,
-        "kwi/urllinker": 20,
-        "christophwurst/nextcloud": 20
+        "kwi/urllinker": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
This allows better CI analyses where Nextcloud's files are not
available because only the app repository is cloned.

This is a little experiment, let's see how well that actually works …