### PR TITLE
Improve redirect check

### DIFF
--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -89,12 +89,8 @@ class ProxyController extends Controller {
 			throw new Exception('URL is not valid.', 1);
 		}
 
-		// If the request has a referrer from this domain redirect the user without interaction
-		// this is there to prevent an open redirector.
-		// Since we can't prevent the referrer from being added with a HTTP only header we rely on an
-		// additional JS file here.
-		$referrer = $this->request->server['HTTP_REFERER'] ?? null;
-		if (is_string($referrer) && parse_url($referrer, PHP_URL_HOST) === $this->hostname) {
+		// If strict cookies are set it means we come from the same domain so no open redirect
+		if ($this->request->passesStrictCookieCheck()) {
 			$authorizedRedirect = true;
 		}
 

--- a/src/autoredirect.js
+++ b/src/autoredirect.js
@@ -1,7 +1,29 @@
-/* global $ */
+/**
+ * @copyright Copyright (c) 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 
-$(document).ready(function() {
-	$('#redirectLink')
-		.get(0)
-		.click()
+document.addEventListener('DOMContentLoaded', () => {
+	const linkEl = document.getElementById('redirectLink')
+
+	if (linkEl) {
+		linkEl.click()
+	}
 })

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -18,12 +18,14 @@ if (process.env.BUNDLE_ANALYZER_TOKEN) {
 }
 
 module.exports = {
-	entry: path.join(__dirname, 'src/main.js'),
+	entry: {
+		autoredirect: path.join(__dirname, 'src/autoredirect.js'),
+		mail: path.join(__dirname, 'src/main.js')
+	},
 	output: {
 		path: path.resolve(__dirname, 'js'),
 		chunkFilename: 'mail.[name].[contenthash].js',
 		publicPath: '/js/',
-		filename: 'mail.js'
 	},
 	node: {
 		fs: 'empty'


### PR DESCRIPTION
Since we don't set the referer header by default now the redirect window
always showed.
This is now moved to the strict cookie check which is only send if you
come from the same domain.

Basically this means:
1. If you enter the url in your addressbar manually => pass
2. If you get redirected from some other site => :boom: 
3. If you get redirected from the mail => should apss (please double check)