### PR TITLE
Detect missing mailbox cache and block access to messages

### DIFF
--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -24,6 +24,7 @@
 namespace OCA\Mail\Contracts;
 
 use OCA\Mail\Account;
+use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Model\IMAPMessage;
 
@@ -36,6 +37,7 @@ interface IMailSearch {
 	 * @param string|null $cursor
 	 *
 	 * @return IMAPMessage[]
+	 * @throws ClientException
 	 * @throws ServiceException
 	 */
 	public function findMessages(Account $account, string $mailboxName, ?string $filter, ?int $cursor): array;

--- a/lib/Controller/FoldersController.php
+++ b/lib/Controller/FoldersController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use Horde_Imap_Client;
+use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\MailboxNotCachedException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\SyncService;
@@ -102,10 +103,12 @@ class FoldersController extends Controller {
 	 * @param string $folderId
 	 * @param string $syncToken
 	 * @param int[] $uids
+	 *
 	 * @return JSONResponse
+	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function sync(int $accountId, string $folderId, array $uids = []): JSONResponse {
+	public function sync(int $accountId, string $folderId, array $uids = [], bool $init = false): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 
 		if (empty($accountId) || empty($folderId) || !is_array($uids)) {
@@ -120,7 +123,7 @@ class FoldersController extends Controller {
 				array_map(function($uid) {
 					return (int) $uid;
 				}, $uids),
-				true
+				!$init
 			);
 		} catch (MailboxNotCachedException $e) {
 			return new JSONResponse(null, Http::STATUS_PRECONDITION_REQUIRED);

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -127,4 +127,16 @@ class Mailbox extends Entity {
 		return $this->getName();
 	}
 
+	public function isCached(): bool {
+		return $this->getSyncNewToken() !== null
+			&& $this->getSyncChangedToken() !== null
+			&& $this->getSyncVanishedToken() !== null;
+	}
+
+	public function hasLocks(): bool {
+		return $this->getSyncNewLock() !== null
+			|| $this->getSyncChangedLock() !== null
+			|| $this->getSyncVanishedLock() !== null;
+	}
+
 }

--- a/lib/Exception/ClientException.php
+++ b/lib/Exception/ClientException.php
@@ -27,7 +27,12 @@ declare(strict_types=1);
 namespace OCA\Mail\Exception;
 
 use Exception;
+use OCP\AppFramework\Http;
 
 class ClientException extends Exception {
+
+	public function getHttpCode(): int {
+		return Http::STATUS_BAD_REQUEST;
+	}
 
 }

--- a/lib/Exception/MailboxLockedException.php
+++ b/lib/Exception/MailboxLockedException.php
@@ -23,8 +23,17 @@
 
 namespace OCA\Mail\Exception;
 
-use Exception;
+use OCA\Mail\Db\Mailbox;
+use OCP\AppFramework\Http;
 
-class ConcurrentSyncException extends Exception {
+class MailboxLockedException extends ClientException {
+
+	public static function from(Mailbox $mailbox): self {
+		return new self($mailbox->getId() . ' is already being synced');
+	}
+
+	public function getHttpCode(): int {
+		return Http::STATUS_CONFLICT;
+	}
 
 }

--- a/lib/Exception/MailboxNotCachedException.php
+++ b/lib/Exception/MailboxNotCachedException.php
@@ -2,6 +2,12 @@
 
 namespace OCA\Mail\Exception;
 
-class MailboxNotCachedException extends ServiceException {
+use OCA\Mail\Db\Mailbox;
+
+class MailboxNotCachedException extends ClientException {
+
+	public static function from(Mailbox $mailbox): self {
+		return new self("mailbox {$mailbox->getId()} is not cached");
+	}
 
 }

--- a/lib/Http/JsonResponse.php
+++ b/lib/Http/JsonResponse.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Http;
 
+use OCA\Mail\Exception\ClientException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse as Base;
 use Throwable;
@@ -40,7 +41,7 @@ use function get_class;
 class JsonResponse extends Base {
 
 	public function __construct($data = [],
-						 int $statusCode = Http::STATUS_OK) {
+								int $statusCode = Http::STATUS_OK) {
 		parent::__construct($data, $statusCode);
 
 		$this->addHeader('x-mail-response', 'true');
@@ -65,6 +66,16 @@ class JsonResponse extends Base {
 				'data' => $data,
 			],
 			$status
+		);
+	}
+
+	public static function failWith(ClientException $exception): self {
+		return self::fail(
+			[
+				'message' => $exception->getMessage(),
+				'type' => get_class($exception),
+			],
+			$exception->getHttpCode()
 		);
 	}
 

--- a/lib/Http/Middleware/ErrorMiddleware.php
+++ b/lib/Http/Middleware/ErrorMiddleware.php
@@ -76,9 +76,7 @@ class ErrorMiddleware extends Middleware {
 		}
 
 		if ($exception instanceof ClientException) {
-			return JsonResponse::fail([
-				'message' => $exception->getMessage()
-			]);
+			return JsonResponse::failWith($exception);
 		}
 
 		if ($exception instanceof DoesNotExistException) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -334,7 +334,7 @@ export default {
 			return envelopes
 		})
 	},
-	syncEnvelopes({commit, getters, dispatch}, {accountId, folderId}) {
+	syncEnvelopes({commit, getters, dispatch}, {accountId, folderId, init = false}) {
 		const folder = getters.getFolder(accountId, folderId)
 
 		if (folder.isUnified) {
@@ -350,6 +350,7 @@ export default {
 									dispatch('syncEnvelopes', {
 										accountId: account.id,
 										folderId: folder.id,
+										init,
 									})
 								)
 						)
@@ -359,7 +360,7 @@ export default {
 
 		const uids = getters.getEnvelopes(accountId, folderId).map(env => env.id)
 
-		return syncEnvelopes(accountId, folderId, uids).then(syncData => {
+		return syncEnvelopes(accountId, folderId, uids, init).then(syncData => {
 			const unifiedFolder = getters.getUnifiedFolder(folder.specialRole)
 
 			syncData.newMessages.forEach(envelope => {

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -38,7 +38,6 @@ use OCA\Mail\Model\Message;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\ItineraryService;
 use OCA\Mail\Service\MailManager;
-use OCA\Mail\Service\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -71,9 +70,6 @@ class MessagesControllerTest extends TestCase {
 
 	/** @var ItineraryService|MockObject */
 	private $itineraryService;
-
-	/** @var SyncService|MockObject */
-	private $syncService;
 
 	/** @var string */
 	private $userId;
@@ -120,7 +116,6 @@ class MessagesControllerTest extends TestCase {
 		$this->mailManager = $this->createMock(IMailManager::class);
 		$this->mailSearch = $this->createMock(IMailSearch::class);
 		$this->itineraryService = $this->createMock(ItineraryService::class);
-		$this->syncService = $this->createMock(SyncService::class);
 		$this->userId = 'john';
 		$this->userFolder = $this->createMock(Folder::class);
 		$this->request = $this->createMock(Request::class);
@@ -145,7 +140,6 @@ class MessagesControllerTest extends TestCase {
 			$this->mailManager,
 			$this->mailSearch,
 			$this->itineraryService,
-			$this->syncService,
 			$this->userId,
 			$this->userFolder,
 			$this->logger,


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/2576, but without the retrying

Todo
- [x] Finish https://github.com/nextcloud/mail/pull/2584
- [x] Detect the error on the client-side and send another request for the sync
- [x] Change UI code to also show a different text for the sync
- [x] BUG: doesn't work with the unified inbox logic

---

Steps to test

0) Close the app
1) Reset cached messages
```
update oc_mail_mailboxes set sync_new_token=null, sync_changed_token=null, sync_vanished_token=null;
delete from oc_mail_messages;
```
2) Open Nextcloud and the browser console
3) Navigate to Mail
4) For each account, see a failing request that returns 400 to /messages, then a successful sync request and then a successful /messages request