### PR TITLE
Allow php nightly to fail on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
-#jobs:
-#  allow_failures:
-#  - php: nightly
+jobs:
+  allow_failures:
+  - php: nightly
 
 addons:
   apt:


### PR DESCRIPTION
They don't pass at the moment due to a change in PDO.