### PR TITLE
Add a database cache for folders

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Mail</name>
 	<summary>IMAP web client</summary>
 	<description>Easy to use email client which connects to your mail server via IMAP and SMTP.</description>
-	<version>0.15.5</version>
+	<version>0.15.6</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Jan-Christoph Borchardt</author>

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -672,4 +672,8 @@ class Account implements JsonSerializable {
 		return new ReplyMessage();
 	}
 
+	public function getLastMailboxSync(): int {
+		return (int) $this->account->getLastMailboxSync();
+	}
+
 }

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -59,6 +59,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setOutboundPassword(string $outboundPassword)
  * @method string|null getSignature()
  * @method void setSignature(string|null $signature)
+ * @method int getLastMailboxSync()
+ * @method void setLastMailboxSync(int $time)
  */
 class MailAccount extends Entity {
 
@@ -76,6 +78,7 @@ class MailAccount extends Entity {
 	protected $outboundUser;
 	protected $outboundPassword;
 	protected $signature;
+	protected $lastMailboxSync;
 
 	/**
 	 * @param array $params
@@ -123,6 +126,8 @@ class MailAccount extends Entity {
 		if (isset($params['smtpPassword'])) {
 			$this->setOutboundPassword($params['smtpPassword']);
 		}
+
+		$this->addType('lastMailboxSync', 'integer');
 	}
 
 	/**

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCA\Mail\Folder;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method string getId()
+ * @method void setId(string $id)
+ * @method int getAccountId()
+ * @method void setAccountId(int $accountId)
+ * @method string getSyncToken()
+ * @method void setSyncToken(string $syncToken)
+ * @method string getAttributes()
+ * @method void setAttributes(string $attributes)
+ * @method string getDelimiter()
+ * @method void setDelimiter(string $delimiter)
+ * @method int getMessages()
+ * @method void setMessages(int $messages)
+ * @method int getUnseen()
+ * @method void setUnseen(int $unseen)
+ * @method bool getSelectable()
+ * @method void setSelectable(bool $selectable)
+ */
+class Mailbox extends Entity {
+
+	protected $accountId;
+	protected $syncToken;
+	protected $attributes;
+	protected $delimiter;
+	protected $messages;
+	protected $unseen;
+	protected $selectable;
+
+	public function __construct() {
+		$this->addType('id', 'string');
+		$this->addType('accountId', 'integer');
+		$this->addType('messages', 'integer');
+		$this->addType('unseen', 'integer');
+		$this->addType('selectable', 'boolean');
+	}
+
+	public function toFolder(): Folder {
+		$folder = new Folder(
+			$this->accountId,
+			new \Horde_Imap_Client_Mailbox($this->id),
+			json_decode($this->getAttributes() ?? '[]', true) ?? [],
+			$this->delimiter
+		);
+		$folder->setSyncToken($this->getSyncToken());
+		return $folder;
+	}
+
+}

--- a/lib/Db/MailboxMapper.php
+++ b/lib/Db/MailboxMapper.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCA\Mail\Account;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+class MailboxMapper extends QBMapper {
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'mail_mailboxes');
+	}
+
+	/**
+	 * @param Account $account
+	 *
+	 * @return Mailbox[]
+	 */
+	public function findAll(Account $account): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('account_id', $qb->createNamedParameter($account->getId())));
+
+		return $this->findEntities($select);
+	}
+
+}

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -26,8 +26,8 @@ use JsonSerializable;
 
 class Folder implements JsonSerializable {
 
-	/** @var Account */
-	private $account;
+	/** @var int */
+	private $accountId;
 
 	/** @var Horde_Imap_Client_Mailbox */
 	private $mailbox;
@@ -59,8 +59,8 @@ class Folder implements JsonSerializable {
 	 * @param array $attributes
 	 * @param string $delimiter
 	 */
-	public function __construct(Account $account, Horde_Imap_Client_Mailbox $mailbox, array $attributes, $delimiter) {
-		$this->account = $account;
+	public function __construct(int $accountId, Horde_Imap_Client_Mailbox $mailbox, array $attributes, $delimiter) {
+		$this->accountId = $accountId;
 		$this->mailbox = $mailbox;
 		$this->attributes = $attributes;
 		$this->delimiter = $delimiter;
@@ -154,6 +154,10 @@ class Folder implements JsonSerializable {
 		$this->syncToken = $syncToken;
 	}
 
+	public function getSyncToken(): ?string {
+		return $this->syncToken;
+	}
+
 	/**
 	 * @return array
 	 */
@@ -164,12 +168,12 @@ class Folder implements JsonSerializable {
 		}
 		return [
 			'id' => base64_encode($this->getMailbox()),
-			'accountId' => $this->account->getId(),
+			'accountId' => $this->accountId,
 			'name' => $this->getDisplayName(),
 			'unseen' => isset($this->status['unseen']) ? $this->status['unseen'] : 0,
 			'total' => isset($this->status['messages']) ? (int) $this->status['messages'] : 0,
 			'isEmpty' => isset($this->status['messages']) ? 0 >= (int) $this->status['messages'] : true,
-			'noSelect' => in_array('\noselect', $this->attributes),
+			'noSelect' => !$this->isSelectable(),
 			'attributes' => $this->attributes,
 			'delimiter' => $this->delimiter,
 			'folders' => array_values($folders),
@@ -177,6 +181,10 @@ class Folder implements JsonSerializable {
 			'specialRole' => empty($this->specialUse) ? null : $this->specialUse[0],
 			'syncToken' => $this->syncToken,
 		];
+	}
+
+	public function isSelectable(): bool {
+		return !in_array('\noselect', $this->attributes);
 	}
 
 }

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -69,7 +69,12 @@ class FolderMapper {
 				continue;
 			}
 
-			$folder = new Folder($account, $mailbox['mailbox'], $mailbox['attributes'], $mailbox['delimiter']);
+			$folder = new Folder(
+				$account->getId(),
+				$mailbox['mailbox'],
+				$mailbox['attributes'],
+				$mailbox['delimiter']
+			);
 
 			if ($folder->isSearchable()) {
 				$folder->setSyncToken($client->getSyncToken($folder->getMailbox()));
@@ -77,7 +82,7 @@ class FolderMapper {
 
 			$folders[] = $folder;
 			if ($mailbox['mailbox']->utf8 === 'INBOX') {
-				$searchFolder = new SearchFolder($account, $mailbox['mailbox'], $mailbox['attributes'], $mailbox['delimiter']);
+				$searchFolder = new SearchFolder($account->getId(), $mailbox['mailbox'], $mailbox['attributes'], $mailbox['delimiter']);
 				if ($folder->isSearchable()) {
 					$searchFolder->setSyncToken($client->getSyncToken($folder->getMailbox()));
 				}
@@ -103,7 +108,7 @@ class FolderMapper {
 			throw new ServiceException("Created mailbox does not exist");
 		}
 
-		return new Folder($account, $mb['mailbox'], $mb['attributes'], $mb['delimiter']);
+		return new Folder($account->getId(), $mb['mailbox'], $mb['attributes'], $mb['delimiter']);
 	}
 
 	/**

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\IMAP;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Folder;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ILogger;
+
+class MailboxSync {
+
+	/** @var MailboxMapper */
+	private $mailboxMapper;
+
+	/** @var FolderMapper */
+	private $folderMapper;
+
+	/** @var MailAccountMapper */
+	private $mailAccountMapper;
+
+	/** @var IMAPClientFactory */
+	private $imapClientFactory;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(MailboxMapper $mailboxMapper,
+								FolderMapper $folderMapper,
+								MailAccountMapper $mailAccountMapper,
+								IMAPClientFactory $imapClientFactory,
+								ITimeFactory $timeFactory,
+								ILogger $logger) {
+		$this->mailboxMapper = $mailboxMapper;
+		$this->folderMapper = $folderMapper;
+		$this->mailAccountMapper = $mailAccountMapper;
+		$this->imapClientFactory = $imapClientFactory;
+		$this->timeFactory = $timeFactory;
+		$this->logger = $logger;
+	}
+
+	public function sync(Account $account): void {
+		if ($account->getMailAccount()->getLastMailboxSync() >= ($this->timeFactory->getTime() - 7200)) {
+			$this->logger->debug("account is up to date, skipping mailbox sync");
+			return;
+		}
+
+		$client = $this->imapClientFactory->getClient($account);
+
+		$folders = $this->folderMapper->getFolders($account, $client);
+		$this->folderMapper->getFoldersStatus($folders, $client);
+		$this->folderMapper->detectFolderSpecialUse($folders);
+
+		$old = $this->mailboxMapper->findAll($account);
+		$indexedOld = array_combine(
+			array_map(function (Mailbox $mb) {
+				return $mb->getId();
+			}, $old),
+			$old
+		);
+
+		$this->persist($account, $folders, $indexedOld);
+	}
+
+	private function persist(Account $account, array $folders, array $existing): void {
+		foreach ($folders as $folder) {
+			if (isset($existing[$folder->getMailbox()])) {
+				$this->updateMailboxFromFolder(
+					$account,
+					$folder,
+					$existing[$folder->getMailbox()]
+				);
+			} else {
+				$this->createMailboxFromFolder(
+					$account,
+					$folder
+				);
+			}
+
+			unset($existing[$folder->getMailbox()]);
+		}
+
+		foreach ($existing as $leftover) {
+			$this->mailboxMapper->delete($leftover);
+		}
+
+		$account->getMailAccount()->setLastMailboxSync($this->timeFactory->getTime());
+		$this->mailAccountMapper->update($account->getMailAccount());
+	}
+
+	private function updateMailboxFromFolder(Account $account, Folder $folder, Mailbox $mailbox): void {
+		$mailbox->setDelimiter($folder->getDelimiter());
+		$mailbox->setSyncToken($folder->getSyncToken());
+		$mailbox->setAttributes(json_encode($folder->getAttributes()));
+		$mailbox->setDelimiter($folder->getDelimiter());
+		$mailbox->setMessages(0); // TODO
+		$mailbox->setUnseen(0); // TODO
+		$mailbox->setSelectable($folder->isSelectable());
+		$this->mailboxMapper->update($mailbox);
+	}
+
+	private function createMailboxFromFolder(Account $account, Folder $folder): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId($folder->getMailbox());
+		$mailbox->setAccountId($account->getId());
+		$mailbox->setSyncToken($folder->getSyncToken());
+		$mailbox->setAttributes(json_encode($folder->getAttributes()));
+		$mailbox->setDelimiter($folder->getDelimiter());
+		$mailbox->setMessages(0); // TODO
+		$mailbox->setUnseen(0); // TODO
+		$mailbox->setSelectable($folder->isSelectable());
+		$this->mailboxMapper->insert($mailbox);
+	}
+
+}

--- a/lib/Migration/Version0156Date20190828140357.php
+++ b/lib/Migration/Version0156Date20190828140357.php
@@ -75,10 +75,10 @@ class Version0156Date20190828140357 extends SimpleMigrationStep {
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('selectable', 'integer', [
+		$mailboxTable->addColumn('selectable', 'boolean', [
 			'notnull' => true,
 			'length' => 1,
-			'default' => 1,
+			'default' => true,
 		]);
 		// We allow each mailbox name just once
 		$mailboxTable->setPrimaryKey([

--- a/lib/Migration/Version0156Date20190828140357.php
+++ b/lib/Migration/Version0156Date20190828140357.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IMigrationStep;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version0156Date20190828140357 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		$accountsTable->addColumn('last_mailbox_sync', 'integer', [
+			'default' => 0,
+		]);
+
+		$mailboxTable = $schema->createTable('mail_mailboxes');
+		$mailboxTable->addColumn('id', 'string', [
+			'notnull' => true,
+			'length' => 255,
+		]);
+		$mailboxTable->addColumn('account_id', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$mailboxTable->addColumn('sync_token', 'string', [
+			'notnull' => true,
+			'length' => 255,
+		]);
+		$mailboxTable->addColumn('attributes', 'string', [
+			'length' => 255,
+			'default' => '[]',
+		]);
+		$mailboxTable->addColumn('delimiter', 'string', [
+			'notnull' => true,
+			'length' => 1,
+		]);
+		$mailboxTable->addColumn('messages', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$mailboxTable->addColumn('unseen', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$mailboxTable->addColumn('selectable', 'integer', [
+			'notnull' => true,
+			'length' => 1,
+			'default' => 1,
+		]);
+		// We allow each mailbox name just once
+		$mailboxTable->setPrimaryKey([
+			'account_id',
+			'id',
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/SearchFolder.php
+++ b/lib/SearchFolder.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -30,11 +30,11 @@ class SearchFolder extends Folder {
 	 * @param Account $account
 	 * @param Horde_Imap_Client_Mailbox $mailbox
 	 * @param array $attributes
-	 * @param type $delimiter
+	 * @param string $delimiter
 	 */
-	public function __construct(Account $account, Horde_Imap_Client_Mailbox $mailbox, array $attributes, $delimiter) {
+	public function __construct(int $accountId, Horde_Imap_Client_Mailbox $mailbox, array $attributes, $delimiter) {
 		$attributes[] = Horde_Imap_Client::SPECIALUSE_FLAGGED;
-		parent::__construct($account, $mailbox, $attributes, $delimiter);
+		parent::__construct($accountId, $mailbox, $attributes, $delimiter);
 	}
 
 	/**

--- a/tests/Db/MailboxMapperTest.php
+++ b/tests/Db/MailboxMapperTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\Db;
+
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailboxMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Diagnostics\IQuery;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MailboxMapperTest extends TestCase {
+
+	use DatabaseTransaction;
+
+	/** @var IDBConnection */
+	private $db;
+
+	/** @var MailboxMapper */
+	private $mapper;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->db = \OC::$server->getDatabaseConnection();
+		$this->mapper = new MailboxMapper(
+			$this->db
+		);
+
+		$qb = $this->db->getQueryBuilder();
+
+		$delete = $qb->delete($this->mapper->getTableName());
+		$delete->execute();
+	}
+
+	public function testFindAllNoData() {
+		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(13);
+
+		$result = $this->mapper->findAll($account);
+
+		$this->assertEmpty($result);
+	}
+
+	public function testFindAll() {
+		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(13);
+		foreach (range(1, 10) as $i) {
+			$qb = $this->db->getQueryBuilder();
+			$insert = $qb->insert($this->mapper->getTableName())
+				->values([
+					'id' => $qb->createNamedParameter("folder$i"),
+					'account_id' => $qb->createNamedParameter($i <= 5 ? 13 : 14, IQueryBuilder::PARAM_INT),
+					'sync_token' => $qb->createNamedParameter('VTEsVjE0Mjg1OTkxNDk='),
+					'delimiter' => $qb->createNamedParameter('.'),
+					'messages' => $qb->createNamedParameter($i * 100, IQueryBuilder::PARAM_INT),
+					'unseen' => $qb->createNamedParameter($i, IQueryBuilder::PARAM_INT),
+					'selectable' => $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL),
+				]);
+			$insert->execute();
+		}
+
+		$result = $this->mapper->findAll($account);
+
+		$this->assertCount(5, $result);
+	}
+
+}

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -29,8 +29,8 @@ use PHPUnit_Framework_MockObject_MockObject;
 
 class FolderTest extends TestCase {
 
-	/** @var Account|PHPUnit_Framework_MockObject_MockObject */
-	private $account;
+	/** @var int */
+	private $accountId;
 
 	/** @var Horde_Imap_Client_Mailbox|PHPUnit_Framework_MockObject_MockObject */
 	private $mailbox;
@@ -39,10 +39,10 @@ class FolderTest extends TestCase {
 	private $folder;
 
 	private function mockFolder(array $attributes = [], $delimiter = '.') {
-		$this->account = $this->createMock(Account::class);
+		$this->accountId = 15;
 		$this->mailbox = $this->createMock(Horde_Imap_Client_Mailbox::class);
 
-		$this->folder = new Folder($this->account, $this->mailbox, $attributes, $delimiter);
+		$this->folder = new Folder($this->accountId, $this->mailbox, $attributes, $delimiter);
 	}
 
 	public function testGetMailbox() {
@@ -131,9 +131,6 @@ class FolderTest extends TestCase {
 			->method('__get')
 			->with($this->equalTo('utf8'))
 			->willReturn('Sent');
-		$this->account->expects($this->once())
-			->method('getId')
-			->willReturn(123);
 
 		$this->folder->setDisplayName('Gesendet');
 		$this->folder->addSpecialUse('sent');
@@ -145,7 +142,7 @@ class FolderTest extends TestCase {
 
 		$expected = [
 			'id' => base64_encode('Sent'),
-			'accountId' => 123,
+			'accountId' => 15,
 			'name' => 'Gesendet',
 			'specialRole' => null,
 			'unseen' => 13,

--- a/tests/IMAP/FolderMapperTest.php
+++ b/tests/IMAP/FolderMapperTest.php
@@ -62,6 +62,7 @@ class FolderMapperTest extends TestCase {
 
 	public function testGetFolders() {
 		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(27);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('listMailboxes')
@@ -86,9 +87,9 @@ class FolderMapperTest extends TestCase {
 				],
 		]);
 		$expected = [
-			new Folder($account, new Horde_Imap_Client_Mailbox('INBOX'), [], '.'),
-			new SearchFolder($account, new Horde_Imap_Client_Mailbox('INBOX'), [], '.'),
-			new Folder($account, new Horde_Imap_Client_Mailbox('Sent'), ['\sent'], '.'),
+			new Folder(27, new Horde_Imap_Client_Mailbox('INBOX'), [], '.'),
+			new SearchFolder(27, new Horde_Imap_Client_Mailbox('INBOX'), [], '.'),
+			new Folder(27, new Horde_Imap_Client_Mailbox('Sent'), ['\sent'], '.'),
 		];
 
 		$folders = $this->mapper->getFolders($account, $client);
@@ -98,6 +99,7 @@ class FolderMapperTest extends TestCase {
 
 	public function testCreateFolder() {
 		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(42);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('createMailbox')
@@ -120,7 +122,7 @@ class FolderMapperTest extends TestCase {
 
 		$created = $this->mapper->createFolder($client, $account, 'new');
 
-		$expected = new Folder($account, new Horde_Imap_Client_Mailbox('new'), [], '.');
+		$expected = new Folder(42, new Horde_Imap_Client_Mailbox('new'), [], '.');
 		$this->assertEquals($expected, $created);
 	}
 

--- a/tests/IMAP/MailboxSyncTest.php
+++ b/tests/IMAP/MailboxSyncTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\IMAP;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Socket;
+use OC\AppFramework\Utility\TimeFactory;
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Folder;
+use OCA\Mail\IMAP\FolderMapper;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\IMAP\MailboxSync;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\ILogger;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MailboxSyncTest extends TestCase {
+
+	/** @var MailboxMapper|MockObject */
+	private $mailboxMapper;
+
+	/** @var FolderMapper|MockObject */
+	private $folderMapper;
+
+	/** @var MailAccountMapper|MockObject */
+	private $mailAccountMapper;
+
+	/** @var IMAPClientFactory|MockObject */
+	private $imapClientFactory;
+
+	/** @var TimeFactory|MockObject */
+	private $timeFactory;
+
+	/** @var ILogger|MockObject */
+	private $logger;
+
+	/** @var MailboxSync */
+	private $sync;
+
+	protected function setUp() {
+		parent::setUp();
+
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->folderMapper = $this->createMock(FolderMapper::class);
+		$this->mailAccountMapper = $this->createMock(MailAccountMapper::class);
+		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(ILogger::class);
+
+		$this->sync = new MailboxSync(
+			$this->mailboxMapper,
+			$this->folderMapper,
+			$this->mailAccountMapper,
+			$this->imapClientFactory,
+			$this->timeFactory,
+			$this->logger
+		);
+	}
+
+	public function testSyncSkipped() {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(100000 - 2000);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$this->imapClientFactory->expects($this->never())
+			->method('getClient');
+
+		$this->sync->sync($account);
+	}
+
+	public function testSync() {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(0);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$folders = [
+			$this->createMock(Folder::class),
+			$this->createMock(Folder::class),
+		];
+		$this->folderMapper->expects($this->once())
+			->method('getFolders')
+			->with($account, $client)
+			->willReturn($folders);
+		$this->folderMapper->expects($this->once())
+			->method('detectFolderSpecialUse')
+			->with($folders)
+			->willReturn($folders);
+
+		$this->sync->sync($account);
+	}
+
+}

--- a/tests/Integration/Service/FolderMapperIntegrationTest.php
+++ b/tests/Integration/Service/FolderMapperIntegrationTest.php
@@ -53,6 +53,7 @@ class FolderMapperIntegrationTest extends TestCase {
 
 	public function testGetFolders() {
 		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(13);
 		$client = $this->getTestClient();
 
 		$folders = $this->mapper->getFolders($account, $client);

--- a/tests/SearchFolderTest.php
+++ b/tests/SearchFolderTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
@@ -29,8 +29,8 @@ use PHPUnit_Framework_MockObject_MockObject;
 
 class SearchFolderTest extends TestCase {
 
-	/** @var Account|PHPUnit_Framework_MockObject_MockObject */
-	private $account;
+	/** @var int */
+	private $accountId;
 
 	/** @var Horde_Imap_Client_Mailbox|PHPUnit_Framework_MockObject_MockObject */
 	private $mailbox;
@@ -41,10 +41,10 @@ class SearchFolderTest extends TestCase {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->account = $this->createMock(Account::class);
+		$this->accountId = 16;
 		$this->mailbox = $this->createMock(Horde_Imap_Client_Mailbox::class);
 
-		$this->folder = new SearchFolder($this->account, $this->mailbox, [], ',');
+		$this->folder = new SearchFolder($this->accountId, $this->mailbox, [], ',');
 	}
 
 	public function testGetMailbox() {


### PR DESCRIPTION
This drastically* speeds up page loads, especially with multi account setups.

Todo

- [x] Store time of last sync
- [x] Only sync folders each x hours
- [x] Update and write tests


*on my two-account test it took an avg of 8s to load a full page (showing a message as well) without this cache and an avg of 4.6 with.