### PR TITLE
Fix initial loading of home component

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,7 +2,7 @@
 	<AppContent v-shortkey.once="['c']" app-name="mail" @shortkey.native="onNewMessage">
 		<Navigation slot="navigation" />
 		<template slot="content">
-			<FolderContent :account="activeAccount" :folder="activeFolder" />
+			<FolderContent v-if="activeAccount" :account="activeAccount" :folder="activeFolder" />
 		</template>
 	</AppContent>
 </template>


### PR DESCRIPTION
On the first render of the home component, there is no active account.
However, the folder content component expects one. This make the folder
content render only if the active account is available.