### PR TITLE
Fix loading status for Save attachments button

### DIFF
--- a/js/controller/messagecontroller.js
+++ b/js/controller/messagecontroller.js
@@ -127,8 +127,9 @@ define(function(require) {
 			OC.dialogs.filepicker(
 				t('mail', 'Choose a folder to store the attachment in'),
 				function(path) {
-					if (typeof callback == 'function')
+					if (typeof callback === 'function') {
 						callback();
+					}
 					Radio.message.request('save:cloud', account,
 						folder, messageId, attachmentId, path).then(function() {
 						if (saveAll) {

--- a/js/controller/messagecontroller.js
+++ b/js/controller/messagecontroller.js
@@ -118,6 +118,7 @@ define(function(require) {
 	 * @param {Folder} folder
 	 * @param {number} messageId
 	 * @param {number} attachmentId
+	 * @param {function} callback
 	 * @returns {Promise}
 	 */
 	function saveAttachmentToFiles(account, folder, messageId, attachmentId, callback) {
@@ -205,6 +206,7 @@ define(function(require) {
 	 * @param {Account} account
 	 * @param {Folder} folder
 	 * @param {number} messageId
+	 * @param {function} callback
 	 * @returns {Promise}
 	 */
 	function saveAttachmentsToFiles(account, folder, messageId, callback) {

--- a/js/controller/messagecontroller.js
+++ b/js/controller/messagecontroller.js
@@ -120,13 +120,14 @@ define(function(require) {
 	 * @param {number} attachmentId
 	 * @returns {Promise}
 	 */
-	function saveAttachmentToFiles(account, folder, messageId, attachmentId) {
+	function saveAttachmentToFiles(account, folder, messageId, attachmentId, callback) {
 		var saveAll = _.isUndefined(attachmentId);
 
 		return new Promise(function(resolve, reject) {
 			OC.dialogs.filepicker(
 				t('mail', 'Choose a folder to store the attachment in'),
 				function(path) {
+					callback();
 					Radio.message.request('save:cloud', account,
 						folder, messageId, attachmentId, path).then(function() {
 						if (saveAll) {
@@ -204,8 +205,8 @@ define(function(require) {
 	 * @param {number} messageId
 	 * @returns {Promise}
 	 */
-	function saveAttachmentsToFiles(account, folder, messageId) {
-		return saveAttachmentToFiles(account, folder, messageId);
+	function saveAttachmentsToFiles(account, folder, messageId, callback) {
+		return saveAttachmentToFiles(account, folder, messageId, null, callback);
 	}
 
 	return {

--- a/js/controller/messagecontroller.js
+++ b/js/controller/messagecontroller.js
@@ -127,7 +127,8 @@ define(function(require) {
 			OC.dialogs.filepicker(
 				t('mail', 'Choose a folder to store the attachment in'),
 				function(path) {
-					callback();
+					if (typeof callback == 'function')
+						callback();
 					Radio.message.request('save:cloud', account,
 						folder, messageId, attachmentId, path).then(function() {
 						if (saveAll) {

--- a/js/views/messageattachment.js
+++ b/js/views/messageattachment.js
@@ -68,14 +68,14 @@ define(function(require) {
 			var folder = require('state').currentFolder;
 			var messageId = this.model.get('messageId');
 			var attachmentId = this.model.get('id');
-			// Loading feedback
-			this.getUI('saveToCloudButton').removeClass('icon-folder')
-				.addClass('icon-loading-small')
-				.prop('disabled', true);
 
 			var _this = this;
-			MessageController.saveAttachmentToFiles(account, folder, messageId, attachmentId)
-				.catch(console.error.bind(this)).then(function() {
+			MessageController.saveAttachmentToFiles(account, folder, messageId, attachmentId, function() {
+				// Loading feedback
+				_this.getUI('saveToCloudButton').removeClass('icon-folder')
+				.addClass('icon-loading-small')
+				.prop('disabled', true);
+			}).catch(console.error.bind(this)).then(function() {
 				// Remove loading feedback again
 				_this.getUI('saveToCloudButton').addClass('icon-folder')
 					.removeClass('icon-loading-small')

--- a/js/views/messageattachments.js
+++ b/js/views/messageattachments.js
@@ -57,14 +57,14 @@ define(function(require) {
 			var account = require('state').currentAccount;
 			var folder = require('state').currentFolder;
 			var messageId = this.message.get('id');
-			// Loading feedback
-			this.getUI('saveAllToCloud').removeClass('icon-folder')
-				.addClass('icon-loading-small')
-				.prop('disabled', true);
 
 			var _this = this;
-			MessageController.saveAttachmentsToFiles(account, folder, messageId)
-				.catch(console.error.bind(this)).then(function() {
+			MessageController.saveAttachmentsToFiles(account, folder, messageId, function() {
+				// Loading feedback
+				_this.getUI('saveAllToCloud').removeClass('icon-folder')
+				.addClass('icon-loading-small')
+				.prop('disabled', true);
+			}).catch(console.error.bind(this)).then(function() {
 				// Remove loading feedback again
 				_this.getUI('saveAllToCloud').addClass('icon-folder')
 					.removeClass('icon-loading-small')


### PR DESCRIPTION
Fix loading status for Save attachments button when closing file chooser without choosing. This fix is for both saving all attachments as well as saving a single attachment