### PR TITLE
Handle folders without delimiter gracefully

### DIFF
--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -111,7 +111,9 @@ class FolderMapper {
 	 */
 	private function getParentId(Folder $folder) {
 		$delimiter = $folder->getDelimiter();
-		if ($delimiter == '') {
+		if ($delimiter === '') {
+			// If no delimiter is detected, it's probably because
+			// this is a top level folder
 			return null;
 		}
 		$hierarchy = explode($delimiter, $folder->getMailbox());
@@ -208,7 +210,7 @@ class FolderMapper {
 		];
 
 		$delimiter = $folder->getDelimiter();
-		if ($delimiter == '') {
+		if ($delimiter === '') {
 			$lowercaseId = strtolower($folder->getMailbox());
 		} else {
 			$lowercaseExplode = explode($delimiter, $folder->getMailbox(), 2);

--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -110,10 +110,11 @@ class FolderMapper {
 	 * @return string
 	 */
 	private function getParentId(Folder $folder) {
-		if ($folder->getDelimiter() == '') {
+		$delimiter = $folder->getDelimiter();
+		if ($delimiter == '') {
 			return null;
 		}
-		$hierarchy = explode($folder->getDelimiter(), $folder->getMailbox());
+		$hierarchy = explode($delimiter, $folder->getMailbox());
 		if (count($hierarchy) <= 1) {
 			// Top level folder
 			return null;
@@ -206,10 +207,11 @@ class FolderMapper {
 			'junk' => ['junk', 'spam', 'bulk mail'],
 		];
 
-		if ($folder->getDelimiter() == '') {
+		$delimiter = $folder->getDelimiter();
+		if ($delimiter == '') {
 			$lowercaseId = strtolower($folder->getMailbox());
 		} else {
-			$lowercaseExplode = explode($folder->getDelimiter(), $folder->getMailbox(), 2);
+			$lowercaseExplode = explode($delimiter, $folder->getMailbox(), 2);
 			$lowercaseId = strtolower(array_pop($lowercaseExplode));
 		}
 		foreach ($specialFoldersDict as $specialRole => $specialNames) {

--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -110,6 +110,9 @@ class FolderMapper {
 	 * @return string
 	 */
 	private function getParentId(Folder $folder) {
+		if ($folder->getDelimiter() == '') {
+			return null;
+		}
 		$hierarchy = explode($folder->getDelimiter(), $folder->getMailbox());
 		if (count($hierarchy) <= 1) {
 			// Top level folder
@@ -203,8 +206,12 @@ class FolderMapper {
 			'junk' => ['junk', 'spam', 'bulk mail'],
 		];
 
-		$lowercaseExplode = explode($folder->getDelimiter(), $folder->getMailbox(), 2);
-		$lowercaseId = strtolower(array_pop($lowercaseExplode));
+		if ($folder->getDelimiter() == '') {
+			$lowercaseId = strtolower($folder->getMailbox());
+		} else {
+			$lowercaseExplode = explode($folder->getDelimiter(), $folder->getMailbox(), 2);
+			$lowercaseId = strtolower(array_pop($lowercaseExplode));
+		}
 		foreach ($specialFoldersDict as $specialRole => $specialNames) {
 			if (in_array($lowercaseId, $specialNames)) {
 				$folder->addSpecialUse($specialRole);

--- a/tests/Service/FolderMapperTest.php
+++ b/tests/Service/FolderMapperTest.php
@@ -245,7 +245,7 @@ class FolderMapperTest extends TestCase {
 			->method('addSpecialUse')
 			->with($this->equalTo('sent'));
 
-		$this->mapper->detectFolderSpecialUse($folders);
+		$this->mapper->detectFolderSpecialUse($folder);
 	}
 
 	public function testSortFolders() {

--- a/tests/Service/FolderMapperTest.php
+++ b/tests/Service/FolderMapperTest.php
@@ -227,6 +227,27 @@ class FolderMapperTest extends TestCase {
 		$this->mapper->detectFolderSpecialUse($folders);
 	}
 
+	public function testGuessSpecialUseWithNoDelimiter() {
+		$folder = $this->createMock(Folder::class);
+		$folder->expects($this->once())
+			->method('getAttributes')
+			->willReturn([]);
+		$folder->expects($this->once())
+			->method('getSpecialUse')
+			->willReturn([]);
+		$folder->expects($this->once())
+			->method('getDelimiter')
+			->willReturn('');
+		$folder->expects($this->once())
+			->method('getMailbox')
+			->willReturn('Sent');
+		$folder->expects($this->once())
+			->method('addSpecialUse')
+			->with($this->equalTo('sent'));
+
+		$this->mapper->detectFolderSpecialUse($folders);
+	}
+
 	public function testSortFolders() {
 		$account = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Horde_Imap_Client_Mailbox::class);

--- a/tests/Service/FolderMapperTest.php
+++ b/tests/Service/FolderMapperTest.php
@@ -245,7 +245,7 @@ class FolderMapperTest extends TestCase {
 			->method('addSpecialUse')
 			->with($this->equalTo('sent'));
 
-		$this->mapper->detectFolderSpecialUse($folder);
+		$this->mapper->guessSpecialUse($folder);
 	}
 
 	public function testSortFolders() {


### PR DESCRIPTION
For some IMAP servers, Horde fails to detect a delimiter. In my case INBOX returned an empty string when calling getDelimiters(). This resulted in warnings in FolderMapper::guessSpecialUse and FolderMapper::getParentId. The following commit fixes the warnings, and enables us to
properly detect that INBOX is actually an inbox.

To be clear, I don't fully understand the implications of this change, other than that it seems to fix my problems, so please inform me if this is stupid :)