### PR TITLE
Fix removed reply to email

### DIFF
--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -29,9 +29,9 @@ export const buildReplyBody = (original, from, date) => {
 
 	if (from) {
 		const dateString = moment.unix(date).format('LLL')
-		return start + `"${from.label}" <${from.email}> – ${dateString}` + body
+		return `${start}"${from.label}" ${from.email} – ${dateString}` + body
 	} else {
-		return start + body
+		return `${start}${body}`
 	}
 }
 
@@ -41,7 +41,7 @@ export const buildHtmlReplyBody = (original, from, date) => {
 
 	if (from) {
 		const dateString = moment.unix(date).format('LLL')
-		return `${start}"${from.label}" <${from.email}> – ${dateString}<br>${body}`
+		return `${start}"${from.label}" ${from.email} – ${dateString}<br>${body}`
 	} else {
 		return `${start}${body}`
 	}

--- a/src/tests/unit/ReplyBuilder.spec.js
+++ b/src/tests/unit/ReplyBuilder.spec.js
@@ -57,7 +57,7 @@ describe('ReplyBuilder', () => {
 
 	it('creates a reply body', () => {
 		const body = 'Newsletter\nhello'
-		const expectedReply = '\n\n"Test User" <test@user.ru> – November 5, 2018 '
+		const expectedReply = '\n\n"Test User" test@user.ru – November 5, 2018 '
 
 		const replyBody = buildReplyBody(
 			body,


### PR DESCRIPTION
Anything between `<` and `>` is removed by CKeditor, hence removing these angle brackets.

Note: escaping with `&lt;` didn't work either https://stackoverflow.com/questions/3581139/how-to-prevent-ckeditor-from-stripping-and-greater-than-less-than