### PR TITLE
Update composer.json to PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,11 @@
 	],
 	"config": {
 		"platform": {
-			"php": "5.6"
+			"php": "7.0.13"
 		}
 	},
 	"require": {
-		"php": ">=5.6.0",
+		"php": ">=7.0.13",
 		"pear-pear.horde.org/Horde_Date": "^2.4.1@stable",
 		"pear-pear.horde.org/Horde_Exception": "^2.0.8@stable",
 		"pear-pear.horde.org/Horde_Imap_Client": "^2.29.16@stable",


### PR DESCRIPTION
Fixes #1042.

I chose `v7.0.13` because its the minimum supported version of PHP 7, but its security support ends in 3 months. Should `v7.1.20` be used instead?

---

PHP supported versions: https://secure.php.net/supported-versions.php