### PR TITLE
Add a CLI command to diagnose IMAP accounts

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -40,6 +40,7 @@
 	</repair-steps>
 	<commands>
 		<command>OCA\Mail\Command\CreateAccount</command>
+		<command>OCA\Mail\Command\DiagnoseAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>
 	</commands>
 	<settings>

--- a/lib/Command/DiagnoseAccount.php
+++ b/lib/Command/DiagnoseAccount.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Command;
+
+use Horde_Imap_Client;
+use Horde_Imap_Client_Data_Capability;
+use Horde_Imap_Client_Exception;
+use Horde_Imap_Client_Mailbox;
+use Horde_Imap_Client_Socket;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\ILogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function array_reduce;
+use function json_decode;
+use function sort;
+
+class DiagnoseAccount extends Command {
+
+	private const ARGUMENT_ACCOUNT_ID = 'account-id';
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var IMAPClientFactory */
+	private $clientFactory;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(AccountService $service,
+								IMAPClientFactory $clientFactory,
+								ILogger $logger) {
+		parent::__construct();
+
+		$this->accountService = $service;
+		$this->clientFactory = $clientFactory;
+		$this->logger = $logger;
+	}
+
+	protected function configure() {
+		$this->setName('mail:account:diagnose');
+		$this->setDescription('Diagnose a user\'s IMAP connection');
+		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
+
+		try {
+			$account = $this->accountService->findById($accountId);
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Account $accountId does not exist</error>");
+			return 1;
+		}
+
+		if ($account->getMailAccount()->getInboundPassword() === null) {
+			$output->writeln('<error>No IMAP passwort set. The user might have to log into their account to set it.</error>');
+		}
+		$imapClient = $this->clientFactory->getClient($account);
+
+		try {
+			$this->printCapabilitiesStats($output, $imapClient);
+			$this->printMailboxesMessagesStats($output, $imapClient);
+		} catch (Horde_Imap_Client_Exception $e) {
+			$this->logger->logException($e, [
+				'message' => 'Could not get account statistics',
+			]);
+			$output->writeln("<error>Horde error occurred: " . $e->getMessage() . ". See nextcloud.log for more details.</error>");
+			return 2;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * @param OutputInterface $output
+	 * @param Horde_Imap_Client_Socket $imapClient
+	 *
+	 * @throws Horde_Imap_Client_Exception
+	 */
+	private function printCapabilitiesStats(OutputInterface $output,
+											Horde_Imap_Client_Socket $imapClient): void {
+		$output->writeln("IMAP capabilities:");
+		$capabilities = array_keys(
+			json_decode(
+				$imapClient->capability->serialize(),
+				true
+			)
+		);
+		sort($capabilities);
+		foreach ($capabilities as $capability) {
+			$output->writeln("- $capability");
+		}
+		$output->writeln("");
+	}
+
+	/**
+	 * @param OutputInterface $output
+	 * @param Horde_Imap_Client_Socket $imapClient
+	 *
+	 * @throws Horde_Imap_Client_Exception
+	 */
+	protected function printMailboxesMessagesStats(OutputInterface $output,
+												   Horde_Imap_Client_Socket $imapClient): void {
+		$mailboxes = $imapClient->listMailboxes('*', Horde_Imap_Client::MBOX_ALL, [
+			'flat' => true,
+		]);
+		$messages = array_reduce($mailboxes, function (int $c, Horde_Imap_Client_Mailbox $mb) use ($imapClient) {
+			$status = $imapClient->status($mb, Horde_Imap_Client::STATUS_MESSAGES);
+			return $c + $status['messages'];
+		}, 0);
+		$output->writeln("Account has " . $messages . " messages in " . count($mailboxes) . " mailboxes");
+	}
+
+}

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -60,6 +60,22 @@ class MailAccountMapper extends QBMapper {
 	}
 
 	/**
+	 * @param int $id
+	 *
+	 * @return MailAccount
+	 * @throws DoesNotExistException
+	 */
+	public function findById(int $id): MailAccount {
+		$qb = $this->db->getQueryBuilder();
+		$query = $qb
+			->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
+
+		return $this->findEntity($query);
+	}
+
+	/**
 	 * Finds all Mail Accounts by user id existing for this user
 	 *
 	 * @param string $userId the id of the user that we want to find

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -87,6 +87,16 @@ class AccountService {
 	}
 
 	/**
+	 * @param int $id
+	 *
+	 * @return Account
+	 * @throws DoesNotExistException
+	 */
+	public function findById(int $id): Account {
+		return new Account($this->mapper->findById($id));
+	}
+
+	/**
 	 * @param int $accountId
 	 */
 	public function delete(string $currentUserId, int $accountId): void {


### PR DESCRIPTION
As a precaution for the database message cache #2064  it make sense to have a
CLI command to diagnose the capabilities and size of an IMAP account in
case of slow or failing syncs.

Prints something like
```
IMAP capabilities:
- AUTH
- ENABLE
- ID
- IDLE
- IMAP4REV1
- LITERAL+
- LOGIN-REFERRALS
- SASL-IR

Account has 60408 messages in 44 mailboxes
```

@nextcloud/mail please review