### PR TITLE
Fix saving an embedded message to Files

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -339,7 +339,9 @@ class MessagesController extends Controller {
 		foreach ($attachmentIds as $attachmentId) {
 			$attachment = $mailBox->getAttachment($messageId, $attachmentId);
 
-			$fileName = $attachment->getName();
+			$fileName = $attachment->getName() ?? $this->l10n->t('Embedded message %s', [
+					$attachmentId,
+				]) . '.eml';
 			$fileParts = pathinfo($fileName);
 			$fileName = $fileParts['filename'];
 			$fileExtension = $fileParts['extension'];


### PR DESCRIPTION
Follow-up to #2541 

## Steps to reproduce

* Open message with embedded message
* Use folder icon to save the message to Files

Before: server error
After: file saved