### PR TITLE
Fix automatic provisioning (for new users)

### DIFF
--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -65,7 +65,12 @@ class ProvisioningMiddleware extends Middleware {
 			// Nothing to update
 			return;
 		}
+		$config = $this->provisioningManager->getConfig();
+		if ($config === null || !$config->isActive()) {
+			return;
+		}
 		try {
+			$this->provisioningManager->provisionSingleUser($config, $user);
 			$this->provisioningManager->updatePassword(
 				$user,
 				$this->credentialStore->getLoginCredentials()->getPassword()


### PR DESCRIPTION
This makes sure that every user has a provisioned account when Mail is accessed.

# Before
new user didn't have provisioned account until admin provisioned for all users

# After
also new users get their account as soon as they access the app

In the future we can use https://github.com/nextcloud/server/pull/18348 to create the account right when the user is created. But it doesn't make a difference at the moment.