### PR TITLE
Fix caching of webpack chunks

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -5,6 +5,7 @@ module.exports = {
 	entry: path.join(__dirname, 'src/main.js'),
 	output: {
 		path: path.resolve(__dirname, 'js'),
+		chunkFilename: 'mail.[name].[contenthash].js',
 		publicPath: '/js/',
 		filename: 'mail.js'
 	},


### PR DESCRIPTION
Fixes #1754 

cc @PriceChild @scarleo  

The problem was that Nextcloud only adds the cache buster argument to scripts it includes. This means only for the main entry bundle. However, webpack will load more chunks asynchronously, hence they also face the cache issues.

This change adds a content hash to the chunk file names. This should make it impossible to run into these problems again.

I could not reproduce the issue locally.