### PR TITLE
Catch UID parsing errors

### DIFF
--- a/src/util/EnvelopeUidParser.js
+++ b/src/util/EnvelopeUidParser.js
@@ -24,6 +24,11 @@ const reg = /^(\d+)-((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}
 export const parseUid = str => {
 	const match = reg.exec(str)
 
+	if (match === null) {
+		console.error(`UID ${str} is invalid`)
+		throw new Error(`UID ${str} is invalid`)
+	}
+
 	return {
 		accountId: parseInt(match[1], 10),
 		folderId: match[2],


### PR DESCRIPTION
Developed for https://github.com/nextcloud/mail/issues/1603, but should give better errors in general