### PR TITLE
Do not double-encode mailto parameters

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -166,7 +166,7 @@ class PageController extends Controller {
 
 		array_walk($params,
 			function (&$value, $key) {
-				$value = "$key=" . urlencode($value);
+				$value = "$key=" . $value;
 			});
 
 		$hashParams = '#mailto?' . implode('&', $params);


### PR DESCRIPTION
Steps to reproduce

* Set up maito: handler from settings menu (#2539)
* Open contacts menu
* Click the mail icon on an entry that has an email address

Before: get the new message page with an email like `user%40domain.tld` filled in
After: get new message page with `user@domain.tld` filled in

The reason for this bug is that `parse_url` does *not* URL decode the parameters, hence they ended up being encoded twice.