### PR TITLE
Allow navigation from more paths to new message composer

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -98,6 +98,12 @@ export default {
 			},
 		}
 	},
+	watch: {
+		value(newVal) {
+			// needed for reset in composer
+			this.text = newVal
+		},
+	},
 	beforeMount() {
 		this.loadEditorTranslations(getLanguage())
 	},


### PR DESCRIPTION
This PR solves issue #110, making navigating from account settings / setup to the new message composer possible again.

To make this possible, the first mail account and first folder available is used when navigating back. This requires at least one account / folder present and will result in the folder contents loaded and rendered again.

Closes #110