### PR TITLE
Re-implement unified inbox for Vue

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -8,16 +8,17 @@
 					  v-scroll="onScroll"
 					  v-shortkey.once="{next: ['arrowright'], prev: ['arrowleft']}" @shortkey.native="navigateEnvelope">
 		<div id="list-refreshing"
-			 :key="'loading'"
+			 key="loading"
 			 class="icon-loading-small"
 			 :class="{refreshing: refreshing}"/>
-		<EmptyFolder v-if="envelopes.length === 0"/>
+		<EmptyFolder v-if="envelopes.length === 0"
+					 key="empty" />
 		<Envelope v-else
 				  v-for="env in envelopes"
-				  :key="env.id"
+				  :key="env.uid"
 				  :data="env"/>
 		<div id="load-more-mail-messages"
-			 :key="'loadingMore'"
+			 key="loadingMore"
 			 :class="{'icon-loading-small': loadingMore}"/>
 	</transition-group>
 </template>

--- a/src/mixins/SidebarItems.js
+++ b/src/mixins/SidebarItems.js
@@ -23,9 +23,9 @@ export default {
 
 			let accounts = this.$store.getters.getAccounts();
 			for (let id in accounts) {
-				let account = accounts[id];
+				const account = accounts[id]
 
-				if (account.visible !== false) {
+				if (account.isUnified !== true && account.visible !== false) {
 					items.push({
 						id: 'account' + account.id,
 						key: 'account' + account.id,
@@ -67,12 +67,14 @@ export default {
 						})
 					})
 
-				items.push({
-					id: 'collapse-' + account.id,
-					key: 'collapse-' + account.id,
-					text: account.collapsed ? t('mail', 'Show all folders') : t('mail', 'Collapse folders'),
-					action: () => this.$store.commit('toggleAccountCollapsed', account.id)
-				})
+				if (!account.isUnified) {
+					items.push({
+						id: 'collapse-' + account.id,
+						key: 'collapse-' + account.id,
+						text: account.collapsed ? t('mail', 'Show all folders') : t('mail', 'Collapse folders'),
+						action: () => this.$store.commit('toggleAccountCollapsed', account.id)
+					})
+				}
 			}
 
 			return {


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/projects/4#card-13188611

- [x] Basic data structure and routing tweaks
- [x] Load combined list of messages from individual mailboxes
- [x] Cut message list at 20 messages
- [x] Load new pages individual (the famous multi source pagination algorithm from the old version)
- [x] Load unified inbox by default