### PR TITLE
Improve design of account settings, move signature and writing mode up

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -42,7 +42,6 @@
 					type="text"
 					:placeholder="t('mail', 'Name')"
 					:disabled="loading"
-					autofocus
 				/>
 				<label for="man-address">{{ t('mail', 'Mail Address') }}</label>
 				<input
@@ -382,12 +381,13 @@ export default {
 
 .tabs-component-tab {
 	flex-grow: 1;
+	text-align: center;
 	color: var(--color-text-lighter);
-	font-weight: bold;
 }
 
 .tabs-component-tab.is-active {
 	border-bottom: 1px solid black;
+	font-weight: bold;
 }
 
 .tabs-component-panels {

--- a/src/components/EditorSettings.vue
+++ b/src/components/EditorSettings.vue
@@ -20,26 +20,29 @@
   -->
 
 <template>
-	<div>
-		<h3>{{ t('mail', 'Editor') }}</h3>
+	<div class="section">
+		<h2>{{ t('mail', 'Writing mode') }}</h2>
+		<p class="settings-hint">
+			{{ t('mail', 'Preferred writing mode for new messages and replies.') }}
+		</p>
 		<p>
-			{{ t('mail', 'Configure your preferred editing mode for new messages and replies.') }}
-			<br />
-			<Multiselect v-model="mode" :options="options" track-by="name" label="label" />
+			<input id="plaintext" v-model="mode" type="radio" class="radio" value="plaintext" />
+			<label :class="{primary: mode === 'plaintext'}" for="plaintext">
+				{{ t('mail', 'Plain text') }}
+			</label>
+			<input id="richtext" v-model="mode" type="radio" class="radio" value="richtext" />
+			<label :class="{primary: mode === 'richtext'}" for="richtext">
+				{{ t('mail', 'Rich text') }}
+			</label>
 		</p>
 	</div>
 </template>
 
 <script>
-import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
-
 import Logger from '../logger'
 
 export default {
 	name: 'EditorSettings',
-	components: {
-		Multiselect,
-	},
 	props: {
 		account: {
 			type: Object,
@@ -47,20 +50,8 @@ export default {
 		},
 	},
 	data() {
-		const options = [
-			{
-				name: 'richtext',
-				label: t('mail', 'Rich text'),
-			},
-			{
-				name: 'plaintext',
-				label: t('mail', 'Plain text'),
-			},
-		]
-
 		return {
-			mode: options.find(o => o.name === this.account.editorMode),
-			options,
+			mode: this.account.editorMode,
 		}
 	},
 	watch: {
@@ -69,7 +60,7 @@ export default {
 				.dispatch('patchAccount', {
 					account: this.account,
 					data: {
-						editorMode: val.name,
+						editorMode: val,
 					},
 				})
 				.then(() => {
@@ -84,3 +75,15 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.settings-hint {
+	margin-top: -12px;
+	margin-bottom: 6px;
+	color: var(--color-text-maxcontrast);
+}
+
+label {
+	padding-right: 12px;
+}
+</style>

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -20,29 +20,34 @@
   -->
 
 <template>
-	<div>
-		<h3>{{ t('mail', 'Signature') }}</h3>
-		<p>
-			{{ t('mail', 'A signature will be added to the text of new and response messages.') }}
+	<div class="section">
+		<h2>{{ t('mail', 'Signature') }}</h2>
+		<p class="settings-hint">
+			{{ t('mail', 'A signature is added to the text of new messages and replies.') }}
 		</p>
+		<textarea v-model="signature" v-autosize="signature" />
 		<p>
-			<textarea v-model="signature" :disabled="loading"></textarea>
-		</p>
-		<p>
-			<input type="submit" :value="t('mail', 'Delete')" :disabled="loading" @click="deleteSignature" />
-			<input
-				type="submit"
+			<button
 				class="primary"
-				:value="t('mail', 'Save')"
+				:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
 				:disabled="loading"
 				@click="saveSignature"
-			/>
+			>
+				{{ t('mail', 'Save signature') }}
+			</button>
+			<button v-if="signature" class="button-text" @click="deleteSignature">
+				{{ t('mail', 'Delete') }}
+			</button>
 		</p>
 	</div>
 </template>
 
 <script>
+import Vue from 'vue'
+import Autosize from 'vue-autosize'
 import Logger from '../logger'
+
+Vue.use(Autosize)
 
 export default {
 	name: 'SignatureSettings',
@@ -91,3 +96,40 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.settings-hint {
+	margin-top: -12px;
+	margin-bottom: 6px;
+	color: var(--color-text-maxcontrast);
+}
+
+textarea {
+	display: block;
+	width: 400px;
+	max-width: 85vw;
+	height: 100px;
+	resize: none;
+}
+
+.primary {
+	padding-left: 26px;
+	background-position: 6px;
+
+	&:after {
+		left: 14px;
+	}
+}
+
+.button-text {
+	background-color: transparent;
+	border: none;
+	color: var(--color-text-maxcontrast);
+	font-weight: normal;
+
+	&:hover,
+	&:focus {
+		color: var(--color-main-text);
+	}
+}
+</style>

--- a/src/views/AccountSettings.vue
+++ b/src/views/AccountSettings.vue
@@ -3,13 +3,25 @@
 		<Navigation />
 		<AppContent>
 			<div class="section">
-				<h2>{{ t('mail', 'Account Settings') }} - {{ email }}</h2>
-				<h3>{{ t('mail', 'Mail server') }}</h3>
+				<h2>{{ t('mail', 'Account settings') }}</h2>
+				<p>
+					<strong>{{ displayName }}</strong> &lt;{{ email }}&gt;
+					<a class="button icon-rename" href="#account-form" :title="t('mail', 'Change name')"></a>
+				</p>
+			</div>
+			<SignatureSettings :account="account" />
+			<EditorSettings :account="account" />
+			<div class="section">
+				<h2>{{ t('mail', 'Mail server') }}</h2>
 				<div id="mail-settings">
-					<AccountForm :display-name="displayName" :email="email" :save="onSave" :account="account" />
+					<AccountForm
+						:key="account.accountId"
+						:display-name="displayName"
+						:email="email"
+						:save="onSave"
+						:account="account"
+					/>
 				</div>
-				<EditorSettings :account="account" />
-				<SignatureSettings :account="account" />
 			</div>
 		</AppContent>
 	</Content>
@@ -71,3 +83,16 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.button.icon-rename {
+	background-color: transparent;
+	border: none;
+	opacity: 0.3;
+
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+}
+</style>


### PR DESCRIPTION
## Before
- Nerdy IMAP and SMTP settings up top so the other stuff was not findable
- Didn’t seem to have structure, stuff too close together
- Elements too small (textarea) or wrong element (dropdown for choice between 2)

![image](https://user-images.githubusercontent.com/925062/66952138-4c57f100-f05c-11e9-8de7-26eb38a46da0.png)
![image](https://user-images.githubusercontent.com/925062/66952186-698cbf80-f05c-11e9-92fc-788dc5332172.png)

## After
- Moved signature and writing mode up so it’s easier to discover
- Proper structure with headings
- Detail fixes and interaction feedback
![image](https://user-images.githubusercontent.com/925062/66951728-59281500-f05b-11e9-8f80-1969d9c3580c.png)


Please review @nextcloud/mail :)