### PR TITLE
Add loading of HTML message bodies

### DIFF
--- a/js/components/Message.vue
+++ b/js/components/Message.vue
@@ -16,7 +16,8 @@
 				</p>
 			</div>
 			<div class="mail-message-body">
-				<MessageHTMLBody v-if="message.hasHtmlBody"/>
+				<MessageHTMLBody v-if="message.hasHtmlBody"
+								 :url="htmlUrl"/>
 				<MessagePlainTextBody v-else
 									  :body="message.body"
 									  :signature="message.signature"/>
@@ -51,6 +52,15 @@
 				loading: true,
 				message: undefined,
 			};
+		},
+		computed: {
+			htmlUrl () {
+				return OC.generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{id}/html', {
+					accountId: this.$route.params.accountId,
+					folderId: this.$route.params.folderId,
+					id: this.$route.params.messageId
+				})
+			}
 		},
 		created () {
 			this.fetchMessage()
@@ -108,9 +118,11 @@
 	.mail-message-attachments {
 		margin: 10px 10px 50px 30px;
 	}
+
 	.mail-message-attachments {
 		margin-top: 10px;
 	}
+
 	#mail-content iframe {
 		width: 100%;
 	}
@@ -131,6 +143,7 @@
 		color: rgba(0, 0, 0, .3) !important;
 		opacity: 1;
 	}
+
 	#mail-message-header .transparency a {
 		color: rgba(0, 0, 0, .5) !important;
 	}

--- a/js/components/MessageHTMLBody.vue
+++ b/js/components/MessageHTMLBody.vue
@@ -6,11 +6,15 @@
 				<!--{{ t 'Show images from this	sender' }}-->
 			</button>
 		</div>
-		<div class="icon-loading">
-			<iframe :srcdoc="body"
-					sandbox=""
-					seamless>
-			</iframe>
+		<div v-if="loading"
+			 class="icon-loading"/>
+		<div :class="{hidden: loading}"
+			 id="message-container">
+			<iframe id="message-frame"
+					ref="iframe"
+					@load="onMessageFrameLoad"
+					:src="url"
+					seamless/>
 		</div>
 	</div>
 </template>
@@ -19,7 +23,35 @@
 	export default {
 		name: "MessageHTMLBody",
 		props: [
-			'body',
-		]
+			'url',
+		],
+		data () {
+			return {
+				loading: true
+			}
+		},
+		methods: {
+			onMessageFrameLoad () {
+				console.log('todo: resize', this.$refs.iframe)
+				this.loading = false
+			}
+		}
 	};
 </script>
+
+<style scoped>
+	#message-container {
+		position: relative;
+		width: 100%;
+		height: 0;
+		padding-bottom: 56.25%;
+	}
+
+	#message-frame {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -199,6 +199,7 @@ class MessagesController extends Controller {
 		try {
 			$mailBox = $this->getFolder($accountId, $folderId);
 
+			/** @var IMAPMessage $m */
 			$m = $mailBox->getMessage($messageId, true);
 			$html = $m->getHtmlBody($accountId, $folderId, $messageId,
 				function ($cid) use ($m) {


### PR DESCRIPTION
Resizing the iframe according to its contents height seems impossible without allowing scripts inside the iframe. I've deliberately not ported the old hacks to get the width but chose a intermediate solution that is css-only. It does not work for certain situations, e.g. when content height changes after the initial load. Even sophisticated solutions like the [iframe resizer](https://github.com/davidjbradshaw/iframe-resizer) fail to handle this as they require scripts inside the iframe as well (their readme even claims that fixing the height without that is impossible).

I'll merge this without a proper fix because we also face these issues on the Marionette (master) branch, so it's not a regression.