### PR TITLE
Fix folder translation and sorting order

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -33,7 +33,7 @@ class FolderMapper {
 	 * @param Account $account
 	 * @param Horde_Imap_Client_Socket $client
 	 * @param string $pattern
-	 * @return Folder
+	 * @return Folder[]
 	 */
 	public function getFolders(Account $account, Horde_Imap_Client_Socket $client,
 		$pattern = '*') {

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -85,8 +85,8 @@ class MailManager implements IMailManager {
 		$havePrefix = $this->prefixDetector->havePrefix($folders);
 		$this->folderMapper->getFoldersStatus($folders, $client);
 		$this->folderMapper->detectFolderSpecialUse($folders);
-		$this->folderMapper->sortFolders($folders);
 		$this->folderNameTranslator->translateAll($folders, $havePrefix);
+		$this->folderMapper->sortFolders($folders);
 		return $this->folderMapper->buildFolderHierarchy($folders, $havePrefix);
 	}
 


### PR DESCRIPTION
The `sortFolder` method expects the folders to have a `displayName` property set, which is populated on `translateAll`. Therefore, the order was wrong. Folders should first be translated and then sorted.

Fixes https://github.com/nextcloud/mail/issues/901

Special thanks to @tenbob for some awesome debugging at https://github.com/nextcloud/mail/issues/901#issuecomment-393751571 - this helped a lot :rocket: 