### PR TITLE
Fix message header on mobile devices

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -44,13 +44,6 @@
 	display: none;
 }
 
-/* make header scroll away on mobile */
-#mail-message-header {
-	position: relative;
-	width: initial;
-	height: 100px;
-}
-
 textarea.message-body {
 	padding-right: 12px;
 }


### PR DESCRIPTION
Before: Header was moved down a bit, overlapped with the content of text messages.

After: Text messages are shown properly, header is where it's supposed to be.