### PR TITLE
Fix displaying and notifications for messages with no sender

### DIFF
--- a/js/service/avatarservice.js
+++ b/js/service/avatarservice.js
@@ -37,6 +37,10 @@ define(function(require) {
 	 * @returns {Promise}
 	 */
 	function loadAvatar(email) {
+		if (email === null) {
+			return Promise.resolve(undefined);
+		}
+
 		var url = OC.generateUrl('/apps/mail/api/avatars/url/{email}', {
 			email: email
 		});

--- a/js/templates/message-list-item.html
+++ b/js/templates/message-list-item.html
@@ -13,7 +13,11 @@
 		{{#if senderImage}}
 		<img src="{{senderImage}}" width="32px" height="32px" />
 		{{else}}
+		{{#if sender}}
 		<div class="avatar" data-user="{{sender.label}}" data-size="32"></div>
+		{{else}}
+		<div class="avatar" data-user="?" data-size="32"></div>
+		{{/if}}
 		{{/if}}
 	</div>
 

--- a/js/util/notificationhandler.js
+++ b/js/util/notificationhandler.js
@@ -74,7 +74,12 @@ define(function(require) {
 			return;
 		}
 
-		var from = _.map(messages, function(m) {
+		var from = messages.filter(function(m) {
+			return m.get('from').length > 0;
+		}).map(function(m) {
+			if (m.get('from').length === 0) {
+				return null;
+			}
 			return m.get('from')[0].label;
 		});
 		from = _.uniq(from);

--- a/js/views/composerview.js
+++ b/js/views/composerview.js
@@ -430,9 +430,10 @@ define(function(require) {
 		setReplyBody: function(from, date, text) {
 			var minutes = date.getMinutes();
 
+			var fromLine = _.isUndefined(from) ? '' : from.label + ' – ';
 			this.$('.message-body').first().text(
 					'\n\n\n' +
-					from.label + ' – ' +
+					fromLine +
 					$.datepicker.formatDate('D, d. MM yy ', date) +
 					date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
 					text.replace(/\n/g, '\n> ')

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -83,6 +83,10 @@ define(function(require) {
 					$(a).height('32px');
 					imageplaceholder(a, from.label, from.label);
 				});
+			} else {
+				var $avatar = this.$('.avatar');
+				$avatar.height('32px');
+				imageplaceholder($avatar, '?', '?');
 			}
 
 			var _this = this;

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -76,12 +76,12 @@ define(function(require) {
 			return json;
 		},
 		onRender: function() {
-			var displayName = this.model.get('from')[0].label;
+			var from = this.model.get('from')[0];
 			// Don't show any placeholder if 'from' isn't set
-			if (displayName) {
+			if (from) {
 				_.each(this.$el.find('.avatar'), function(a) {
 					$(a).height('32px');
-					imageplaceholder(a, displayName, displayName);
+					imageplaceholder(a, from.label, from.label);
 				});
 			}
 

--- a/js/views/messageview.js
+++ b/js/views/messageview.js
@@ -53,8 +53,10 @@ define(function(require) {
 				var minutes = date.getMinutes();
 				var text = HtmlHelper.htmlToText(this.messageBody.get('body'));
 
+				var from = this.messageBody.get('from')[0];
+				var fromLine = _.isUndefined(from) ? '' : from.label + ' – ';
 				this.reply.body = '\n\n\n\n' +
-						this.messageBody.get('from')[0].label + ' – ' +
+						fromLine +
 						$.datepicker.formatDate('D, d. MM yy ', date) +
 						date.getHours() + ':' + (minutes < 10 ? '0' : '') + minutes + '\n> ' +
 						text.replace(/\n/g, '\n> ');


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/930.
Fixes #911.

Note: I had no data to properly test this. I *hope* this doesn't :boom: on existing data. I used search to identify spots where we blindly assume there's more than one element in `from`.

cc @iamdoubz @itchytm @e-alfred @akaro if anybody has a setup to reproduce the issue, please let me know and I'll provide you with an app archive to test the patch. Thanks!