### PR TITLE
Clean up reply-all/forward handling and add reply-to-sender

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -367,6 +367,11 @@
 .composer-fields {
 	position: relative;
 }
+.composer-bottom {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+}
 input.to,
 input.cc,
 input.bcc,
@@ -442,17 +447,6 @@ label.bcc-label {
 textarea.reply {
 	min-height: 100px;
 }
-input.submit-message,
-.submit-message-wrapper {
-	position: fixed;
-	bottom: 10px;
-	right: 15px;
-}
-.submit-message-wrapper {
-	position: fixed;
-	height: 36px;
-	width: 60px;
-}
 
 .submit-message-wrapper-inside {
 	position: absolute;
@@ -466,12 +460,6 @@ input.submit-message,
 	float: left;
 }
 
-/* extra button styles */
-.submit-message.send,
-#mail_new_attachment,
-#forward-button {
-	padding: 12px;
-}
 .new-message-attachments,
 #forward-button {
 	margin-left: 30px;
@@ -557,23 +545,36 @@ input.submit-message,
 }
 
 #mail-message-header {
-	position: fixed;
-	height: 90px;
-	width: 50%;
-	z-index: 100;
-	background: -webkit-linear-gradient(rgba(255,255,255,.97), rgba(255,255,255,.9) 80%, rgba(255,255,255,0));
-	background: -o-linear-gradient(rgba(255,255,255,.97), rgba(255,255,255,.9) 80%, rgba(255,255,255,0));
-	background: -moz-linear-gradient(rgba(255,255,255,.97), rgba(255,255,255,.9) 80%, rgba(255,255,255,0));
-	background: linear-gradient(rgba(255,255,255,.97), rgba(255,255,255,.9) 80%, rgba(255,255,255,0));
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border-bottom: 1px solid #eee;
+}
+#mail-message-header > div:first-child {
+	flex-grow: 1;
+	margin-right: 20px;
+}
+#mail-message-header > div:first-child > h2 {
+	word-wrap: break-word;
+}
+#mail-message-header > div:last-child {
+	flex-shrink: 0;
 }
 
-#mail-message-header h2,
-#mail-message-header p {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	padding-bottom: 7px;
-	margin-bottom: 0;
+.button-group > button {
+	border-radius: 0px;
+	margin-right: -1px;
+	z-index: 0;
+}
+.button-group > button:hover {
+	z-index: 1;
+}
+.button-group > button:first-child {
+	border-radius: 3px 0px 0px 3px;
+}
+
+.button-group > button:last-child {
+	border-radius: 0px 3px 3px 0px;
 }
 
 #mail-message-close {
@@ -582,7 +583,7 @@ input.submit-message,
 
 #mail-content,
 .mail-message-attachments {
-	margin: 100px 10px 50px 30px;
+	margin: 10px 10px 50px 30px;
 }
 .mail-message-attachments {
 	margin-top: 10px;
@@ -630,11 +631,8 @@ input.submit-message,
 	overflow-x: hidden;
 }
 .mail-message-container {
-	position: absolute;
-	top: 0px;
-	right: 0px;
-	bottom: 0px;
-	left: 0px;
+	display: flex;
+	flex-direction: column;
 }
 
 .new-message-attachments li {

--- a/js/templates/composer.html
+++ b/js/templates/composer.html
@@ -41,10 +41,10 @@
 			  class="message-body"
 			  placeholder="{{ t 'Message …' }}">{{message}}</textarea>
 	</div>
-	<div class="submit-message-wrapper">
-		<input class="submit-message send primary" type="submit" value="{{submitButtonTitle}}" disabled>
-		<div class="submit-message-wrapper-inside" ></div>
-	</div>
-	<div class="new-message-attachments">
+	<div class="composer-bottom">
+		<div class="new-message-attachments"></div>
+		<div>
+			<input class="submit-message send primary" type="submit" value="{{submitButtonTitle}}" disabled>
+		<div>
 	</div>
 </div>

--- a/js/templates/message.html
+++ b/js/templates/message.html
@@ -1,14 +1,21 @@
 <div id="mail-message-close" class="icon-close"></div>
 <div id="mail-message-header" class="section">
-	<h2 title="{{subject}}">{{subject}}</h2>
-	<p class="transparency">
-		{{printAddressList from}}
-		{{ t 'to' }}
-		{{printAddressList to}}
-		{{#if cc.length}}
-		({{ t 'cc' }} {{printAddressList cc}})
-		{{/if}}
-	</p>
+	<div>
+		<h2 title="{{subject}}">{{subject}}</h2>
+		<p class="transparency">
+			{{printAddressList from}}
+			{{ t 'to' }}
+			{{printAddressList to}}
+			{{#if cc.length}}
+			({{ t 'cc' }} {{printAddressList cc}})
+			{{/if}}
+		</p>
+	</div>
+	<div class="button-group">
+		<button>Reply</button><!--
+		--><button>Reply to all</button><!--
+		--><button>Forward</button>
+	</div>
 </div>
 <div class="mail-message-body">
 	<div id="mail-content">
@@ -33,5 +40,4 @@
 
 	<div class="mail-message-attachments"></div>
 	<div id="reply-composer"></div>
-	<input type="button" id="forward-button" value="{{ t 'Forward' }}">
 </div>


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/598

TODO:
- [x] Clean up UI
   * Add reply/reply-all/forward button group to the message header
   * Fix long message subjects (fully show them)
   * Do not scroll message body under the header as that looks super confusing, esp. on mobile phones - element boundaries were not clear
   * Move floating and confusing composer send button to a fixed position
- [ ] Add simple reply
- [ ] Fix reply-all
- [ ] Fix forward message
- [ ] Test on mobile
- [ ] Fix l10n
- [ ] Squash commits

--

Current state
![](https://user-images.githubusercontent.com/1374172/35670039-6d7171d2-0737-11e8-854b-c4a03edf089d.png)
