### PR TITLE
Fix next/prev message navigation when non-open message is deleted

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -124,6 +124,10 @@ export default {
 				Logger.debug('envelope to delete does not exist in envelope list')
 				return
 			}
+			if (envelope.uid !== this.$route.params.messageUid) {
+				Logger.debug('other message open, not jumping to the next/previous message')
+				return
+			}
 
 			let next
 			if (idx === 0) {


### PR DESCRIPTION
## Steps to reproduce

* Open a message
* Delete another one

***Expected***

Current message stays open

***Actual (before)***

App navigates to previous/next message of the deleted one