### PR TITLE
In MessagePlainTextBody, translates all newline chars into '<br>'

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<div id="mail-content" v-html="body"></div>
+		<div id="mail-content" v-html="sanitizedBody"></div>
 		<div v-if="signature" class="mail-signature" v-html="signature"></div>
 	</div>
 </template>
@@ -18,6 +18,17 @@ export default {
 			default: () => undefined,
 		},
 	},
+	computed: {
+		/**
+		 * Caution: Despite its name this function doesn't really sanitize a message's body.
+		 * It just replaces newline chars by '<br>' HTML tags.
+		 * The message's body is expected to have been properly sanitized earlier (currently
+		 * via the app's Html service (PHP), via UrlLinker->linkUrlsAndEscapeHtml()).
+		 */
+		sanitizedBody() {
+			return this.body.replace(/\n/g,'<br>')
+		}
+	}
 }
 </script>
 


### PR DESCRIPTION
In MessagePlainTextBody, translates all newline chars into `<br>` to better display plain text messages.

Fixes https://github.com/nextcloud/mail/issues/2092

Eventually, I've discovered PHP's `nl2br` function. So, a better fix might be to updated the `IMAPMessage` class's getFullMessage function as follow:

```php
        public function getFullMessage(int $accountId, string $mailbox, int $id): array {
                $mailBody = $this->plainMessage;

                $data = $this->jsonSerialize();
                if ($this->hasHtmlMessage) {
                        $data['hasHtmlBody'] = true;
                        $data['body'] = $this->getHtmlBody($accountId, $mailbox, $id);
                } else {
---                        $mailBody = $this->htmlService->convertLinks($mailBody);
+++                        $mailBody = nl2br($this->htmlService->convertLinks($mailBody));
                        list($mailBody, $signature) = $this->htmlService->parseMailBody($mailBody);
                        $data['body'] = $mailBody;
                        $data['signature'] = $signature;
                }

                $data['attachments'] = $this->attachments;

                return $data;
        }
```

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>