### PR TITLE
Show recipients in envelopes' list when displaying a 'sent' folder

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1,7 +1,7 @@
 <template>
 	<router-link class="app-content-list-item" :class="{unseen: data.flags.unseen, draft}" :to="link">
 		<div
-			v-if="showAccountColor"
+			v-if="folder.isUnified"
 			class="mail-message-account-color"
 			:style="{'background-color': accountColor}"
 		></div>
@@ -13,8 +13,8 @@
 		<div class="app-content-list-item-icon">
 			<Avatar :display-name="sender" :email="senderEmail" />
 		</div>
-		<div class="app-content-list-item-line-one" :title="sender">
-			{{ sender }}
+		<div class="app-content-list-item-line-one" :title="addresses">
+			{{ addresses }}
 		</div>
 		<div class="app-content-list-item-line-two" :title="data.subject">
 			<span v-if="data.flags.answered" class="icon-reply" />
@@ -57,9 +57,9 @@ export default {
 			type: Object,
 			required: true,
 		},
-		showAccountColor: {
-			type: Boolean,
-			default: false,
+		folder: {
+			type: Object,
+			required: true,
 		},
 	},
 	computed: {
@@ -96,14 +96,16 @@ export default {
 				}
 			}
 		},
-		sender() {
-			if (this.data.from.length === 0) {
-				// No sender
-				return '?'
+		addresses() {
+			// Show recipients' label/address in a sent folder
+			if (this.folder.specialRole === 'sent') {
+				let recipients = [this.data.to, this.data.cc].flat().map(function(recipient) {
+					return recipient.label ? recipient.label : recipient.email
+				})
+				return recipients.length > 0 ? recipients.join(', ') : t('mail', 'Bcc recipients only')
 			}
-
-			const first = this.data.from[0]
-			return first.label || first.email
+			// Show sender label/address in other folder types
+			return this.data.from.length === 0 ? '?' : this.data.from[0].label || this.data.from[0].email
 		},
 		senderEmail() {
 			if (this.data.from.length > 0) {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -16,7 +16,7 @@
 				v-else
 				:key="env.uid"
 				:data="env"
-				:show-account-color="folder.isUnified"
+				:folder="folder"
 				@delete="onEnvelopeDeleted"
 			/>
 			<div id="load-more-mail-messages" key="loadingMore" :class="{'icon-loading-small': loadingMore}" />


### PR DESCRIPTION
Fix to https://github.com/nextcloud/mail/issues/2019

![image](https://user-images.githubusercontent.com/8179031/65249433-47069580-daf4-11e9-9d65-568fac84f09b.png)
