### PR TITLE
Make it possible to change the order of accounts in the sidebar

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>0.20.3</version>
+	<version>0.21.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Jan-Christoph Borchardt</author>

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -184,11 +184,13 @@ class AccountsController extends Controller {
 	 *
 	 * @param int $accountId
 	 * @param string|null $editorMode
+	 * @param int|null $order
 	 *
 	 * @return JSONResponse
 	 */
 	public function patchAccount(int $accountId,
-								 string $editorMode = null): JSONResponse {
+								 string $editorMode = null,
+								 int $order = null): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 
 		if ($account === null) {
@@ -198,6 +200,9 @@ class AccountsController extends Controller {
 		$dbAccount = $account->getMailAccount();
 		if ($editorMode !== null) {
 			$dbAccount->setEditorMode($editorMode);
+		}
+		if ($order !== null) {
+			$dbAccount->setOrder($order);
 		}
 		return new JSONResponse(
 			$this->accountService->save($dbAccount)->toJson()

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -65,6 +65,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setEditorMode(string $editorMode)
  * @method bool getProvisioned()
  * @method void setProvisioned(bool $provisioned)
+ * @method int getOrder()
+ * @method void setOrder(int $order)
  */
 class MailAccount extends Entity {
 
@@ -85,6 +87,7 @@ class MailAccount extends Entity {
 	protected $lastMailboxSync;
 	protected $editorMode;
 	protected $provisioned;
+	protected $order;
 
 	/**
 	 * @param array $params
@@ -132,8 +135,11 @@ class MailAccount extends Entity {
 			$this->setOutboundPassword($params['smtpPassword']);
 		}
 
+		$this->addType('inboundPort', 'integer');
+		$this->addType('outboundPort', 'integer');
 		$this->addType('lastMailboxSync', 'integer');
 		$this->addType('provisioned', 'bool');
+		$this->addType('order', 'integer');
 	}
 
 	/**
@@ -143,6 +149,7 @@ class MailAccount extends Entity {
 		$result = [
 			'accountId' => $this->getId(),
 			'name' => $this->getName(),
+			'order' => $this->getOrder(),
 			'emailAddress' => $this->getEmail(),
 			'imapHost' => $this->getInboundHost(),
 			'imapPort' => $this->getInboundPort(),

--- a/lib/Migration/Version0210Date20191212144925.php
+++ b/lib/Migration/Version0210Date20191212144925.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version0210Date20191212144925 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		$accountsTable->addColumn('order', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+			'default' => 1,
+		]);
+
+		return $schema;
+	}
+
+}

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -29,7 +29,13 @@
 		/>
 		<ul id="accounts-list">
 			<template v-for="group in menu">
-				<NavigationAccount v-if="group.account" :key="group.account.id" :account="group.account" />
+				<NavigationAccount
+					v-if="group.account"
+					:key="group.account.id"
+					:account="group.account"
+					:is-first="isFirst(group.account)"
+					:is-last="isLast(group.account)"
+				/>
 				<NavigationFolder
 					v-for="item in group.folders"
 					v-show="!group.account.collapsed || SHOW_COLLAPSED.indexOf(item.specialRole) !== -1"
@@ -109,6 +115,14 @@ export default {
 					messageUid: 'new',
 				},
 			})
+		},
+		isFirst(account) {
+			const accounts = this.$store.getters.getAccounts()
+			return account === accounts[1]
+		},
+		isLast(account) {
+			const accounts = this.$store.getters.getAccounts()
+			return account === accounts[accounts.length - 1]
 		},
 	},
 }

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -43,6 +43,12 @@
 			<ActionInput icon="icon-add" @submit="createFolder">
 				{{ t('mail', 'Add folder') }}
 			</ActionInput>
+			<ActionButton v-if="!isFirst" icon="icon-triangle-n" @click="changeAccountOrderUp">
+				{{ t('mail', 'Move Up') }}
+			</ActionButton>
+			<ActionButton v-if="!isLast" icon="icon-triangle-s" @click="changeAccountOrderDown">
+				{{ t('mail', 'Move down') }}
+			</ActionButton>
 		</template>
 	</AppNavigationItem>
 </template>
@@ -71,6 +77,14 @@ export default {
 		account: {
 			type: Object,
 			required: true,
+		},
+		isFirst: {
+			type: Boolean,
+			default: false,
+		},
+		isLast: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {
@@ -125,6 +139,16 @@ export default {
 					location.href = generateUrl('/apps/mail')
 				})
 				.catch(error => logger.error('could not delete account', {error}))
+		},
+		changeAccountOrderUp() {
+			this.$store
+				.dispatch('moveAccount', {account: this.account, up: true})
+				.catch(error => logger.error('could not move account up', {error}))
+		},
+		changeAccountOrderDown() {
+			this.$store
+				.dispatch('moveAccount', {account: this.account})
+				.catch(error => logger.error('could not move account down', {error}))
 		},
 	},
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -112,6 +112,28 @@ export default {
 			commit('addFolder', {account, folder})
 		})
 	},
+	moveAccount({commit, getters}, {account, up}) {
+		const accounts = getters.getAccounts()
+		const index = accounts.indexOf(account)
+		if (up) {
+			const previous = accounts[index - 1]
+			accounts[index - 1] = account
+			accounts[index] = previous
+		} else {
+			const next = accounts[index + 1]
+			accounts[index + 1] = account
+			accounts[index] = next
+		}
+		return Promise.all(
+			accounts.map((account, idx) => {
+				if (account.id === 0) {
+					return
+				}
+				commit('saveAccountsOrder', {account, order: idx})
+				return patchAccount(account, {order: idx})
+			})
+		)
+	},
 	markFolderRead({dispatch}, {account, folderId}) {
 		return markFolderRead(account.id, folderId).then(
 			dispatch('syncEnvelopes', {

--- a/tests/Integration/Db/MailAccountMapperTest.php
+++ b/tests/Integration/Db/MailAccountMapperTest.php
@@ -67,6 +67,8 @@ class MailAccountMapperTest extends TestCase {
 		$this->account->setOutboundSslMode('ssl');
 		$this->account->setUserId('user12345');
 		$this->account->setEditorMode('plaintext');
+		$this->account->setProvisioned(false);
+		$this->account->setOrder(27);
 	}
 
 	public function testFind(){

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -44,6 +44,7 @@ class MailAccountTest extends TestCase {
 		$a->setOutboundSslMode('ssl');
 		$a->setEditorMode('html');
 		$a->setProvisioned(false);
+		$a->setOrder(13);
 
 		$this->assertEquals(array(
 			'accountId' => 12345,
@@ -60,6 +61,7 @@ class MailAccountTest extends TestCase {
 			'signature' => null,
 			'editorMode' => 'html',
 			'provisioned' => false,
+			'order' => 13,
 			), $a->toJson());
 	}
 
@@ -79,6 +81,7 @@ class MailAccountTest extends TestCase {
 			'signature' => null,
 			'editorMode' => null,
 			'provisioned' => false,
+			'order' => null,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency


### PR DESCRIPTION
Right now we show the accounts in the order they were added, because the database sorts them by primary key. However, as a user I want to change the order. Adding an account later doesn't mean it's less important.

Todo
- [x]  front-end @GretaD 
  - [x] sort accounts by `order` attribute in the sidbar
  - [x] add a "Move up" and "Move down" action in the account's action menu
  - [x] update the account order attribute locally
  - [x] send the attribute change to the server
  - [x] The first account should not have the button _move up_
  - [x] The last account should not have the button _move down_
  - [x]  _All inboxes_ is defined as _an account_, we should find a way how to exclude it and not to be count as an account.
- [x] back-end @ChristophWurst 
  - [x] add a `order` attribute to the JSON of all accounts
  - [x] add `PATCH` support for this new attribute
  - [x] create a new column in the DB
  - [x] update the row on `PATCH`
- [x] bugs
  - [x] Move doesn't change anything on the second try