### PR TITLE
Fix subfolder click event propagation

### DIFF
--- a/js/views/folderview.js
+++ b/js/views/folderview.js
@@ -92,6 +92,10 @@ define(function(require) {
 		},
 
 		loadFolder: function(e) {
+			if (e.isDefaultPrevented()) {
+				// Event has been handled already, e.g. by a subfolder
+				return;
+			}
 			e.preventDefault();
 			// TODO: account should be property of folder
 			var account = require('state').accounts.get(this.model.get('accountId'));


### PR DESCRIPTION
This prevents unintended loading of the parent folder if a subfolder
is clicked because the event is now only handled one.

Note that for some reasons not all accounts are effected. Somehow my Gmail account's subfolder can be opened even without this fix.

Fixes https://github.com/nextcloud/mail/issues/613