### PR TITLE
Fix issue template URL to point to new template chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ And in the works for the [coming versions](https://github.com/nextcloud/mail/mil
 * :books: Proper grouping of message threads
 * :package: Folder management
 
-If you experience any issues or have any suggestions for improvement, use the [issue tracker](https://github.com/nextcloud/mail/issues). Please follow the [issue template](https://raw.githubusercontent.com/nextcloud/mail/master/.github/issue_template.md) so we get the info needed to debug and fix the problem. Thanks!
+If you experience any issues or have any suggestions for improvement, use the [issue tracker](https://github.com/nextcloud/mail/issues). Please follow the [issue template chooser](https://github.com/nextcloud/mail/issues/new/choose) so we get the info needed to debug and fix the problem. Thanks!
 
 ## Development setup
 


### PR DESCRIPTION
As detected by @ifrx in https://github.com/nextcloud/mail/issues/951.