### PR TITLE
Move favorite toggle to menu, otherwise not distinguishable

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -6,6 +6,7 @@
 			:style="{'background-color': accountColor}"
 		></div>
 		<div
+			v-if="data.flags.flagged"
 			class="app-content-list-item-star icon-starred"
 			:data-starred="data.flags.flagged ? 'true' : 'false'"
 			@click.prevent="onToggleFlagged"
@@ -28,6 +29,9 @@
 			<Moment :timestamp="data.dateInt" />
 		</div>
 		<Actions class="app-content-list-item-menu" menu-align="right">
+			<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">{{
+				data.flags.flagged ? t('mail', 'Unfavorite') : t('mail', 'Favorite')
+			}}</ActionButton>
 			<ActionButton icon="icon-mail" @click.prevent="onToggleSeen">{{
 				data.flags.unseen ? t('mail', 'Mark read') : t('mail', 'Mark unread')
 			}}</ActionButton>


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/1032

Before, basically every mail looked like it was favorited. Now we only show a star for mails which really are favorited. And the favorite toggle is moved to the menu.

This aligns it with how we do it in Files as well. :)

Before & after:
![favorites list before](https://user-images.githubusercontent.com/925062/69479345-b9665f80-0e2e-11ea-93fa-fbd89760f70a.png) | | | ![favorites now](https://user-images.githubusercontent.com/925062/69479347-b9fef600-0e2e-11ea-8ad2-eeaf5f56699f.png)

Menu:
![favorite menu](https://user-images.githubusercontent.com/925062/69479346-b9665f80-0e2e-11ea-9042-84700b38b204.png)