### PR TITLE
Do not fail when no CATEGORY is set on contacts 

### DIFF
--- a/lib/Service/Group/ContactsGroupService.php
+++ b/lib/Service/Group/ContactsGroupService.php
@@ -70,7 +70,7 @@ class ContactsGroupService implements IGroupService {
 			if (!isset($r['EMAIL'])) {
 				continue;
 			}
-			foreach (explode(',', $r['CATEGORIES']) as $group) {
+			foreach (explode(',', $r['CATEGORIES'] ?? '') as $group) {
 				$receivers[] =[
 					'id' => $group,
 					'name' => $group


### PR DESCRIPTION
It's set for contacts. But any other address book might not set this prop, hence adding a fallback.