### PR TITLE
Add missing color indicator for envelopes in a unified mailbox

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -162,14 +162,6 @@
 	display: none;
 }
 
-.mail-message-account-color {
-	position: absolute;
-	left: 0px;
-	width: 2px;
-	height: 69px;
-	z-index: 1;
-}
-
 .account-toggle-collapse {
 	opacity: .5;
 }

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -11,6 +11,10 @@
       },
       exact: true}"
   >
+    <div class="mail-message-account-color"
+         v-if="showAccountColor"
+         :style="{ 'background-color': accountColor }">
+    </div>
     <div
       class="app-content-list-item-star icon-starred"
       :data-starred="data.flags.flagged ? 'true':'false'"
@@ -49,8 +53,9 @@
 
 <script>
 import { Action, Avatar, PopoverMenu, PopoverMenuItem } from 'nextcloud-vue'
-
 import Moment from './Moment'
+
+import {calculateAccountColor} from '../util/AccountColor'
 
 export default {
 	name: 'Envelope',
@@ -59,8 +64,22 @@ export default {
 		Avatar,
 		Moment,
 	},
-	props: ['data'],
+	props: {
+		data: {
+			type: Object,
+            required: true,
+        },
+        showAccountColor: {
+			type: Boolean,
+            default: false,
+        }
+	},
 	computed: {
+		accountColor() {
+			return calculateAccountColor(
+				this.$store.getters.getAccount(this.data.accountId).name
+            )
+        },
 		sender() {
 			if (this.data.from.length === 0) {
 				// No sender
@@ -101,6 +120,14 @@ export default {
 </script>
 
 <style scoped>
+.mail-message-account-color {
+	position: absolute;
+	left: 0px;
+	width: 2px;
+	height: 69px;
+	z-index: 1;
+}
+
 .app-content-list-item.unseen {
 	font-weight: bold;
 }

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -16,7 +16,8 @@
 		<Envelope v-else
 				  v-for="env in envelopes"
 				  :key="env.uid"
-				  :data="env"/>
+				  :data="env"
+				  :show-account-color="folder.isUnified"/>
 		<div id="load-more-mail-messages"
 			 key="loadingMore"
 			 :class="{'icon-loading-small': loadingMore}"/>
@@ -38,6 +39,12 @@
 		computed: {
 			envelopes () {
 				return this.$store.getters.getEnvelopes(
+					this.$route.params.accountId,
+					this.$route.params.folderId
+				)
+			},
+			folder () {
+				return this.$store.getters.getFolder(
 					this.$route.params.accountId,
 					this.$route.params.folderId
 				)

--- a/src/mixins/SidebarItems.js
+++ b/src/mixins/SidebarItems.js
@@ -1,6 +1,6 @@
-import conv from 'color-convert'
-import md5 from 'md5'
 import {translate as t} from 'nextcloud-server/dist/l10n'
+
+import {calculateAccountColor} from '../util/AccountColor'
 
 const SHOW_COLLAPSED = Object.seal([
 	'inbox',
@@ -11,13 +11,6 @@ const SHOW_COLLAPSED = Object.seal([
 
 export default {
 	methods: {
-		accountBulletColor (name) {
-			const hashed = md5(name)
-			const hsl = conv.hex.hsl(hashed)
-			const fixedHsl = [Math.round(hsl[0] / 40) * 40, hsl[1], hsl[2]]
-			return '#' + conv.hsl.hex(fixedHsl)
-		},
-
 		buildMenu () {
 			let items = [];
 
@@ -30,7 +23,7 @@ export default {
 						id: 'account' + account.id,
 						key: 'account' + account.id,
 						text: account.emailAddress,
-						bullet: this.accountBulletColor(account.name), // TODO
+						bullet: calculateAccountColor(account.name), // TODO
 						router: {
 							name: 'accountSettings',
 							params: {

--- a/src/util/AccountColor.js
+++ b/src/util/AccountColor.js
@@ -1,0 +1,31 @@
+/*
+ * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import md5 from 'md5'
+import conv from 'color-convert'
+
+export const calculateAccountColor = name => {
+	const hashed = md5(name)
+	const hsl = conv.hex.hsl(hashed)
+	const fixedHsl = [Math.round(hsl[0] / 40) * 40, hsl[1], hsl[2]]
+
+	return '#' + conv.hsl.hex(fixedHsl)
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/1276
