### PR TITLE
Fix NPM deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2935,9 +2935,9 @@
       }
     },
     "js-storage": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/js-storage/-/js-storage-1.0.3.tgz",
-      "integrity": "sha1-Dv110/dTUtceACpT5y5Xo+9ZuU0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-storage/-/js-storage-1.0.1.tgz",
+      "integrity": "sha1-O1t/z0xIDwiVsXKYlL/Ohi+PjN8="
     },
     "js-yaml": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2917,27 +2917,27 @@
       "dev": true
     },
     "jquery": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.3.tgz",
-      "integrity": "sha1-ReB+QZAzTeNsnhpktDsfE3PZF1g="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
     },
     "jquery-ui": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.10.4.tgz",
-      "integrity": "sha1-oJb+X04PKraaBYXPEEVYd/V1Br0="
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
     },
     "jquery-visibility": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/jquery-visibility/-/jquery-visibility-1.0.11.tgz",
       "integrity": "sha1-gOc8yFL5JWLi/XXEjBfJ+FREr5U=",
       "requires": {
-        "jquery": "2.2.3"
+        "jquery": "2.2.4"
       }
     },
     "js-storage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js-storage/-/js-storage-1.0.1.tgz",
-      "integrity": "sha1-O1t/z0xIDwiVsXKYlL/Ohi+PjN8="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/js-storage/-/js-storage-1.0.3.tgz",
+      "integrity": "sha1-Dv110/dTUtceACpT5y5Xo+9ZuU0="
     },
     "js-yaml": {
       "version": "3.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2922,9 +2922,9 @@
       "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
     },
     "jquery-ui": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
-      "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE="
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.10.4.tgz",
+      "integrity": "sha1-oJb+X04PKraaBYXPEEVYd/V1Br0="
     },
     "jquery-visibility": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "handlebars-loader": "^1.6.0",
     "ical.js": "^1.2.2",
     "jquery": "^2.2.4",
-    "jquery-ui": "^1.12.1",
+    "jquery-ui": "^1.10.4",
     "jquery-visibility": "^1.0.11",
     "js-storage": "1.0.1",
     "requirejs": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
     "handlebars": "^4.0.11",
     "handlebars-loader": "^1.6.0",
     "ical.js": "^1.2.2",
-    "jquery": "^2.2.3",
-    "jquery-ui": "^1.10.4",
+    "jquery": "^2.2.4",
+    "jquery-ui": "^1.12.1",
     "jquery-visibility": "^1.0.11",
-    "js-storage": "^1.0.1",
+    "js-storage": "^1.0.3",
     "requirejs": "^2.3.5",
     "underscore": "^1.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "jquery": "^2.2.4",
     "jquery-ui": "^1.12.1",
     "jquery-visibility": "^1.0.11",
-    "js-storage": "^1.0.3",
+    "js-storage": "1.0.1",
     "requirejs": "^2.3.5",
     "underscore": "^1.8.3"
   }


### PR DESCRIPTION
For some yet unknown error one of the Travis CI jobs fails for the three most recent PRs

```
ERROR in ./node_modules/js-storage/js.storage.js
Module parse failed: Unexpected token (421:59)
You may need an appropriate loader to handle this file type.
|     // Check if storages are natively available on browser and check is js-cookie is present
|     var storage_available = _testStorage('localStorage');
|     var cookies_available = typeof Cookies !== 'undefined';*
| 
|     // Namespace object
 @ ./js/cache.js 16:15-36
 @ ./js/app.js
 @ ./js/init.js
make: *** [optimize-js] Error 2
```

Apparently js-storage has a newer version available, let's see if it magically solves the issues here.