### PR TITLE
Test on php7.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 addons:
   apt:


### PR DESCRIPTION
Once [php7.2 is available for Travis](https://docs.travis-ci.com/user/languages/php/), we should test against it as well.