### PR TITLE
Fix js tests by excluding build artefacts

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function (config) {
 			// all files ending in "_test"
 			{pattern: 'js/tests/*_spec.js', watched: false},
 			{pattern: 'js/tests/**/*_spec.js', watched: false},
-			{pattern: 'js/build/build.js', included: true}
+			{pattern: 'js/build/build.js', included: false}
 		],
 
 		// list of files to exclude


### PR DESCRIPTION
Yet again, js tests wouldn't run on my local instance whereas on Travis the always pass 😠 

Turns out we include the `build.js` artefact and thus the app starts up and causes all kinds of weird errors 🙈 