### PR TITLE
Fix phpunit warnings and apply stricter CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ script:
 
   # Run PHP tests
   - cd tests
-  - ../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml
+  - ../vendor/phpunit/phpunit/phpunit --configuration phpunit.xml --fail-on-warning
   - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then wget https://scrutinizer-ci.com/ocular.phar;
     fi
   - if [[ "$PHP_COVERAGE" = "TRUE" ]]; then php ocular.phar code-coverage:upload --format=php-clover

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -125,7 +125,7 @@ class AccountsController extends Controller {
 		try {
 			$account = $this->accountService->find($this->currentUserId, $accountId);
 
-			return new JSONResponse($account->jsonSerialize());
+			return new JSONResponse($account);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], 404);
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -64,9 +64,7 @@ class PageController extends Controller {
 	 * @param AliasesService $aliasesService
 	 * @param string $UserId
 	 */
-	public function __construct($appName, IRequest $request,
-		IURLGenerator $urlGenerator, IConfig $config, AccountService $accountService,
-		AliasesService $aliasesService, $UserId, IUserSession $userSession) {
+	public function __construct($appName, IRequest $request, IURLGenerator $urlGenerator, IConfig $config, AccountService $accountService, AliasesService $aliasesService, $UserId, IUserSession $userSession) {
 		parent::__construct($appName, $request);
 		$this->urlGenerator = $urlGenerator;
 		$this->config = $config;
@@ -87,9 +85,9 @@ class PageController extends Controller {
 
 		$accountsJson = [];
 		foreach ($mailAccounts as $mailAccount) {
-			$conf = $mailAccount->jsonSerialize();
-			$conf['aliases'] = $this->aliasesService->findAll($conf['accountId'], $this->currentUserId);
-			$accountsJson[] = $conf;
+			$json = $mailAccount->jsonSerialize();
+			$json['aliases'] = $this->aliasesService->findAll($mailAccount->getId(), $this->currentUserId);
+			$accountsJson[] = $json;
 		}
 
 		$user = $this->userSession->getUser();
@@ -101,12 +99,9 @@ class PageController extends Controller {
 			'prefill_email' => $this->config->getUserValue($user->getUID(), 'settings', 'email', ''),
 		]);
 
-		// set csp rules for ownCloud 8.1
-		if (class_exists('OCP\AppFramework\Http\ContentSecurityPolicy')) {
-			$csp = new ContentSecurityPolicy();
-			$csp->addAllowedFrameDomain('\'self\'');
-			$response->setContentSecurityPolicy($csp);
-		}
+		$csp = new ContentSecurityPolicy();
+		$csp->addAllowedFrameDomain('\'self\'');
+		$response->setContentSecurityPolicy($csp);
 
 		return $response;
 	}

--- a/tests/Controller/AccountsControllerTest.php
+++ b/tests/Controller/AccountsControllerTest.php
@@ -111,7 +111,7 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 
 	public function testIndex() {
 		$this->account->expects($this->once())
-			->method('getConfiguration')
+			->method('jsonSerialize')
 			->will($this->returnValue([
 					'accountId' => 123,
 		]));
@@ -140,13 +140,10 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 			->method('find')
 			->with($this->equalTo($this->userId), $this->equalTo($this->accountId))
 			->will($this->returnValue($this->account));
-		$this->account->expects($this->once())
-			->method('getConfiguration')
-			->will($this->returnValue('conf'));
 
 		$response = $this->controller->show($this->accountId);
 
-		$expectedResponse = new JSONResponse('conf');
+		$expectedResponse = new JSONResponse($this->account);
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -154,9 +151,6 @@ class AccountsControllerTest extends PHPUnit_Framework_TestCase {
 		$this->accountService->expects($this->once())
 			->method('find')
 			->with($this->equalTo($this->userId), $this->equalTo($this->accountId))
-			->will($this->returnValue($this->account));
-		$this->account->expects($this->once())
-			->method('getConfiguration')
 			->will($this->throwException(new DoesNotExistException('test123')));
 
 		$response = $this->controller->show($this->accountId);


### PR DESCRIPTION
Since a few weeks I'm constantly seeing four warnings whenever
I attempt to run phpunit locally. As they didn't make out CI jobs
fail, nobody seemed to care. As that's a risky situation, I've
fixed all the reported warnings and - to ensure this doesn't happen
again - I've enabled failure on warnings.