### PR TITLE
Filter out empty MX'es

### DIFF
--- a/lib/Service/AutoConfig/MxRecord.php
+++ b/lib/Service/AutoConfig/MxRecord.php
@@ -43,6 +43,14 @@ class MxRecord {
 			$this->logger->debug("no MX records for host <$host> found");
 			return false;
 		}
+		$mxRecords = array_filter($mxRecords, function($record) {
+			return !empty($record);
+		});
+		if (empty(($mxRecords))) {
+			$this->logger->debug("all records for <$host>'s MX are empty");
+			return false;
+		}
+
 		$this->logger->debug("found " . count($mxRecords) . " MX records for host <$host>");
 
 		// TODO: sort by weight


### PR DESCRIPTION
example.com recently changed, and so our tests fail.


```
$ host -t mx example.com
example.com mail is handled by 0 .
```

This breaks CI on all current PRs.