### PR TITLE
Fix layout of message list until we move to component

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -254,12 +254,6 @@
 	font-weight: normal;
 }
 
-.avatar {
-	width: 32px;
-	height: 32px;
-	object-fit: cover;
-}
-
 .star {
 	padding: 20px;
 	background-size: 16px;

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -20,8 +20,8 @@
   -->
 
 <template>
-	<BaseAvatar v-if="loading || !hasAvatar" :display-name="displayName" />
-	<BaseAvatar v-else :display-name="displayName" :url="avatarUrl" />
+	<BaseAvatar v-if="loading || !hasAvatar" :display-name="displayName" size="40" />
+	<BaseAvatar v-else :display-name="displayName" :url="avatarUrl" size="40" />
 </template>
 
 <script>

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -133,7 +133,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .mail-message-account-color {
 	position: absolute;
 	left: 0px;
@@ -164,5 +164,16 @@ export default {
 .icon-attachment {
 	-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=25)';
 	opacity: 0.25;
+}
+
+// Fix layout of messages in list until we move to component
+
+.app-content-list-item-line-two,
+.app-content-list-item-menu {
+	margin-top: -8px;
+}
+
+.app-content-list-item-menu {
+	margin-right: -2px;
 }
 </style>


### PR DESCRIPTION
This will eventually be fixed when we use the AppContentListItem component, cc @ma12-co https://github.com/nextcloud/nextcloud-vue/pull/616 (This is also essentially a mockup of how this should look like in Mail)

Before:
- Avatar small and not vertically centered
- Second row is too low and falls off
- Action icon hover/focus feedback is outside of element

![Mail messages before](https://user-images.githubusercontent.com/925062/67027142-52f07200-f109-11e9-80a5-60742c7ff791.png)

Now:
- Nice vertical alignment
- Basically same layout as list in Contacts
- Menu hover/focus feedback fits into entry
- The only thing a bit off is that timestamp text and icon don’t right-align, but that’s something for another time, or possibly not fixable since we need the clickable area.
![mail list layout new](https://user-images.githubusercontent.com/925062/67027143-53890880-f109-11e9-81d7-80a45e271f7a.png)
