### PR TITLE
Make it possible to create subfolders and show folder stats

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -54,6 +54,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'folders#stats',
+			'url' => '/api/accounts/{accountId}/folders/{folderId}/stats',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'messages#downloadAttachment',
 			'url' => '/api/accounts/{accountId}/folders/{folderId}/messages/{messageId}/attachment/{attachmentId}',
 			'verb' => 'GET'

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -25,6 +25,7 @@ namespace OCA\Mail\Contracts;
 
 use OCA\Mail\Account;
 use OCA\Mail\Folder;
+use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\Sync\Request as SyncRequest;
 use OCA\Mail\IMAP\Sync\Response as SyncResponse;
 
@@ -45,6 +46,14 @@ interface IMailManager {
 	public function createFolder(Account $account, string $name): Folder;
 
 	/**
+	 * @param Account $account
+	 * @param string $folderId
+	 *
+	 * @return FolderStats
+	 */
+	public function getFolderStats(Account $account, string $folderId): FolderStats;
+
+	/**
 	 * @param Account
 	 * @param SyncRequest $syncRequest
 	 * @return SyncResponse
@@ -60,4 +69,5 @@ interface IMailManager {
 	 */
 	public function moveMessage(Account $sourceAccount, string $sourceFolderId, int $messageId,
 								Account $destinationAccount, string $destFolderId);
+
 }

--- a/lib/Controller/FoldersController.php
+++ b/lib/Controller/FoldersController.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Controller;
 
+use function base64_decode;
+use function is_array;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Http\JSONResponse;
@@ -100,6 +102,27 @@ class FoldersController extends Controller {
 		$syncResponse = $this->mailManager->syncMessages($account, new SyncRequest(base64_decode($folderId), $syncToken, $uids));
 
 		return new JSONResponse($syncResponse);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $accountId
+	 * @param string $folderId
+	 *
+	 * @return JSONResponse
+	 */
+	public function stats(int $accountId, string $folderId): JSONResponse {
+		$account = $this->accountService->find($this->currentUserId, $accountId);
+
+		if (empty($accountId) || empty($folderId)) {
+			return new JSONResponse(null, Http::STATUS_BAD_REQUEST);
+		}
+
+		$stats = $this->mailManager->getFolderStats($account, base64_decode($folderId));
+
+		return new JSONResponse($stats);
 	}
 
 	/**

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -23,15 +23,16 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP;
 
+use function array_filter;
+use function array_map;
+use function reset;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Exception;
-use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
 use OCA\Mail\SearchFolder;
-use function reset;
 
 class FolderMapper {
 
@@ -125,6 +126,22 @@ class FolderMapper {
 				$folder->setStatus($status[$folder->getMailbox()]);
 			}
 		}
+	}
+
+	/**
+	 * @param Horde_Imap_Client_Socket $client
+	 * @param string $mailbox
+	 *
+	 * @throws Horde_Imap_Client_Exception
+	 */
+	public function getFoldersStatusAsObject(Horde_Imap_Client_Socket $client,
+											 string $mailbox) {
+		$status = $client->status($mailbox);
+
+		return new FolderStats(
+			$status['messages'],
+			$status['unseen']
+		);
 	}
 
 	/**

--- a/lib/IMAP/FolderStats.php
+++ b/lib/IMAP/FolderStats.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\IMAP;
+
+use JsonSerializable;
+
+class FolderStats implements JsonSerializable {
+
+	/** @var int */
+	private $total;
+
+	/** @var int */
+	private $unread;
+
+	public function __construct(int $total, int $unread) {
+
+		$this->total = $total;
+		$this->unread = $unread;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'total' => $this->total,
+			'unread' => $this->unread,
+		];
+	}
+}

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -28,6 +28,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
+use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\IMAP\Sync\Request;
@@ -84,6 +85,18 @@ class MailManager implements IMailManager {
 		$this->folderMapper->getFoldersStatus([$folder], $client);
 		$this->folderMapper->detectFolderSpecialUse([$folder]);
 		return $folder;
+	}
+
+	/**
+	 * @param Account $account
+	 * @param string $folderId
+	 *
+	 * @return FolderStats
+	 */
+	public function getFolderStats(Account $account, string $folderId): FolderStats {
+		$client = $this->imapClientFactory->getClient($account);
+
+		return $this->folderMapper->getFoldersStatusAsObject($client, $folderId);
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3166,7 +3166,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -4153,7 +4153,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -5913,7 +5913,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
@@ -9383,7 +9383,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -9401,7 +9401,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -9506,7 +9506,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {

--- a/src/service/FolderService.js
+++ b/src/service/FolderService.js
@@ -1,5 +1,5 @@
 import {generateUrl} from 'nextcloud-server/dist/router'
-import HttpClient from 'nextcloud-axios'
+import Axios from 'nextcloud-axios'
 
 export function fetchAll(accountId) {
 	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders', {
@@ -8,7 +8,7 @@ export function fetchAll(accountId) {
 
 	// FIXME: this return format is weird and should be avoided
 	// TODO: respect `resp.data.delimiter` value
-	return HttpClient.get(url).then(resp => resp.data.folders)
+	return Axios.get(url).then(resp => resp.data.folders)
 }
 
 export function create(accountId, name) {
@@ -19,5 +19,14 @@ export function create(accountId, name) {
 	const data = {
 		name,
 	}
-	return HttpClient.post(url, data).then(resp => resp.data)
+	return Axios.post(url, data).then(resp => resp.data)
+}
+
+export function getFolderStats(accountId, folderId) {
+	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/stats', {
+		accountId,
+		folderId,
+	})
+
+	return Axios.get(url).then(resp => resp.data)
 }

--- a/tests/Controller/FoldersControllerTest.php
+++ b/tests/Controller/FoldersControllerTest.php
@@ -21,12 +21,14 @@
 
 namespace OCA\Mail\Tests\Controller;
 
+use function base64_encode;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Controller\FoldersController;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Folder;
 use OCA\Mail\Http\JSONResponse;
+use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\Service\AccountService;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCP\IRequest;
@@ -116,6 +118,25 @@ class FoldersControllerTest extends TestCase {
 		$response = $this->controller->create($accountId, 'new');
 
 		$expected = new JSONResponse($folder);
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testStats() {
+		$account = $this->createMock(Account::class);
+		$stats = $this->createMock(FolderStats::class);
+		$accountId = 28;
+		$this->accountService->expects($this->once())
+			->method('find')
+			->with($this->equalTo($this->userId), $this->equalTo($accountId))
+			->willReturn($account);
+		$this->mailManager->expects($this->once())
+			->method('getFolderStats')
+			->with($this->equalTo($account), $this->equalTo('INBOX'))
+			->willReturn($stats);
+
+		$response = $this->controller->stats($accountId, base64_encode('INBOX'));
+
+		$expected = new JSONResponse($stats);
 		$this->assertEquals($expected, $response);
 	}
 

--- a/tests/IMAP/FolderMapperTest.php
+++ b/tests/IMAP/FolderMapperTest.php
@@ -27,6 +27,7 @@ use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
+use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\SearchFolder;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 
@@ -190,6 +191,22 @@ class FolderMapperTest extends TestCase {
 			->method('setStatus');
 
 		$this->mapper->getFoldersStatus($folders, $client);
+	}
+
+	public function testGetFoldersStatusAsObject() {
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$client->expects($this->once())
+			->method('status')
+			->with('INBOX')
+			->willReturn([
+				'messages' => 123,
+				'unseen' => 2,
+			]);
+
+		$stats = $this->mapper->getFoldersStatusAsObject($client, 'INBOX');
+
+		$expected = new FolderStats(123, 2);
+		$this->assertEquals($expected, $stats);
 	}
 
 	public function testDetectSpecialUseFromAttributes() {

--- a/tests/Service/MailManagerTest.php
+++ b/tests/Service/MailManagerTest.php
@@ -26,6 +26,7 @@ use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
+use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\IMAP\Sync\Request;
@@ -48,7 +49,7 @@ class MailManagerTest extends TestCase {
 	/** @var Synchronizer|MockObject */
 	private $sync;
 
-	/** @varr MailManager */
+	/** @var MailManager */
 	private $manager;
 
 	protected function setUp() {
@@ -112,6 +113,23 @@ class MailManagerTest extends TestCase {
 		$created = $this->manager->createFolder($account, 'new');
 
 		$this->assertEquals($folder, $created);
+	}
+
+	public function testGetFolderStats() {
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$account = $this->createMock(Account::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$stats = $this->createMock(FolderStats::class);
+		$this->folderMapper->expects($this->once())
+			->method('getFoldersStatusAsObject')
+			->with($this->equalTo($client), $this->equalTo('INBOX'))
+			->willReturn($stats);
+
+		$actual = $this->manager->getFolderStats($account, 'INBOX');
+
+		$this->assertEquals($stats, $actual);
 	}
 
 	public function testSync() {


### PR DESCRIPTION
This adds a convenient way of adding subfolders to top-level folders without having to know the delimiter.

I had to find a secondary action to prevent the vue components from rending a single action and thus making the *add folder* form unusable. Therefore we now show some simple folder stats:

![Bildschirmfoto von 2019-04-19 10-14-43](https://user-images.githubusercontent.com/1374172/56414786-fb716680-628b-11e9-8c9b-7ffe95eb4114.png)