### PR TITLE
Add missing Navigation when adding another account

### DIFF
--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -1,5 +1,6 @@
 <template>
 	<Content app-name="mail">
+		<Navigation v-if="hasAccounts" />
 		<div id="emptycontent">
 			<div class="icon-mail"></div>
 			<h2>{{ t('mail', 'Connect your mail account') }}</h2>
@@ -18,6 +19,7 @@ import {loadState} from '@nextcloud/initial-state'
 import {translate as t} from '@nextcloud/l10n'
 
 import AccountForm from '../components/AccountForm'
+import Navigation from '../components/Navigation'
 import logger from '../logger'
 
 export default {
@@ -25,6 +27,7 @@ export default {
 	components: {
 		AccountForm,
 		Content,
+		Navigation,
 	},
 	data() {
 		return {
@@ -32,6 +35,11 @@ export default {
 			email: loadState('mail', 'prefill_email'),
 			error: null,
 		}
+	},
+	computed: {
+		hasAccounts() {
+			return this.$store.getters.getAccounts().length > 1
+		},
 	},
 	methods: {
 		onSave(data) {


### PR DESCRIPTION
* Add at least one account account
* Go to setup

Before
* See setup full screen
After
* Still see navigation of existing accounts that allows navigating back