### PR TITLE
Do not show the <> around email if no name given

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -353,6 +353,10 @@ export default {
 		 * @returns {string}
 		 */
 		formatAliases(alias) {
+			if (!alias.name) {
+				return alias.emailAddress
+			}
+
 			return `${alias.name} <${alias.emailAddress}>`
 		},
 		bodyWithSignature(alias, body) {


### PR DESCRIPTION
This email changes the "From" address when no name was given.
Before: `<mail@domain.com>`
After: `mail@domain.com`

When the name is given it stays `Full Name <mail@domain.com>`

Signed-off-by: Jakob Sack <mail@jakobsack.de>