### PR TITLE
Fix redirect in proxy controller with no referrer

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -70,7 +70,6 @@ class Application extends App {
 		});
 
 		$container->registerParameter("testSmtp", $testSmtp);
-		$container->registerParameter("referrer", isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : null);
 		$container->registerParameter("hostname", Util::getServerHostName());
 
 		$container->registerAlias('ErrorMiddleware', ErrorMiddleware::class);

--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -93,7 +93,7 @@ class ProxyController extends Controller {
 		// this is there to prevent an open redirector.
 		// Since we can't prevent the referrer from being added with a HTTP only header we rely on an
 		// additional JS file here.
-		$referrer = $this->request['server']['HTTP_REFERER'] ?? null;
+		$referrer = $this->request->server['HTTP_REFERER'] ?? null;
 		if (is_string($referrer) && parse_url($referrer, PHP_URL_HOST) === $this->hostname) {
 			$authorizedRedirect = true;
 		}

--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -47,9 +47,6 @@ class ProxyController extends Controller {
 	private $clientService;
 
 	/** @var string */
-	private $referrer;
-
-	/** @var string */
 	private $hostname;
 
 	/**
@@ -58,16 +55,19 @@ class ProxyController extends Controller {
 	 * @param IURLGenerator $urlGenerator
 	 * @param ISession $session
 	 * @param IClientService $clientService
-	 * @param string $referrer
 	 * @param string $hostname
 	 */
-	public function __construct(string $appName, IRequest $request,
-								IURLGenerator $urlGenerator, ISession $session, IClientService $clientService, $referrer, $hostname) {
+	public function __construct(string $appName,
+								IRequest $request,
+								IURLGenerator $urlGenerator,
+								ISession $session,
+								IClientService $clientService,
+								$hostname) {
 		parent::__construct($appName, $request);
+		$this->request = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
 		$this->clientService = $clientService;
-		$this->referrer = $referrer;
 		$this->hostname = $hostname;
 	}
 
@@ -93,7 +93,8 @@ class ProxyController extends Controller {
 		// this is there to prevent an open redirector.
 		// Since we can't prevent the referrer from being added with a HTTP only header we rely on an
 		// additional JS file here.
-		if (parse_url($this->referrer, PHP_URL_HOST) === $this->hostname) {
+		$referrer = $this->request['server']['HTTP_REFERER'] ?? null;
+		if (is_string($referrer) && parse_url($referrer, PHP_URL_HOST) === $this->hostname) {
 			$authorizedRedirect = true;
 		}
 

--- a/tests/Controller/ProxyControllerTest.php
+++ b/tests/Controller/ProxyControllerTest.php
@@ -47,10 +47,7 @@ class ProxyControllerTest extends TestCase {
 		parent::setUp();
 
 		$this->appName = 'mail';
-		$this->request = $this->createMock([
-			IRequest::class,
-			ArrayAccess::class,
-		]);
+		$this->request = $this->createMock(IRequest::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->clientService = $this->createMock(IClientService::class);
@@ -102,14 +99,9 @@ class ProxyControllerTest extends TestCase {
 			->method('linkToRoute')
 			->with('mail.page.index')
 			->will($this->returnValue('mail-route'));
-		$serverData = [
+		$this->request->server = [
 			'HTTP_REFERER' => $referrer,
 		];
-		$this->request
-			->expects($this->once())
-			->method('offsetGet')
-			->with('server')
-			->willReturn($serverData);
 		$this->controller = new ProxyController(
 			$this->appName,
 			$this->request,


### PR DESCRIPTION
Due to the strict typing, `parse_url` fails when a non-string value is passed.
To prevent that, a `is_string` check is added. Additionally, the referrer is
now read directly in the controller instead of injecting via the DI container.

Fixes https://sentry.io/share/issue/83a7268d63f145eca3d7f4640dd26636/