### PR TITLE
Label the unified inbox as "All inboxes"

### DIFF
--- a/src/l10n/MailboxTranslator.js
+++ b/src/l10n/MailboxTranslator.js
@@ -40,7 +40,11 @@ const translateSpecial = folder => {
 	}
 	if (folder.specialUse.includes('inbox')) {
 		// TRANSLATORS: translated mail box name
-		return t('mail', 'Inbox')
+		if (folder.isUnified === true) {
+			return t('mail', 'All inboxes')
+		} else {
+			return t('mail', 'Inbox')
+		}
 	}
 	if (folder.specialUse.includes('junk')) {
 		// TRANSLATORS: translated mail box name

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -102,7 +102,6 @@ export default new Vuex.Store({
 				isUnified: true,
 				specialUse: ['inbox'],
 				specialRole: 'inbox',
-				name: t('mail', 'All inboxes'), // TODO,
 				unread: 0,
 				folders: [],
 				envelopes: [],


### PR DESCRIPTION
I've simply used the existing "All inboxes" label. 

I can change it if you prefer "Unified inobx".

Fixes #2217 

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>