### PR TITLE
Fix sync requests for fav folder

### DIFF
--- a/lib/Controller/FoldersController.php
+++ b/lib/Controller/FoldersController.php
@@ -23,13 +23,11 @@
 
 namespace OCA\Mail\Controller;
 
-use Horde_Imap_Client_Exception;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\IMAP\Sync\Request as SyncRequest;
 use OCA\Mail\IMAP\Sync\Response as SyncResponse;
 use OCA\Mail\Service\AccountService;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;

--- a/lib/Service/FolderMapper.php
+++ b/lib/Service/FolderMapper.php
@@ -68,7 +68,7 @@ class FolderMapper {
 			$folders[] = $folder;
 			if ($mailbox['mailbox']->utf8 === 'INBOX') {
 				$searchFolder = new SearchFolder($account, $mailbox['mailbox'], $mailbox['attributes'], $mailbox['delimiter']);
-				if ($searchFolder->isSearchable()) {
+				if ($folder->isSearchable()) {
 					$searchFolder->setSyncToken($client->getSyncToken($folder->getMailbox()));
 				}
 				$folders[] = $searchFolder;


### PR DESCRIPTION
If you attempt to sync the fav folder, you'll get an error. This happened because there was an empty sync token for that special folder. This was caused due to a false check on the searchability of the fav folder, where we should actually check the inbox.

Note that this is only half of the story. The sync kind of works. But actually it doesnt. Well, the truth lies somewhere between: New message are correctly synced. But when they arrive, they are usually not flagged. Thus, they get ignored on the first sync request and later on we don't really retrieve any messages that have not been in the active collection before.
I think this also causes some edge case issues for other folders like inboxes. I will think about a solution. Maybe we have to send a list of UIDs to the server on sync and then optionally check for missing messages.