### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,41 +1,39 @@
-### Steps to reproduce
-1.
-2.
-3.
+---
+name: 🐛 Bug
+about: Have you encountered a bug?
+version: 0.1
+---
 
-### Expected behaviour
+### Expected behavior
 Tell us what should happen
 
-### Actual behaviour
+### Actual behavior
 Tell us what happens instead
 
 ### Mail app
 
-**Mail app version:** (see apps admin page)
+**Mail app version:** (see apps admin page, e.g. 0.5.3)
 
 **Mailserver or service:** (e.g. Outlook, Yahoo, Gmail, Exchange,...)
 
-**Number of accounts:**
+**Number of accounts:** (e.g. 1 or 2)
 
 
 ### Server configuration
-<!--
-You can use the Issue Template application to prefill most of the required information: https://apps.nextcloud.com/apps/issuetemplate
--->
-**Operating system**:
 
-**Web server:**
+**Operating system**: (e.g. Debian 8)
 
-**Database:**
+**Web server:** (e.g. Apache, Nginx,...)
 
-**PHP version:**
+**Database:** (e.g. MariaDB, SQLite, PostgreSQL,...)
 
-**Version:** (see admin page)
+**PHP version:** (e.g. 7.0)
+
+**Nextcloud Version:** (see admin page, e.g. 13.0.2)
 
 **Updated from an older version or fresh install:**
 
 **List of activated apps:**
-
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ app:list
@@ -43,8 +41,6 @@ from within your server installation folder
 ```
 
 **The content of config/config.php:**
-
-<details>
 ```
 If you have access to your command line run e.g.:
 sudo -u www-data php occ config:list system
@@ -55,46 +51,37 @@ or
 Insert your config.php content here
 Make sure to remove all sensitive content such as passwords. (e.g. database password, passwordsalt, secret, smtp password, …)
 ```
-</details>
 
 #### Client configuration
-**Browser:**
+**Browser:** (e.g. Firefox 48)
 
-**Operating system:**
+**Operating system:** (e.g. Arch Linux)
 
 #### Logs
 ##### Web server error log
 ```
-Insert your webserver log here
+Insert your webserver log here (e.g. /var/log/apache2/...)
 ```
 
 ##### Server log (data/nextcloud.log)
-<details>
 ```
 Insert your server log here
 ```
-</details>
 
 ##### IMAP log (data/horde_imap.log)
-<details>
 ```
 Enable debug mode and insert your horde IMAP log here, see https://docs.nextcloud.com/server/13/developer_manual/general/debugging.html#debug-mode
 ```
-</details>
 
 ##### SMTP log (data/horde_smtp.log)
-<details>
 ```
 Enable debug mode and insert your horde IMAP log here, see https://docs.nextcloud.com/server/13/developer_manual/general/debugging.html#debug-mode
 ```
-</details>
 
 ##### Browser log
-<details>
 ```
 Insert your browser log here, this could for example include:
 
 a) The javascript console log
 b) The network log 
 ```
-</details>

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: 🚀 Feature Request
+about: You have a neat idea that should be implemented?
+version: 0.1
+---
+
+### Feature Request
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+#### Summary
+
+<!-- Provide a summary of the feature you would like to see implemented. -->


### PR DESCRIPTION
These are based on the old issue template, which I generalized as https://github.com/ChristophWurst/nextcloud_issue_templates which is based on https://github.com/doctrine/doctrine2/tree/master/.github/ISSUE_TEMPLATE :see_no_evil: 

See the template selection in action: https://github.com/nextcloud/twofactor_u2f/issues/new/choose

cc @nextcloud/mail @skjnldsv 