### PR TITLE
Fix address tooltip to show the actual address and not the label

### DIFF
--- a/src/components/Address.vue
+++ b/src/components/Address.vue
@@ -1,7 +1,7 @@
 <template>
 	<router-link :to="newMessageRoute"
 				 exact
-				 v-tooltip.bottom="label">{{ label }}
+				 v-tooltip.bottom="email">{{ label }}
 	</router-link>
 </template>
 


### PR DESCRIPTION
![bildschirmfoto von 2019-01-08 08-53-26](https://user-images.githubusercontent.com/1374172/50817062-e4cd8200-1322-11e9-9126-86718dec8155.png)
