### PR TITLE
Do not fetch headers if we don't use them

### DIFF
--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -62,22 +62,9 @@ class Attachment {
 	private $mimePart;
 
 	private function load() {
-		$headers = [];
-
 		$fetch_query = new \Horde_Imap_Client_Fetch_Query();
 		$fetch_query->bodyPart($this->attachmentId);
 		$fetch_query->mimeHeader($this->attachmentId);
-
-		$headers = array_merge($headers, [
-			'importance',
-			'list-post',
-			'x-priority'
-		]);
-		$headers[] = 'content-type';
-
-		$fetch_query->headers('imp', $headers, [
-			'cache' => true
-		]);
 
 		// $list is an array of Horde_Imap_Client_Data_Fetch objects.
 		$ids = new \Horde_Imap_Client_Ids($this->messageId);

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -79,16 +79,6 @@ class MessageMapper {
 		$query->uid();
 		$query->imapDate();
 		$query->structure();
-		$query->headers('imp',
-			[
-				'importance',
-				'list-post',
-				'x-priority',
-				'content-type',
-			], [
-				'cache' => true,
-				'peek' => true,
-			]);
 
 		$fetchResults = iterator_to_array($client->fetch($mailbox, $query, [
 			'ids' => new Horde_Imap_Client_Ids($ids),

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -289,26 +289,12 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	}
 
 	private function loadMessageBodies() {
-		$headers = [];
-
 		$fetch_query = new Horde_Imap_Client_Fetch_Query();
 		$fetch_query->envelope();
 		$fetch_query->structure();
 		$fetch_query->flags();
 		$fetch_query->size();
 		$fetch_query->imapDate();
-
-		$headers = array_merge($headers, [
-			'importance',
-			'list-post',
-			'x-priority'
-		]);
-		$headers[] = 'content-type';
-
-		$fetch_query->headers('imp', $headers, [
-			'cache' => true,
-			'peek' => true
-		]);
 
 		// $list is an array of Horde_Imap_Client_Data_Fetch objects.
 		$ids = new Horde_Imap_Client_Ids($this->messageId);

--- a/lib/Service/MailSearch.php
+++ b/lib/Service/MailSearch.php
@@ -120,19 +120,6 @@ class MailSearch implements IMailSearch {
 			$fetchQuery->uid();
 			$fetchQuery->imapDate();
 			$fetchQuery->structure();
-			$fetchQuery->headers(
-				'imp',
-				[
-					'importance',
-					'list-post',
-					'x-priority',
-					'content-type',
-				],
-				[
-					'cache' => true,
-					'peek' => true
-				]
-			);
 
 			$fetchResult = $client->fetch($mailbox->getMailbox(), $fetchQuery, ['ids' => $ids]);
 		} catch (Horde_Imap_Client_Exception $e) {


### PR DESCRIPTION
Debugging performance problems of #2064 I found out that we do a lot of over-fetching with our IMAP queries. Then I tried to gradually remove stuff we fetch but obviously don't use and it turns out that some expensive queries can take 85% less time if headers aren't fetched.

I could not find any problems in my manual tests. @nextcloud/mail please verify :)