### PR TITLE
Fix invalid envelope avatar display name

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -11,7 +11,7 @@
 			@click.prevent="onToggleFlagged"
 		></div>
 		<div class="app-content-list-item-icon">
-			<Avatar :display-name="sender" :email="senderEmail" />
+			<Avatar :display-name="addresses" :email="senderEmail" />
 		</div>
 		<div class="app-content-list-item-line-one" :title="addresses">
 			{{ addresses }}


### PR DESCRIPTION
Fixes a regression from https://github.com/nextcloud/mail/pull/2020 that causes Vue validation errors.