### PR TITLE
Fix slow account loading by using serialized data

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,8 @@ import {generateFilePath} from 'nextcloud-server/dist/router'
 import VueShortKey from 'vue-shortkey'
 import VTooltip from 'v-tooltip'
 
+import {fixAccountId} from './service/AccountService'
+
 __webpack_nonce__ = btoa(OC.requestToken)
 __webpack_public_path__ = generateFilePath('mail', '', 'js/')
 
@@ -65,6 +67,11 @@ store.commit('savePreference', {
 	key: 'external-avatars',
 	value: getPreferenceFromPage('external-avatars')
 })
+
+const accounts = JSON.parse(atob(getPreferenceFromPage('serialized-accounts')))
+accounts
+	.map(fixAccountId)
+	.forEach(account => store.commit('addAccount', account))
 
 new Vue({
 	el: '#content',

--- a/src/service/AccountService.js
+++ b/src/service/AccountService.js
@@ -1,7 +1,7 @@
 import {generateUrl} from 'nextcloud-server/dist/router'
 import HttpClient from 'nextcloud-axios'
 
-const fixAccountId = original => {
+export const fixAccountId = original => {
 	return {
 		id: original.accountId,
 		...original

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
 	<div id="content"
 		 class="app-mail"
-	     v-shortkey.once="['c']"
+		 v-shortkey.once="['c']"
 		 @shortkey="onNewMessage">
 		<Loading v-if="loading" :hint="t('mail', 'Loading your accounts')"/>
 		<template v-else>
@@ -41,19 +41,16 @@
 			}
 		},
 		created () {
-			this.$store.dispatch('fetchAccounts')
-				.then(accounts => {
-					return Promise.all(accounts.map(account => {
-						return this.$store.dispatch('fetchFolders', {
-							accountId: account.id,
-						})
-					})).then(() => {
-						return accounts
-					})
-				}).then(accounts => {
+			const accounts = this.$store.getters.getAccounts()
+
+			return Promise.all(accounts.map(account => {
+				return this.$store.dispatch('fetchFolders', {
+					accountId: account.id,
+				})
+			})).then(() => {
 				this.loading = false
 
-				console.debug('accounts fetched', accounts)
+				console.debug('account folders fetched', accounts)
 
 				if (this.$route.name === 'home' && accounts.length > 0) {
 					// Show first account


### PR DESCRIPTION
This is a performance regression. The previous version already had that improvement, but I forgot to re-implement it.