### PR TITLE
Drag'n'Drop support

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "vue-slide-up-down": "^2.0.0",
     "vue-tabs-component": "^1.5.0",
     "vuex": "^3.1.2",
+    "vue-draggable": "^2.0.2",
     "vuex-router-sync": "^5.0.0"
   },
   "browserslist": [

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<AppNavigationItem :item="data" ref="navigationItem" :title="title" @click="toggleCollapse" />
+	<AppNavigationItem :item="data" :title="title" @click="toggleCollapse" />
 </template>
 
 <script>
@@ -45,6 +45,16 @@ export default {
 			return this.account.collapsed ? t('mail', 'Show all folders') : t('mail', 'Collapse folders')
 		},
 	},
+	data() {
+		return {
+			timeoutID: '',
+			id: 'collapse-' + this.account.id,
+			key: 'collapse-' + this.account.id,
+			classes: ['collapse-folders'],
+			text: this.account.collapsed ? t('mail', 'Show all folders') : t('mail', 'Collapse folders'),
+			action: () => this.$store.commit('toggleAccountCollapsed', this.account.id),
+		}
+	},
 	methods: {
 		toggleCollapse() {
 			this.$store.commit('toggleAccountCollapsed', this.account.id)
@@ -53,7 +63,20 @@ export default {
 	mounted() {
 		let self = this
 		this.$el.ondragenter = function() {
-			self.$store.commit('toggleAccountCollapsed', self.account.id)
+			this.style.background = '#F5F5F5'
+			if (self.timeoutID === '') {
+				self.timeoutID = window.setTimeout(function() {
+					self.$store.commit('toggleAccountCollapsed', self.account.id)
+					self.timeoutID = ''
+				}, 800)
+			}
+		}
+		this.$el.ondragleave = function() {
+			this.style.background = ''
+			if (self.timeoutID !== '') {
+				window.clearTimeout(self.timeoutID)
+				self.timeoutID = ''
+			}
 		}
 	}
 }

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<AppNavigationItem :title="title" @click="toggleCollapse" />
+	<AppNavigationItem :item="data" ref="navigationItem" :title="title" @click="toggleCollapse" />
 </template>
 
 <script>
@@ -50,6 +50,12 @@ export default {
 			this.$store.commit('toggleAccountCollapsed', this.account.id)
 		},
 	},
+	mounted() {
+		let self = this
+		this.$el.ondragenter = function() {
+			self.$store.commit('toggleAccountCollapsed', self.account.id)
+		}
+	}
 }
 </script>
 

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -105,6 +105,7 @@ export default {
 	},
 	data() {
 		return {
+			timeoutID: '',
 			folderOpen: false,
 			menuOpen: false,
 			loadingFolderStats: true,
@@ -135,7 +136,20 @@ export default {
 	mounted() {
 		let self = this
 		this.$el.ondragenter = function() {
-			self.folderOpen = true
+			this.style.background = '#F5F5F5'
+			if (self.data.children.length > 0 && self.timeoutID === '') {
+				self.timeoutID = window.setTimeout(function() {
+					self.folderOpen = !self.folderOpen
+					self.timeoutID = ''
+				}, 800)
+			}
+		}
+		this.$el.ondragleave = function() {
+			this.style.background = ''
+			if (self.timeoutID !== '') {
+				window.clearTimeout(self.timeoutID)
+				self.timeoutID = ''
+			}
 		}
 	},
 	methods: {

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -120,7 +120,6 @@ export default {
 		folderId() {
 			return atob(this.folder.id)
 		},
-<<<<<<< HEAD
 		icon() {
 			return this.folder.specialRole ? 'icon-' + this.folder.specialRole : 'icon-folder'
 		},
@@ -131,7 +130,8 @@ export default {
 					accountId: this.account.id,
 					folderId: this.folder.id,
 				},
-=======
+			}
+		}
 	},
 	mounted() {
 		let self = this
@@ -157,7 +157,6 @@ export default {
 			let icon = 'folder'
 			if (folder.specialRole) {
 				icon = folder.specialRole
->>>>>>> Implements basic auto-expansion of folders when dragging an envelope over them
 			}
 		},
 		subFolders() {

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -21,12 +21,15 @@
 
 <template>
 	<AppNavigationItem
+		:item="data"
 		:id="genId(folder)"
 		:key="genId(folder)"
 		:allow-collapse="true"
 		:icon="icon"
 		:title="title"
 		:to="to"
+		:menu-open.sync="menuOpen"
+		:open.sync="folderOpen"
 		@update:menuOpen="onMenuToggle"
 	>
 		<!-- actions -->
@@ -102,6 +105,9 @@ export default {
 	},
 	data() {
 		return {
+			folderOpen: false,
+			menuOpen: false,
+			loadingFolderStats: true,
 			folderStats: undefined,
 			loadingMarkAsRead: false,
 		}
@@ -113,6 +119,7 @@ export default {
 		folderId() {
 			return atob(this.folder.id)
 		},
+<<<<<<< HEAD
 		icon() {
 			return this.folder.specialRole ? 'icon-' + this.folder.specialRole : 'icon-folder'
 		},
@@ -123,6 +130,20 @@ export default {
 					accountId: this.account.id,
 					folderId: this.folder.id,
 				},
+=======
+	},
+	mounted() {
+		let self = this
+		this.$el.ondragenter = function() {
+			self.folderOpen = true
+		}
+	},
+	methods: {
+		folderToEntry(folder, top) {
+			let icon = 'folder'
+			if (folder.specialRole) {
+				icon = folder.specialRole
+>>>>>>> Implements basic auto-expansion of folders when dragging an envelope over them
 			}
 		},
 		subFolders() {

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@
  */
 
 import Vue from 'vue'
+import VueDraggable from 'vue-draggable'
 import App from './App'
 import {getRequestToken} from '@nextcloud/auth'
 import router from './router'
@@ -47,6 +48,7 @@ Vue.mixin({
 
 Vue.use(VueShortKey, {prevent: ['input', 'div']})
 Vue.use(VTooltip)
+Vue.use(VueDraggable)
 
 const getPreferenceFromPage = key => {
 	const elem = document.getElementById(key)

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -95,3 +95,13 @@ export function deleteMessage(accountId, folderId, id) {
 
 	return HttpClient.delete(url).then(resp => resp.data)
 }
+
+export function moveMessage(accountId, startFolderId, targetFolderId, id) {
+	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{startFolderId}/messages/{id}/move', {
+		accountId,
+		startFolderId,
+		id,
+	})
+
+	return HttpClient.post(url, {destAccountId: accountId, destFolderId: targetFolderId}).then(resp => resp.data)
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -40,8 +40,8 @@ import {
 	fetchAll as fetchAllAccounts,
 } from '../service/AccountService'
 import {fetchAll as fetchAllFolders, create as createFolder, markFolderRead} from '../service/FolderService'
-import {deleteMessage, fetchEnvelopes, fetchMessage, setEnvelopeFlag, syncEnvelopes} from '../service/MessageService'
 import logger from '../logger'
+import {moveMessage, deleteMessage, fetchEnvelopes, fetchMessage, setEnvelopeFlag, syncEnvelopes} from '../service/MessageService'
 import {showNewMessagesNotification} from '../service/NotificationService'
 import {parseUid} from '../util/EnvelopeUidParser'
 
@@ -467,6 +467,33 @@ export default {
 			data,
 			newUid: uid,
 		})
+	},
+	moveMessage({getters, commit}, data) {
+		const folder = getters.getFolder(data.accountId, data.startFolderId)
+		commit('removeEnvelope', {
+			accountId: data.accountId,
+			folder,
+			id: data.msgId,
+		})
+		return moveMessage(data.accountId, data.startFolderId, data.targetFolderId, data.msgId)
+			.then(() => {
+				commit('removeMessage', {
+					accountId: data.accountId,
+					folder,
+					id: data.msgId,
+				})
+				console.log('message moved')
+			})
+			.catch(err => {
+				console.error('could not move message', err)
+				const env = getters.getEnvelope(data.accountId, data.startFolderId, data.msgId)
+				commit('addEnvelope', {
+					accountId: data.accountId,
+					folder,
+					env,
+				})
+				throw err
+			})
 	},
 	deleteMessage({getters, commit}, envelope) {
 		const folder = getters.getFolder(envelope.accountId, envelope.folderId)

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -50,8 +50,6 @@ export default {
 			// FIXME: this assumes that there's at least one folder
 			let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
 
-			console.debug('loading first folder of first account', firstAccount.id, firstFolder.id)
-
 			this.$router.replace({
 				name: 'folder',
 				params: {
@@ -66,7 +64,7 @@ export default {
 			})
 		} else if (this.$route.name === 'mailto') {
 			if (accounts.length === 0) {
-				console.error('cannot handle mailto:, no accounts configured')
+				Logger.error('cannot handle mailto:, no accounts configured')
 				return
 			}
 
@@ -74,8 +72,6 @@ export default {
 			let firstAccount = accounts[0]
 			// FIXME: this assumes that there's at least one folder
 			let firstFolder = this.$store.getters.getFolders(firstAccount.id)[0]
-
-			console.debug('loading composer with first account and folder', firstAccount.id, firstFolder.id)
 
 			this.$router.replace({
 				name: 'message',
@@ -96,25 +92,64 @@ export default {
 	},
 	methods: {
 		moveMessage(e) {
+
+			// We don't want to use this.activeAccount here because we want it to work in the unified inbox
 			var startAccount = e.items[0].attributes.href.baseURI.match(/message\/(\d)/)
 			var targetAccount = e.droptarget.href.match(/accounts\/(\d)/)
+
 			if (targetAccount[1] == startAccount[1]) {
 				var accountId = targetAccount[1]
+
+				// We don't want to use this.activeFolder here because we want it to work in the unified inbox
 				var startFolderId = e.items[0].attributes.href.baseURI.match(/.+-([^-]+)-\d+$/)
 				var targetFolderId = e.droptarget.href.match(/.+\/([\S]+)$/)
+
 				if (startFolderId[1] != targetFolderId[1]) {
 					var msgId = e.items[0].attributes.href.baseURI.match(/.+-([\S]+)$/)
+
+					// Find out next/previous envelope
+					let envelopes = this.$store.getters.getEnvelopes(this.$route.params.accountId, this.$route.params.folderId)
+					let currentEnv = this.$store.getters.getEnvelope(startAccount[1], startFolderId[1], msgId[1])
+					let next
+					const idx = envelopes.indexOf(currentEnv)
+					if (idx === -1) {
+					        Logger.debug('envelope to delete does not exist in envelope list')
+					        return
+					} else if (idx === 0) {
+					        next = envelopes[idx + 1]
+					} else {
+					        next = envelopes[idx - 1]
+					}
+
+					// Move message and navigate to next/previous envelope
 					this.$store.dispatch('moveMessage', {
 						accountId: accountId,
 						startFolderId: startFolderId[1],
 						targetFolderId: targetFolderId[1],
 						msgId: msgId[1],
+					}).then(() => {
+
+						if (!next) {
+						        Logger.debug('no next/previous envelope, not navigating')
+						        return
+						}
+
+						// Keep the selected account-folder combination, but navigate to a different message
+						// (it's not a bug that we don't use next.accountId and next.folderId here)
+						this.$router.push({
+						        name: 'message',
+						        params: {
+						                accountId: this.$route.params.accountId,
+						                folderId: this.$route.params.folderId,
+						                messageUid: next.uid,
+						        },
+						})
 					})
 				} else {
-					console.info('target folder is the same as start folder => wont try to move email')
+					Logger.info('target folder is the same as start folder => wont try to move email')
 				}
 			} else {
-				console.info('Cannot move email in another mailbox')
+				Logger.info('Cannot move email in another mailbox')
 			}
 		},
 		onNewMessage() {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,16 @@
 <template>
-	<Content v-shortkey.once="['c']" app-name="mail" @shortkey.native="onNewMessage">
+	<Content
+		v-shortkey.once="['c']"
+		v-drag-and-drop:options="{
+			dropzoneSelector: '.icon-folder',
+			draggableSelector: '.app-content-list-item',
+			onDrop: function(e) {
+				moveMessage(e)
+			},
+		}"
+		app-name="mail"
+		@shortkey.native="onNewMessage"
+	>
 		<Navigation />
 		<FolderContent v-if="activeAccount" :account="activeAccount" :folder="activeFolder" />
 	</Content>
@@ -84,6 +95,28 @@ export default {
 		}
 	},
 	methods: {
+		moveMessage(e) {
+			var startAccount = e.items[0].attributes.href.baseURI.match(/message\/(\d)/)
+			var targetAccount = e.droptarget.href.match(/accounts\/(\d)/)
+			if (targetAccount[1] == startAccount[1]) {
+				var accountId = targetAccount[1]
+				var startFolderId = e.items[0].attributes.href.baseURI.match(/.+-([^-]+)-\d+$/)
+				var targetFolderId = e.droptarget.href.match(/.+\/([\S]+)$/)
+				if (startFolderId[1] != targetFolderId[1]) {
+					var msgId = e.items[0].attributes.href.baseURI.match(/.+-([\S]+)$/)
+					this.$store.dispatch('moveMessage', {
+						accountId: accountId,
+						startFolderId: startFolderId[1],
+						targetFolderId: targetFolderId[1],
+						msgId: msgId[1],
+					})
+				} else {
+					console.info('target folder is the same as start folder => wont try to move email')
+				}
+			} else {
+				console.info('Cannot move email in another mailbox')
+			}
+		},
 		onNewMessage() {
 			// FIXME: assumes that we're on the 'message' route already
 			this.$router.push({


### PR DESCRIPTION
Drag'n'Drop support implementation with https://github.com/Vivify-Ideas/vue-draggable

Remaining issues:

- [ ] It seems the code isn't properly initialized: If you load the mail apps from your browser, the drag'n'drop functionality won't work directly. You first have to perform an action (eg: selecting another email than the default one displayed) before the drag'n'drop functionality will work;
- [ ] Shouldn't navigate when the moved message is not tghe one currently displayed
- [ ] Do not expand when folder's account is not the same as envelope account
- [ ] Polishing