### PR TITLE
Fix error matching in production build

### DIFF
--- a/src/components/FolderContent.vue
+++ b/src/components/FolderContent.vue
@@ -168,14 +168,14 @@ export default {
 				}
 			} catch (error) {
 				await matchError(error, {
-					[MailboxLockedError.name]: async error => {
+					[MailboxLockedError.getName()]: async error => {
 						logger.info('Mailbox is locked', {error})
 
 						await wait(15 * 1000)
 						// Keep trying
 						await this.loadEnvelopes()
 					},
-					[MailboxNotCachedError.name]: async error => {
+					[MailboxNotCachedError.getName()]: async error => {
 						logger.info('Mailbox not cached. Triggering initialization', {error})
 						this.loadingEnvelopes = false
 

--- a/src/errors/MailboxLockedError.js
+++ b/src/errors/MailboxLockedError.js
@@ -22,7 +22,11 @@
 export default class MailboxLockedError extends Error {
 	constructor(message) {
 		super(message)
-		this.name = 'MailboxLockedError'
+		this.name = MailboxLockedError.getName()
 		this.message = message
+	}
+
+	static getName() {
+		return 'MailboxLockedError'
 	}
 }

--- a/src/errors/MailboxNotCachedError.js
+++ b/src/errors/MailboxNotCachedError.js
@@ -22,7 +22,11 @@
 export default class MailboxNotCachedError extends Error {
 	constructor(message) {
 		super(message)
-		this.name = 'MailboxNotCachedError'
+		this.name = MailboxNotCachedError.getName()
 		this.message = message
+	}
+
+	static getName() {
+		return 'MailboxNotCachedError'
 	}
 }


### PR DESCRIPTION
Webpack renames classes, hence this didn't work in production mode.

cc @nextcloud/mail 

Steps to reproduce

* Clear message cache
* Load app

Before: unhandled error in console
After: missing cache detected, new requests dispatched and everything loads again