### PR TITLE
Remove unused date fields from message response

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -432,9 +432,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'bcc' => $this->getBCC()->jsonSerialize(),
 			'fromEmail' => is_null($this->getFrom()->first()) ? null : $this->getFrom()->first()->getEmail(),
 			'subject' => $this->getSubject(),
-			'date' => OC::$server->getDateTimeFormatter()->formatDate($this->getSentDate()->format('U')),
 			'dateInt' => $this->getSentDate()->getTimestamp(),
-			'dateIso' => $this->getSentDate()->format('c'),
 			'size' => Util::humanFileSize($this->getSize()),
 			'flags' => $this->getFlags(),
 		];


### PR DESCRIPTION
They are not used on the client, but only `dateInt` is.