### PR TITLE
Fix Travis build matrix for stable13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ services:
 
 env:
   global:
-  - CORE_BRANCH=master
+  - CORE_BRANCH=stable13
   - TEST_JS=FALSE
   - PHP_COVERAGE=FALSE
   - PACKAGE=FALSE


### PR DESCRIPTION
Nextcloud 13 was branched off, hence master is nc14 now and thus Travis fails to install the app.

As long as https://github.com/nextcloud/mail/issues/697 is unresolved, I'd like to stay on nc12-nc13, publish a fix and then make the switch to nc13-nc14.