### PR TITLE
Treat MIME part IDs as strings, not ints

### DIFF
--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -33,7 +33,7 @@ class Attachment {
 	 * @param \Horde_Imap_Client_Socket $conn
 	 * @param \Horde_Imap_Client_Mailbox $mailBox
 	 * @param int $messageId
-	 * @param int $attachmentId
+	 * @param string $attachmentId
 	 */
 	public function __construct($conn, $mailBox, $messageId, $attachmentId) {
 		$this->conn = $conn;

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -278,7 +278,7 @@ class MessagesController extends Controller {
 	 * @return AttachmentDownloadResponse
 	 */
 	public function downloadAttachment(int $accountId, string $folderId, int $messageId,
-									   int $attachmentId) {
+									   string $attachmentId) {
 		$mailBox = $this->getFolder($accountId, $folderId);
 
 		$attachment = $mailBox->getAttachment($messageId, $attachmentId);
@@ -300,10 +300,10 @@ class MessagesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function saveAttachment(int $accountId, string $folderId, int $messageId,
-								   int $attachmentId, string $targetPath) {
+								   string $attachmentId, string $targetPath) {
 		$mailBox = $this->getFolder($accountId, $folderId);
 
-		if ($attachmentId === 0) {
+		if ($attachmentId === '0') {
 			// Save all attachments
 			/* @var $m IMAPMessage */
 			$m = $mailBox->getMessage($messageId);

--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -295,10 +295,10 @@ class Mailbox implements IMailBox {
 
 	/**
 	 * @param int $messageId
-	 * @param int $attachmentId
+	 * @param string $attachmentId
 	 * @return Attachment
 	 */
-	public function getAttachment(int $messageId, int $attachmentId): Attachment {
+	public function getAttachment(int $messageId, string $attachmentId): Attachment {
 		return new Attachment($this->conn, $this->mailBox, $messageId, $attachmentId);
 	}
 

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -342,7 +342,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 				return;
 			}
 			$this->attachments[] = [
-				'id' => (int) $p->getMimeId(),
+				'id' => $p->getMimeId(),
 				'messageId' => $this->messageId,
 				'fileName' => $filename,
 				'mime' => $p->getType(),

--- a/lib/Service/IMailBox.php
+++ b/lib/Service/IMailBox.php
@@ -49,10 +49,10 @@ interface IMailBox {
 
 	/**
 	 * @param int $messageId
-	 * @param int $attachmentId
+	 * @param string $attachmentId
 	 * @return Attachment
 	 */
-	public function getAttachment(int $messageId, int $attachmentId): Attachment;
+	public function getAttachment(int $messageId, string $attachmentId): Attachment;
 
 	/**
 	 * @param int $messageId

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -247,7 +247,7 @@ class MessagesControllerTest extends TestCase {
 		$accountId = 17;
 		$folderId = base64_encode('my folder');
 		$messageId = 123;
-		$attachmentId = 3;
+		$attachmentId = '2.2';
 		$targetPath = 'Downloads';
 
 		$this->accountService->expects($this->once())
@@ -295,7 +295,7 @@ class MessagesControllerTest extends TestCase {
 		$accountId = 17;
 		$folderId = base64_encode('my folder');
 		$messageId = 123;
-		$attachmentId = 3;
+		$attachmentId = '0';
 		$targetPath = 'Downloads';
 
 		$this->accountService->expects($this->once())
@@ -343,8 +343,13 @@ class MessagesControllerTest extends TestCase {
 			->will($this->returnValue('abcdefg'));
 
 		$expected = new JSONResponse();
-		$response = $this->controller->saveAttachment($accountId, $folderId,
-			$messageId, 0, $targetPath);
+		$response = $this->controller->saveAttachment(
+			$accountId,
+			$folderId,
+			$messageId,
+			$attachmentId,
+			$targetPath
+		);
 
 		$this->assertEquals($expected, $response);
 	}


### PR DESCRIPTION
This is the result of what happens when you blindly assume the type of a value you're not familiar with.

The MIME Ids are strings like `1` or `2`, so I assumed converting and treating as `int` is fine. But sometimes they can also be `2.2` or similar. Hence when you we generated the download link for attachment of part ID `2.2` it resulted in the one for `2` due to the conversion.

Reproducible with mails with (inline) attachments sent from Apple mail.