### PR TITLE
Set imap port type - Fixes Gmail account setup error

### DIFF
--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -145,7 +145,7 @@ class IspDbConfigurationDetector {
 	 */
 	private function testImapConfiguration(array $imap, string $email, string $password, string $name) {
 		$host = $imap['hostname'];
-		$port = $imap['port'];
+		$port = (int) $imap['port'];
 		$encryptionProtocol = 'none';
 		if ($imap['socketType'] === 'SSL') {
 			$encryptionProtocol = 'ssl';


### PR DESCRIPTION
The `connect` function in https://github.com/nextcloud/mail/blob/master/lib/Service/AutoConfig/ImapConnector.php#L63 expects the port to be an `int` but it's currently sent as a string instead.
This sets the port to have the correct type

Fixes #1054