### PR TITLE
Fixes for dark theme

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -328,25 +328,25 @@
 
 /* icons */
 .icon-inbox {
-	background-image: url('../img/inbox.svg');
+	@include icon-color('inbox', 'mail', $color-black);
 }
 .icon-flagged {
-	background-image: url('../img/star.svg');
+	@include icon-color('star', 'mail', $color-black);
 }
 .icon-drafts {
-	background-image: url('../img/drafts.svg');
+	@include icon-color('drafts', 'mail', $color-black);
 }
 .icon-sent {
-	background-image: url('../img/sent.svg');
+	@include icon-color('sent', 'mail', $color-black);
 }
 .icon-archive {
-	background-image: url('../img/archive.svg');
+	@include icon-color('archive', 'mail', $color-black);
 }
 .icon-junk {
-	background-image: url('../img/junk.svg');
+	@include icon-color('junk', 'mail', $color-black);
 }
 .icon-trash {
-	background-image: url('../img/trash.svg');
+	@include icon-color('trash', 'mail', $color-black);
 }
 
 

--- a/css/mail.scss
+++ b/css/mail.scss
@@ -299,8 +299,8 @@
 }
 
 .transparency {
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
-	opacity: .5;
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=60)";
+	opacity: .6;
 }
 
 

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -376,7 +376,7 @@
 	.composer-fields {
 		display: flex;
 		align-items: center;
-		border-top: 1px solid #eee;
+		border-top: 1px solid var(--color-border);
 		padding-right: 30px;
 	}
 	.composer-fields .multiselect,

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -256,11 +256,10 @@
 	}
 
 	#mail-message-header .transparency {
-		color: rgba(0, 0, 0, .3) !important;
-		opacity: 1;
+		opacity: .6;
 	}
 
 	#mail-message-header .transparency a {
-		color: rgba(0, 0, 0, .5) !important;
+		font-weight: bold;
 	}
 </style>


### PR DESCRIPTION

## Fixed mail subtitle
![mail subtitle before](https://user-images.githubusercontent.com/925062/51317238-5ad69500-1a57-11e9-9d98-15eb70af7848.png)
![mail header after](https://user-images.githubusercontent.com/925062/51317243-5b6f2b80-1a57-11e9-8f1d-2bb726361280.png)

## Fixed mail composer borders
![mail composer borders before](https://user-images.githubusercontent.com/925062/51317240-5ad69500-1a57-11e9-9244-949696d0dd1d.png)
![composer borders after](https://user-images.githubusercontent.com/925062/51317242-5b6f2b80-1a57-11e9-843c-9bb556f5eb8b.png)

## Tried to fix folder icons
But for some reason inbox, favorites, and trash are not replaced. Any idea why @skjnldsv?
![mail folder icons before](https://user-images.githubusercontent.com/925062/51317237-5ad69500-1a57-11e9-92eb-0d3577b4a249.png)  ![mail icons after](https://user-images.githubusercontent.com/925062/51317241-5b6f2b80-1a57-11e9-9ea7-a6859c330fe0.png)



Please review @nextcloud/mail  :)