### PR TITLE
Fix account delete redirection

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -53,9 +53,10 @@ import AppNavigationIconBullet from '@nextcloud/vue/dist/Components/AppNavigatio
 import ActionRouter from '@nextcloud/vue/dist/Components/ActionRouter'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
+import {generateUrl} from '@nextcloud/router'
 
 import {calculateAccountColor} from '../util/AccountColor'
-import Logger from '../logger'
+import logger from '../logger'
 
 export default {
 	name: 'NavigationAccount',
@@ -102,20 +103,28 @@ export default {
 	methods: {
 		createFolder(e) {
 			const name = e.target.elements[0].value
-			Logger.info('creating folder ' + name)
+			logger.info('creating folder ' + name)
 			this.menuOpen = false
 			this.$store
 				.dispatch('createFolder', {account: this.account, name})
-				.then(() => Logger.info(`folder ${name} created`))
+				.then(() => logger.info(`folder ${name} created`))
 				.catch(error => {
-					Logger.error('could not create folder', {error})
+					logger.error('could not create folder', {error})
 					throw error
 				})
 		},
 		deleteAccount() {
+			const id = this.account.id
+
 			this.$store
 				.dispatch('deleteAccount', this.account)
-				.catch(error => Logger.error('could not delete account', {error}))
+				.then(() => {
+					logger.info(`account ${id} deleted, redirecting …`)
+
+					// TODO: update store and handle this more efficiently
+					location.href = generateUrl('/apps/mail')
+				})
+				.catch(error => logger.error('could not delete account', {error}))
 		},
 	},
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -101,15 +101,10 @@ export default {
 		})
 	},
 	deleteAccount({commit}, account) {
-		return deleteAccount(account.id)
-			.then(account => {
-				console.debug('account deleted')
-				location.reload() // TODO: better handling of this
-			})
-			.catch(err => {
-				console.error('could not delete account', err)
-				throw err
-			})
+		return deleteAccount(account.id).catch(err => {
+			console.error('could not delete account', err)
+			throw err
+		})
 	},
 	createFolder({commit}, {account, name}) {
 		return createFolder(account.id, name).then(folder => {


### PR DESCRIPTION
We're cowardly redirection when an account is delete, just because we're lazy and writing a Vuex action to properly clean up the data from the deleted account is hard. This introduced a little bug: often you got redirected to a route that was no longer valid, e.g. for for a folder of a previously deleted account. Now redirection to root, where our usual logic kicks in that redirects the user when the open the app via the app icon in the navigation bar.