### PR TITLE
Fix 'home' -> 'folder' redirection

### DIFF
--- a/js/views/Home.vue
+++ b/js/views/Home.vue
@@ -43,7 +43,7 @@
 
 				console.debug('accounts fetched', accounts)
 
-				if (accounts.length > 0) {
+				if (this.$route.name === 'home' && accounts.length > 0) {
 					// Show first account
 
 					let firstAccount = accounts[0]


### PR DESCRIPTION
This should only happen if the current route is 'home', otherwise it
always redirects to the first account's first folder on reload.
