### PR TITLE
Add missing /api prefix to API route

### DIFF
--- a/js/service/attachmentservice.js
+++ b/js/service/attachmentservice.js
@@ -44,7 +44,7 @@ define(function(require) {
 	 */
 	function saveToFiles(account, folder, messageId, attachmentId, path) {
 		var url = OC.generateUrl(
-			'apps/mail/accounts/{accountId}/' +
+			'apps/mail/api/accounts/{accountId}/' +
 			'folders/{folderId}/messages/{messageId}/' +
 			'attachment/{attachmentId}', {
 				accountId: account.get('accountId'),


### PR DESCRIPTION
This pull request adds a missing API prefix in the saveToFiles attachmentservice function. 
#588 