### PR TITLE
Fix deletion of synced envelopes

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -303,11 +303,11 @@ export const actions = {
 					envelope
 				})
 			})
-			syncData.vanishedMessages.forEach(envelope => {
+			syncData.vanishedMessages.forEach(id => {
 				commit('removeEnvelope', {
 					accountId,
 					folder,
-					id: envelope.id
+					id
 				})
 			})
 			commit('updateFolderSyncToken', {


### PR DESCRIPTION
Discovered while working on https://github.com/nextcloud/mail/pull/1288.

The sync response only contains the UID (obviously).