### PR TITLE
Fix searching in message cache (and IMAP)

### DIFF
--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -24,9 +24,9 @@
 namespace OCA\Mail\Contracts;
 
 use OCA\Mail\Account;
+use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
-use OCA\Mail\Model\IMAPMessage;
 
 interface IMailSearch {
 
@@ -36,7 +36,7 @@ interface IMailSearch {
 	 * @param string|null $filter
 	 * @param string|null $cursor
 	 *
-	 * @return IMAPMessage[]
+	 * @return Message[]
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -195,10 +195,11 @@ class MessageMapper extends QBMapper {
 	/**
 	 * @param Mailbox $mailbox
 	 * @param SearchQuery $query
+	 * @param int[]|null $uids
 	 *
 	 * @return int[]
 	 */
-	public function findUidsByQuery(Mailbox $mailbox, SearchQuery $query): array {
+	public function findUidsByQuery(Mailbox $mailbox, SearchQuery $query, array $uids = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$select = $qb
@@ -232,12 +233,12 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->in('r1.email', $qb->createNamedParameter($query->getTo(), IQueryBuilder::PARAM_STR_ARRAY))
 			);
 		}
-		if (!empty($query->getTo())) {
+		if (!empty($query->getCc())) {
 			$select->andWhere(
 				$qb->expr()->in('r2.email', $qb->createNamedParameter($query->getCc(), IQueryBuilder::PARAM_STR_ARRAY))
 			);
 		}
-		if (!empty($query->getTo())) {
+		if (!empty($query->getBcc())) {
 			$select->andWhere(
 				$qb->expr()->in('r3.email', $qb->createNamedParameter($query->getBcc(), IQueryBuilder::PARAM_STR_ARRAY))
 			);
@@ -246,6 +247,11 @@ class MessageMapper extends QBMapper {
 		if ($query->getCursor() !== null) {
 			$select->andWhere(
 				$qb->expr()->lt('sent_at', $qb->createNamedParameter($query->getCursor(), IQueryBuilder::PARAM_INT))
+			);
+		}
+		if ($uids !== null) {
+			$select->andWhere(
+				$qb->expr()->in('uid', $qb->createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY))
 			);
 		}
 


### PR DESCRIPTION
* Query IMAP only if necessary
* Fix pagination (when IMAP results are used)
* Fix CC and BCC search queries

Fixes https://github.com/nextcloud/mail/issues/2586

cc @nextcloud/mail for testing

Before this PR search is unreliable. Now it should yield correct results.