### PR TITLE
Collapse folders only if there is less than 6 and remember collapse choice

### DIFF
--- a/src/mixins/SidebarItems.js
+++ b/src/mixins/SidebarItems.js
@@ -9,6 +9,8 @@ const SHOW_COLLAPSED = Object.seal([
 	'sent'
 ]);
 
+const COLLAPSE_BUTTON_MIN_FOLDERS = 6;
+
 export default {
 	methods: {
 		buildMenu () {
@@ -62,11 +64,11 @@ export default {
 				}
 
 				this.$store.getters.getFolders(account.id)
-					.filter(folder => !account.collapsed || SHOW_COLLAPSED.indexOf(folder.specialRole) !== -1)
+					.filter(folder =>  account.folders.length < COLLAPSE_BUTTON_MIN_FOLDERS || !account.collapsed || SHOW_COLLAPSED.indexOf(folder.specialRole) !== -1)
 					.map(folderToEntry)
 					.forEach(i => items.push(i))
 
-				if (!account.isUnified) {
+				if (!account.isUnified && account.folders.length >= COLLAPSE_BUTTON_MIN_FOLDERS) {
 					items.push({
 						id: 'collapse-' + account.id,
 						key: 'collapse-' + account.id,

--- a/src/store.js
+++ b/src/store.js
@@ -26,6 +26,7 @@ Vue.use(Vuex)
 const UNIFIED_ACCOUNT_ID = 0
 const UNIFIED_INBOX_ID = 'inbox'
 const UNIFIED_INBOX_UID = UNIFIED_ACCOUNT_ID + '-' + UNIFIED_INBOX_ID
+const LOCALSTORAGE_NOT_COLLAPSED_PREFIX = 'nc-mail-not-collapsed-';
 
 export const mutations = {
 	savePreference (state, {key, value}) {
@@ -33,7 +34,8 @@ export const mutations = {
 	},
 	addAccount (state, account) {
 		account.folders = []
-		account.collapsed = true
+		account.collapsed = !(window.localStorage &&
+				window.localStorage.getItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + account.id))
 		Vue.set(state.accounts, account.id, account)
 		Vue.set(
 			state,
@@ -43,6 +45,14 @@ export const mutations = {
 	},
 	toggleAccountCollapsed (state, accountId) {
 		state.accounts[accountId].collapsed = !state.accounts[accountId].collapsed
+
+		if (window.localStorage) {
+			if (state.accounts[accountId].collapsed) {
+				window.localStorage.removeItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + accountId);
+			} else {
+				window.localStorage.setItem(LOCALSTORAGE_NOT_COLLAPSED_PREFIX + accountId, true);
+			}
+		}
 	},
 	addFolder (state, {account, folder}) {
 		const addToState = folder => {


### PR DESCRIPTION
This commit fixes #692 in a more generic way in the Vue refactoring branch :
If there are less than 6 folders in an account, it hides the "Show all folders" button ans show all of them. It fix the initial need.
More, the second commit add a feature to store the "collapse folders" button state in localStorage in browser. It's a per account setting.