### PR TITLE
Keyboard accessibility

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -737,8 +737,8 @@ input.submit-message,
 				padding-left: 38px !important;
 			}
 
-			&:focus,
 			&:hover,
+			& a:focus,
 			&.active,
 			a.selected {
 				&,

--- a/js/templates/account.html
+++ b/js/templates/account.html
@@ -37,7 +37,7 @@
 {{#unless isUnifiedInbox}}
 {{#if hasFolders}}
 <li class="account-toggle-collapse">
-	<a>{{toggleCollapseMessage}}</a>
+	<a href="#">{{toggleCollapseMessage}}</a>
 </li>
 {{/if}}
 {{/unless}}

--- a/js/templates/message-list-item.html
+++ b/js/templates/message-list-item.html
@@ -1,4 +1,4 @@
-<div class="app-content-list-item {{#if flags.unseen}}unseen{{/if}} {{#if active}}active{{/if}}" data-message-id="{{id}}">
+<div class="app-content-list-item {{#if flags.unseen}}unseen{{/if}} {{#if active}}active{{/if}}" data-message-id="{{id}}" tabindex="0">
 	{{#if isUnified}}
 	<div class="mail-message-account-color" style="background-color: {{accountColor accountMail}}"></div>
 	{{/if}}
@@ -40,7 +40,7 @@
 			</span>
 		</div>
 		<div class="app-content-list-item-menu">
-			<div class="icon-more toggle-menu"></div>
+			<div class="icon-more toggle-menu" tabindex="0"></div>
 			<div class="popovermenu">
 				<ul>
 					<li>

--- a/js/views/messagesitem.js
+++ b/js/views/messagesitem.js
@@ -33,6 +33,7 @@ define(function(require) {
 			'click @ui.self': 'openMessage',
 			'click @ui.star': 'toggleMessageStar',
 			'click @ui.toggleMenu': 'toggleActionsMenu',
+			'keyup @ui.toggleMenu': 'toggleActionsMenuKeyboard',
 			'click .action.delete': 'deleteMessage',
 			'click .action.toggle-read': 'toggleMessageRead'
 		},
@@ -179,6 +180,12 @@ define(function(require) {
 		toggleActionsMenu: function() {
 			this.actionsMenuShown = !this.actionsMenuShown;
 			this.toggleMenuClass();
+		},
+
+		toggleActionsMenuKeyboard: function(event) {
+			if (event.key === ' ' || event.key === 'Enter') {
+				this.toggleActionsMenu();
+			}
 		},
 
 		toggleMenuClass: function() {


### PR DESCRIPTION
This fixes that there’s currently almost no keyboard navigation feedback in the mail app.

- Fix keyboard tab feedback in app-navigation
- Fix keyboard feedback and navigability for showing more folders
- Fix keyboard feedback for message list 

Still missing is that the message list (and the 3-dot-menu in the message list) is actually interactive. @ChristophWurst I guess you know how to do that?