### PR TITLE
Load account folders with the page and add error handling

### DIFF
--- a/src/components/FolderContent.vue
+++ b/src/components/FolderContent.vue
@@ -55,6 +55,11 @@
 			fetchData () {
 				this.loading = true
 
+				if (!this.$route.params.accountId && !this.$route.params.folderId) {
+					console.warn('no account nor folder id -> cannot fetch envelopes in FolderContent')
+					return;
+				}
+
 				this.$store.dispatch(
 					'fetchEnvelopes', {
 						accountId: this.$route.params.accountId,

--- a/src/main.js
+++ b/src/main.js
@@ -71,7 +71,12 @@ store.commit('savePreference', {
 const accounts = JSON.parse(atob(getPreferenceFromPage('serialized-accounts')))
 accounts
 	.map(fixAccountId)
-	.forEach(account => store.commit('addAccount', account))
+	.forEach(account => {
+		const folders = account.folders;
+		delete account.folders;
+		store.commit('addAccount', account)
+		folders.forEach(folder => store.commit('addFolder', {account, folder}))
+	})
 
 new Vue({
 	el: '#content',

--- a/src/mixins/SidebarItems.js
+++ b/src/mixins/SidebarItems.js
@@ -17,13 +17,15 @@ export default {
 			let accounts = this.$store.getters.getAccounts();
 			for (let id in accounts) {
 				const account = accounts[id]
+				const isError = account.error;
 
 				if (account.isUnified !== true && account.visible !== false) {
 					items.push({
 						id: 'account' + account.id,
 						key: 'account' + account.id,
 						text: account.emailAddress,
-						bullet: calculateAccountColor(account.name), // TODO
+						bullet: isError ? undefined : calculateAccountColor(account.name), // TODO
+						icon: isError ? 'icon-error' : undefined,
 						router: {
 							name: 'accountSettings',
 							params: {
@@ -66,7 +68,7 @@ export default {
 					.map(folderToEntry)
 					.forEach(i => items.push(i))
 
-				if (!account.isUnified) {
+				if (!account.isUnified && account.folders.length > 0) {
 					items.push({
 						id: 'collapse-' + account.id,
 						key: 'collapse-' + account.id,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,25 +2,22 @@
 	<AppContent app-name="mail"
 				v-shortkey.once="['c']"
 				@shortkey.native="onNewMessage">
-		<Loading v-if="loading" :hint="t('mail', 'Loading your accounts')"/>
-		<template v-else>
-			<template slot="navigation">
-				<AppNavigationNew :text="t('mail', 'New message')"
-								  buttonId="mail_new_message"
-								  buttonClass="icon-add"
-								  @click="onNewMessage"/>
-				<ul id="accounts-list">
-					<AppNavigationItem v-for="item in menu"
-									   :key="item.key"
-									   :item="item"/>
-				</ul>
-				<AppNavigationSettings :title="t('mail', 'Settings')">
-					<AppSettingsMenu />
-				</AppNavigationSettings>
-			</template>
-			<template slot="content">
-				<FolderContent/>
-			</template>
+		<template slot="navigation">
+			<AppNavigationNew :text="t('mail', 'New message')"
+							  buttonId="mail_new_message"
+							  buttonClass="icon-add"
+							  @click="onNewMessage"/>
+			<ul id="accounts-list">
+				<AppNavigationItem v-for="item in menu"
+								   :key="item.key"
+								   :item="item"/>
+			</ul>
+			<AppNavigationSettings :title="t('mail', 'Settings')">
+				<AppSettingsMenu/>
+			</AppNavigationSettings>
+		</template>
+		<template slot="content">
+			<FolderContent/>
 		</template>
 	</AppContent>
 </template>
@@ -34,7 +31,6 @@
 	} from 'nextcloud-vue'
 	import AppSettingsMenu from '../components/AppSettingsMenu'
 	import FolderContent from '../components/FolderContent'
-	import Loading from '../components/Loading'
 
 	import SidebarItems from '../mixins/SidebarItems'
 
@@ -48,12 +44,6 @@
 			AppNavigationSettings,
 			AppSettingsMenu,
 			FolderContent,
-			Loading,
-		},
-		data () {
-			return {
-				loading: true
-			}
 		},
 		computed: {
 			menu () {
@@ -63,60 +53,50 @@
 		created () {
 			const accounts = this.$store.getters.getAccounts()
 
-			return Promise.all(accounts.map(account => {
-				return this.$store.dispatch('fetchFolders', {
-					accountId: account.id,
-				})
-			})).then(() => {
-				this.loading = false
+			if (this.$route.name === 'home' && accounts.length > 0) {
+				// Show first account
+				let firstAccount = accounts[0]
+				// FIXME: this assumes that there's at least one folder
+				let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
 
-				console.debug('account folders fetched', accounts)
+				console.debug('loading first folder of first account', firstAccount.id, firstFolder.id)
 
-				if (this.$route.name === 'home' && accounts.length > 0) {
-					// Show first account
-					let firstAccount = accounts[0]
-					// FIXME: this assumes that there's at least one folder
-					let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
-
-					console.debug('loading first folder of first account', firstAccount.id, firstFolder.id)
-
-					this.$router.replace({
-						name: 'folder',
-						params: {
-							accountId: firstAccount.id,
-							folderId: firstFolder.id,
-						}
-					})
-				} else if (this.$route.name === 'mailto') {
-					if (accounts.length === 0) {
-						console.error('cannot handle mailto:, no accounts configured')
-						return
+				this.$router.replace({
+					name: 'folder',
+					params: {
+						accountId: firstAccount.id,
+						folderId: firstFolder.id,
 					}
-
-					// Show first account
-					let firstAccount = accounts[0]
-					// FIXME: this assumes that there's at least one folder
-					let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
-
-					console.debug('loading composer with first account and folder', firstAccount.id, firstFolder.id)
-
-					this.$router.replace({
-						name: 'message',
-						params: {
-							accountId: firstAccount.id,
-							folderId: firstFolder.id,
-							messageUid: 'new',
-						},
-						query: {
-							to: this.$route.query.to,
-							cc: this.$route.query.cc,
-							bcc: this.$route.query.bcc,
-							subject: this.$route.query.subject,
-							body: this.$route.query.body,
-						}
-					})
+				})
+			} else if (this.$route.name === 'mailto') {
+				if (accounts.length === 0) {
+					console.error('cannot handle mailto:, no accounts configured')
+					return
 				}
-			}).catch(console.error.bind(this))
+
+				// Show first account
+				let firstAccount = accounts[0]
+				// FIXME: this assumes that there's at least one folder
+				let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
+
+				console.debug('loading composer with first account and folder', firstAccount.id, firstFolder.id)
+
+				this.$router.replace({
+					name: 'message',
+					params: {
+						accountId: firstAccount.id,
+						folderId: firstFolder.id,
+						messageUid: 'new',
+					},
+					query: {
+						to: this.$route.query.to,
+						cc: this.$route.query.cc,
+						bcc: this.$route.query.bcc,
+						subject: this.$route.query.subject,
+						body: this.$route.query.body,
+					}
+				})
+			}
 		},
 		methods: {
 			onNewMessage () {


### PR DESCRIPTION
This loads the accounts list with the page to both speed up the initial rendering as well as fix a double-fetching issue when navigating between settings and folders.

The app now loads just fine if one of the individual accounts does throw errors (e.g. due to changed password).