### PR TITLE
Add avatar URL memoization to prevent duplicate requests

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -39,6 +39,7 @@ define(function(require) {
 	require('controller/foldercontroller');
 	require('controller/messagecontroller');
 	require('service/accountservice');
+	require('service/avatarservice');
 	require('service/aliasesservice');
 	require('service/attachmentservice');
 	require('service/backgroundsyncservice');

--- a/js/radio.js
+++ b/js/radio.js
@@ -18,6 +18,7 @@ define(function(require) {
 		'account',
 		'aliases',
 		'attachment',
+		'avatar',
 		'folder',
 		'dav',
 		'keyboard',

--- a/js/service/avatarservice.js
+++ b/js/service/avatarservice.js
@@ -1,0 +1,66 @@
+/* global Promise */
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+define(function(require) {
+	'use strict';
+
+	var _ = require('underscore');
+	var $ = require('jquery');
+	var OC = require('OC');
+	var Radio = require('radio');
+
+	Radio.avatar.reply('avatar', _.memoize(loadAvatar));
+
+	/**
+	 * @param {string} email
+	 * @returns {Promise}
+	 */
+	function loadAvatar(email) {
+		var url = OC.generateUrl('/apps/mail/api/avatars/url/{email}', {
+			email: email
+		});
+
+		return Promise.resolve($.ajax(url))
+				.then(function(avatar) {
+					if (avatar.isExternal) {
+						return OC.generateUrl('/apps/mail/api/avatars/image/{email}', {
+							email: email
+						});
+					} else {
+						return avatar.url;
+					}
+				}.bind(this))
+				.catch(function(e) {
+					if (e.status && e.status === 404) {
+						return Promise.resolve(undefined);
+					}
+					return Promise.reject(e);
+				});
+	}
+
+	return {
+		loadAvatar: loadAvatar
+	};
+
+});

--- a/js/tests/service/avatarservice_spec.js
+++ b/js/tests/service/avatarservice_spec.js
@@ -1,0 +1,78 @@
+/* global sinon, expect */
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+define([
+	'service/avatarservice'
+], function(AvatarService) {
+	'use strict';
+
+	describe('AvatarService', function() {
+		var server;
+
+		beforeEach(function() {
+			server = sinon.fakeServer.create();
+		});
+
+		afterEach(function() {
+			server.restore();
+		});
+
+		it('does not load the image if no avatar is available', function(done) {
+			var loading = AvatarService.loadAvatar('user@domain.com');
+
+			expect(server.requests.length).toBe(1);
+			server.requests[0].respond(
+					404,
+					{
+						'Content-Type': 'application/json'
+					});
+
+			loading.then(function(url) {
+				expect(url).toBe(undefined);
+				done();
+			}).catch(done.fail);
+		});
+
+		it('does load the image if an avatar is available', function(done) {
+			var loading = AvatarService.loadAvatar('user@domain.com');
+
+			expect(server.requests.length).toBe(1);
+			server.requests[0].respond(
+					200,
+					{
+						'Content-Type': 'application/json'
+					},
+					JSON.stringify({
+						isExternal: true,
+						mime: 'image/jpeg',
+						url: 'https://domain.com/favicon.ico'
+					}));
+
+			loading.then(function(url) {
+				expect(url).not.toBe(undefined);
+				done();
+			}).catch(done.fail);
+		});
+	});
+});

--- a/js/tests/views/foldercontent_spec.js
+++ b/js/tests/views/foldercontent_spec.js
@@ -1,3 +1,5 @@
+/* global spyOn, expect */
+
 /**
  * @author Luc Calaresu <dev@calaresu.com>
  *
@@ -49,6 +51,10 @@ define(['jquery',
 			account: account,
 			folder: folder,
 			searchQuery: undefined
+		});
+
+		spyOn(Radio.avatar, 'request').and.callFake(function() {
+			return Promise.resolve(undefined);
 		});
 	});
 

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -1,5 +1,3 @@
-/* global Promise */
-
 /**
  * Mail
  *
@@ -16,7 +14,6 @@ define(function(require) {
 	var $ = require('jquery');
 	require('jquery-ui/ui/widgets/draggable');
 	var _ = require('underscore');
-	var OC = require('OC');
 	var Marionette = require('backbone.marionette');
 	var Radio = require('radio');
 	var MessageTemplate = require('templates/message-list-item.html');
@@ -113,19 +110,11 @@ define(function(require) {
 		 * @private
 		 */
 		_fetchAvatar: function() {
-			var url = OC.generateUrl('/apps/mail/api/avatars/url/{email}', {
-				email: this.model.get('fromEmail')
-			});
-
-			Promise.resolve($.ajax(url)).then(function(avatar) {
-				if (avatar.isExternal) {
-					this.model.set('senderImage', OC.generateUrl('/apps/mail/api/avatars/image/{email}', {
-						email: this.model.get('fromEmail')
-					}));
-				} else {
-					this.model.set('senderImage', avatar.url);
+			Radio.avatar.request('avatar', this.model.get('fromEmail')).then(function(url) {
+				if (url) {
+					this.model.set('senderImage', url);
 				}
-			}.bind(this));
+			}.bind(this)).catch(console.error.bind(this));
 		},
 
 		toggleMessageStar: function(event) {


### PR DESCRIPTION
* Extract external avatar logic into a service
* Add tests for the new service
* Memoize (cache) the return value of avatar URL calls and thus eliminate duplicate requests