### PR TITLE
Add support for signatures

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,6 +44,11 @@ return [
 			'verb' => 'POST'
 		],
 		[
+			'name' => 'accounts#updateSignature',
+			'url' => '/api/accounts/{accountId}/signature',
+			'verb' => 'PUT'
+		],
+		[
 			'name' => 'folders#sync',
 			'url' => '/api/accounts/{accountId}/folders/{folderId}/sync',
 			'verb' => 'GET'

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -196,6 +196,20 @@ class AccountsController extends Controller {
 	 * @NoAdminRequired
 	 * @TrapError
 	 *
+	 * @param int $accountId
+	 * @param string|null $signature
+	 *
+	 * @return JSONResponse
+	 */
+	public function updateSignature(int $accountId, string $signature = null) {
+		$this->accountService->updateSignature($accountId, $this->currentUserId, $signature);
+		return new JSONResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
 	 * @param int $id
 	 * @return JSONResponse
 	 */

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -57,22 +57,25 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOutboundUser(string $outboundUser)
  * @method string getOutboundPassword()
  * @method void setOutboundPassword(string $outboundPassword)
+ * @method string|null getSignature()
+ * @method void setSignature(string|null $signature)
  */
 class MailAccount extends Entity {
 
-	public $userId;
-	public $name;
-	public $email;
-	public $inboundHost;
-	public $inboundPort;
-	public $inboundSslMode;
-	public $inboundUser;
-	public $inboundPassword;
-	public $outboundHost;
-	public $outboundPort;
-	public $outboundSslMode;
-	public $outboundUser;
-	public $outboundPassword;
+	protected $userId;
+	protected $name;
+	protected $email;
+	protected $inboundHost;
+	protected $inboundPort;
+	protected $inboundSslMode;
+	protected $inboundUser;
+	protected $inboundPassword;
+	protected $outboundHost;
+	protected $outboundPort;
+	protected $outboundSslMode;
+	protected $outboundUser;
+	protected $outboundPassword;
+	protected $signature;
 
 	/**
 	 * @param array $params
@@ -134,6 +137,7 @@ class MailAccount extends Entity {
 			'imapPort' => $this->getInboundPort(),
 			'imapUser' => $this->getInboundUser(),
 			'imapSslMode' => $this->getInboundSslMode(),
+			'signature' => $this->getSignature(),
 		];
 
 		if (!is_null($this->getOutboundHost())) {

--- a/lib/Migration/Version0130Date20190408134101.php
+++ b/lib/Migration/Version0130Date20190408134101.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version0130Date20190408134101 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		$accountsTable->addColumn('signature', 'text', [
+			'notnull' => false,
+			'length' => 1024,
+			'default' => '',
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -28,6 +28,7 @@ use Exception;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\DefaultAccount\Manager;
 use OCP\IL10N;
 
@@ -127,6 +128,16 @@ class AccountService {
 	 */
 	public function save(MailAccount $newAccount): MailAccount {
 		return $this->mapper->save($newAccount);
+	}
+
+	public function updateSignature(int $id, string $uid, string $signature = null) {
+		$account = $this->find($uid, $id);
+		if ($account === null) {
+			throw new ServiceException("Account does not exist or user is not permitted to change it");
+		}
+		$mailAccount = $account->getMailAccount();
+		$mailAccount->setSignature($signature);
+		$this->mapper->save($mailAccount);
 	}
 
 }

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -226,8 +226,10 @@ export default {
 	beforeMount() {
 		if (this.fromAccount) {
 			this.selectedAlias = this.aliases.find(alias => alias.id === this.fromAccount)
+		} else {
+			this.selectedAlias = this.aliases[0]
 		}
-		this.selectedAlias = this.aliases[0]
+		this.bodyVal = this.bodyWithSignature(this.selectedAlias, this.body)
 	},
 	methods: {
 		recipientToRfc822(recipient) {
@@ -345,6 +347,15 @@ export default {
 		 */
 		formatAliases(alias) {
 			return `${alias.name} <${alias.emailAddress}>`
+		},
+		bodyWithSignature(alias, body) {
+			console.info(alias)
+
+			if (!alias || !alias.signature) {
+				return body
+			}
+
+			return body + '\n\n--\n\n' + alias.signature
 		},
 	},
 }

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -1,0 +1,90 @@
+<!--
+  - @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div>
+		<h3>{{ t('mail', 'Signature') }}</h3>
+		<p>
+			{{ t('mail', 'A signature will be added to the text of new and response messages.') }}
+		</p>
+		<p>
+			<textarea v-model="signature" :disabled="loading"></textarea>
+		</p>
+		<p>
+			<input type="submit" :value="t('mail', 'Delete')" :disabled="loading" @click="deleteSignature" />
+			<input
+				type="submit"
+				class="primary"
+				:value="t('mail', 'Save')"
+				:disabled="loading"
+				@click="saveSignature"
+			/>
+		</p>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'SignatureSettings',
+	props: {
+		account: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+		}
+	},
+	methods: {
+		deleteSignature() {
+			this.loading = true
+
+			this.$store
+				.dispatch('updateAccountSignature', {account: this.account, signature: null})
+				.then(() => {
+					console.info('signature deleted')
+					this.signature = ''
+					this.loading = false
+				})
+				.catch(e => {
+					console.error('could not delete account signature', e)
+					throw e
+				})
+		},
+		saveSignature() {
+			this.loading = true
+
+			this.$store
+				.dispatch('updateAccountSignature', {account: this.account, signature: this.signature})
+				.then(() => {
+					console.info('signature updated')
+					this.loading = false
+				})
+				.catch(e => {
+					console.error('could not update account signature', e)
+					throw e
+				})
+		},
+	},
+}
+</script>

--- a/src/service/AccountService.js
+++ b/src/service/AccountService.js
@@ -26,6 +26,19 @@ export const update = data => {
 		.then(fixAccountId)
 }
 
+export const updateSignature = (account, signature) => {
+	const url = generateUrl(`/apps/mail/api/accounts/{id}/signature`, {
+		id: account.id,
+	})
+	const data = {
+		signature,
+	}
+
+	return HttpClient.put(url, data)
+		.then(resp => resp.data)
+		.then(fixAccountId)
+}
+
 export const fetchAll = () => {
 	const url = generateUrl('/apps/mail/api/accounts')
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -25,6 +25,7 @@ import {savePreference} from '../service/PreferenceService'
 import {
 	create as createAccount,
 	update as updateAccount,
+	updateSignature,
 	deleteAccount,
 	fetch as fetchAccount,
 	fetchAll as fetchAllAccounts,
@@ -76,6 +77,14 @@ export default {
 	updateAccount({commit}, config) {
 		return updateAccount(config).then(account => {
 			console.debug('account updated', account)
+			commit('editAccount', account)
+			return account
+		})
+	},
+	updateAccountSignature({commit}, {account, signature}) {
+		return updateSignature(account, signature).then(() => {
+			console.debug('account signature updated')
+			account.signature = signature
 			commit('editAccount', account)
 			return account
 		})

--- a/src/views/AccountSettings.vue
+++ b/src/views/AccountSettings.vue
@@ -4,9 +4,11 @@
 		<template slot="content">
 			<div class="section">
 				<h2>{{ t('mail', 'Account Settings') }} - {{ email }}</h2>
+				<h3>{{ t('mail', 'Mail server') }}</h3>
 				<div id="mail-settings">
 					<AccountForm :display-name="displayName" :email="email" :save="onSave" :account="account" />
 				</div>
+				<SignatureSettings :account="account" />
 			</div>
 		</template>
 	</AppContent>
@@ -17,6 +19,7 @@ import {AppContent} from 'nextcloud-vue'
 
 import AccountForm from '../components/AccountForm'
 import Navigation from '../components/Navigation'
+import SignatureSettings from '../components/SignatureSettings'
 
 export default {
 	name: 'AccountSettings',
@@ -24,13 +27,18 @@ export default {
 		AccountForm,
 		AppContent,
 		Navigation,
+		SignatureSettings,
+	},
+	data() {
+		const account = this.$store.getters.getAccount(this.$route.params.accountId)
+		return {
+			account,
+			signature: account.signature,
+		}
 	},
 	computed: {
 		menu() {
 			return this.buildMenu()
-		},
-		account() {
-			return this.$store.getters.getAccount(this.$route.params.accountId)
 		},
 		displayName() {
 			return this.$store.getters.getAccount(this.$route.params.accountId).name

--- a/tests/Controller/AccountsControllerTest.php
+++ b/tests/Controller/AccountsControllerTest.php
@@ -168,6 +168,28 @@ class AccountsControllerTest extends TestCase {
 		$this->controller->show($this->accountId);
 	}
 
+	public function testUpdateSignature() {
+		$this->accountService->expects($this->once())
+			->method('updateSignature')
+			->with($this->equalTo($this->accountId), $this->equalTo($this->userId), 'sig');
+
+		$response = $this->controller->updateSignature($this->accountId, 'sig');
+
+		$expectedResponse = new JSONResponse();
+		$this->assertEquals($expectedResponse, $response);
+	}
+
+	public function testDeleteSignature() {
+		$this->accountService->expects($this->once())
+			->method('updateSignature')
+			->with($this->equalTo($this->accountId), $this->equalTo($this->userId), null);
+
+		$response = $this->controller->updateSignature($this->accountId, null);
+
+		$expectedResponse = new JSONResponse();
+		$this->assertEquals($expectedResponse, $response);
+	}
+
 	public function testDestroy() {
 		$this->accountService->expects($this->once())
 			->method('delete')

--- a/tests/Db/MailAccountTest.php
+++ b/tests/Db/MailAccountTest.php
@@ -53,7 +53,8 @@ class TestMailAccount extends TestCase {
 			'smtpHost' => 'smtp.marvel.com',
 			'smtpPort' => 458,
 			'smtpUser' => 'spiderman',
-			'smtpSslMode' => 'ssl'
+			'smtpSslMode' => 'ssl',
+			'signature' => null,
 			), $a->toJson());
 	}
 
@@ -69,7 +70,8 @@ class TestMailAccount extends TestCase {
 			'smtpHost' => 'smtp.marvel.com',
 			'smtpPort' => 458,
 			'smtpUser' => 'spiderman',
-			'smtpSslMode' => 'ssl'
+			'smtpSslMode' => 'ssl',
+			'signature' => null,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency

--- a/tests/Service/AccountServiceTest.php
+++ b/tests/Service/AccountServiceTest.php
@@ -134,4 +134,23 @@ class AccountServiceTest extends TestCase {
 		$this->assertEquals($account, $actual);
 	}
 
+	public function testUpdateSignature() {
+		$id = 3;
+		$uid = 'ian';
+		$signature = 'sig';
+		$mailAccount = $this->createMock(MailAccount::class);
+		$this->mapper->expects($this->once())
+			->method('find')
+			->with(
+				$uid,
+				$id
+			)
+			->willReturn($mailAccount);
+		$this->mapper->expects($this->once())
+			->method('save')
+			->with($mailAccount);
+
+		$this->accountService->updateSignature($id, $uid, $signature);
+	}
+
 }


### PR DESCRIPTION
To do
- [x] Create a `signature` column for accounts
- [x] Extend the mail account class with a new property
- [x] Automatically insert the signature for new emails
- [x] Automatically insert the signature for replies
- [x] Add a settings entry to set (and delete) the signature

Fine tuning in follow-up PRs (~~will open~~ **opened** tickets for that)
- [x] Possibility to define a signature as HTML (requires a HTML editor) https://github.com/nextcloud/mail/issues/1659
- [x] Possibility to switch between signatures (requires enhanced text manipulation logic) https://github.com/nextcloud/mail/issues/1660
- [x] Possibility to add signatures to aliases (requires working aliases) https://github.com/nextcloud/mail/issues/1661

Fixes https://github.com/nextcloud/mail/issues/190