### PR TITLE
Remove \OCA\Mail\Account::createMailbox

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -198,6 +198,21 @@ class Account implements JsonSerializable {
 	}
 
 	/**
+	 * @param string $folderId
+	 * @return Mailbox
+	 */
+	public function getMailbox($folderId) {
+		$conn = $this->getImapConnection();
+		$parts = explode('/', $folderId);
+		if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
+			$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
+			return new SearchMailbox($conn, $mailbox, []);
+		}
+		$mailbox = new Horde_Imap_Client_Mailbox($folderId);
+		return new Mailbox($conn, $mailbox, []);
+	}
+
+	/**
 	 * @return array
 	 */
 	public function jsonSerialize() {

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -153,18 +153,6 @@ class Account implements JsonSerializable {
 
 	/**
 	 * @param string $mailBox
-	 * @param array $opts
-	 * @return Mailbox
-	 */
-	public function createMailbox($mailBox, $opts = []) {
-		$conn = $this->getImapConnection();
-		$conn->createMailbox($mailBox, $opts);
-
-		return $this->getMailbox($mailBox);
-	}
-
-	/**
-	 * @param string $mailBox
 	 */
 	public function deleteMailbox($mailBox) {
 		if ($mailBox instanceof Mailbox) {
@@ -207,21 +195,6 @@ class Account implements JsonSerializable {
 		}
 
 		return $mailboxes;
-	}
-
-	/**
-	 * @param string $folderId
-	 * @return Mailbox
-	 */
-	public function getMailbox($folderId) {
-		$conn = $this->getImapConnection();
-		$parts = explode('/', $folderId);
-		if (count($parts) > 1 && $parts[1] === 'FLAGGED') {
-			$mailbox = new Horde_Imap_Client_Mailbox($parts[0]);
-			return new SearchMailbox($conn, $mailbox, []);
-		}
-		$mailbox = new Horde_Imap_Client_Mailbox($folderId);
-		return new Mailbox($conn, $mailbox, []);
 	}
 
 	/**

--- a/tests/IMAP/AccountTest.php
+++ b/tests/IMAP/AccountTest.php
@@ -38,7 +38,7 @@ class AccountTest extends AbstractTest {
 		$this->getTestAccount()->createMailBox($name);
 		$this->assertMailBoxExists($name);
 
-		$this->getTestAccount()->deleteMailbox($name);
+		$this->getTestAccount()->getImapConnection()->deleteMailbox($name);
 		$this->assertMailBoxNotExists($name);
 	}
 

--- a/tests/IMAP/AccountTest.php
+++ b/tests/IMAP/AccountTest.php
@@ -51,25 +51,4 @@ class AccountTest extends AbstractTest {
 			['äöü']
 		];
 	}
-
-	/**
-	 * @dataProvider providesMailBoxNames
-	 * @param $name
-	 */
-	public function testListMessages($name) {
-		$name = uniqid($name);
-		$newMailBox = $this->getTestAccount()->getImapConnection()->createMailBox($name);
-		$count = $newMailBox->getTotalMessages();
-		$this->assertEquals(0, $count);
-		$messages = $newMailBox->getMessages();
-		$this->assertInternalType('array', $messages);
-		$this->assertEquals(0, count($messages));
-		$this->createTestMessage($newMailBox);
-		$count = $newMailBox->getTotalMessages();
-		$this->assertEquals(1, $count);
-		$messages = $newMailBox->getMessages();
-		$this->assertInternalType('array', $messages);
-		$this->assertEquals(1, count($messages));
-	}
-
 }

--- a/tests/IMAP/AccountTest.php
+++ b/tests/IMAP/AccountTest.php
@@ -58,7 +58,7 @@ class AccountTest extends AbstractTest {
 	 */
 	public function testListMessages($name) {
 		$name = uniqid($name);
-		$newMailBox = parent::createMailBox($name);
+		$newMailBox = $this->getTestAccount()->getImapConnection()->createMailBox($name);
 		$count = $newMailBox->getTotalMessages();
 		$this->assertEquals(0, $count);
 		$messages = $newMailBox->getMessages();

--- a/tests/IMAP/AccountTest.php
+++ b/tests/IMAP/AccountTest.php
@@ -35,10 +35,12 @@ class AccountTest extends AbstractTest {
 	 */
 	public function testCreateAndDelete($name) {
 		$name = uniqid($name);
-		$this->getTestAccount()->createMailBox($name);
+		$imapConnection = $this->getTestAccount()->getImapConnection();
+
+		$imapConnection->createMailBox($name);
 		$this->assertMailBoxExists($name);
 
-		$this->getTestAccount()->getImapConnection()->deleteMailbox($name);
+		$imapConnection->deleteMailbox($name);
 		$this->assertMailBoxNotExists($name);
 	}
 

--- a/tests/IMAP/AccountTest.php
+++ b/tests/IMAP/AccountTest.php
@@ -35,7 +35,7 @@ class AccountTest extends AbstractTest {
 	 */
 	public function testCreateAndDelete($name) {
 		$name = uniqid($name);
-		$this->createMailBox($name);
+		$this->getTestAccount()->createMailBox($name);
 		$this->assertMailBoxExists($name);
 
 		$this->getTestAccount()->deleteMailbox($name);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2031

Changes:
- Removed createMailbox() and getMailbox() from OCA\Mail\Account
- Replaced existing test on Account with getTestAccount from
  OCA\Mail\Tests\IMAP\AbstractTest