### PR TITLE
Update authors list to most active contributors in 1y

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,8 +15,10 @@
 	<version>1.2.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
+	<author>Roeland Jago Douma</author>
+	<author>Greta Doçi</author>
+	<author>Cyrille Bollu</author>
 	<author>Jan-Christoph Borchardt</author>
-	<author>Steffen Lindner</author>
 	<namespace>Mail</namespace>
 	<documentation>
 		<admin>https://github.com/nextcloud/mail#readme</admin>


### PR DESCRIPTION
Based on https://github.com/nextcloud/mail/graphs/contributors?from=2019-02-05&to=2020-02-04&type=c

cc @nextcloud/mail