### PR TITLE
Improve error handling of the message sync

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace OCA\Mail\Contracts;
 
 use OCA\Mail\Account;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\Sync\Request as SyncRequest;
@@ -57,6 +59,9 @@ interface IMailManager {
 	 * @param Account
 	 * @param SyncRequest $syncRequest
 	 * @return SyncResponse
+	 *
+	 * @throws ClientException
+	 * @throws ServiceException
 	 */
 	public function syncMessages(Account $account, SyncRequest $syncRequest): SyncResponse;
 


### PR DESCRIPTION
This ensures that [the error middleware](https://github.com/nextcloud/mail/blob/master/lib/Http/Middleware/ErrorMiddleware.php) can catch more client errors via the [attribute in the controller](https://github.com/nextcloud/mail/blob/master/lib/Controller/FoldersController.php#L87) and thus produce fewer Sentry reports.