### PR TITLE
Fix empty password for provisioned account

### DIFF
--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -162,9 +162,9 @@ class Manager {
 		try {
 			$account = $this->mailAccountMapper->findProvisionedAccount($user);
 
-			if ($account->getInboundPassword() !== null
+			if (!empty($account->getInboundPassword())
 				&& $this->crypto->decrypt($account->getInboundPassword()) === $password
-				&& $account->getOutboundPassword() !== null
+				&& !empty($account->getOutboundPassword())
 				&& $this->crypto->decrypt($account->getOutboundPassword()) === $password) {
 				$this->logger->debug('Password of provisioned account is up to date');
 				return;


### PR DESCRIPTION
Passwords can't just be `null` but also an empty string. The code did
not handle that properly. Now checking against `empty` so both `null`
and `''` trigger shortcut evaluation and prevent decrypting of an
invalid value.

Fixes https://github.com/nextcloud/mail/issues/2337