### PR TITLE
Fix 'make optimize-js'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ install-npm-deps:
 install-npm-deps-dev:
 	npm install --deps
 
-optimize-js: install-npm-deps
+optimize-js: install-npm-deps-dev
 	./node_modules/webpack/bin/webpack.js --config js/webpack.prod.config.js
 
 dev-setup: install-composer-deps-dev install-npm-deps-dev


### PR DESCRIPTION
To *optimize* js files we need webpack, which is a npm dev dependency and
thus we have to first install those.

Fixes https://github.com/nextcloud/mail/pull/469#issuecomment-344356047