### PR TITLE
Disable slow Scrutinizer security analysis

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             tests:
                 override:
-                    - php-scrutinizer-run --enable-security-analysis
+                    - php-scrutinizer-run
 
 filter:
     excluded_paths:


### PR DESCRIPTION
Never reported anything useful and is slow.