### PR TITLE
Feature contact group send

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,32 +24,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\AppInfo;
 
-use OCA\Mail\Contracts\IAttachmentService;
-use OCA\Mail\Contracts\IAvatarService;
-use OCA\Mail\Contracts\IMailManager;
-use OCA\Mail\Contracts\IMailTransmission;
-use OCA\Mail\Contracts\IUserPreferences;
-use OCA\Mail\Events\BeforeMessageDeletedEvent;
-use OCA\Mail\Events\DraftSavedEvent;
-use OCA\Mail\Events\MessageSentEvent;
-use OCA\Mail\Events\SaveDraftEvent;
-use OCA\Mail\Http\Middleware\ErrorMiddleware;
-use OCA\Mail\Listener\AddressCollectionListener;
-use OCA\Mail\Listener\DeleteDraftListener;
-use OCA\Mail\Listener\DraftMailboxCreatorListener;
-use OCA\Mail\Listener\FlagRepliedMessageListener;
-use OCA\Mail\Listener\TrashMailboxCreatorListener;
-use OCA\Mail\Listener\SaveSentMessageListener;
-use OCA\Mail\Service\Attachment\AttachmentService;
-use OCA\Mail\Service\AvatarService;
-use OCA\Mail\Service\Group\IGroupService;
-use OCA\Mail\Service\Group\NextcloudGroupService;
-use OCA\Mail\Service\MailManager;
-use OCA\Mail\Service\MailTransmission;
-use OCA\Mail\Service\UserPreferenceSevice;
 use OCP\AppFramework\App;
-use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Util;
 
 class Application extends App {
 

--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -46,6 +46,7 @@ use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\AvatarService;
 use OCA\Mail\Service\Group\IGroupService;
 use OCA\Mail\Service\Group\NextcloudGroupService;
+use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\MailManager;
 use OCA\Mail\Service\MailSearch;
 use OCA\Mail\Service\MailTransmission;
@@ -115,6 +116,7 @@ class BootstrapSingleton {
 		$container->registerMiddleWare('ProvisioningMiddleware');
 
 		$container->registerAlias(IGroupService::class, NextcloudGroupService::class);
+		$container->registerAlias(IGroupService::class, ContactsGroupService::class);
 	}
 
 	private function registerEvents(IAppContainer $container): void {

--- a/lib/Service/Group/ContactsGroupService.php
+++ b/lib/Service/Group/ContactsGroupService.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Matthias Rella <mrella@pisys.eu>
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Boris Fritscher <boris.fritscher@gmail.com>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Service\Group;
+
+use OCP\Contacts\IManager;
+use OCP\IConfig;
+
+class ContactsGroupService implements IGroupService {
+
+	/** @var IManager */
+	private $contactsManager;
+
+	/** @var IConfig */
+	private $config;
+
+	/**
+	 * Group's namespace
+	 *
+	 * @var string
+	 */
+	private $namespace = "Contacts";
+
+	public function __construct(IManager $contactsManager, IConfig $config) {
+		$this->contactsManager = $contactsManager;
+		$this->config = $config;
+	}
+
+	public function getNamespace(): string {
+		return $this->namespace;
+	}
+
+	public function search(string $term): array {
+		if (!$this->contactsManager->isEnabled()) {
+			return [];
+		}
+
+		// If 'Allow username autocompletion in share dialog' is disabled in the admin sharing settings, then we must not
+		// auto-complete system users
+		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+
+		$result = $this->contactsManager->search($term, ['CATEGORIES']);
+		$receivers = [];
+		foreach ($result as $r) {
+			if (!$allowSystemUsers && isset($r['isLocalSystemBook']) && $r['isLocalSystemBook']) {
+				continue;
+			}
+			if (!isset($r['EMAIL'])) {
+				continue;
+			}
+			foreach (explode(',', $r['CATEGORIES']) as $group) {
+				$receivers[] =[
+					'id' => $group,
+					'name' => $group
+				];
+			}
+		}
+		return array_unique($receivers, SORT_REGULAR);
+	}
+
+	public function getUsers(string $groupId): array {
+		if (!$this->contactsManager->isEnabled()) {
+			return [];
+		}
+
+		// If 'Allow username autocompletion in share dialog' is disabled in the admin sharing settings, then we must not
+		// auto-complete system users
+		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+
+		$result = $this->contactsManager->search($groupId, ['CATEGORIES']);
+		$receivers = [];
+		foreach ($result as $r) {
+			if (!$allowSystemUsers && isset($r['isLocalSystemBook']) && $r['isLocalSystemBook']) {
+				continue;
+			}
+			if (!isset($r['EMAIL'])) {
+				continue;
+			}
+			$groups = explode(',', $r['CATEGORIES']);
+
+			// search matches substring but we only want full match
+			if (!in_array($groupId, $groups)) {
+				continue;
+			}
+
+			$email = $r['EMAIL'];
+			// only take first email ?
+			if (is_array($email) && count($email) > 0) {
+				$email = $email[0];
+			}
+
+			$receivers[] = [
+				'email' => $email
+			];
+		}
+		return $receivers;
+	}
+}

--- a/lib/Service/Group/ContactsGroupService.php
+++ b/lib/Service/Group/ContactsGroupService.php
@@ -105,15 +105,15 @@ class ContactsGroupService implements IGroupService {
 				continue;
 			}
 
-			$email = $r['EMAIL'];
-			// only take first email ?
-			if (is_array($email) && count($email) > 0) {
-				$email = $email[0];
+			$emails = $r['EMAIL'];
+			if (!is_array($emails)) {
+				$emails = [$emails];
 			}
-
-			$receivers[] = [
-				'email' => $email
-			];
+			foreach($emails as $email) {
+				$receivers[] = [
+					'email' => $email
+				];
+			}
 		}
 		return $receivers;
 	}

--- a/tests/Unit/Service/Group/ContactsGroupServiceTest.php
+++ b/tests/Unit/Service/Group/ContactsGroupServiceTest.php
@@ -131,7 +131,7 @@ class ContactsGroupServiceTest extends TestCase {
 				'CATEGORIES' => 'work,family'
 			],
 			[
-				// take first email
+				// take all email
 				'UID' => 2,
 				'FN' => 'John Doe',
 				'EMAIL' => [
@@ -165,6 +165,9 @@ class ContactsGroupServiceTest extends TestCase {
 			],
 			[
 				'email' => 'john@doe.info',
+			],
+			[
+				'email' => 'doe@john.info',
 			],
 		];
 

--- a/tests/Unit/Service/Group/ContactsGroupServiceTest.php
+++ b/tests/Unit/Service/Group/ContactsGroupServiceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+* @author Boris Fritscher <boris.fritscher@gmail.com>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\Group;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Service\Group\ContactsGroupService;
+use OCP\Contacts\IManager;
+use OCP\IConfig;
+
+class ContactsGroupServiceTest extends TestCase {
+
+	/** @var IManager */
+	private $contactsManager;
+
+	/** @var IConfig */
+	private $config;
+
+	private $groupService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->contactsManager = $this->createMock(IManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->groupService = new ContactsGroupService($this->contactsManager,
+			$this->config);
+	}
+
+	public function testDisabledContactsManager() {
+		$this->contactsManager->expects($this->once())
+			->method('isEnabled')
+			->will($this->returnValue(false));
+		$this->contactsManager->expects($this->never())
+			->method('search');
+
+		$expected = [];
+		$actual = $this->groupService->search("abc");
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testSearchGroups() {
+		$term = 'wor'; // searching for: group Work
+		$searchResult = [
+			[
+				// multiple groups
+				'UID' => 1,
+				'FN' => 'Jonathan Frakes',
+				'EMAIL' => 'jonathan@frakes.com',
+				'CATEGORIES' => 'work1,work2,family'
+			],
+			[
+				// 1 group
+				'UID' => 2,
+				'FN' => 'John Doe',
+				'EMAIL' => [
+					'john@doe.info',
+					'doe@john.info',
+				],
+				'CATEGORIES' => 'work3'
+			],
+			[
+				// 1 group no e-mail
+				'UID' => 3,
+				'FN' => 'Johann Strauss II',
+				'CATEGORIES' => 'suppliers'
+			]
+		];
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'no')
+			->willReturn('yes');
+		$this->contactsManager->expects($this->once())
+			->method('isEnabled')
+			->will($this->returnValue(true));
+		$this->contactsManager->expects($this->once())
+			->method('search')
+			->with($term, ['CATEGORIES'])
+			->will($this->returnValue($searchResult));
+		$expected = [
+			[
+				'id' => 'work1',
+				'name' => 'work1',
+			],
+			[
+				'id' => 'work2',
+				'name' => 'work2',
+			],
+			[
+				'id' => 'family',
+				'name' => 'family',
+			],
+			[
+				'id' => 'work3',
+				'name' => 'work3',
+			],
+		];
+
+		$actual = $this->groupService->search($term);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testGetUsersForGroup() {
+		$groupId = 'work'; // searching for: group Work
+		$searchResult = [
+			[
+				// multiple groups
+				'UID' => 1,
+				'FN' => 'Jonathan Frakes',
+				'EMAIL' => 'jonathan@frakes.com',
+				'CATEGORIES' => 'work,family'
+			],
+			[
+				// take first email
+				'UID' => 2,
+				'FN' => 'John Doe',
+				'EMAIL' => [
+					'john@doe.info',
+					'doe@john.info',
+				],
+				'CATEGORIES' => 'work'
+			],
+			[
+				// substring of group should not match
+				'UID' => 3,
+				'FN' => 'Jonathan Frakes',
+				'EMAIL' => 'jonathan2@frakes.com',
+				'CATEGORIES' => 'work2'
+			]
+		];
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'no')
+			->willReturn('yes');
+		$this->contactsManager->expects($this->once())
+			->method('isEnabled')
+			->will($this->returnValue(true));
+		$this->contactsManager->expects($this->once())
+			->method('search')
+			->with($groupId, ['CATEGORIES'])
+			->will($this->returnValue($searchResult));
+		$expected = [
+			[
+				'email' => 'jonathan@frakes.com',
+			],
+			[
+				'email' => 'john@doe.info',
+			],
+		];
+
+		$actual = $this->groupService->getUsers($groupId);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+
+}
+


### PR DESCRIPTION
Test of implementing contact group lookup and expansion
By adding a new GroupService implementation and copying some code of the ContactsIntegration.php 
This is a first attempt to fix issue #41 . Some open questions I identified the following open issues:
- To which email of the contact do we send? first or all?
- Should we hide the expansion in the BCC field?
- GroupService only seems to use email field no label?

Fixes https://github.com/nextcloud/mail/issues/41
