### PR TITLE
Use Files icon for 'Add from Files' button

### DIFF
--- a/js/templates/attachments.html
+++ b/js/templates/attachments.html
@@ -1,8 +1,8 @@
 <ul></ul>
 <button type="button" id="add-local-attachment" style="display: inline-block;">
-  <span class="icon-upload"/> {{ t 'Add attachment' }}
+  <span class="icon-upload"/> {{ t 'Upload attachment' }}
 </button>
 <button type="button" id="add-cloud-attachment" style="display: inline-block;">
-  <span class="icon-folder"/> {{ t 'Add from Files' }}
+  <span class="icon-folder"/> {{ t 'Add attachment from Files' }}
 </button>
 <input type="file" multiple id="local-attachments" style="display: none;">

--- a/js/templates/attachments.html
+++ b/js/templates/attachments.html
@@ -3,6 +3,6 @@
   <span class="icon-upload"/> {{ t 'Add attachment' }}
 </button>
 <button type="button" id="add-cloud-attachment" style="display: inline-block;">
-  <span class="icon-edit"/> {{ t 'Add from Files' }}
+  <span class="icon-folder"/> {{ t 'Add from Files' }}
 </button>
 <input type="file" multiple id="local-attachments" style="display: none;">

--- a/js/tests/views/attachments_spec.js
+++ b/js/tests/views/attachments_spec.js
@@ -38,7 +38,7 @@ define([
   <span class="icon-upload"></span> Add attachment\n\
 </button>\n\
 <button type="button" id="add-cloud-attachment" style="display: inline-block;">\n\
-  <span class="icon-edit"></span> Add from Files\n\
+  <span class="icon-folder"></span> Add from Files\n\
 </button>\n\
 <input type="file" multiple="" id="local-attachments" style="display: none;">\n');
 		});

--- a/js/tests/views/attachments_spec.js
+++ b/js/tests/views/attachments_spec.js
@@ -35,10 +35,10 @@ define([
 			expect(view.el.innerHTML)
 				.toContain('<ul></ul>\n\
 <button type="button" id="add-local-attachment" style="display: inline-block;">\n\
-  <span class="icon-upload"></span> Add attachment\n\
+  <span class="icon-upload"></span> Upload attachment\n\
 </button>\n\
 <button type="button" id="add-cloud-attachment" style="display: inline-block;">\n\
-  <span class="icon-folder"></span> Add from Files\n\
+  <span class="icon-folder"></span> Add attachment from Files\n\
 </button>\n\
 <input type="file" multiple="" id="local-attachments" style="display: none;">\n');
 		});


### PR DESCRIPTION
This was the folder icon before, and should stay the folder/Files icon cause it refers to the Files app. :)
Before:
![screenshot from 2017-09-28 12-50-41](https://user-images.githubusercontent.com/925062/30962878-bf36b7a6-a44b-11e7-9f9a-c737ca7f7ce3.png)
After:
![screenshot from 2017-09-28 12-50-13](https://user-images.githubusercontent.com/925062/30962879-bf36f19e-a44b-11e7-82e1-688616b48e02.png)
Please review @nextcloud/mail 