### PR TITLE
Reduce date size and don't bold on unread

### DIFF
--- a/css/mail.css
+++ b/css/mail.css
@@ -351,6 +351,7 @@
 
 .mail-message-summary .date {
 	position: absolute;
+	font-size: 80%;
 	right: 0;
 	top: 0;
 	max-width: 40%;
@@ -359,8 +360,7 @@
 }
 
 .mail-message-summary.unseen .mail-message-summary-from,
-.mail-message-summary.unseen .mail-message-summary-subject,
-.mail-message-summary.unseen .date {
+.mail-message-summary.unseen .mail-message-summary-subject {
 	font-weight: bold;
 }
 


### PR DESCRIPTION
Before & after:
![screenshot from 2017-09-26 14-57-01](https://user-images.githubusercontent.com/925062/30861433-fad7c390-a2ca-11e7-889d-94b48fd363a1.png) ![screenshot from 2017-09-26 14-56-26](https://user-images.githubusercontent.com/925062/30861432-fac8034c-a2ca-11e7-85d9-27bea298d1d3.png)

Just a detail change to not take away focus from sender & subject. Please review @nextcloud/mail 
