### PR TITLE
Fix unexpected linebreaks in mails, responsive text flow, fix #2181

### DIFF
--- a/src/util/HtmlHelper.js
+++ b/src/util/HtmlHelper.js
@@ -17,7 +17,7 @@ export const htmlToText = html => {
 		noLinkBrackets: true,
 		ignoreHref: true,
 		ignoreImage: true,
-		wordwrap: 78, // 80 minus '> ' prefix for replies
+		wordwrap: false,
 		format: {
 			blockquote: function(element, fn, options) {
 				return fn(element.children, options)


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/2181 and use proper responsive text flow, as most other email apps do. See research in comment https://github.com/nextcloud/mail/issues/2181#issuecomment-554183882 

## Before
Wrapping at 78 characters. Breaks quickly on mobile devices or when there’s more than 1 reply. Is also entirely unexpected:
![mail wrap before](https://user-images.githubusercontent.com/925062/69360690-97999b00-0cbd-11ea-8258-09fe276b308f.png)

## After
Sends the mail just like you see it and expect it. And it responsively adjusts to the screen size of the client:
![Mail wrap after](https://user-images.githubusercontent.com/925062/69360689-97999b00-0cbd-11ea-90a0-03a2f85f71db.png)