### PR TITLE
When deleting account also delete all its aliases

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -186,6 +186,7 @@ class AccountsController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function destroy($id) {
+		$this->aliasesService->deleteAll($id, $this->currentUserId);
 		$this->accountService->delete($this->currentUserId, $id);
 		return new JSONResponse();
 	}

--- a/lib/Service/AliasesService.php
+++ b/lib/Service/AliasesService.php
@@ -79,4 +79,15 @@ class AliasesService {
 		return $alias;
 	}
 
+	/**
+	 * Deletes all aliases of an account.
+	 * @param int $accountId the account which aliases will be deleted
+	 * @param string $currentUserId the user whom the account belongs to
+	 */
+	public function deleteAll($accountId, $currentUserId) {
+		$aliases = $this->mapper->findAll($accountId, $currentUserId);
+		foreach ($aliases as $alias) {
+			$this->mapper->delete($alias);
+		}
+	}
 }


### PR DESCRIPTION
Not sure if if new `deleteAll()` should return the deleted aliases like the other methods do.