### PR TITLE
Fix appNavigation exact routing by making it configurable

### DIFF
--- a/js/components/core/navigationItem.vue
+++ b/js/components/core/navigationItem.vue
@@ -152,7 +152,7 @@
 						is: 'router-link',
 						tag: 'li',
 						to: item.router,
-						exact: true
+						exact: item.exact || false
 					}
 				}
 				return {


### PR DESCRIPTION
Otherwise the redirection from `/accounts/1/folders/SU5CT1g=` to `/accounts/1/folders/SU5CT1g=/message/1` when we show the first message removes the visual *active* state of the nav item.