### PR TITLE
Increase SMTP timeout

### DIFF
--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -76,7 +76,7 @@ class SmtpClientFactory {
 			'port' => $mailAccount->getOutboundPort(),
 			'username' => $mailAccount->getOutboundUser(),
 			'secure' => $security === 'none' ? false : $security,
-			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 2)
+			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 10)
 		];
 		if ($this->config->getSystemValue('debug', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';


### PR DESCRIPTION
I kept getting the error: `Server denied authentication` while logging to my mail server. After some debugging, I found the SMTP timeout to be the problem.

This may fix issues #966 & #808.