### PR TITLE
Fix js tests execution

### DIFF
--- a/js/tests/test-main.js
+++ b/js/tests/test-main.js
@@ -28,6 +28,9 @@ OC = {
 
 		}
 	},
+	filePath: function(app, type, path) {
+		return type + '/' + path;
+	},
 	generateUrl: function(url, params) {
 		var props = [];
 		for (var prop in params) {

--- a/js/tests/views/composerview_spec.js
+++ b/js/tests/views/composerview_spec.js
@@ -77,6 +77,7 @@ define([
 				folder: folder,
 				type: 'reply'
 			});
+			spyOn(view, 'saveDraft');
 
 			expect(view.type).toBe('reply');
 			expect(view.isReply()).toBe(true);
@@ -88,6 +89,7 @@ define([
 			var view = new ComposerView({
 				accounts: accounts
 			});
+			spyOn(view, 'saveDraft');
 
 			expect(view.draftUID).toBeUndefined();
 		});
@@ -96,6 +98,7 @@ define([
 			var view = new ComposerView({
 				accounts: accounts
 			});
+			spyOn(view, 'saveDraft');
 
 			var expected = [
 				{
@@ -120,6 +123,7 @@ define([
 			var view = new ComposerView({
 				accounts: accounts
 			});
+			spyOn(view, 'saveDraft');
 
 			view.render();
 
@@ -152,6 +156,7 @@ define([
 				view = new ComposerView({
 					accounts: accounts
 				});
+				spyOn(view, 'saveDraft');
 
 				view.render();
 				view.bindUIElements();
@@ -249,7 +254,7 @@ define([
 					view.attachments.add(localAttachmentA);
 					expect(view.checkAllAttachmentsValid()).toBe(false);
 				});
-			}),
+			});
 
 			describe('from Files', function () {
 				it('always consider attachments from Files as valid', function() {
@@ -263,7 +268,7 @@ define([
 					view.attachments.add(localAttachmentA);
 					expect(view.checkAllAttachmentsValid()).toBe(true);
 				});
-			})
+			});
 
 		});
 	});

--- a/js/webpack.base.config.js
+++ b/js/webpack.base.config.js
@@ -6,6 +6,12 @@ module.exports = {
 		filename: 'build.js',
 		path: path.resolve(__dirname, 'build')
 	},
+	resolve: {
+		modules: [path.resolve(__dirname), 'node_modules'],
+		alias: {
+			'handlebars': 'handlebars/runtime.js'
+		}
+	},
 	module: {
 		rules: [
 			{test: /davclient/, use: 'exports-loader?dav'},
@@ -19,11 +25,5 @@ module.exports = {
 		loaders: [
 			{test: /ical/, loader: 'exports-loader?ICAL'}
 		]
-	},
-	resolve: {
-		modules: [path.resolve(__dirname), 'node_modules'],
-		alias: {
-			'handlebars': 'handlebars/runtime.js'
-		}
 	}
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,9 +19,6 @@ module.exports = function (config) {
 			{pattern: 'node_modules/jquery/dist/jquery.js', included: true},
 			{pattern: 'node_modules/underscore/underscore.js', included: true},
 			{pattern: 'js/tests/test-main.js', included: true},
-			//{pattern: 'js/**/*.js', included: false},
-			//{pattern: 'js/*.js', included: false},
-			//{pattern: 'js/templates/*.html', included: false},
 			// all files ending in "_test"
 			{pattern: 'js/tests/*_spec.js', watched: false},
 			{pattern: 'js/tests/**/*_spec.js', watched: false},
@@ -36,12 +33,10 @@ module.exports = function (config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			//'js/build/build.js': ['webpack'],
 			'js/**[!vendor]/*[!spec].js': ['coverage'],
 			// add webpack as preprocessor
 			'js/tests/*_spec.js': ['webpack'],
 			'js/tests/**/*_spec.js': ['webpack']
-			//'js/build/build.js': ['webpack', 'sourcemap']
 		},
 
 		webpackMiddleware: {


### PR DESCRIPTION
Due to the new split webpack config, the app was started (again) which
has been fixed in a previous PR but due to re-ordering of webpack
config properties, this seems to have come back. Not js unit tests can
be executed successfully again.

Tests ran fine locally. Let's see how they perform on Travis.