### PR TITLE
#160 - display 'text/calendar' as attachment

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -283,8 +283,10 @@ class MessagesController extends Controller {
 
 		$attachment = $mailBox->getAttachment($messageId, $attachmentId);
 
+        // NU: This is probably a bad fix, we assume that an attachment without
+        // a name is a calendar event.
 		return new AttachmentDownloadResponse(
-			$attachment->getContents(), $attachment->getName(), $attachment->getType());
+			$attachment->getContents(), $attachment->getName()??'calendar.ics', $attachment->getType());
 	}
 
 	/**

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -269,6 +269,10 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			 */
 			$filename = $p->getName();
 
+            if (empty($filename) && 'text/calendar' === $p->getType()) {
+                $filename = 'calendar.ics';
+            }
+
 			if (!is_null($p->getContentId())) {
 				continue;
 			}
@@ -337,6 +341,10 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		// Any part with a filename is an attachment,
 		// so an attached text file (type 0) is not mistaken as the message.
 		$filename = $p->getName();
+        if (empty($filename) && 'text/calendar' === $p->getType()) {
+            $filename = 'calendar.ics';
+        }
+
 		if (isset($filename)) {
 			if (in_array($filename, $this->attachmentsToIgnore)) {
 				return;


### PR DESCRIPTION
This is a rudimentary fix for issue #160

It will display message parts of type 'text/calendar' that don't have a filename as 'calendar.ics'. This issue seems to occur when the sender is using Microsoft Exchange (or possibly even just any version of Microsoft Outlook). Outlook or Exchange does not add a filename to the calendar attachment, which leads to nextcloud/mail to not recognize it as an attachment resulting in it not beeing displayed in the mail detail view.

There already is a check for 'text/calendar' in `lib/Model/IMAPMessage.php` around line 374 which is not implemented.