### PR TITLE
Fix favicon caching on invalid paths

### DIFF
--- a/lib/Service/Avatar/FaviconSource.php
+++ b/lib/Service/Avatar/FaviconSource.php
@@ -44,6 +44,7 @@ class FaviconSource implements IAvatarSource {
 								IMimeTypeDetector $mimeDetector) {
 		$this->clientService = $clientService;
 		$this->favicon = $favicon;
+		$this->favicon->setCacheTimeout(-1);
 		$this->mimeDetector = $mimeDetector;
 	}
 


### PR DESCRIPTION
This prevents the lib from writing cache files to the `vendor` dir.

- [ ] Blocked by #1006 

Ref https://sentry.rullzer.com/share/issue/b64f0d016338469f8b059ddc2f4a6e4a/.