### PR TITLE
Show embedded messages as attachments

### DIFF
--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -114,7 +114,7 @@ class Attachment {
 	}
 
 	/**
-	 * @return string
+	 * @return string|null
 	 */
 	public function getName() {
 		return $this->mimePart->getName();

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -292,8 +292,21 @@ class MessagesController extends Controller {
 
 		$attachment = $mailBox->getAttachment($messageId, $attachmentId);
 
+		// Body party and embedded messages do not have a name
+		if ($attachment->getName() === null) {
+			return new AttachmentDownloadResponse(
+				$attachment->getContents(),
+				$this->l10n->t('Embedded message %s', [
+					$attachmentId,
+				]) . '.eml',
+				$attachment->getType()
+			);
+		}
 		return new AttachmentDownloadResponse(
-			$attachment->getContents(), $attachment->getName(), $attachment->getType());
+			$attachment->getContents(),
+			$attachment->getName(),
+			$attachment->getType()
+		);
 	}
 
 	/**
@@ -452,7 +465,7 @@ class MessagesController extends Controller {
 	 * @return boolean
 	 */
 	private function attachmentIsCalendarEvent(array $attachment): bool {
-		return in_array($attachment['mime'],  ['text/calendar', 'application/ics'], true);
+		return in_array($attachment['mime'], ['text/calendar', 'application/ics'], true);
 	}
 
 }

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -263,21 +263,20 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 */
 	private function hasAttachments($part) {
 		foreach ($part->getParts() as $p) {
-			/**
-			 * @var Horde_Mime_Part $p
-			 */
+			/** @var Horde_Mime_Part $p */
 			$filename = $p->getName();
 
-			if (!is_null($p->getContentId())) {
+			if ($p->getContentId() !== null) {
 				continue;
 			}
-			if (isset($filename)) {
+			// TODO: show embedded messages and don't treat them as attachments
+			if ($p->getType() === 'message/rfc822' || isset($filename)) {
 				// do not show technical attachments
 				if (in_array($filename, $this->attachmentsToIgnore)) {
 					continue;
-				} else {
-					return true;
 				}
+
+				return true;
 			}
 			if ($this->hasAttachments($p)) {
 				return true;
@@ -336,7 +335,8 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		// Any part with a filename is an attachment,
 		// so an attached text file (type 0) is not mistaken as the message.
 		$filename = $p->getName();
-		if (isset($filename)) {
+		// TODO: show embedded messages and don't treat them as attachments
+		if ($p->getType() === 'message/rfc822' || isset($filename)) {
 			if (in_array($filename, $this->attachmentsToIgnore)) {
 				return;
 			}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -14,6 +14,7 @@
 				:hide-selected="true"
 				:custom-label="formatAliases"
 				:placeholder="t('mail', 'Select account')"
+				:clear-on-select="false"
 				@keyup="onInputChanged"
 			/>
 		</div>
@@ -31,6 +32,7 @@
 				track-by="email"
 				:multiple="true"
 				:placeholder="t('mail', 'Contact or email address …')"
+				:clear-on-select="false"
 				:show-no-options="false"
 				@keyup="onInputChanged"
 				@tag="onNewToAddr"
@@ -53,6 +55,7 @@
 				track-by="email"
 				:multiple="true"
 				:placeholder="t('mail', '')"
+				:clear-on-select="false"
 				:show-no-options="false"
 				@keyup="onInputChanged"
 				@tag="onNewCcAddr"

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -24,7 +24,7 @@
 		<img v-if="isImage" class="mail-attached-image" :src="url" />
 		<img class="attachment-icon" :src="mimeUrl" />
 		<span class="attachment-name" :title="label"
-			>{{ fileName }}
+			>{{ name }}
 			<span class="attachment-size">({{ humanReadable(size) }})</span>
 		</span>
 		<button
@@ -78,7 +78,7 @@ export default {
 		},
 		fileName: {
 			type: String,
-			required: true,
+			required: false,
 		},
 		url: {
 			type: String,
@@ -86,6 +86,10 @@ export default {
 		},
 		size: {
 			type: Number,
+			required: true,
+		},
+		mime: {
+			type: String,
 			required: true,
 		},
 		mimeUrl: {
@@ -110,7 +114,16 @@ export default {
 		}
 	},
 	computed: {
+		name() {
+			if (this.mime === 'message/rfc822') {
+				return t('mail', 'Embedded message')
+			}
+			return this.fileName
+		},
 		label() {
+			if (this.mime === 'message/rfc822') {
+				return t('mail', 'Embedded message') + ' (' + formatFileSize(this.size) + ')'
+			}
 			return this.fileName + ' (' + formatFileSize(this.size) + ')'
 		},
 		calendarMenuEntries() {

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -31,6 +31,7 @@
 				:url="attachment.downloadUrl"
 				:is-image="attachment.isImage"
 				:is-calendar-event="attachment.isCalendarEvent"
+				:mime="attachment.mime"
 				:mime-url="attachment.mimeUrl"
 			/>
 		</div>

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -235,7 +235,7 @@ class MessagesControllerTest extends TestCase {
 		$this->attachment->expects($this->once())
 			->method('getContents')
 			->will($this->returnValue($contents));
-		$this->attachment->expects($this->once())
+		$this->attachment->expects($this->any())
 			->method('getName')
 			->will($this->returnValue($name));
 		$this->attachment->expects($this->once())


### PR DESCRIPTION
The real fix will be to show embedded messages. But this needs som proper planning. For the time being we can show them as attachments. This is better than hiding them.

Steps to reproduce
* Use another IMAP client
* Forward a message *embedded* (not cited, not as attachment). Evolution can do this for example
* Open the received message with this app

## Before

See the outer message but not the embedded one.

## Now

See the outer message and the embedded one as attachment that can be downloaded and opened with the other IMAP client (or inspected with a text editor).

@nextcloud/mail please test :pray: 