### PR TITLE
Fix flagges shown as subfolder on some accounts

### DIFF
--- a/src/imap/MailboxHierarchy.js
+++ b/src/imap/MailboxHierarchy.js
@@ -22,7 +22,7 @@
 const getParentId = (mailbox, hasPrefix) => {
 	const top = hasPrefix ? 1 : 0
 	const hierarchy = atob(mailbox.id).split(mailbox.delimiter)
-	if (hierarchy.length <= top + 1) {
+	if (hierarchy.length <= top + 1 || atob(mailbox.id) === 'INBOX/FLAGGED') {
 		return
 	}
 	if (hasPrefix) {

--- a/src/tests/unit/imap/MailboxHierarchy.spec.js
+++ b/src/tests/unit/imap/MailboxHierarchy.spec.js
@@ -122,6 +122,42 @@ describe('mailboxHierarchyBuilder', () => {
 		])
 	})
 
+	it('does not use the flagged inbox as subfolder of inbox', () => {
+		const mb1 = {
+			id: btoa('INBOX'),
+			delimiter: '/',
+		}
+		const mb2 = {
+			id: btoa('INBOX/FLAGGED'),
+			delimiter: '/',
+		}
+		const mb3 = {
+			id: btoa('Archive'),
+			delimiter: '/',
+		}
+		const mailboxes = [mb1, mb2, mb3]
+
+		const hierarchy = buildMailboxHierarchy(mailboxes)
+
+		expect(hierarchy).to.deep.equal([
+			{
+				id: btoa('INBOX'),
+				delimiter: '/',
+				folders: [],
+			},
+			{
+				id: btoa('INBOX/FLAGGED'),
+				delimiter: '/',
+				folders: [],
+			},
+			{
+				id: btoa('Archive'),
+				delimiter: '/',
+				folders: [],
+			},
+		])
+	})
+
 	it('builds a nested hierarchy with a prefix', () => {
 		const mb1 = {
 			id: btoa('INBOX.Archive'),


### PR DESCRIPTION
Our own special mailbox should always be on the top level.

@nextcloud/mail please review