### PR TITLE
Fix unnecessary line breaks in quoted reply text

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -98,12 +98,12 @@ class Html {
 		$signature = null;
 		$parts = explode("-- \r\n", $body);
 		if (count($parts) > 1) {
-			$signature = nl2br(array_pop($parts));
+			$signature = array_pop($parts);
 			$body = implode("-- \r\n", $parts);
 		}
 
 		return [
-			nl2br($body),
+			$body,
 			$signature
 		];
 	}

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<div id="mail-content" v-html="body"></div>
-		<div v-if="signature" class="mail-signature" v-html="signature"></div>
+		<div id="mail-content" v-html="htmlBody"></div>
+		<div v-if="signature" class="mail-signature" v-html="htmlSignature"></div>
 	</div>
 </template>
 
@@ -16,6 +16,19 @@ export default {
 		signature: {
 			type: String,
 			default: () => undefined,
+		},
+	},
+	computed: {
+		htmlBody() {
+			return this.nl2br(this.body)
+		},
+		htmlSignature() {
+			return this.nl2br(this.signature)
+		},
+	},
+	methods: {
+		nl2br(str) {
+			return str.replace(/(\r\n|\n\r|\n|\r)/g, '<br />')
 		},
 	},
 }

--- a/tests/Service/HtmlTest.php
+++ b/tests/Service/HtmlTest.php
@@ -82,7 +82,7 @@ class HtmlTest extends TestCase {
 		return [
 				['abc', null, 'abc'],
 				['abc', 'def', "abc-- \r\ndef"],
-				["abc-- <br />\r\ndef", 'ghi', "abc-- \r\ndef-- \r\nghi"],
+				["abc-- \r\ndef", 'ghi', "abc-- \r\ndef-- \r\nghi"],
 		];
 	}
 


### PR DESCRIPTION
Back-end concerns should be handled on the back-end, front-end ones on the front-end. Hence the `nl2br` on the server was a mistake (#2167). We don't only need the text for displaying, but also to build the quoted reply. The latter is where the old code fell apart, adding more line breaks than necessary. Now both displaying the original message and quoting its text for replies looks good.