### PR TITLE
Fix encoding issues of the folder display name

### DIFF
--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -48,9 +48,6 @@ class Folder implements JsonSerializable {
 	private $specialUse;
 
 	/** @var string */
-	private $displayName;
-
-	/** @var string */
 	private $syncToken;
 
 	/**
@@ -67,7 +64,6 @@ class Folder implements JsonSerializable {
 		$this->folders = [];
 		$this->status = [];
 		$this->specialUse = [];
-		$this->displayName = '';
 	}
 
 	/**
@@ -120,20 +116,6 @@ class Folder implements JsonSerializable {
 	}
 
 	/**
-	 * @return string
-	 */
-	public function getDisplayName() {
-		return $this->displayName;
-	}
-
-	/**
-	 * @param string $displayName
-	 */
-	public function setDisplayName($displayName) {
-		$this->displayName = $displayName;
-	}
-
-	/**
 	 * @return Folder[]
 	 */
 	public function getFolders() {
@@ -169,7 +151,7 @@ class Folder implements JsonSerializable {
 		return [
 			'id' => base64_encode($this->getMailbox()),
 			'accountId' => $this->accountId,
-			'name' => $this->getDisplayName(),
+			'displayName' => $this->getMailbox(),
 			'unseen' => isset($this->status['unseen']) ? $this->status['unseen'] : 0,
 			'total' => isset($this->status['messages']) ? (int) $this->status['messages'] : 0,
 			'isEmpty' => isset($this->status['messages']) ? 0 >= (int) $this->status['messages'] : true,

--- a/src/components/FolderContent.vue
+++ b/src/components/FolderContent.vue
@@ -13,7 +13,7 @@
 				/>
 				<NewMessageDetail v-if="newMessage" />
 				<Message v-else-if="showMessage" />
-				<NoMessageSelected v-else-if="hasMessages" :mailbox="folder.name" />
+				<NoMessageSelected v-else-if="hasMessages" />
 			</template>
 		</div>
 	</AppContent>

--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -35,12 +35,6 @@ export default {
 	components: {
 		AppContentDetails,
 	},
-	props: {
-		mailbox: {
-			type: String,
-			required: true,
-		},
-	},
 }
 </script>
 

--- a/src/l10n/MailboxTranslator.js
+++ b/src/l10n/MailboxTranslator.js
@@ -62,9 +62,8 @@ export const translate = folder => {
 		try {
 			return translateSpecial(folder)
 		} catch (e) {
-			console.error(e)
-			return atob(folder.id)
+			console.error('could not translate special folder', e)
 		}
 	}
-	return atob(folder.id)
+	return folder.displayName
 }

--- a/src/tests/unit/l10n/MailboxTranslator.spec.js
+++ b/src/tests/unit/l10n/MailboxTranslator.spec.js
@@ -36,6 +36,7 @@ describe('MailboxTranslator', () => {
 	it('does not translate an arbitrary mailbox', () => {
 		const folder = {
 			id: btoa('Newsletters'),
+			displayName: 'Newsletters',
 			specialUse: [],
 		}
 

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -98,13 +98,6 @@ class FolderTest extends TestCase {
 		$this->assertSame('flagged', $this->folder->getSpecialUse()[0]);
 	}
 
-	public function testDisplayName() {
-		$this->mockFolder();
-
-		$this->folder->setDisplayName('Eingang');
-		$this->assertSame('Eingang', $this->folder->getDisplayName());
-	}
-
 	public function testIsSearchable() {
 		$this->mockFolder([]);
 
@@ -127,12 +120,11 @@ class FolderTest extends TestCase {
 		$subFolder->expects($this->once())
 			->method('jsonSerialize')
 			->willReturn(['subdir data']);
-		$this->mailbox->expects($this->once())
+		$this->mailbox->expects($this->exactly(2))
 			->method('__get')
 			->with($this->equalTo('utf8'))
 			->willReturn('Sent');
 
-		$this->folder->setDisplayName('Gesendet');
 		$this->folder->addSpecialUse('sent');
 		$this->folder->setStatus([
 			'unseen' => 13,
@@ -143,7 +135,7 @@ class FolderTest extends TestCase {
 		$expected = [
 			'id' => base64_encode('Sent'),
 			'accountId' => 15,
-			'name' => 'Gesendet',
+			'displayName' => 'Sent',
 			'specialRole' => null,
 			'unseen' => 13,
 			'total' => 333,


### PR DESCRIPTION
Folders (technically speaking: mailboxes) have utf7/utf8 names. When we
encode the ID for the client, we use base64. The decoding will fail as
JavaScript assumes that base64 encoded strings are actually ASCII.
Instead of rewriting all the ID handling to not use base64, I decided to
just add a new prop with the unencoded displayname. Then it stays utf8
all the time.

Fixes https://github.com/nextcloud/mail/issues/1959