### PR TITLE
Add support for basic "advanced search"

### DIFF
--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -100,10 +100,8 @@ class Mailbox implements IMailBox {
 		if ($filter instanceof Horde_Imap_Client_Search_Query) {
 			$query = $filter;
 		} else {
-			$query = new Horde_Imap_Client_Search_Query();
-			if ($filter) {
-				$query->text($filter, false);
-			}
+			$searchHelper = new SearchHelper();
+			$query = $searchHelper->parseFilterString($filter);
 		}
 		if ($this->getSpecialRole() !== 'trash') {
 			$query->flag(Horde_Imap_Client::FLAG_DELETED, false);

--- a/lib/SearchHelper.php
+++ b/lib/SearchHelper.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail;
+
+
+class SearchHelper {
+	const FLAG_MAP = [
+		'read' => ['SEEN', true],
+		'unread' => ['SEEN', false],
+		'answered' => ['ANSWERED', true],
+	];
+
+	/**
+	 * @param string $filter
+	 * @return \Horde_Imap_Client_Search_Query
+	 */
+	public function parseFilterString($filter) {
+		$query = new \Horde_Imap_Client_Search_Query();
+		if (!$filter) {
+			return $query;
+		}
+		$tokens = explode(' ', $filter);
+		$textTokens = [];
+		foreach ($tokens as $token) {
+			if (!$this->parseFilterToken($query, $token)) {
+				$textTokens[] = $token;
+			}
+		}
+		if (count($textTokens)) {
+			$query->text(implode(' ', $textTokens), false);
+		}
+
+		return $query;
+	}
+
+	private function parseFilterToken(\Horde_Imap_Client_Search_Query $query, $token) {
+		if (strpos($token, ':')) {
+			list($type, $param) = explode(':', $token);
+			$type = strtolower($type);
+
+			switch ($type) {
+				case 'is':
+				case 'not':
+					if (array_key_exists($param, self::FLAG_MAP)) {
+						$flag = self::FLAG_MAP[$param];
+						$query->flag($flag[0], $type === 'is' ? $flag[1] : !$flag[1]);
+						return true;
+					}
+					break;
+				case 'from':
+				case 'to':
+				case 'cc':
+				case 'bcc':
+				case 'subject':
+					$query->headerText($type, $param);
+					return true;
+			}
+		}
+		return false;
+	}
+}

--- a/tests/SearchHelperTest.php
+++ b/tests/SearchHelperTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\SearchHelper;
+
+class SearchHelperTest extends TestCase {
+	private function search($filter) {
+		$helper = new SearchHelper();
+		$query = $helper->parseFilterString($filter);
+		return (string)($query->build()['query']);
+	}
+
+	public function testSearchEmpty() {
+		$this->assertEquals('ALL', $this->search(''));
+	}
+
+	public function testSearchTest() {
+		$this->assertEquals('TEXT "dummy text"', $this->search('dummy text'));
+	}
+
+	public function testSearchUnread() {
+		$this->assertEquals('UNSEEN', $this->search('is:unread'));
+	}
+
+	public function testSearchNotAnswered() {
+		$this->assertEquals('UNANSWERED', $this->search('not:answered'));
+	}
+
+	public function testSearchFrom() {
+		$this->assertEquals('FROM somebody@example.com', $this->search('from:somebody@example.com'));
+	}
+
+	public function testSearchMixed() {
+		$this->assertEquals('UNSEEN FROM somebody@example.com TEXT nextcloud', $this->search('from:somebody@example.com is:unread nextcloud'));
+	}
+}


### PR DESCRIPTION
Allows for the following searches:

- Whether or not the `read`, `unread` and `answered` flags are set (`is:unread`)
- Search in `from`, `to`, `cc`, `bcc` and `subject` (`from:somebody@example.com`)


Born from the need to find that one unread message in my inbox