### PR TITLE
Cleanup address handling

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1358,16 +1358,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.20",
+            "version": "5.7.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b"
+                "reference": "10df877596c9906d4110b5b905313829043f2ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
-                "reference": "3cb94a5f8c07a03c8b7527ed7468a2926203f58b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/10df877596c9906d4110b5b905313829043f2ada",
+                "reference": "10df877596c9906d4110b5b905313829043f2ada",
                 "shasum": ""
             },
             "require": {
@@ -1436,7 +1436,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-22T07:42:55+00:00"
+            "time": "2017-09-24T07:23:38+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/js/models/message.js
+++ b/js/models/message.js
@@ -21,7 +21,11 @@ define(function(require) {
 		folder: undefined,
 		defaults: {
 			flags: [],
-			active: false
+			active: false,
+			from: [],
+			to: [],
+			cc: [],
+			bcc: []
 		},
 		initialize: function() {
 			this.set('flags', new MessageFlags(this.get('flags')));
@@ -31,6 +35,7 @@ define(function(require) {
 				this.unset('folder');
 			}
 			this.listenTo(this.get('flags'), 'change', this._transformEvent);
+			this.set('dateMicro', this.get('dateInt') * 1000);
 		},
 		_transformEvent: function() {
 			this.trigger('change');

--- a/js/replybuilder.js
+++ b/js/replybuilder.js
@@ -1,0 +1,100 @@
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var _ = require('underscore');
+
+	var RecipientType = Object.seal({
+		None: 0,
+		To: 1,
+		Cc: 2
+	});
+
+	var buildReply = function(message, messageBody) {
+		var recipientType = RecipientType.None;
+		var ownAddress = message.folder.account.get('emailAddress');
+		var isOwnAddress = function(a) {
+			return a.email === ownAddress;
+		};
+		var isNotOwnAddress = _.negate(isOwnAddress);
+
+		// Locate why we received this message
+		// Can be in 'to', 'cc' or unknown
+		var replyingAddress = _.find(messageBody.get('to'), isOwnAddress);
+		if (!_.isUndefined(replyingAddress)) {
+			recipientType = RecipientType.To;
+		} else {
+			replyingAddress = _.find(messageBody.get('cc'), isOwnAddress);
+			if (!_.isUndefined(replyingAddress)) {
+				recipientType = RecipientType.Cc;
+			}
+		}
+
+		var to = [];
+		var cc = [];
+		if (recipientType === RecipientType.To) {
+			// Send to everyone except yourself plus the original sender
+			to = messageBody.get('to').filter(isNotOwnAddress);
+			to = to.concat(messageBody.get('from'));
+
+			// Super rare case: if you write an email to yourself, your email must not be removed
+			/* if (to.length === 0 &&
+			 messageBody.get('to').length === 1 &&
+			 messageBody.get('to')[0].email === message.folder.account.get('emailAddress')) {
+			 console.error('ALA');
+			 to.push(messageBody.get('to')[0]);
+			 } */
+
+			// CC remains the same
+			cc = messageBody.get('cc');
+		} else if (recipientType === RecipientType.Cc) {
+			// Send to the same people plus the sender
+			to = messageBody.get('to').concat(messageBody.get('from'));
+
+			// All CC values are being kept except the replying address
+			cc = messageBody.get('cc').filter(isNotOwnAddress);
+		} else {
+			// Send to the sender
+			to = messageBody.get('from');
+
+			// Keep CC values
+			cc = messageBody.get('cc');
+		}
+
+		console.error(recipientType, replyingAddress, to, cc);
+
+		return {
+			to: to,
+			from: [replyingAddress],
+			fromEmail: message.folder.account.get('emailAddress'), // TODO: alias?
+			cc: cc,
+			body: ''
+		};
+	};
+
+	return {
+		buildReply: buildReply
+	};
+
+});

--- a/js/templatehelpers/ifHasCC.js
+++ b/js/templatehelpers/ifHasCC.js
@@ -17,13 +17,13 @@
  *
  */
 
-define(function(require) {
+define(function() {
 	'use strict';
 
-	var _ = require('underscore');
-
-	return function(cc, ccList, options) {
-		if (!_.isUndefined(cc) || (!_.isUndefined(ccList) && ccList.length > 0)) {
+	return function(options) {
+		var hasCc = this.cc.length > 0;
+		var hasBcc = this.bcc.length > 0;
+		if (hasCc || hasBcc) {
 			return options.fn(this);
 		} else {
 			return options.inverse(this);

--- a/js/templatehelpers/unlessHasCC.js
+++ b/js/templatehelpers/unlessHasCC.js
@@ -17,15 +17,13 @@
  *
  */
 
-define(function(require) {
+define(function() {
 	'use strict';
 
-	var _ = require('underscore');
-
 	return function(options) {
-		var hasCc = _.isUndefined(this.cc) && (_.isUndefined(this.ccList) || this.ccList.length === 0);
-		var hasBcc = _.isUndefined(this.bcc) && (_.isUndefined(this.bccList) || this.bccList.length === 0);
-		if (hasCc || hasBcc) {
+		var hasCc = this.cc.length > 0;
+		var hasBcc = this.bcc.length > 0;
+		if (!hasCc && !hasBcc) {
 			return options.fn(this);
 		} else {
 			return options.inverse(this);

--- a/js/templates/composer.html
+++ b/js/templates/composer.html
@@ -6,57 +6,37 @@
 	</select>
 	<div class="composer-fields">
 		<a href="#" class="composer-cc-bcc-toggle transparency
-			{{#ifHasCC replyCc replyCcList}}
+			{{#ifHasCC}}
 			hidden
 			{{/ifHasCC}}">{{ t '+ cc/bcc' }}</a>
 		<input type="text" name="to"
-		    {{#if isReply}}
-		    value="{{printAddressListPlain replyToList}}"
-		    {{else}}
-			{{#if toList}}
-			value="{{printAddressListPlain toList}}"
-			{{else}}
-			value="{{to}}"
-			{{/if}}
-		    {{/if}}
+		    value="{{printAddressListPlain to}}"
 		    class="to recipient-autocomplete" />
-		<label class="to-label" for="to" class="transparency">{{ t 'to' }}</label>
+		<label class="to-label transparency" for="to">{{ t 'to' }}</label>
 		<div class="composer-cc-bcc
 		    {{#unlessHasCC}}
 		    hidden
 		    {{/unlessHasCC}}">
-			<input type="text" name="cc" class="cc recipient-autocomplete"
-			    {{#if isReply}}
-			    value="{{replyCc}}"
-			    {{else}}
-				{{#if ccList}}
-				value="{{printAddressListPlain ccList}}"
-				{{else}}
-				value="{{cc}}"
-				{{/if}}
-			    {{/if}}
-			    />
+			<input type="text"
+			       name="cc"
+			       class="cc recipient-autocomplete"
+			       value="{{printAddressListPlain cc}}"
+			       />
 			<label for="cc" class="cc-label transparency">{{ t 'cc' }}</label>
-			<input type="text" name="cc" class="bcc recipient-autocomplete"
-			    {{#if isReply}}
-			    value="{{replyBcc}}"
-			    {{else}}
-				{{#if bccList}}
-				value="{{printAddressListPlain bccList}}"
-				{{else}}
-				value="{{bcc}}"
-				{{/if}}
-			    {{/if}}
-			    />
+			<input type="text"
+			       name="bcc"
+			       class="bcc recipient-autocomplete"
+			       value="{{printAddressListPlain bcc}}"
+			       />
 			<label for="bcc" class="bcc-label transparency">{{ t 'bcc' }}</label>
 		</div>
 		{{#unless isReply}}
 		<input type="text" name="subject" value="{{subject}}" class="subject" autocomplete="off"
 			placeholder="{{ t 'Subject' }}" />
 		{{/unless}}
-		<textarea name="body" class="message-body
-					{{#if isReply}} reply{{/if}}"
-			placeholder="{{ t 'Message …' }}">{{message}}</textarea>
+		<textarea name="body"
+			  class="message-body"
+			  placeholder="{{ t 'Message …' }}">{{message}}</textarea>
 	</div>
 	<div class="submit-message-wrapper">
 		<input class="submit-message send primary" type="submit" value="{{submitButtonTitle}}" disabled>

--- a/js/templates/message-list-item.html
+++ b/js/templates/message-list-item.html
@@ -7,7 +7,7 @@
 			{{#if senderImage}}
 			<img src="{{senderImage}}" width="32px" height="32px" />
 			{{else}}
-			<div class="avatar" data-user="{{from}}" data-size="32"></div>
+			<div class="avatar" data-user="{{sender.label}}" data-size="32"></div>
 			{{/if}}
 		</div>
 
@@ -25,7 +25,7 @@
 		<div class="icon-public icon-attachment"></div>
 		{{/if}}
 
-		<div class="mail-message-summary-from" title="{{fromEmail}}">{{from}}</div>
+		<div class="mail-message-summary-from" title="{{sender.email}}">{{sender.label}}</div>
 		<div class="mail-message-summary-subject" title="{{subject}}">
 			{{subject}}
 		</div>

--- a/js/templates/message.html
+++ b/js/templates/message.html
@@ -2,13 +2,11 @@
 <div id="mail-message-header" class="section">
 	<h2 title="{{subject}}">{{subject}}</h2>
 	<p class="transparency">
-		{{printAddressList fromList}}
-		{{#if toList}}
+		{{printAddressList from}}
 		{{ t 'to' }}
-		{{printAddressList toList}}
-		{{/if}}
-		{{#if ccList}}
-		({{ t 'cc' }} {{printAddressList ccList}})
+		{{printAddressList to}}
+		{{#if cc.length}}
+		({{ t 'cc' }} {{printAddressList cc}})
 		{{/if}}
 	</p>
 </div>

--- a/js/tests/replybuilder_spec.js
+++ b/js/tests/replybuilder_spec.js
@@ -1,0 +1,156 @@
+/* global expect */
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+define([
+	'replybuilder',
+	'models/message',
+	'models/folder',
+	'models/account',
+	'backbone'
+], function(ReplyBuilder, Message, Folder, Account, Backbone) {
+
+	describe('ReplyBuilder', function() {
+
+		var message, messageBody, folder, account;
+
+		beforeEach(function() {
+			message = new Message();
+			messageBody = new Backbone.Model();
+			folder = new Folder();
+			account = new Account();
+			account.addFolder(folder);
+			folder.addMessage(message);
+		});
+
+		var createAddress = function(addr) {
+			return {
+				label: addr,
+				email: addr
+			};
+		};
+
+		var setEmail = function(message, address) {
+			message.folder.account.set('emailAddress', address.email);
+		};
+
+		var assertSameAddressList = function(l1, l2) {
+			var rawL1 = l1.map(function(a) {
+				return a.email;
+			});
+			var rawL2 = l2.map(function(a) {
+				return a.email;
+			});
+			rawL1.sort();
+			rawL2.sort();
+			expect(rawL1).toEqual(rawL2);
+		};
+
+		// b -> a to a -as b
+		it('handles a one-on-one reply', function() {
+			var a = createAddress('a@domain.tld');
+			var b = createAddress('b@domain.tld');
+			messageBody.set('from', [b]);
+			messageBody.set('to', [a]);
+			messageBody.set('cc', []);
+			setEmail(message, a);
+
+			var reply = ReplyBuilder.buildReply(message, messageBody);
+
+			assertSameAddressList(reply.from, [a]);
+			assertSameAddressList(reply.to, [b]);
+			assertSameAddressList(reply.cc, []);
+		});
+
+		it('handles simple group reply', function() {
+			var a = createAddress('a@domain.tld');
+			var b = createAddress('b@domain.tld');
+			var c = createAddress('c@domain.tld');
+			messageBody.set('from', [a]);
+			messageBody.set('to', [b, c]);
+			messageBody.set('cc', []);
+			setEmail(message, b);
+
+			var reply = ReplyBuilder.buildReply(message, messageBody);
+
+			assertSameAddressList(reply.from, [b]);
+			assertSameAddressList(reply.to, [a, c]);
+			assertSameAddressList(reply.cc, []);
+		});
+
+
+		it('handles group reply with CC', function() {
+			var a = createAddress('a@domain.tld');
+			var b = createAddress('b@domain.tld');
+			var c = createAddress('c@domain.tld');
+			var d = createAddress('d@domain.tld');
+			messageBody.set('from', [a]);
+			messageBody.set('to', [b, c]);
+			messageBody.set('cc', [d]);
+			setEmail(message, b);
+
+			var reply = ReplyBuilder.buildReply(message, messageBody);
+
+			assertSameAddressList(reply.from, [b]);
+			assertSameAddressList(reply.to, [a, c]);
+			assertSameAddressList(reply.cc, [d]);
+		});
+
+		it('handles group reply of CC address', function() {
+			var a = createAddress('a@domain.tld');
+			var b = createAddress('b@domain.tld');
+			var c = createAddress('c@domain.tld');
+			var d = createAddress('d@domain.tld');
+			messageBody.set('from', [a]);
+			messageBody.set('to', [b, c]);
+			messageBody.set('cc', [d]);
+			setEmail(message, d);
+
+			var reply = ReplyBuilder.buildReply(message, messageBody);
+
+			assertSameAddressList(reply.from, [d]);
+			assertSameAddressList(reply.to, [a, b, c]);
+			assertSameAddressList(reply.cc, []);
+		});
+
+		it('handles group reply of CC address with many CCs', function() {
+			var a = createAddress('a@domain.tld');
+			var b = createAddress('b@domain.tld');
+			var c = createAddress('c@domain.tld');
+			var d = createAddress('d@domain.tld');
+			var e = createAddress('e@domain.tld');
+			messageBody.set('from', [a]);
+			messageBody.set('to', [b, c]);
+			messageBody.set('cc', [d, e]);
+			setEmail(message, e);
+
+			var reply = ReplyBuilder.buildReply(message, messageBody);
+
+			assertSameAddressList(reply.from, [e]);
+			assertSameAddressList(reply.to, [a, b, c]);
+			assertSameAddressList(reply.cc, [d]);
+		});
+
+	});
+
+});

--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -64,6 +64,10 @@ $.fn.droppable = function() {
 
 };
 
+$.fn.imageplaceholder = function() {
+
+};
+
 formatDate = function(arg) {
 	return arg;
 };

--- a/js/tests/views/composerview_spec.js
+++ b/js/tests/views/composerview_spec.js
@@ -1,4 +1,4 @@
-/* global expect */
+/* global expect, spyOn */
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -60,6 +60,7 @@ define([
 			var view = new ComposerView({
 				accounts: accounts
 			});
+			spyOn(view, 'saveDraft');
 
 			expect(view.type).toBe('new');
 			expect(view.isReply()).toBe(false);

--- a/js/tests/views/foldercontent_spec.js
+++ b/js/tests/views/foldercontent_spec.js
@@ -35,7 +35,14 @@ define(['views/foldercontent',
 		folder = new Folder({
 			account: account
 		});
-		message = new Message();
+		message = new Message({
+			from: [
+				{
+					label: 'Christoph Wurst',
+					email: 'christoph@domain.tld'
+				}
+			]
+		});
 		folder.addMessage(message);
 		view = new FolderContent({
 			account: account,

--- a/js/util/notificationhandler.js
+++ b/js/util/notificationhandler.js
@@ -76,7 +76,7 @@ define(function(require) {
 		}
 
 		var from = _.map(messages, function(m) {
-			return m.get('from');
+			return m.get('from')[0].label;
 		});
 		from = _.uniq(from);
 		if (from.length > 2) {

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -36,17 +36,11 @@ define(function(require) {
 				aliases: aliases,
 				isReply: this.isReply(),
 				to: this.data.to,
-				toList: this.data.toList,
 				cc: this.data.cc,
-				ccList: this.data.ccList,
-				bccList: this.data.bccList,
+				bcc: this.data.bcc,
 				subject: this.data.subject,
 				message: this.data.body,
-				submitButtonTitle: this.isReply() ? t('mail', 'Reply') : t('mail', 'Send'),
-				// Reply data
-				replyToList: this.data.replyToList,
-				replyCc: this.data.replyCc,
-				replyCcList: this.data.replyCcList
+				submitButtonTitle: this.isReply() ? t('mail', 'Reply') : t('mail', 'Send')
 			};
 		},
 		type: 'new',
@@ -93,14 +87,16 @@ define(function(require) {
 				type: 'new',
 				account: null,
 				repliedMessage: null,
-				data: {
-					to: '',
-					cc: '',
-					subject: '',
-					body: ''
-				}
+				data: {}
 			};
 			_.defaults(options, defaultOptions);
+			_.defaults(options.data, {
+				to: [],
+				cc: [],
+				bcc: [],
+				subject: '',
+				body: '',
+			});
 
 			/**
 			 * Composer type (new, reply)
@@ -125,13 +121,12 @@ define(function(require) {
 			 */
 			this.data = options.data;
 
+			this.accounts = options.accounts;
 			if (!this.isReply()) {
-				this.accounts = options.accounts;
 				this.account = options.account || this.accounts.at(0);
 				this.draftUID = options.data.id;
 			} else {
 				this.account = options.account;
-				this.accounts = options.accounts;
 				this.folder = options.folder;
 				this.repliedMessage = options.repliedMessage;
 			}
@@ -309,7 +304,7 @@ define(function(require) {
 			// if available get account from drop-down list
 			if (this.$('.mail-account').length > 0) {
 				alias = this.findAliasById(this.$('.mail-account').
-					find(':selected').val());
+						find(':selected').val());
 				this.account = this.accounts.get(alias.accountId);
 			}
 
@@ -331,9 +326,9 @@ define(function(require) {
 				if (!!options.repliedMessage) {
 					// Reply -> flag message as replied
 					Radio.message.trigger('flag',
-						options.repliedMessage,
-						'answered',
-						true);
+							options.repliedMessage,
+							'answered',
+							true);
 				}
 
 				_this.$('#mail_new_message').prop('disabled', false);
@@ -348,7 +343,7 @@ define(function(require) {
 					// the sent message was a draft
 					if (!_.isUndefined(Radio.ui.request('messagesview:collection'))) {
 						Radio.ui.request('messagesview:collection').
-							remove({id: _this.draftUID});
+								remove({id: _this.draftUID});
 					}
 					_this.draftUID = null;
 				}
@@ -371,7 +366,7 @@ define(function(require) {
 				bcc.prop('disabled', false);
 				subject.prop('disabled', false);
 				_this.$('.new-message-attachments-action').
-					css('display', 'inline-block');
+						css('display', 'inline-block');
 				_this.$('#add-cloud-attachment').prop('disabled', false);
 				_this.$('#add-local-attachment').prop('disabled', false);
 				newMessageBody.prop('disabled', false);
@@ -392,7 +387,7 @@ define(function(require) {
 			// if available get account from drop-down list
 			if (this.$('.mail-account').length > 0) {
 				var alias = this.findAliasById(this.$('.mail-account').
-					find(':selected').val());
+						find(':selected').val());
 				this.account = this.accounts.get(alias.accountId);
 			}
 
@@ -424,12 +419,12 @@ define(function(require) {
 			var minutes = date.getMinutes();
 
 			this.$('.message-body').first().text(
-				'\n\n\n' +
-				from + ' – ' +
-				$.datepicker.formatDate('D, d. MM yy ', date) +
-				date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
-				text.replace(/\n/g, '\n> ')
-				);
+					'\n\n\n' +
+					from.email + ' – ' +
+					$.datepicker.formatDate('D, d. MM yy ', date) +
+					date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
+					text.replace(/\n/g, '\n> ')
+					);
 
 			this.setAutoSize(false);
 			// Expand reply message body on click
@@ -463,17 +458,17 @@ define(function(require) {
 
 				elem.bind('keydown', function(event) {
 					if (event.keyCode === $.ui.keyCode.TAB &&
-						typeof elem.data('autocomplete') !== 'undefined' &&
-						elem.data('autocomplete').menu.active) {
+							typeof elem.data('autocomplete') !== 'undefined' &&
+							elem.data('autocomplete').menu.active) {
 						event.preventDefault();
 					}
 				}).autocomplete({
 					source: function(request, response) {
 						$.getJSON(
-							OC.generateUrl('/apps/mail/api/autoComplete'),
-							{
-								term: extractLast(request.term)
-							}, response);
+								OC.generateUrl('/apps/mail/api/autoComplete'),
+								{
+									term: extractLast(request.term)
+								}, response);
 					},
 					search: function() {
 						// custom minLength
@@ -499,9 +494,7 @@ define(function(require) {
 						this.value = terms.join(', ');
 						return false;
 					}
-				}).
-					data('ui-autocomplete')._renderItem = function(
-					$ul, item) {
+				}).data('ui-autocomplete')._renderItem = function($ul, item) {
 					var $item = $('<li/>');
 					var $row = $('<a/>');
 
@@ -578,7 +571,7 @@ define(function(require) {
 					});
 				} else {
 					var firstAccount = this.accounts.filter(function(
-						account) {
+							account) {
 						return account.get('accountId') !== -1;
 					})[0];
 					alias = _.find(this.aliases, function(alias) {
@@ -586,9 +579,9 @@ define(function(require) {
 					});
 				}
 			} else {
-				var toEmail = this.data.toEmail;
+				var fromEmail = this.data.fromEmail;
 				alias = _.find(this.aliases, function(alias) {
-					return alias.emailAddress === toEmail;
+					return alias.emailAddress === fromEmail;
 				});
 			}
 			if (alias) {

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -34,6 +34,7 @@ define(function(require) {
 		serializeModel: function() {
 			var json = this.model.toJSON();
 			json.isUnified = require('state').currentAccount && require('state').currentAccount.get('isUnified');
+			json.sender = this.model.get('from')[0];
 			return json;
 		},
 		onRender: function() {
@@ -45,7 +46,7 @@ define(function(require) {
 			this.$el.unwrap();
 			this.setElement(this.$el);
 
-			var displayName = this.model.get('from');
+			var displayName = this.model.get('from')[0].label;
 			// Don't show any placeholder if 'from' isn't set
 			if (displayName) {
 				_.each(this.$el.find('.avatar'), function(a) {

--- a/js/views/messageview.js
+++ b/js/views/messageview.js
@@ -21,6 +21,7 @@ define(function(require) {
 	var ComposerView = require('views/composerview');
 	var MessageAttachmentsView = require('views/messageattachments');
 	var MessageTemplate = require('templates/message.html');
+	var ReplyBuilder = require('replybuilder');
 
 	return Marionette.View.extend({
 		template: MessageTemplate,
@@ -42,13 +43,7 @@ define(function(require) {
 			this.folder = options.folder;
 			this.message = options.message;
 			this.messageBody = options.model;
-			this.reply = {
-				replyToList: this.messageBody.get('replyToList'),
-				replyCc: this.messageBody.get('replyCc'),
-				toEmail: this.messageBody.get('toEmail'),
-				replyCcList: this.messageBody.get('replyCcList'),
-				body: ''
-			};
+			this.reply = ReplyBuilder.buildReply(this.message, this.messageBody);
 
 			// Add body content to inline reply (text mails)
 			if (!this.messageBody.get('hasHtmlBody')) {
@@ -57,10 +52,10 @@ define(function(require) {
 				var text = HtmlHelper.htmlToText(this.messageBody.get('body'));
 
 				this.reply.body = '\n\n\n\n' +
-					this.messageBody.get('from') + ' – ' +
-					$.datepicker.formatDate('D, d. MM yy ', date) +
-					date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
-					text.replace(/\n/g, '\n> ');
+						this.messageBody.get('from') + ' – ' +
+						$.datepicker.formatDate('D, d. MM yy ', date) +
+						date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
+						text.replace(/\n/g, '\n> ');
 			}
 
 			// Save current messages's content for later use (forward)
@@ -110,7 +105,7 @@ define(function(require) {
 			// Does the html mail have blocked images?
 			var hasBlockedImages = false;
 			if (this.getUI('messageIframe').contents().
-				find('[data-original-src],[data-original-style]').length) {
+					find('[data-original-src],[data-original-style]').length) {
 				hasBlockedImages = true;
 			}
 
@@ -125,7 +120,7 @@ define(function(require) {
 			var text = this.getUI('messageIframe').contents().find('body').html();
 			text = HtmlHelper.htmlToText(text);
 			var date = new Date(this.messageBody.get('dateIso'));
-			this.getChildView('replyComposer').setReplyBody(this.messageBody.get('from'), date, text);
+			this.getChildView('replyComposer').setReplyBody(this.messageBody.get('from')[0], date, text);
 
 			// Safe current mesages's content for later use (forward)
 			require('state').currentMessageBody = text;

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -37,7 +37,6 @@ use Horde_Imap_Client;
 use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Socket;
-use Horde_Mail_Rfc822_Address;
 use Horde_Mail_Rfc822_List;
 use Horde_Mail_Transport;
 use Horde_Mail_Transport_Null;
@@ -186,13 +185,11 @@ class Account implements IAccount {
 	 */
 	public function sendMessage(IMessage $message, Horde_Mail_Transport $transport, $draftUID) {
 		// build mime body
-		$from = new Horde_Mail_Rfc822_Address($message->getFrom());
-		$from->personal = $this->getName();
 		$headers = [
-			'From' => $from,
-			'To' => $message->getToList(),
-			'Cc' => $message->getCCList(),
-			'Bcc' => $message->getBCCList(),
+			'From' => $message->getFrom()->first()->toHorde(),
+			'To' => $message->getTo()->toHorde(),
+			'Cc' => $message->getCC()->toHorde(),
+			'Bcc' => $message->getBCC()->toHorde(),
 			'Subject' => $message->getSubject(),
 		];
 
@@ -238,13 +235,11 @@ class Account implements IAccount {
 	 */
 	public function saveDraft(IMessage $message, $previousUID) {
 		// build mime body
-		$from = new Horde_Mail_Rfc822_Address($message->getFrom());
-		$from->personal = $this->getName();
 		$headers = [
-			'From' => $from,
-			'To' => $message->getToList(),
-			'Cc' => $message->getCCList(),
-			'Bcc' => $message->getBCCList(),
+			'From' => $message->getFrom()->first()->toHorde(),
+			'To' => $message->getTo()->toHorde(),
+			'Cc' => $message->getCC()->toHorde(),
+			'Bcc' => $message->getBCC()->toHorde(),
 			'Subject' => $message->getSubject(),
 			'Date' => Horde_Mime_Headers_Date::create(),
 		];

--- a/lib/Address.php
+++ b/lib/Address.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail;
+
+use Horde_Mail_Rfc822_Address;
+use JsonSerializable;
+use SGH\Comparable\Comparable;
+
+class Address implements JsonSerializable {
+
+	/** @var Horde_Mail_Rfc822_Address */
+	private $wrapped;
+
+	/**
+	 * @param string $label
+	 * @param string $email
+	 */
+	public function __construct($label, $email) {
+		$this->wrapped = new Horde_Mail_Rfc822_Address($email);
+		// If no label is set we use the email
+		if ($label !== $email && !is_null($label)) {
+			$this->wrapped->personal = $label;
+		}
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getLabel() {
+		$personal = $this->wrapped->personal;
+		if (is_null($personal)) {
+			// Fallback
+			return $this->getEmail();
+		}
+		return $personal;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getEmail() {
+		return $this->wrapped->bare_address;
+	}
+
+	/**
+	 * @return Horde_Mail_Rfc822_Address
+	 */
+	public function toHorde() {
+		return $this->wrapped;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			'label' => $this->getLabel(),
+			'email' => $this->getEmail(),
+		];
+	}
+
+	/**
+	 * @param Address $object
+	 * @return boolean
+	 */
+	public function equals($object) {
+		return $this->getEmail() === $object->getEmail()
+			&& $this->getLabel() === $object->getLabel();
+	}
+
+}

--- a/lib/AddressList.php
+++ b/lib/AddressList.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail;
+
+use Countable;
+use Horde_Mail_Rfc822_Address;
+use Horde_Mail_Rfc822_List;
+use Horde_Mail_Rfc822_Object;
+use JsonSerializable;
+
+class AddressList implements Countable, JsonSerializable {
+
+	/** @var Address[] */
+	private $addresses;
+
+	/**
+	 * @param Address[] $addresses
+	 */
+	public function __construct(array $addresses = []) {
+		$this->addresses = $addresses;
+	}
+
+	/**
+	 * Parse an address (list) like "a@b.c" or "a@b.c, d@e.f"
+	 *
+	 * @param string|string[] $str address list string to parse
+	 * @return AddressList
+	 */
+	public static function parse($str) {
+		$hordeList = new Horde_Mail_Rfc822_List($str);
+		return self::fromHorde($hordeList);
+	}
+
+	/**
+	 * Construct a new list from an horde list
+	 *
+	 * @param Horde_Mail_Rfc822_List $hordeList
+	 * @return AddressList
+	 */
+	public static function fromHorde(Horde_Mail_Rfc822_List $hordeList) {
+		$addresses = array_map(function(Horde_Mail_Rfc822_Address $addr) {
+			return new Address($addr->personal, $addr->bare_address);
+		}, array_filter(iterator_to_array($hordeList), function(Horde_Mail_Rfc822_Object $obj) {
+				// TODO: how to handle non-addresses? This doesn't seem right …
+				return $obj instanceof Horde_Mail_Rfc822_Address;
+			}));
+		return new AddressList($addresses);
+	}
+
+	/**
+	 * Get first element
+	 *
+	 * Returns null if the list is empty
+	 *
+	 * @return Address|null
+	 */
+	public function first() {
+		if (empty($this->addresses)) {
+			return null;
+		}
+
+		return $this->addresses[0];
+	}
+
+	/**
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return array_map(function(Address $address) {
+			return $address->jsonSerialize();
+		}, $this->addresses);
+	}
+
+	/**
+	 * @return int
+	 */
+	public function count() {
+		return count($this->addresses);
+	}
+
+	/**
+	 * Iterate over the internal list of addresses using a generator method
+	 */
+	public function iterate() {
+		foreach ($this->addresses as $address) {
+			yield $address;
+		}
+	}
+
+	/**
+	 * @param AddressList $other
+	 * @return AddressList
+	 */
+	public function merge(AddressList $other) {
+		$addresses = $this->addresses;
+
+		array_walk($other->addresses, function(Address $address) use (&$addresses) {
+			$same = array_filter($addresses, function(Address $our) use ($address) {
+				// Check whether our array contains the other address
+				return $our->equals($address);
+			});
+			if (empty($same)) {
+				// No dup found, hence the address is new and we
+				// have to add it
+				$addresses[] = $address;
+			}
+		});
+
+		return new AddressList($addresses);
+	}
+
+	/**
+	 * @return Horde_Mail_Rfc822_List
+	 */
+	public function toHorde() {
+		$hordeAddresses = array_map(function(Address $address) {
+			return $address->toHorde();
+		}, $this->addresses);
+		return new Horde_Mail_Rfc822_List($hordeAddresses);
+	}
+
+}

--- a/lib/Model/ConvertAddresses.php
+++ b/lib/Model/ConvertAddresses.php
@@ -53,18 +53,6 @@ trait ConvertAddresses {
 	}
 
 	/**
-	 * @param Horde_Mail_Rfc822_List $list
-	 * @return array
-	 */
-	protected function hordeListToAssocArray(Horde_Mail_Rfc822_List $list) {
-		$addresses = [];
-		foreach ($list as $address) {
-			$addresses[] = $this->hordeToAssoc($address);
-		}
-		return $addresses;
-	}
-
-	/**
 	 * @param Horde_Imap_Client_Data_Envelope|Horde_Mail_Rfc822_List $envelope
 	 * @return array
 	 */

--- a/lib/Model/IMessage.php
+++ b/lib/Model/IMessage.php
@@ -21,6 +21,7 @@
 namespace OCA\Mail\Model;
 
 use Horde_Mail_Rfc822_List;
+use OCA\Mail\AddressList;
 use OCA\Mail\Db\LocalAttachment;
 use OCP\Files\File;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -47,52 +48,44 @@ interface IMessage {
 	public function setFlags(array $flags);
 
 	/**
-	 * @return string
+	 * @return AddressList
 	 */
 	public function getFrom();
 
 	/**
 	 * @param string $from
 	 */
-	public function setFrom($from);
+	public function setFrom(AddressList $from);
 
 	/**
-	 * @return string
+	 * @return AddressList
 	 */
 	public function getTo();
 
 	/**
-	 * @param Horde_Mail_Rfc822_List $to
+	 * @param AddressList $to
 	 */
-	public function setTo(Horde_Mail_Rfc822_List $to);
+	public function setTo(AddressList $to);
 
 	/**
-	 * @param bool $assoc
-	 * @return string[]
+	 * @return AddressList
 	 */
-	public function getToList($assoc = false);
+	public function getCC();
 
 	/**
-	 * @param bool $assoc
-	 * @return string[]
+	 * @param AddressList $cc
 	 */
-	public function getCCList($assoc = false);
+	public function setCC(AddressList $cc);
 
 	/**
-	 * @param Horde_Mail_Rfc822_List $cc
+	 * @return AddressList
 	 */
-	public function setCC(Horde_Mail_Rfc822_List $cc);
+	public function getBCC();
 
 	/**
-	 * @param bool $assoc
-	 * @return string[]
+	 * @param AddressList $bcc
 	 */
-	public function getBCCList($assoc = false);
-
-	/**
-	 * @param Horde_Mail_Rfc822_List $bcc
-	 */
-	public function setBcc(Horde_Mail_Rfc822_List $bcc);
+	public function setBcc(AddressList $bcc);
 
 	/**
 	 * @return IMessage

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -23,6 +23,7 @@ namespace OCA\Mail\Model;
 
 use Horde_Mail_Rfc822_List;
 use Horde_Mime_Part;
+use OCA\Mail\AddressList;
 use OCA\Mail\Db\LocalAttachment;
 use OCP\Files\File;
 use OCP\Files\SimpleFS\ISimpleFile;
@@ -34,16 +35,16 @@ class Message implements IMessage {
 	/** @var string */
 	private $subject = '';
 
-	/** @var string */
-	private $from = '';
+	/** @var AddressList */
+	private $from;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $to;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $cc;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $bcc;
 
 	/** @var IMessage */
@@ -61,18 +62,11 @@ class Message implements IMessage {
 	/** @var int[] */
 	private $localAttachments = [];
 
-	/**
-	 * @param string $list
-	 * @return Horde_Mail_Rfc822_List
-	 */
-	public static function parseAddressList($list) {
-		return new Horde_Mail_Rfc822_List($list);
-	}
-
 	public function __construct() {
-		$this->to = new Horde_Mail_Rfc822_List();
-		$this->cc = new Horde_Mail_Rfc822_List();
-		$this->bcc = new Horde_Mail_Rfc822_List();
+		$this->from = new AddressList();
+		$this->to = new AddressList();
+		$this->cc = new AddressList();
+		$this->bcc = new AddressList();
 	}
 
 	/**
@@ -101,83 +95,58 @@ class Message implements IMessage {
 	}
 
 	/**
-	 * @return string
+	 * @return AddressList
 	 */
 	public function getFrom() {
 		return $this->from;
 	}
 
 	/**
-	 * @param string $from
+	 * @param AddressList $from
 	 */
-	public function setFrom($from) {
+	public function setFrom(AddressList $from) {
 		$this->from = $from;
 	}
 
 	/**
-	 * @return string
+	 * @return AddressList
 	 */
 	public function getTo() {
-		if ($this->to->count() > 0) {
-			return $this->to->first()->writeAddress();
-		}
-		return null;
+		return $this->to;
 	}
 
 	/**
-	 * @param Horde_Mail_Rfc822_List $to
+	 * @param AddressList $to
 	 */
-	public function setTo(Horde_Mail_Rfc822_List $to) {
+	public function setTo(AddressList $to) {
 		$this->to = $to;
 	}
 
 	/**
-	 * @param bool $assoc
-	 * @return string[]
+	 * @return AddressList
 	 */
-	public function getToList($assoc = false) {
-		if ($assoc) {
-			return $this->hordeListToAssocArray($this->to);
-		} else {
-			return $this->hordeListToStringArray($this->to);
-		}
+	public function getCC() {
+		return $this->cc;
 	}
 
 	/**
-	 * @param bool $assoc
-	 * @return Horde_Mail_Rfc822_List
+	 * @param AddressList $cc
 	 */
-	public function getCCList($assoc = false) {
-		if ($assoc) {
-			return $this->hordeListToAssocArray($this->cc);
-		} else {
-			return $this->hordeListToStringArray($this->cc);
-		}
-	}
-
-	/**
-	 * @param Horde_Mail_Rfc822_List $cc
-	 */
-	public function setCC(Horde_Mail_Rfc822_List $cc) {
+	public function setCC(AddressList $cc) {
 		$this->cc = $cc;
 	}
 
 	/**
-	 * @param bool $assoc
-	 * @return Horde_Mail_Rfc822_List
+	 * @return AddressList
 	 */
-	public function getBCCList($assoc = false) {
-		if ($assoc) {
-			return $this->hordeListToAssocArray($this->bcc);
-		} else {
-			return $this->hordeListToStringArray($this->bcc);
-		}
+	public function getBCC() {
+		return $this->bcc;
 	}
 
 	/**
-	 * @param Horde_Mail_Rfc822_List $bcc
+	 * @param AddressList $bcc
 	 */
-	public function setBcc(Horde_Mail_Rfc822_List $bcc) {
+	public function setBcc(AddressList $bcc) {
 		$this->bcc = $bcc;
 	}
 
@@ -254,8 +223,7 @@ class Message implements IMessage {
 	 * @param LocalAttachment $attachment
 	 * @param ISimpleFile $file
 	 */
-	public function addLocalAttachment(LocalAttachment $attachment,
-		ISimpleFile $file) {
+	public function addLocalAttachment(LocalAttachment $attachment, ISimpleFile $file) {
 		$part = new Horde_Mime_Part();
 		$part->setCharset('us-ascii');
 		$part->setDisposition('attachment');

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -23,6 +23,7 @@ namespace OCA\Mail\Model;
 
 use Horde_Mail_Rfc822_List;
 use OCA\Mail\Account;
+use OCA\Mail\AddressList;
 
 /**
  * Simple data class that wraps the request data of a new message or reply
@@ -32,13 +33,13 @@ class NewMessageData {
 	/** @var Account */
 	private $account;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $to;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $cc;
 
-	/** @var Horde_Mail_Rfc822_List */
+	/** @var AddressList */
 	private $bcc;
 
 	/** @var string */
@@ -52,15 +53,14 @@ class NewMessageData {
 
 	/**
 	 * @param Account $account
-	 * @param Horde_Mail_Rfc822_List $to
-	 * @param Horde_Mail_Rfc822_List $cc
-	 * @param Horde_Mail_Rfc822_List $bcc
+	 * @param AddressList $to
+	 * @param AddressList $cc
+	 * @param AddressList $bcc
 	 * @param string $subject
 	 * @param string $body
 	 * @param array $attachments
 	 */
-	public function __construct(Account $account, Horde_Mail_Rfc822_List $to, Horde_Mail_Rfc822_List $cc,
-		Horde_Mail_Rfc822_List $bcc, $subject, $body, array $attachments) {
+	public function __construct(Account $account, AddressList $to, AddressList $cc, AddressList $bcc, $subject, $body, array $attachments) {
 		$this->account = $account;
 		$this->to = $to;
 		$this->cc = $cc;
@@ -81,12 +81,12 @@ class NewMessageData {
 	 * @return NewMessageData
 	 */
 	public static function fromRequest(Account $account, $to, $cc, $bcc, $subject, $body, $attachments) {
-		$toArray = is_null($to) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($to);
-		$ccArray = is_null($cc) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($cc);
-		$bccArray = is_null($bcc) ? new Horde_Mail_Rfc822_List() : Message::parseAddressList($bcc);
+		$toList = AddressList::parse($to ?: '');
+		$ccList = AddressList::parse($cc ?: '');
+		$bccList = AddressList::parse($bcc ?: '');
 		$attchmentsArray = is_null($attachments) ? [] : $attachments;
 
-		return new NewMessageData($account, $toArray, $ccArray, $bccArray, $subject, $body, $attchmentsArray);
+		return new NewMessageData($account, $toList, $ccList, $bccList, $subject, $body, $attchmentsArray);
 	}
 
 	/**
@@ -97,21 +97,21 @@ class NewMessageData {
 	}
 
 	/**
-	 * @return Horde_Mail_Rfc822_List
+	 * @return AddressList
 	 */
 	public function getTo() {
 		return $this->to;
 	}
 
 	/**
-	 * @return Horde_Mail_Rfc822_List
+	 * @return AddressList
 	 */
 	public function getCc() {
 		return $this->cc;
 	}
 
 	/**
-	 * @return Horde_Mail_Rfc822_List
+	 * @return AddressList
 	 */
 	public function getBcc() {
 		return $this->bcc;

--- a/tests/AddressListTest.php
+++ b/tests/AddressListTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests;
+
+use Horde_Mail_Rfc822_Address;
+use Horde_Mail_Rfc822_Group;
+use Horde_Mail_Rfc822_List;
+use OCA\Mail\Address;
+use OCA\Mail\AddressList;
+
+class AddressListTest extends TestCase {
+
+	public function testSerialize() {
+		$list = new AddressList([
+			new Address('User 1', 'user1@domain.tld'),
+			new Address('User 2', 'user2@domain.tld'),
+		]);
+		$expected = [
+			[
+				'label' => 'User 1',
+				'email' => 'user1@domain.tld',
+			],
+			[
+				'label' => 'User 2',
+				'email' => 'user2@domain.tld',
+			],
+		];
+
+		$json = $list->jsonSerialize();
+
+		$this->assertCount(2, $json);
+		$this->assertEquals($expected, $json);
+	}
+
+	public function testParseSingleAddress() {
+		$source = 'a@b.c';
+		$expected = new AddressList([
+			new Address('a@b.c', 'a@b.c'),
+		]);
+
+		$list = AddressList::parse($source);
+
+		$this->assertEquals($expected, $list);
+	}
+
+	public function testFromHordeList() {
+		$hordeList = new Horde_Mail_Rfc822_List([
+			new Horde_Mail_Rfc822_Address(),
+			new Horde_Mail_Rfc822_Group(),
+		]);
+
+		$list = AddressList::fromHorde($hordeList);
+
+		$this->assertCount(1, $list);
+	}
+
+	public function testToHorde() {
+		$list = new AddressList([
+			new Address('A', 'a@domain.tld'),
+			new Address('B', 'b@domain.tld'),
+		]);
+		$add1 = new Horde_Mail_Rfc822_Address('a@domain.tld');
+		$add1->personal = 'A';
+		$add2 = new Horde_Mail_Rfc822_Address('b@domain.tld');
+		$add2->personal = 'B';
+		$expected = new Horde_Mail_Rfc822_List([
+			$add1,
+			$add2
+		]);
+
+		$hordeList = $list->toHorde();
+
+		$this->assertEquals($expected, $hordeList);
+	}
+
+	public function testFromAndToHorde() {
+		$add1 = new Horde_Mail_Rfc822_Address('a@domain.tld');
+		$add1->personal = 'A';
+		$add2 = new Horde_Mail_Rfc822_Address('b@domain.tld');
+		$add2->personal = 'B';
+		$source = new Horde_Mail_Rfc822_List([
+			$add1,
+			$add2,
+		]);
+		$expected = new Horde_Mail_Rfc822_List([
+			$add1,
+			$add2,
+		]);
+		$list = AddressList::fromHorde($source);
+
+		$hordeList = $list->toHorde();
+
+		$this->assertEquals($expected, $hordeList);
+	}
+
+	public function testMergeIdentical() {
+		$a = new AddressList([
+			new Address('A', 'a@b.c'),
+		]);
+		$b = new AddressList([
+			new Address('A', 'a@b.c'),
+		]);
+
+		$c = $a->merge($b);
+
+		$this->assertCount(1, $c);
+	}
+
+	public function testMergeNonIdentical() {
+		$a = new AddressList([
+			new Address('A', 'a@b.c'),
+		]);
+		$b = new AddressList([
+			new Address('B', 'b@b.c'),
+		]);
+
+		$c = $a->merge($b);
+
+		$this->assertCount(1, $a);
+		$this->assertCount(1, $b);
+		$this->assertCount(2, $c);
+	}
+
+	public function testMergeMixed() {
+		$a = new AddressList([
+			new Address('A', 'a@b.c'),
+			new Address('B', 'b@b.c'),
+		]);
+		$b = new AddressList([
+			new Address('B', 'b@b.c'),
+		]);
+
+		$c = $a->merge($b);
+
+		$this->assertCount(2, $c);
+	}
+
+	public function testMergeEmpty() {
+		$a = new AddressList([
+			new Address('A', 'a@b.c'),
+			new Address('B', 'b@b.c'),
+		]);
+		$b = new AddressList();
+
+		$c = $a->merge($b);
+
+		$this->assertCount(2, $c);
+	}
+
+	public function testMergeToEmpty() {
+		$a = new AddressList([
+		]);
+		$b = new AddressList([
+			new Address('A', 'a@b.c'),
+			new Address('B', 'b@b.c'),
+		]);
+
+		$c = $a->merge($b);
+
+		$this->assertCount(2, $c);
+	}
+
+}

--- a/tests/AddressTest.php
+++ b/tests/AddressTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests;
+
+use Horde_Mail_Rfc822_Address;
+use OCA\Mail\Address;
+
+class AddressTest extends TestCase {
+
+	public function testSerialization() {
+		$address = new Address('Christoph Wurst', 'christoph@domain.tld');
+
+		$expected = [
+			'label' => 'Christoph Wurst',
+			'email' => 'christoph@domain.tld',
+		];
+		$json = $address->jsonSerialize();
+
+		$this->assertEquals($expected, $json);
+	}
+
+	public function testToHorde() {
+		$address = new Address('Christoph Wurst', 'christoph@domain.tld');
+		$expected = new Horde_Mail_Rfc822_Address('christoph@domain.tld');
+		$expected->personal = 'Christoph Wurst';
+
+		$horde = $address->toHorde();
+
+		$this->assertEquals($expected, $horde);
+	}
+
+	public function testEqualsIdentical() {
+		$address = new Address('Christoph Wurst', 'christoph@domain.tld');
+
+		$equals = $address->equals($address);
+
+		$this->assertTrue($equals);
+	}
+
+	public function testEquals() {
+		$address1 = new Address('Christoph Wurst', 'christoph@domain1.tld');
+		$address2 = new Address('Christoph Wurst', 'christoph@domain1.tld');
+
+		$equals = $address1->equals($address2);
+
+		$this->assertTrue($equals);
+	}
+
+	public function testDoesNotEqual() {
+		$address1 = new Address('Christoph Wurst', 'christoph@domain1.tld');
+		$address2 = new Address('Christoph Wurst', 'christoph@domain2.tld');
+
+		$equals = $address1->equals($address2);
+
+		$this->assertFalse($equals);
+	}
+
+	public function testDoesNotEqualBecauseDifferentLabel() {
+		$address1 = new Address('Christoph Wurst', 'christoph@domain.tld');
+		$address2 = new Address('Wurst Christoph', 'christoph@domain.tld');
+
+		$equals = $address1->equals($address2);
+
+		$this->assertFalse($equals);
+	}
+
+}

--- a/tests/Model/ImapMessageTest.php
+++ b/tests/Model/ImapMessageTest.php
@@ -24,6 +24,7 @@ namespace OCA\Mail\Tests\Model;
 use Horde_Imap_Client_Data_Fetch;
 use Horde_Imap_Client_Fetch_Results;
 use Horde_Mime_Part;
+use OCA\Mail\AddressList;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\Html;
 use PHPUnit_Framework_TestCase;
@@ -34,28 +35,7 @@ class ImapMessageTest extends PHPUnit_Framework_TestCase {
 		$data = new Horde_Imap_Client_Data_Fetch();
 		$m = new IMAPMessage(null, 'INBOX', 123, $data);
 
-		$this->assertNull($m->getFrom());
-		$this->assertNull($m->getFromEmail());
-	}
-
-	public function testGetReplyCcList() {
-		$data = new Horde_Imap_Client_Data_Fetch();
-		$data->setEnvelope(array(
-			'to' => 'a@b.org, tom@example.org, b@example.org',
-			'cc' => 'a@b.org, tom@example.org, a@example.org'
-		));
-		$message = new IMAPMessage(null, 'INBOX', 123, $data);
-
-		$cc = $message->getReplyCcList('a@b.org');
-		$this->assertTrue(is_array($cc));
-		$this->assertEquals(3, count($cc));
-		$cc = array_map(function($item) {
-			return $item['email'];
-		}, $cc);
-
-		$this->assertContains('tom@example.org', $cc);
-		$this->assertContains('a@example.org', $cc);
-		$this->assertContains('b@example.org', $cc);
+		$this->assertEquals(new AddressList(), $m->getFrom());
 	}
 
 	public function testIconvHtmlMessage() {

--- a/tests/Model/MessageTest.php
+++ b/tests/Model/MessageTest.php
@@ -18,9 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 namespace OCA\Mail\Tests\Model;
 
 use Horde_Mime_Part;
+use OCA\Mail\Address;
+use OCA\Mail\AddressList;
 use OCA\Mail\Model\Message;
 use PHPUnit_Framework_TestCase;
 
@@ -32,56 +35,6 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 		parent::setUp();
 
 		$this->message = new Message();
-	}
-
-	public function addressListDataProvider() {
-		return [
-			[
-				// simple address
-				'user@example.com',
-				[
-					'user@example.com'
-				]
-			],
-			[
-				// address list with comma as delimiter
-				'user@example.com, anotheruser@example.com',
-				[
-					'user@example.com',
-					'anotheruser@example.com'
-				]
-			],
-			[
-				// empty list
-				'',
-				[]
-			],
-			[
-				// address with name
-				'"user" <user@example.com>',
-				[
-					'user@example.com'
-				]
-			],
-			[
-				// Trailing slash
-				'"user" <user@example.com>,',
-				[
-					'user@example.com'
-				]
-			]
-		];
-	}
-
-	/**
-	 * @dataProvider addressListDataProvider
-	 */
-	public function testParseAddressList($list, $expected) {
-		$result = Message::parseAddressList($list);
-
-		foreach ($expected as $exp) {
-			$this->assertTrue($result->contains($exp));
-		}
 	}
 
 	public function testFlags() {
@@ -96,7 +49,9 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testFrom() {
-		$from = 'user@example.com';
+		$from = new AddressList([
+			new Address('Fritz', 'fritz@domain.tld'),
+		]);
 
 		$this->message->setFrom($from);
 
@@ -108,49 +63,47 @@ class MessageTest extends PHPUnit_Framework_TestCase {
 			'alice@example.com',
 			'Bob <bob@example.com>',
 		];
-		$to = Message::parseAddressList($expected);
+		$to = AddressList::parse($expected);
 
 		$this->message->setTo($to);
 
-		$this->assertEquals($expected, $this->message->getToList());
-		$this->assertEquals($to[0], $this->message->getTo());
+		$this->assertEquals($to, $this->message->getTo());
 	}
 
 	public function testEmptyTo() {
-		$this->assertNull($this->message->getTo());
-		$this->assertEquals([], $this->message->getToList());
+		$this->assertEquals(new AddressList(), $this->message->getTo());
 	}
 
 	public function testCC() {
-		$expected = [
+		$raw = [
 			'alice@example.com',
 			'Bob <bob@example.com>',
 		];
-		$cc = Message::parseAddressList($expected);
+		$cc = AddressList::parse($raw);
 
 		$this->message->setCC($cc);
 
-		$this->assertEquals($expected, $this->message->getCCList());
+		$this->assertEquals($cc, $this->message->getCC());
 	}
 
 	public function testEmptyCC() {
-		$this->assertEquals([], $this->message->getCCList());
+		$this->assertEquals(new AddressList(), $this->message->getCC());
 	}
 
 	public function testBCC() {
-		$expected = [
+		$raw = [
 			'alice@example.com',
 			'Bob <bob@example.com>',
 		];
-		$bcc = Message::parseAddressList($expected);
+		$bcc = AddressList::parse($raw);
 
 		$this->message->setBCC($bcc);
 
-		$this->assertEquals($expected, $this->message->getBCCList());
+		$this->assertEquals($bcc, $this->message->getBCC());
 	}
 
 	public function testEmptyBCC() {
-		$this->assertEquals([], $this->message->getBCCList());
+		$this->assertEquals(new AddressList(), $this->message->getBCC());
 	}
 
 	public function testRepliedMessage() {

--- a/tests/Model/NewMessageDataTest.php
+++ b/tests/Model/NewMessageDataTest.php
@@ -21,8 +21,8 @@
 
 namespace OCA\Mail\Tests\Model;
 
-use Horde_Mail_Rfc822_List;
 use OCA\Mail\Account;
+use OCA\Mail\AddressList;
 use OCA\Mail\Model\NewMessageData;
 use PHPUnit_Framework_TestCase;
 
@@ -39,9 +39,9 @@ class NewMessageDataTest extends PHPUnit_Framework_TestCase {
 		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
 
 		$this->assertEquals($account, $messageData->getAccount());
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getTo());
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getCc());
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getBcc());
+		$this->assertInstanceOf(AddressList::class, $messageData->getTo());
+		$this->assertInstanceOf(AddressList::class, $messageData->getCc());
+		$this->assertInstanceOf(AddressList::class, $messageData->getBcc());
 		$this->assertEquals('Hello', $messageData->getSubject());
 		$this->assertEquals('Hi!', $messageData->getBody());
 		$this->assertEquals([], $messageData->getAttachments());
@@ -58,12 +58,12 @@ class NewMessageDataTest extends PHPUnit_Framework_TestCase {
 		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
 
 		$this->assertEquals($account, $messageData->getAccount());
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getTo());
-		$this->assertEquals(['test@domain.com', 'test2@domain.de'], $messageData->getTo()->bare_addresses);
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getCc());
-		$this->assertEquals(['test2@domain.at'], $messageData->getCc()->bare_addresses);
-		$this->assertInstanceOf(Horde_Mail_Rfc822_List::class, $messageData->getBcc());
-		$this->assertEquals(['test3@domain.net'], $messageData->getBcc()->bare_addresses);
+		$this->assertInstanceOf(AddressList::class, $messageData->getTo());
+		$this->assertEquals(['test@domain.com', 'test2@domain.de'], $messageData->getTo()->toHorde()->bare_addresses);
+		$this->assertInstanceOf(AddressList::class, $messageData->getCc());
+		$this->assertEquals(['test2@domain.at'], $messageData->getCc()->toHorde()->bare_addresses);
+		$this->assertInstanceOf(AddressList::class, $messageData->getBcc());
+		$this->assertEquals(['test3@domain.net'], $messageData->getBcc()->toHorde()->bare_addresses);
 		$this->assertEquals('Hello', $messageData->getSubject());
 		$this->assertEquals('Hi!', $messageData->getBody());
 		$this->assertEquals([], $messageData->getAttachments());

--- a/tests/Service/Autocompletion/AddressCollectorTest.php
+++ b/tests/Service/Autocompletion/AddressCollectorTest.php
@@ -21,9 +21,11 @@
 
 namespace OCA\Mail\Tests\Service\Autocompletion;
 
-use PHPUnit_Framework_TestCase;
+use OCA\Mail\AddressList;
 use OCA\Mail\Db\CollectedAddress;
+use OCA\Mail\Model\Message;
 use OCA\Mail\Service\AutoCompletion\AddressCollector;
+use PHPUnit_Framework_TestCase;
 
 class AddressCollectorTest extends PHPUnit_Framework_TestCase {
 
@@ -50,6 +52,7 @@ class AddressCollectorTest extends PHPUnit_Framework_TestCase {
 			'"User" <user@example.com>',
 			'Example <example@user.com>',
 		];
+		$addressList = AddressList::parse($addresses);
 		$address1 = new CollectedAddress();
 		$address1->setDisplayName('User');
 		$address1->setEmail('user@example.com');
@@ -74,13 +77,14 @@ class AddressCollectorTest extends PHPUnit_Framework_TestCase {
 			->method('insert')
 			->with($address2);
 
-		$this->collector->addAddresses($addresses);
+		$this->collector->addAddresses($addressList);
 	}
 
 	public function testAddDuplicateAddresses() {
 		$addresses = [
 			'user@example.com',
 		];
+		$addressList = AddressList::parse($addresses);
 
 		$this->mapper->expects($this->at(0))
 			->method('exists')
@@ -89,7 +93,7 @@ class AddressCollectorTest extends PHPUnit_Framework_TestCase {
 		$this->mapper->expects($this->never())
 			->method('insert');
 
-		$this->collector->addAddresses($addresses);
+		$this->collector->addAddresses($addressList);
 	}
 
 	public function testSearchAddress() {


### PR DESCRIPTION
* Server-side
  + [x] Create our own `Address` class that serializes to an useful format for the client side
  + [x] Create a `AddressList` to wrap a list of addresses, e.g. for the recipients, cc and bcc
  + [x] Return only (serialized) address lists in responses
  + [x] Write and adjust tests
  + [x] Return `AddressList` in `Message::parseAddressList`
* Client-side
  + [x] Make use of address lists in messages list
  + [x] Make use of address lists in the message view
  + [x] Make use of address lists in the composer view
  + [x] Get rid of any `replyTo`, `replyCC` and similar stuff. The composer view must not have to know whether it's a reply or now. The surrounding view/logic has to handle that
  + [x] Make use of address lists in notifications
  + [x] Make use of address lists in (resumed) drafts
  + [x] Find out what's the correct/standard way of handling to/cc fields for group replies, ref comment `on reply, fill cc with everyone from to and cc except yourself`
  + [x] Test/fix reply handling (composer constructor args might have to be adjusted)
  + [x] mailto handling (to,cc and such are passed as strings rather than objects)