### PR TITLE
Add a lazy structure analyzation to get the attachments icon back

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.2.0</version>
+	<version>1.3.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Roeland Jago Douma</author>

--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -26,7 +26,6 @@ namespace OCA\Mail\Db;
 use JsonSerializable;
 use OCA\Mail\AddressList;
 use OCP\AppFramework\Db\Entity;
-use function json_encode;
 
 /**
  * @method void setUid(int $uid)
@@ -55,6 +54,12 @@ use function json_encode;
  * @method bool getFlagJunk()
  * @method void setFlagNotjunk(bool $notjunk)
  * @method bool getFlagNotjunk()
+ * @method void setStructureAnalyzed(bool $analyzed)
+ * @method bool getStructureAnalyzed()
+ * @method void setFlagAttachments(?bool $hasAttachments)
+ * @method null|bool getFlagAttachments()
+ * @method void setPreviewText(?string $subject)
+ * @method null|string getPreviewText()
  * @method void setUpdatedAt(int $time)
  * @method int getUpdatedAt()
  */
@@ -74,6 +79,9 @@ class Message extends Entity implements JsonSerializable {
 	protected $flagJunk;
 	protected $flagNotjunk;
 	protected $updatedAt;
+	protected $structureAnalyzed;
+	protected $flagAttachments;
+	protected $previewText;
 
 	/** @var AddressList */
 	private $from;
@@ -103,6 +111,8 @@ class Message extends Entity implements JsonSerializable {
 		$this->addType('flagForwarded', 'bool');
 		$this->addType('flagJunk', 'bool');
 		$this->addType('flagNotjunk', 'bool');
+		$this->addType('structureAnalyzed', 'bool');
+		$this->addType('flagAttachments', 'bool');
 		$this->addType('updatedAt', 'integer');
 	}
 
@@ -174,7 +184,7 @@ class Message extends Entity implements JsonSerializable {
 				'deleted' => $this->getFlagDeleted(),
 				'draft' => $this->getFlagDraft(),
 				'forwarded' => $this->getFlagForwarded(),
-				'hasAttachments' => false, // TODO
+				'hasAttachments' => $this->getFlagAttachments() ?? false,
 			],
 			'from' => $this->getFrom()->jsonSerialize(),
 			'to' => $this->getTo()->jsonSerialize(),

--- a/lib/IMAP/MessageStructureData.php
+++ b/lib/IMAP/MessageStructureData.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\IMAP;
+
+class MessageStructureData {
+
+	/** @var bool */
+	private $hasAttachments;
+
+	/** @var string */
+	private $previewText;
+
+	public function __construct(bool $hasAttachments,
+								string $previewText) {
+		$this->hasAttachments = $hasAttachments;
+		$this->previewText = $previewText;
+	}
+
+	public function hasAttachments(): bool {
+		return $this->hasAttachments;
+	}
+
+	public function getPreviewText(): string {
+		return $this->previewText;
+	}
+
+}

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\IMAP;
+
+use Horde_Imap_Client_Exception;
+use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageMapper as DbMapper;
+use OCA\Mail\IMAP\MessageMapper as ImapMapper;
+use OCP\ILogger;
+use function array_key_exists;
+use function array_map;
+use function array_merge;
+use function array_reduce;
+
+class PreviewEnhancer {
+
+	/** @var IMAPClientFactory */
+	private $clientFactory;
+
+	/** @var ImapMapper */
+	private $imapMapper;
+
+	/** @var DbMapper */
+	private $mapper;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(IMAPClientFactory $clientFactory,
+								ImapMapper $imapMapper,
+								DbMapper $dbMapper,
+								ILogger $logger) {
+		$this->clientFactory = $clientFactory;
+		$this->imapMapper = $imapMapper;
+		$this->mapper = $dbMapper;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param Message[] $messages
+	 *
+	 * @return Message[]
+	 */
+	public function process(Account $account, Mailbox $mailbox, array $messages): array {
+		$needAnalyze = array_reduce($messages, function (array $carry, Message $message) {
+			if ($message->getStructureAnalyzed()) {
+				// Nothing to do
+				return $carry;
+			}
+
+			return array_merge($carry, [$message->getUid()]);
+		}, []);
+
+		if (empty($needAnalyze)) {
+			// Nothing to enhance
+			return $messages;
+		}
+
+		try {
+			$data = $this->imapMapper->getBodyStructureData(
+				$this->clientFactory->getClient($account),
+				$mailbox->getMailbox(),
+				$needAnalyze
+			);
+		} catch (Horde_Imap_Client_Exception $e) {
+			// Ignore for now, but log
+			$this->logger->logException($e, [
+				'message' => 'Could not fetch structure detail data to enhance message previews',
+				'level' => ILogger::WARN,
+			]);
+
+			return $messages;
+		}
+
+		return $this->mapper->updatePreviewDataBulk(...array_map(function (Message $message) use ($data) {
+			if (!array_key_exists($message->getUid(), $data)) {
+				// Nothing to do
+				return $message;
+			}
+
+			/** @var MessageStructureData $structureData */
+			$structureData = $data[$message->getUid()];
+			$message->setFlagAttachments($structureData->hasAttachments());
+			$message->setPreviewText($structureData->getPreviewText());
+			$message->setStructureAnalyzed(true);
+
+			return $message;
+		}, $messages));
+	}
+
+}

--- a/lib/Migration/Version1020Date20200206134751.php
+++ b/lib/Migration/Version1020Date20200206134751.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1020Date20200206134751 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+		$messagesTable->addColumn('structure_analyzed', 'boolean', [
+			'notnull' => true,
+			'default' => false,
+		]);
+		$messagesTable->addColumn('flag_attachments', 'boolean', [
+			'notnull' => false,
+		]);
+		$messagesTable->addColumn('preview_text', 'string', [
+			'notnull' => false,
+			'length' => 255,
+		]);
+
+		return $schema;
+	}
+
+}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -619,6 +619,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$msg->setFlagForwarded(in_array(Horde_Imap_Client::FLAG_FORWARDED, $flags, true));
 		$msg->setFlagJunk(in_array(Horde_Imap_Client::FLAG_JUNK, $flags, true));
 		$msg->setFlagNotjunk(in_array(Horde_Imap_Client::FLAG_NOTJUNK, $flags, true));
+		$msg->setFlagAttachments(false);
 
 		return $msg;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud-mail",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -18,7 +18,7 @@
 		</div>
 		<div class="app-content-list-item-line-two" :title="data.subject">
 			<span v-if="data.flags.answered" class="icon-reply" />
-			<span v-if="data.flags.hasAttachments" class="icon-public icon-attachment" />
+			<span v-if="data.flags.hasAttachments === true" class="icon-public icon-attachment" />
 			<span v-if="draft" class="draft">
 				<em>{{ t('mail', 'Draft: ') }}</em>
 			</span>

--- a/tests/Unit/Service/Search/MailSearchTest.php
+++ b/tests/Unit/Service/Search/MailSearchTest.php
@@ -31,6 +31,7 @@ use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Exception\MailboxLockedException;
 use OCA\Mail\Exception\MailboxNotCachedException;
+use OCA\Mail\IMAP\PreviewEnhancer;
 use OCA\Mail\IMAP\Search\Provider;
 use OCA\Mail\Service\Search\FilterStringParser;
 use OCA\Mail\Service\Search\MailSearch;
@@ -55,6 +56,9 @@ class MailSearchTest extends TestCase {
 	/** @var Provider|MockObject */
 	private $imapSearchProvider;
 
+	/** @var PreviewEnhancer|MockObject */
+	private $previewEnhancer;
+
 	/** @var MessageMapper|MockObject */
 	private $messageMapper;
 
@@ -65,6 +69,7 @@ class MailSearchTest extends TestCase {
 		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
 		$this->imapSearchProvider = $this->createMock(Provider::class);
 		$this->messageMapper = $this->createMock(MessageMapper::class);
+		$this->previewEnhancer = $this->createMock(PreviewEnhancer::class);
 		$this->logger = $this->createMock(ILogger::class);
 
 		$this->search = new MailSearch(
@@ -72,6 +77,7 @@ class MailSearchTest extends TestCase {
 			$this->mailboxMapper,
 			$this->imapSearchProvider,
 			$this->messageMapper,
+			$this->previewEnhancer,
 			$this->logger
 		);
 	}
@@ -158,6 +164,9 @@ class MailSearchTest extends TestCase {
 			]);
 		$this->imapSearchProvider->expects($this->never())
 			->method('findMatches');
+		$this->previewEnhancer->expects($this->once())
+			->method('process')
+			->willReturnArgument(2);
 
 		$messages = $this->search->findMessages(
 			$account,
@@ -200,6 +209,9 @@ class MailSearchTest extends TestCase {
 				$this->createMock(Message::class),
 				$this->createMock(Message::class),
 			]);
+		$this->previewEnhancer->expects($this->once())
+			->method('process')
+			->willReturnArgument(2);
 
 		$messages = $this->search->findMessages(
 			$account,


### PR DESCRIPTION
As of #2064 we load messages from the database instead of IMAP. For performance reasons the structure information (body parts) is not fetched during the (initial) sync, as this requires downloading of lots of data from IMAP. Instead this PR adds a lazy *preview enhancer* that queries IMAP on demand and updates a few messages with the structure details.

Fixes #2580 
Required for #2579 

Todo
- [x] Fix for message search
- [x] Fix for new messages sync