### PR TITLE
Extract Account::createTransport into a SmtpClientFactory class

### DIFF
--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\SMTP;
+
+use Horde_Mail_Transport;
+use Horde_Mail_Transport_Mail;
+use Horde_Mail_Transport_Smtphorde;
+use OCA\Mail\Account;
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+
+class SmtpClientFactory {
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var ICrypto */
+	private $crypto;
+
+	/**
+	 * @param IConfig $config
+	 * @param ICrypto $crypto
+	 */
+	public function __construct(IConfig $config, ICrypto $crypto) {
+		$this->config = $config;
+		$this->crypto = $crypto;
+	}
+
+	/**
+	 * @param Account $account
+	 * @return Horde_Mail_Transport
+	 */
+	public function create(Account $account) {
+		$mailAccount = $account->getMailAccount();
+		$transport = $this->config->getSystemValue('app.mail.transport', 'smtp');
+		if ($transport === 'php-mail') {
+			return new Horde_Mail_Transport_Mail();
+		}
+
+		$password = $mailAccount->getOutboundPassword();
+		$password = $this->crypto->decrypt($password);
+		$security = $mailAccount->getOutboundSslMode();
+		$params = [
+			'host' => $mailAccount->getOutboundHost(),
+			'password' => $password,
+			'port' => $mailAccount->getOutboundPort(),
+			'username' => $mailAccount->getOutboundUser(),
+			'secure' => $security === 'none' ? false : $security,
+			'timeout' => (int) $this->config->getSystemValue('app.mail.smtp.timeout', 2)
+		];
+		if ($this->config->getSystemValue('debug', false)) {
+			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';
+		}
+		return new Horde_Mail_Transport_Smtphorde($params);
+	}
+
+}

--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -29,6 +29,7 @@ use Horde_Mail_Exception;
 use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\SMTP\SmtpClientFactory;
 use OCP\Security\ICrypto;
 use OpenCloud\Common\Log\Logger;
 
@@ -51,19 +52,24 @@ class IspDbConfigurationDetector {
 	/** @var ImapConnector */
 	private $imapConnector;
 
+	/** @var SmtpClientFactory */
+	private $smtpClientFactory;
+
 	/**
 	 * @param Logger $logger
 	 * @param string $UserId
 	 * @param ICrypto $crypto
 	 * @param IspDb $ispDb
 	 * @param ImapConnector $imapConnector
+	 * @param SmtpClientFactory $smtpClientFactory
 	 */
-	public function __construct(Logger $logger, $UserId, ICrypto $crypto, IspDb $ispDb, ImapConnector $imapConnector) {
+	public function __construct(Logger $logger, $UserId, ICrypto $crypto, IspDb $ispDb, ImapConnector $imapConnector, SmtpClientFactory $smtpClientFactory) {
 		$this->logger = $logger;
 		$this->UserId = $UserId;
 		$this->ispDb = $ispDb;
 		$this->crypto = $crypto;
 		$this->imapConnector = $imapConnector;
+		$this->smtpClientFactory = $smtpClientFactory;
 	}
 
 	/**
@@ -206,7 +212,7 @@ class IspDbConfigurationDetector {
 			$account->setOutboundSslMode(strtolower($smtp['socketType']));
 
 			$a = new Account($account);
-			$transport = $a->createTransport();
+			$transport = $this->smtpClientFactory->create($a);
 			if ($transport instanceof Horde_Mail_Transport_Smtphorde) {
 				$transport->getSMTPObject();
 			}

--- a/lib/Service/AutoConfig/SmtpConnectivityTester.php
+++ b/lib/Service/AutoConfig/SmtpConnectivityTester.php
@@ -25,6 +25,7 @@ use Exception;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Service\Logger;
+use OCA\Mail\SMTP\SmtpClientFactory;
 use OCP\Security\ICrypto;
 
 class SmtpConnectivityTester {
@@ -35,6 +36,9 @@ class SmtpConnectivityTester {
 	/** @var ICrypto */
 	private $crypto;
 
+	/** @var SmtpClientFactory */
+	private $clientFactory;
+
 	/** @var Logger */
 	private $logger;
 
@@ -44,13 +48,14 @@ class SmtpConnectivityTester {
 	/**
 	 * @param ConnectivityTester $connectivityTester
 	 * @param ICrypto $crypto
+	 * @param SmtpClientFactory $clientFactory
 	 * @param Logger $logger
 	 * @param string $UserId
 	 */
-	public function __construct(ConnectivityTester $connectivityTester,
-		ICrypto $crypto, Logger $logger, $UserId) {
+	public function __construct(ConnectivityTester $connectivityTester, ICrypto $crypto, SmtpClientFactory $clientFactory, Logger $logger, $UserId) {
 		$this->connectivityTester = $connectivityTester;
 		$this->crypto = $crypto;
+		$this->clientFactory = $clientFactory;
 		$this->logger = $logger;
 		$this->userId = $UserId;
 	}
@@ -63,8 +68,7 @@ class SmtpConnectivityTester {
 	 * @param bool $withHostPrefix
 	 * @return bool
 	 */
-	public function test(MailAccount $account, $host, $users, $password,
-		$withHostPrefix = false) {
+	public function test(MailAccount $account, $host, $users, $password, $withHostPrefix = false) {
 		if (!is_array($users)) {
 			$users = [$users];
 		}
@@ -115,8 +119,8 @@ class SmtpConnectivityTester {
 	 * @throws Exception
 	 */
 	protected function testStmtpConnection(MailAccount $mailAccount) {
-		$a = new Account($mailAccount);
-		$smtp = $a->createTransport();
+		$account = new Account($mailAccount);
+		$smtp = $this->clientFactory->create($account);
 		$smtp->getSMTPObject();
 	}
 

--- a/lib/Service/SetupService.php
+++ b/lib/Service/SetupService.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\AutoConfig\AutoConfig;
+use OCA\Mail\SMTP\SmtpClientFactory;
+use OCP\Security\ICrypto;
+
+class SetupService {
+
+	/** @var AutoConfig */
+	private $autoConfig;
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var ICrypto */
+	private $crypto;
+
+	/** @var SmtpClientFactory */
+	private $smtpClientFactory;
+
+	/** var Logger */
+	private $logger;
+
+	/**
+	 * @param AutoConfig $autoConfig
+	 * @param AccountService $accountService
+	 * @param ICrypto $crypto
+	 * @param Logger $logger
+	 */
+	public function __construct(AutoConfig $autoConfig, AccountService $accountService, ICrypto $crypto, SmtpClientFactory $smtpClientFactory, Logger $logger) {
+		$this->autoConfig = $autoConfig;
+		$this->accountService = $accountService;
+		$this->crypto = $crypto;
+		$this->smtpClientFactory = $smtpClientFactory;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param string $accountName
+	 * @param string $emailAddress
+	 * @param string $password
+	 * @return Account|null
+	 */
+	public function createNewAutoConfiguredAccount($accountName, $emailAddress, $password) {
+		$this->logger->info('setting up auto detected account');
+		$mailAccount = $this->autoConfig->createAutoDetected($emailAddress, $password, $accountName);
+		if (is_null($mailAccount)) {
+			return null;
+		}
+		return new Account($mailAccount);
+	}
+
+	/**
+	 * @param string $accountName
+	 * @param string $emailAddress
+	 * @param string $imapHost
+	 * @param int $imapPort
+	 * @param string $imapSslMode
+	 * @param string $imapUser
+	 * @param string $imapPassword
+	 * @param string $smtpHost
+	 * @param int $smtpPort
+	 * @param string $smtpSslMode
+	 * @param string $smtpUser
+	 * @param string $smtpPassword
+	 * @param string $uid
+	 */
+	public function createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $uid) {
+		$this->logger->info('Setting up manually configured account');
+		$newAccount = new MailAccount([
+			'accountName' => $accountName,
+			'emailAddress' => $emailAddress,
+			'imapHost' => $imapHost,
+			'imapPort' => $imapPort,
+			'imapSslMode' => $imapSslMode,
+			'imapUser' => $imapUser,
+			'imapPassword' => $imapPassword,
+			'smtpHost' => $smtpHost,
+			'smtpPort' => $smtpPort,
+			'smtpSslMode' => $smtpSslMode,
+			'smtpUser' => $smtpUser,
+			'smtpPassword' => $smtpPassword
+		]);
+		$newAccount->setUserId($uid);
+		$newAccount->setInboundPassword($this->crypto->encrypt($newAccount->getInboundPassword()));
+		$newAccount->setOutboundPassword($this->crypto->encrypt($newAccount->getOutboundPassword()));
+
+		$account = new Account($newAccount);
+		$this->logger->debug('Connecting to account {account}', ['account' => $newAccount->getEmail()]);
+		$transport = $this->smtpClientFactory->create($account);
+		$account->testConnectivity($transport);
+
+		if ($newAccount) {
+			$this->accountService->save($newAccount);
+			$this->logger->debug("account created " . $newAccount->getId());
+			return new Account($newAccount);
+		}
+
+		return null;
+	}
+
+}

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -32,6 +32,7 @@ use OCA\Mail\Service\Attachment\UploadedFile;
 use OCA\Mail\Service\AutoCompletion\AddressCollector;
 use OCA\Mail\Service\Logger;
 use OCA\Mail\Service\MailTransmission;
+use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Tests\Integration\Framework\ImapTest;
 use OCA\Mail\Tests\Integration\Framework\TestUser;
 use OCA\Mail\Tests\Integration\TestCase;
@@ -39,7 +40,8 @@ use OCP\IUser;
 
 class MailTransmissionIntegrationTest extends TestCase {
 
-	use ImapTest, TestUser;
+	use ImapTest,
+     TestUser;
 
 	/** @var Account */
 	private $account;
@@ -73,7 +75,7 @@ class MailTransmissionIntegrationTest extends TestCase {
 		$this->attachmentService = OC::$server->query(IAttachmentService::class);
 		$this->user = $this->createTestUser();
 		$userFolder = OC::$server->getUserFolder($this->user->getUID());
-		$this->transmission = new MailTransmission(OC::$server->query(AddressCollector::class), $userFolder, $this->attachmentService, OC::$server->query(Logger::class));
+		$this->transmission = new MailTransmission(OC::$server->query(AddressCollector::class), $userFolder, $this->attachmentService, OC::$server->query(SmtpClientFactory::class), OC::$server->query(Logger::class));
 	}
 
 	public function testSendMail() {

--- a/tests/SMTP/SmtpClientFactoryTest.php
+++ b/tests/SMTP/SmtpClientFactoryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\Smtp;
+
+use Horde_Mail_Transport_Mail;
+use Horde_Mail_Transport_Smtphorde;
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\SMTP\SmtpClientFactory;
+use OCA\Mail\Tests\TestCase;
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class SmtpClientFactoryTest extends TestCase {
+
+	/** @var IConfig|PHPUnit_Framework_MockObject_MockObject */
+	private $config;
+
+	/** @var ICrypto|PHPUnit_Framework_MockObject_MockObject */
+	private $crypto;
+
+	/** @var SmtpClientFactory */
+	private $factory;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+
+		$this->factory = new SmtpClientFactory($this->config, $this->crypto);
+	}
+
+	public function testPhpMailTransport() {
+		$account = $this->createMock(Account::class);
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('app.mail.transport', 'smtp')
+			->willReturn('php-mail');
+
+		$transport = $this->factory->create($account);
+
+		$this->assertNotNull($transport);
+		$this->assertInstanceOf(Horde_Mail_Transport_Mail::class, $transport);
+	}
+
+	public function testSmtpTransport() {
+		$mailAccount = new MailAccount([
+			'smtpHost' => 'smtp.domain.tld',
+			'smtpPort' => 25,
+			'smtpSslMode' => 'none',
+			'smtpUser' => 'user@domain.tld',
+			'smtpPassword' => 'obenc',
+		]);
+		$account = new Account($mailAccount);
+		$this->config->expects($this->at(0))
+			->method('getSystemValue')
+			->with('app.mail.transport', 'smtp')
+			->willReturn('smtp');
+		$this->config->expects($this->at(2))
+			->method('getSystemValue')
+			->with('debug', false)
+			->willReturn(false);
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->with('obenc')
+			->willReturn('pass123');
+		$this->config->expects($this->at(1))
+			->method('getSystemValue')
+			->with('app.mail.smtp.timeout', 2)
+			->willReturn(2);
+		$expected = new Horde_Mail_Transport_Smtphorde([
+			'host' => 'smtp.domain.tld',
+			'password' => 'pass123',
+			'port' => '25',
+			'username' => 'user@domain.tld',
+			'secure' => false,
+			'timeout' => 2,
+		]);
+
+		$transport = $this->factory->create($account);
+
+		$this->assertNotNull($transport);
+		$this->assertInstanceOf(Horde_Mail_Transport_Smtphorde::class, $transport);
+		$this->assertEquals($expected, $transport);
+	}
+
+}

--- a/tests/Service/MailTransmissionTest.php
+++ b/tests/Service/MailTransmissionTest.php
@@ -22,6 +22,7 @@
 namespace OCA\Mail\Tests\Service;
 
 use Horde_Imap_Client;
+use Horde_Mail_Transport;
 use OC\Files\Node\File;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IAttachmentService;
@@ -34,6 +35,7 @@ use OCA\Mail\Model\ReplyMessage;
 use OCA\Mail\Service\AutoCompletion\AddressCollector;
 use OCA\Mail\Service\Logger;
 use OCA\Mail\Service\MailTransmission;
+use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Tests\TestCase;
 use OCP\Files\Folder;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -49,6 +51,9 @@ class MailTransmissionTest extends TestCase {
 	/** @var IAttachmentService|PHPUnit_Framework_MockObject_MockObject */
 	private $attachmentService;
 
+	/** @var SmtpClientFactory|PHPUnit_Framework_MockObject_MockObject */
+	private $clientFactory;
+
 	/** @var Logger|PHPUnit_Framework_MockObject_MockObject */
 	private $logger;
 
@@ -61,10 +66,10 @@ class MailTransmissionTest extends TestCase {
 		$this->addressCollector = $this->createMock(AddressCollector::class);
 		$this->userFolder = $this->createMock(Folder::class);
 		$this->attachmentService = $this->createMock(IAttachmentService::class);
+		$this->clientFactory = $this->createMock(SmtpClientFactory::class);
 		$this->logger = $this->createMock(Logger::class);
 
-		$this->transmission = new MailTransmission($this->addressCollector, $this->userFolder, $this->attachmentService,
-			$this->logger);
+		$this->transmission = new MailTransmission($this->addressCollector, $this->userFolder, $this->attachmentService, $this->clientFactory, $this->logger);
 	}
 
 	public function testSendNewMessage() {
@@ -75,9 +80,14 @@ class MailTransmissionTest extends TestCase {
 		$account->expects($this->once())
 			->method('newMessage')
 			->willReturn($message);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 		$account->expects($this->once())
 			->method('sendMessage')
-			->with($message, null);
+			->with($message, $transport, null);
 
 		$this->transmission->sendMessage('garfield', $messageData, $replyData);
 	}
@@ -90,9 +100,14 @@ class MailTransmissionTest extends TestCase {
 		$account->expects($this->once())
 			->method('newMessage')
 			->willReturn($message);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 		$account->expects($this->once())
 			->method('sendMessage')
-			->with($message, 123);
+			->with($message, $transport, 123);
 
 		$this->transmission->sendMessage('garfield', $messageData, $replyData, null, 123);
 	}
@@ -107,9 +122,14 @@ class MailTransmissionTest extends TestCase {
 		$account->expects($this->once())
 			->method('newMessage')
 			->willReturn($message);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 		$account->expects($this->once())
 			->method('sendMessage')
-			->with($message, null);
+			->with($message, $transport, null);
 		$account->expects($this->once())
 			->method('setAlias')
 			->with($alias);
@@ -137,9 +157,14 @@ class MailTransmissionTest extends TestCase {
 		$account->expects($this->once())
 			->method('newMessage')
 			->willReturn($message);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 		$account->expects($this->once())
 			->method('sendMessage')
-			->with($message, null);
+			->with($message, $transport, null);
 		$this->userFolder->expects($this->exactly(2))
 			->method('nodeExists')
 			->willReturnMap([
@@ -181,12 +206,22 @@ class MailTransmissionTest extends TestCase {
 		$message->expects($this->once())
 			->method('setRepliedMessage')
 			->with($repliedMessage);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 		$account->expects($this->once())
 			->method('sendMessage')
-			->with($message, null);
+			->with($message, $transport, null);
 		$mailbox->expects($this->once())
 			->method('setMessageFlag')
 			->with($repliedMessageId, Horde_Imap_Client::FLAG_ANSWERED, true);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->clientFactory->expects($this->once())
+			->method('create')
+			->with($account)
+			->willReturn($transport);
 
 		$this->transmission->sendMessage('garfield', $messageData, $replyData);
 	}


### PR DESCRIPTION
Just another little cleanup of our codebase to make critical paths more testable. Still lots of work to do.