### PR TITLE
Replace the legacy appstore target in Makefile with the Krankerl command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,10 @@ cache:
 before_install:
   - php --info
 
+  # Install Krankerl
+  - wget https://github.com/ChristophWurst/krankerl/releases/download/v0.10.1/krankerl_0.10.1_amd64.deb
+  - sudo dpkg -i krankerl_0.10.1_amd64.deb
+
   # Set up DB
   - if [[ "$DB" == 'pgsql' ]]; then createuser -U travis -s oc_autotest; fi
   - if [[ "$DB" == 'mysql' ]]; then mysql -u root -e 'create database oc_autotest;'; fi

--- a/Makefile
+++ b/Makefile
@@ -64,53 +64,6 @@ update-composer: composer.phar
 	rm -f composer.lock
 	php composer.phar install --prefer-dist
 
-appstore: clean install-deps optimize-js
-	mkdir -p $(sign_dir)
-	rsync -a \
-	--exclude=bower.json \
-	--exclude=.bowerrc \
-	--exclude=composer.json \
-	--exclude=composer.lock \
-	--exclude=composer.phar \
-	--exclude=CONTRIBUTING.md \
-	--exclude=coverage \
-	--exclude=.git \
-	--exclude=.gitattributes \
-	--exclude=.github \
-	--exclude=.gitignore \
-	--exclude=Gruntfile.js \
-	--exclude=.hg \
-	--exclude=issue_template.md \
-	--exclude=.jscsrc \
-	--exclude=.jshintignore \
-	--exclude=.jshintrc \
-	--exclude=js/tests \
-	--exclude=karma.conf.js \
-	--exclude=l10n/no-php \
-	--exclude=.tx \
-	--exclude=Makefile \
-	--exclude=nbproject \
-	--exclude=/node_modules \
-	--exclude=package.json \
-	--exclude=.phan \
-	--exclude=phpunit*xml \
-	--exclude=screenshots \
-	--exclude=.scrutinizer.yml \
-	--exclude=tests \
-	--exclude=.travis.yml \
-	--exclude=vendor/bin \
-	$(project_dir)/ $(sign_dir)/$(app_name)
-	@if [ -f $(cert_dir)/$(app_name).key ]; then \
-		echo "Signing app files…"; \
-		php ../../occ integrity:sign-app \
-			--privateKey=$(cert_dir)/$(app_name).key\
-			--certificate=$(cert_dir)/$(app_name).crt\
-			--path=$(sign_dir)/$(app_name); \
-	fi
-	tar -czf $(build_dir)/$(app_name).tar.gz \
-		-C $(sign_dir) $(app_name)
-	@if [ -f $(cert_dir)/$(app_name).key ]; then \
-		echo "Signing package…"; \
-		openssl dgst -sha512 -sign $(cert_dir)/$(app_name).key $(build_dir)/$(app_name).tar.gz | openssl base64; \
-	fi
+appstore:
+	krankerl package
 


### PR DESCRIPTION
Nobody should use this, hence removing it.