### PR TITLE
Fix autoconfig null check

### DIFF
--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -120,7 +120,7 @@ class IspDbConfigurationDetector {
 
 		foreach ($ispdb['imap'] as $imap) {
 			$account = $this->testImapConfiguration($imap, $email, $password, $name);
-			if (!no_null($account)) {
+			if (!is_null($account)) {
 				return $account;
 			}
 		}


### PR DESCRIPTION
`no_null` should be `is_null`

Fixes https://github.com/nextcloud/mail/issues/589

Testd with Gmail and now I can create a autoconfigured account again.

cc @Skymirrh