### PR TITLE
Removed max width for messages.  Fixes issue with nextcloud 17

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -271,6 +271,7 @@ export default {
 <style lang="scss">
 #mail-message {
 	flex-grow: 1;
+	max-width: none !important;
 }
 
 .mail-message-body {


### PR DESCRIPTION
Messages in nextcloud 17 are not taking up the entire space.

Before this PR
![before](https://user-images.githubusercontent.com/14130581/71705904-59f15d00-2da7-11ea-8f70-f65e2c8cd4ad.png)

After
![after](https://user-images.githubusercontent.com/14130581/71705905-5d84e400-2da7-11ea-80fc-9de4381e06a5.png)
