### PR TITLE
Install composer deps with -o flag to fix an autoloading error

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,6 +1,6 @@
 [package]
 before_cmds = [
-	"composer install --no-dev",
+	"composer install --no-dev -o",
 	"npm install --deps",
 	"npm run build",
 ]


### PR DESCRIPTION
For an yet unknown reason, composer suddenly fails to load the
UrlLinker class if dependencies haven't been installed with the
optimize flag.

Ref #697

Package for testing:
[mail.tar.gz](https://github.com/nextcloud/mail/files/1631671/mail.tar.gz)
