### PR TITLE
Allow formatted replies

### DIFF
--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -20,11 +20,8 @@
  *
  */
 
+import moment from '@nextcloud/moment'
 import negate from 'lodash/fp/negate'
-import moment from 'moment'
-import {getLocale} from '@nextcloud/l10n'
-
-moment.locale(getLocale())
 
 export const buildReplyBody = (original, from, date) => {
 	const start = '\n\n'
@@ -35,6 +32,18 @@ export const buildReplyBody = (original, from, date) => {
 		return start + `"${from.label}" <${from.email}> – ${dateString}` + body
 	} else {
 		return start + body
+	}
+}
+
+export const buildHtmlReplyBody = (original, from, date) => {
+	const start = `<p></p>`
+	const body = `<blockquote>${original}</blockquote>`
+
+	if (from) {
+		const dateString = moment.unix(date).format('LLL')
+		return `${start}"${from.label}" <${from.email}> – ${dateString}<br>${body}`
+	} else {
+		return `${start}${body}`
 	}
 }
 

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -233,7 +233,7 @@ export default {
 			autocompleteRecipients: this.to.concat(this.cc).concat(this.bcc),
 			newRecipients: [],
 			subjectVal: this.subject,
-			bodyVal: this.isPlainText ? this.body.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br>$2') : this.body,
+			bodyVal: this.isPlainText ? this.textToSimpleHtml(this.body) : this.body,
 			attachments: [],
 			noReply: this.to.some(to => to.email.startsWith('noreply@') || to.email.startsWith('no-reply@')),
 			submitButtonTitle: t('mail', 'Send'),
@@ -265,6 +265,11 @@ export default {
 		},
 	},
 	watch: {
+		editorPlainText(val) {
+			if (!val) {
+				this.bodyVal = this.textToSimpleHtml(this.bodyVal)
+			}
+		},
 		selectedAlias(val) {
 			if (val) {
 				// TODO: warn user before formatting is lost?
@@ -409,6 +414,9 @@ export default {
 			}
 
 			return body + '\n\n--\n\n' + alias.signature
+		},
+		textToSimpleHtml(text) {
+			return text.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br>$2')
 		},
 	},
 }

--- a/src/components/EditorSettings.vue
+++ b/src/components/EditorSettings.vue
@@ -67,7 +67,7 @@ export default {
 					Logger.info('editor mode updated')
 				})
 				.catch(error => {
-					Logger.error('could not upate editor mode', {error})
+					Logger.error('could not update editor mode', {error})
 					this.editorMode = oldVal
 					throw error
 				})

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -28,10 +28,9 @@ import AppContentDetails from '@nextcloud/vue/dist/Components/AppContentDetails'
 import Axios from '@nextcloud/axios'
 import {generateUrl} from '@nextcloud/router'
 
-import {buildForwardSubject, buildReplyBody, buildReplySubject} from '../ReplyBuilder'
+import {buildForwardSubject, buildHtmlReplyBody, buildReplyBody, buildReplySubject} from '../ReplyBuilder'
 import Composer from './Composer'
 import {getRandomMessageErrorMessage} from '../util/ErrorMessageFactory'
-import {htmlToText} from '../util/HtmlHelper'
 import Error from './Error'
 import Loading from './Loading'
 import Logger from '../logger'
@@ -223,9 +222,8 @@ export default {
 				})
 		},
 		getForwardReplyBody() {
-			// TODO: in case of an HTML message, do not remove HTML but use the rich editor if possible
 			if (this.original.hasHtmlBody) {
-				return buildReplyBody(htmlToText(this.originalBody), this.original.from[0], this.original.dateInt)
+				return buildHtmlReplyBody(this.originalBody, this.original.from[0], this.original.dateInt)
 			}
 			return buildReplyBody(this.originalBody, this.original.from[0], this.original.dateInt)
 		},

--- a/src/tests/unit/util/HtmlHelper.spec.js
+++ b/src/tests/unit/util/HtmlHelper.spec.js
@@ -34,18 +34,18 @@ describe('HtmlHelper', () => {
 		expect(actual).to.equal(expected)
 	})
 
-	it('concats divs', () => {
+	it('breaks on divs', () => {
 		const html = '<div>one</div><div>two</div>'
-		const expected = 'onetwo'
+		const expected = 'one\ntwo'
 
 		const actual = htmlToText(html)
 
 		expect(actual).to.equal(expected)
 	})
 
-	it('does not produce large number of line breaks for nested elements', () => {
+	it('produces a line break for each ending div element', () => {
 		const html = '<div>' + '    <div>' + '        line1' + '    </div>' + '</div>' + '<div>line2</div>'
-		const expected = ' line1 line2'
+		const expected = ' line1\n\nline2'
 
 		const actual = htmlToText(html)
 
@@ -103,6 +103,30 @@ describe('HtmlHelper', () => {
 	it('does not leak internal redirection URLs', () => {
 		const html = '<a href="https://localhost/apps/mail/redirect?src=domain.tld">domain.tld</a>'
 		const expected = 'domain.tld'
+
+		const actual = htmlToText(html)
+
+		expect(actual).to.equal(expected)
+	})
+
+	it('preserves quotes', () => {
+		const html = `<blockquote><div><b>yes.</b></div><div><br /></div><div>Am Montag, den 21.10.2019, 16:51 +0200 schrieb Christoph Wurst:</div><blockquote style="margin:0 0 0 .8ex;border-left:2px #729fcf solid;padding-left:1ex;"><div>ok cool</div><div><br /></div><div>Am Montag, den 21.10.2019, 16:51 +0200 schrieb Christoph Wurst:</div><blockquote style="margin:0 0 0 .8ex;border-left:2px #729fcf solid;padding-left:1ex;"><div>Hello</div><div><br /></div><div>this is some t<i>e</i>xt</div><div><br /></div><div>yes</div><div><br /></div><div>cheers</div><br></blockquote><br></blockquote></blockquote>`
+		const expected = `> yes.
+>
+> Am Montag, den 21.10.2019, 16:51 +0200 schrieb Christoph Wurst:
+> > ok cool
+> >
+> > Am Montag, den 21.10.2019, 16:51 +0200 schrieb Christoph Wurst:
+> > > Hello
+> > >
+> > > this is some text
+> > >
+> > > yes
+> > >
+> > > cheers
+> > >
+> > >
+> >`
 
 		const actual = htmlToText(html)
 

--- a/src/util/HtmlHelper.js
+++ b/src/util/HtmlHelper.js
@@ -11,10 +11,24 @@
 import {fromString} from 'html-to-text'
 
 export const htmlToText = html => {
-	return fromString(html, {
+	const withBlockBreaks = html.replace(/<\/div>/gi, '</div><br>')
+
+	const text = fromString(withBlockBreaks, {
 		noLinkBrackets: true,
 		ignoreHref: true,
 		ignoreImage: true,
 		wordwrap: 78, // 80 minus '> ' prefix for replies
+		format: {
+			blockquote: function(element, fn, options) {
+				return fn(element.children, options)
+					.replace(/\n\n\n/g, '\n\n') // remove triple line breaks
+					.replace(/^/gm, '> ') // add > quotation to each line
+			},
+		},
 	})
+
+	return text
+		.replace(/\n\n\n/g, '\n\n') // remove triple line breaks
+		.replace(/^[\n\r]+/g, '') // trim line breaks at beginning and end
+		.replace(/ $/gm, '') // trim white space at end of each line
 }


### PR DESCRIPTION
- [x] Remove html-to-text conversion and let the editor handle it if necessary
- [x] Fix conversion from HTML blockquote to text-only

Test 1
* Set rich editor as default
* Open a (HTML) message
* Click reply
* See block quote formatted message body

Test 2
* Start reply
* Switch between rich and plain text mode
  * Block quotes become `> ` in simple mode
  * `> ` stay the same when switching from simple to rich