### PR TITLE
Collapse folders only if there is less than 6 and remember collapse choice

### DIFF
--- a/js/templates/account.html
+++ b/js/templates/account.html
@@ -35,7 +35,7 @@
 
 <div class="folders"></div>
 {{#unless isUnifiedInbox}}
-{{#if hasFolders}}
+{{#if hasCollapseFoldersButton}}
 <li class="account-toggle-collapse">
 	<a>{{toggleCollapseMessage}}</a>
 </li>

--- a/js/views/accountview.js
+++ b/js/views/accountview.js
@@ -17,6 +17,8 @@ define(function(require) {
 	var FolderListView = require('views/folderlistview');
 	var AccountTemplate = require('templates/account.html');
 
+	var COLLAPSE_BUTTON_MIN_FOLDERS = 6;
+
 	return Marionette.View.extend({
 
 		template: AccountTemplate,
@@ -27,7 +29,7 @@ define(function(require) {
 				isUnifiedInbox: this.model.get('accountId') === -1,
 				toggleCollapseMessage: toggleCollapseMessage,
 				hasMenu: this.model.get('accountId') !== -1,
-				hasFolders: this.model.folders.length > 0,
+				hasCollapseFoldersButton: this.model.folders.length >= COLLAPSE_BUTTON_MIN_FOLDERS,
 				isDeletable: this.model.get('accountId') !== -2
 			};
 		},
@@ -131,7 +133,7 @@ define(function(require) {
 
 			this.showChildView('folders', new FolderListView({
 				collection: this.model.folders,
-				collapsed: this.collapsed
+				collapsed: this.collapsed && this.model.folders.length >= COLLAPSE_BUTTON_MIN_FOLDERS
 			}));
 		},
 

--- a/js/views/accountview.js
+++ b/js/views/accountview.js
@@ -17,6 +17,8 @@ define(function(require) {
 	var FolderListView = require('views/folderlistview');
 	var AccountTemplate = require('templates/account.html');
 
+	var LOCALSTORAGE_NOT_COLLAPSED_PREFIX = 'nc-mail-not-collapsed-';
+
 	var COLLAPSE_BUTTON_MIN_FOLDERS = 6;
 
 	return Marionette.View.extend({
@@ -70,10 +72,24 @@ define(function(require) {
 		 */
 		initialize: function(options) {
 			this.model = options.model;
+
+			if (window.localStorage &&
+				window.localStorage.getItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + this.model.get('accountId'))) {
+				this.collapsed = false;
+			}
 		},
 
 		toggleCollapse: function() {
 			this.collapsed = !this.collapsed;
+
+			if (window.localStorage) {
+				if (this.collapsed) {
+					window.localStorage.removeItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + this.model.get('accountId'));
+				} else {
+					window.localStorage.setItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + this.model.get('accountId'), true);
+				}
+			}
+
 			this.render();
 		},
 


### PR DESCRIPTION
This commit fixes #692 in a more generic way :
If there are less than 6 folders in an account, it hides the "Show all folders" button ans show all of them. It fix the initial need.
More, the second commit add a feature to store the "collapse folders" button state in localStorage in browser. It's a per account setting.