### PR TITLE
Fix accidental provisioning when it's actually disabled

### DIFF
--- a/lib/Migration/ProvisionAccounts.php
+++ b/lib/Migration/ProvisionAccounts.php
@@ -48,6 +48,10 @@ class ProvisionAccounts implements IRepairStep {
 			$output->info("No Mail provisioning config set");
 			return;
 		}
+		if (!$config->isActive()) {
+			$output->info("Mail provisioning is disabled");
+			return;
+		}
 
 		$cnt = $this->provisioningManager->provision($config);
 		$output->info("$cnt accounts provisioned");

--- a/lib/Service/Provisioning/Config.php
+++ b/lib/Service/Provisioning/Config.php
@@ -30,7 +30,7 @@ class Config implements JsonSerializable {
 
 	private const VERSION = 1;
 
-	/** @var string[] */
+	/** @var mixed[] */
 	private $data;
 
 	/**
@@ -56,10 +56,10 @@ class Config implements JsonSerializable {
 	}
 
 	/**
-	 * @return string|int
+	 * @return int
 	 */
-	public function getImapPort() {
-		return $this->data['imapPort'];
+	public function getImapPort(): int {
+		return (int) $this->data['imapPort'];
 	}
 
 	/**
@@ -87,10 +87,10 @@ class Config implements JsonSerializable {
 	}
 
 	/**
-	 * @return string|int
+	 * @return int
 	 */
-	public function getSmtpPort() {
-		return $this->data['smtpPort'];
+	public function getSmtpPort(): int {
+		return (int) $this->data['smtpPort'];
 	}
 
 	/**
@@ -131,6 +131,10 @@ class Config implements JsonSerializable {
 	public function setActive(bool $state): self {
 		$this->data['active'] = $state;
 		return $this;
+	}
+
+	public function isActive(): bool {
+		return (bool) ($this->data['active'] ?? true);
 	}
 
 	public function jsonSerialize() {


### PR DESCRIPTION
Of provisioning is disabled, we keep the config but add `active: false` to the json. During the repair step, however, this prop wasn't checked, so the app created accounts nevertheless.

cc @nextcloud/mail 