### PR TITLE
Fix vanishing newlines of plaintext drafts

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -419,6 +419,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'subject' => $this->getSubject(),
 			'dateInt' => $this->getSentDate()->getTimestamp(),
 			'flags' => $this->getFlags(),
+			'hasHtmlBody' => $this->hasHtmlMessage,
 		];
 	}
 

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -64,7 +64,7 @@ export default {
 					bcc: this.draft.bcc, // TODO: impl in composer
 					subject: this.draft.subject,
 					body: this.draft.body,
-					isPlainText: this.draft.hasHtmlBody !== undefined,
+					isPlainText: !this.draft.hasHtmlBody,
 				}
 			} else if (this.$route.query.uid !== undefined) {
 				// Forward or reply to a message

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -42,7 +42,7 @@ import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph'
 
 import {getLanguage} from '@nextcloud/l10n'
 
-import {htmlToText} from '../util/HtmlHelper'
+import logger from '../logger'
 
 export default {
 	name: 'TextEditor',
@@ -130,13 +130,12 @@ export default {
 
 			// Set value as late as possible, so the custom schema listener is used
 			// for the initial editor model
-			if (this.html) {
-				this.text = this.value
-			} else {
-				this.text = `<p>${htmlToText(this.value).replace(/[\n\r]/gm, '<br>')}</p>`
-			}
+			this.text = this.value
+
+			logger.debug(`setting TextEditor contents to <${this.text}>`)
 		},
 		onInput() {
+			logger.debug(`TextEditor input changed to <${this.text}>`)
 			this.$emit('input', this.text)
 		},
 	},


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2377

## Steps to reproduce

* Make sure account is set to plaintext editing
* Start *New message*
* Type "Christoph<kbd>Enter</kbd>is<kbd>Shift+Enter</kbd>awesome"
* Go to drafts
* Open first message
* See
```
Christoph

is
awesome
```
in the editor.