### PR TITLE
Fix INBOX prefixing

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -81,20 +81,3 @@ If you can not access your Gmail account use https://accounts.google.com/Display
 ### Outlook.com
 
 If you can not access your Outlook.com account try to enable the 'Two-Factor Verification' (https://account.live.com/proofs/Manage) and set up an app password (https://account.live.com/proofs/AppPassword), which you then use for the Nextcloud Mail app.
-
-### Dovecot IMAP
-
-If your Dovecot IMAP server prefixes all folders with `INBOX`, Nextcloud Mail does not work correctly.
-
-Check `/etc/dovecot/dovecot.conf`:
-
-```
-namespace inbox {
-        separator = .
-        # All folders prefixed
-        # prefix = INBOX.
-        prefix =
-        inbox = yes
-        type = private
-}
-```

--- a/lib/IMAP/MailboxPrefixDetector.php
+++ b/lib/IMAP/MailboxPrefixDetector.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\IMAP;
+
+use OCA\Mail\Folder;
+use OCA\Mail\SearchFolder;
+
+class MailboxPrefixDetector {
+
+	const PREFIX = 'INBOX';
+
+	/**
+	 * @param Folder[] $folders
+	 * @return bool
+	 */
+	public function havePrefix(array $folders) {
+		foreach ($folders as $folder) {
+			if ($folder instanceof SearchFolder) {
+				// Ignore special flagged mailbox
+				continue;
+			}
+
+			$parts = explode($folder->getDelimiter(), $folder->getMailbox());
+			if (count($parts) < 1 || $parts[0] !== self::PREFIX) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/lib/Service/FolderNameTranslator.php
+++ b/lib/Service/FolderNameTranslator.php
@@ -68,17 +68,19 @@ class FolderNameTranslator {
 
 	/**
 	 * @param Folder[] $folders
+	 * @param bool $havePrefix
 	 */
-	public function translateAll(array $folders) {
+	public function translateAll(array $folders, $havePrefix) {
 		foreach ($folders as $folder) {
-			$this->translate($folder);
+			$this->translate($folder, $havePrefix);
 		}
 	}
 
 	/**
 	 * @param Folder $folder
+	 * @param bool $hasPrefix
 	 */
-	public function translate(Folder $folder) {
+	private function translate(Folder $folder, $hasPrefix = false) {
 		$translations = $this->buildTranslations();
 		// TODO: only list "best" one per type? e.g. only one inbox
 		$specialUses = $folder->getSpecialUse();
@@ -86,7 +88,15 @@ class FolderNameTranslator {
 		if (!is_null($specialUse) && isset($translations[$specialUse])) {
 			$folder->setDisplayName($translations[$specialUse]);
 		} else {
-			$folder->setDisplayName($folder->getMailbox());
+			$mailbox = $folder->getMailbox();
+			$prefix = 'INBOX' . $folder->getDelimiter();
+			if ($hasPrefix && strpos($mailbox, $prefix) === 0) {
+				// Mailbox name starts with prefix -> remove it
+				$trimmed = substr($mailbox, strlen($prefix));
+				$folder->setDisplayName($trimmed);
+			} else {
+				$folder->setDisplayName($mailbox);
+			}
 		}
 	}
 

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -87,7 +87,7 @@ class MailManager implements IMailManager {
 		$this->folderMapper->detectFolderSpecialUse($folders);
 		$this->folderMapper->sortFolders($folders);
 		$this->folderNameTranslator->translateAll($folders, $havePrefix);
-		return $this->folderMapper->buildFolderHierarchy($folders);
+		return $this->folderMapper->buildFolderHierarchy($folders, $havePrefix);
 	}
 
 	/**

--- a/tests/IMAP/FolderMapperTest.php
+++ b/tests/IMAP/FolderMapperTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OCA\Mail\Tests\Service;
+namespace OCA\Mail\Tests\IMAP;
 
 use Horde_Imap_Client;
 use Horde_Imap_Client_Mailbox;
@@ -95,7 +95,7 @@ class FolderMapperTest extends TestCase {
 		$this->assertEquals($expected, $folders);
 	}
 
-	public function testBuildHierarchy() {
+	public function testBuildHierarchyWithoutPrefix() {
 		$account = $this->createMock(Account::class);
 		$folder1 = new Folder($account, new Horde_Imap_Client_Mailbox('test'), [], '.');
 		$folder2 = new Folder($account, new Horde_Imap_Client_Mailbox('test.sub'), [], '.');
@@ -111,8 +111,33 @@ class FolderMapperTest extends TestCase {
 			$folder1,
 		];
 
-		$result = $this->mapper->buildFolderHierarchy($folders);
+		$result = $this->mapper->buildFolderHierarchy($folders, false);
 
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testBuildHierarchyWithPrefix() {
+		$account = $this->createMock(Account::class);
+		$folder1 = new Folder($account, new Horde_Imap_Client_Mailbox('INBOX'), [], '.');
+		$folder2 = new Folder($account, new Horde_Imap_Client_Mailbox('INBOX.sub'), [], '.');
+		$folder3 = new Folder($account, new Horde_Imap_Client_Mailbox('INBOX.sub.sub'), [], '.');
+		$folder4 = new Folder($account, new Horde_Imap_Client_Mailbox('INBOX.sub.sub.sub'), [], '.');
+		$folders = [
+			clone $folder1,
+			clone $folder2,
+			clone $folder3,
+			clone $folder4,
+		];
+		$folder2->addFolder($folder3);
+		$folder2->addFolder($folder4);
+		$expected = [
+			$folder1,
+			$folder2,
+		];
+
+		$result = $this->mapper->buildFolderHierarchy($folders, true);
+
+		$this->assertCount(count($expected), $result);
 		$this->assertEquals($expected, $result);
 	}
 

--- a/tests/IMAP/MailboxPrefixDetectorTest.php
+++ b/tests/IMAP/MailboxPrefixDetectorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @copyright 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2017 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\IMAP;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Folder;
+use OCA\Mail\IMAP\MailboxPrefixDetector;
+use OCA\Mail\SearchFolder;
+
+class MailboxPrefixDetectorTest extends TestCase {
+
+	/** @var MailboxPrefixDetector */
+	private $detector;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->detector = new MailboxPrefixDetector();
+	}
+
+	public function testDetectWithPrefix() {
+		$folder1 = $this->createMock(Folder::class);
+		$folder2 = $this->createMock(Folder::class);
+		$folder1->expects($this->once())
+			->method('getMailbox')
+			->willReturn('INBOX');
+		$folder1->expects($this->once())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder2->expects($this->once())
+			->method('getMailbox')
+			->willReturn('INBOX.Sent');
+		$folder2->expects($this->once())
+			->method('getDelimiter')
+			->willReturn('.');
+
+		$havePrefix = $this->detector->havePrefix([
+			$folder1,
+			$folder2,
+		]);
+
+		$this->assertTrue($havePrefix);
+	}
+
+	public function testDetectWithoutPrefix() {
+		$folder1 = $this->createMock(Folder::class);
+		$folder2 = $this->createMock(Folder::class);
+		$folder1->expects($this->once())
+			->method('getMailbox')
+			->willReturn('INBOX');
+		$folder1->expects($this->once())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder2->expects($this->once())
+			->method('getMailbox')
+			->willReturn('Sent');
+		$folder2->expects($this->once())
+			->method('getDelimiter')
+			->willReturn('.');
+
+		$havePrefix = $this->detector->havePrefix([
+			$folder1,
+			$folder2,
+		]);
+
+		$this->assertFalse($havePrefix);
+	}
+
+	public function testDetectWithSearchFolder() {
+		$folder1 = $this->createMock(Folder::class);
+		$folder2 = $this->createMock(SearchFolder::class);
+		$folder1->expects($this->any())
+			->method('getMailbox')
+			->willReturn('INBOX');
+		$folder1->expects($this->any())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder2->expects($this->any())
+			->method('getMailbox')
+			->willReturn('INBOX/Flagged');
+		$folder2->expects($this->any())
+			->method('getDelimiter')
+			->willReturn('.');
+
+		$havePrefix = $this->detector->havePrefix([
+			$folder1,
+			$folder2,
+		]);
+
+		$this->assertTrue($havePrefix);
+	}
+
+}

--- a/tests/Service/FolderNameTranslatorTest.php
+++ b/tests/Service/FolderNameTranslatorTest.php
@@ -21,9 +21,9 @@
 
 namespace OCA\Mail\Tests\Service;
 
+use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Folder;
 use OCA\Mail\Service\FolderNameTranslator;
-use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCP\IL10N;
 use PHPUnit_Framework_MockObject_MockObject;
 
@@ -48,24 +48,68 @@ class FolderNameTranslatorTest extends TestCase {
 		$this->translator = new FolderNameTranslator($this->l10n);
 	}
 
-	public function testTranslateAll() {
+	public function testTranslate() {
 		$folder = $this->createMock(Folder::class);
-
+		$folder->expects($this->any())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder->expects($this->any())
+			->method('getMailbox')
+			->willReturn('Archive');
 		$folder->expects($this->once())
 			->method('getSpecialUse')
 			->willReturn([]);
+		$folder->expects($this->once())
+			->method('setDisplayName')
+			->with('Archive');
 
-		$this->translator->translateAll([$folder]);
+		$this->translator->translateAll([$folder], false);
+	}
+
+	public function testTranslatePrefixed() {
+		$folder1 = $this->createMock(Folder::class);
+		$folder2 = $this->createMock(Folder::class);
+		$folder1->expects($this->any())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder2->expects($this->any())
+			->method('getDelimiter')
+			->willReturn('.');
+		$folder1->expects($this->any())
+			->method('getMailbox')
+			->willReturn('INBOX');
+		$folder2->expects($this->any())
+			->method('getMailbox')
+			->willReturn('INBOX.Sent');
+		$folder1->expects($this->once())
+			->method('getSpecialUse')
+			->willReturn(['inbox']);
+		$folder2->expects($this->once())
+			->method('getSpecialUse')
+			->willReturn([]);
+		$folder1->expects($this->once())
+			->method('setDisplayName')
+			->with('Translated Inbox');
+		$folder2->expects($this->once())
+			->method('setDisplayName')
+			->with('Sent');
+
+		$this->translator->translateAll([$folder1, $folder2], true);
 	}
 
 	public function testTranslateSpecialUse() {
 		$folder = $this->createMock(Folder::class);
-
+		$folder->expects($this->any())
+			->method('getMailbox')
+			->willReturn('Sent');
 		$folder->expects($this->once())
 			->method('getSpecialUse')
-			->willReturn(['flagged']);
+			->willReturn(['sent']);
+		$folder->expects($this->once())
+			->method('setDisplayName')
+			->with('Translated Sent');
 
-		$this->translator->translate($folder);
+		$this->translator->translateAll([$folder], false);
 	}
 
 }


### PR DESCRIPTION
TODO
* [x] Remove prefix from *translated* folder names
* [x] Don't set prefixed folders as subfolders of inbox

Tested with
* Unit tests (see changes)
* Manually with a community provided mail server

Fixes https://github.com/nextcloud/mail/issues/386