### PR TITLE
Delete cached messages when deleting them on IMAP

### DIFF
--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -23,7 +23,6 @@
 
 namespace OCA\Mail\AppInfo;
 
-use OC\Hooks\PublicEmitter;
 use OCA\Mail\Contracts\IAttachmentService;
 use OCA\Mail\Contracts\IAvatarService;
 use OCA\Mail\Contracts\IMailManager;
@@ -32,6 +31,7 @@ use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Events\DraftSavedEvent;
+use OCA\Mail\Events\MessageDeletedEvent;
 use OCA\Mail\Events\MessageSentEvent;
 use OCA\Mail\Events\SaveDraftEvent;
 use OCA\Mail\Http\Middleware\ErrorMiddleware;
@@ -40,6 +40,7 @@ use OCA\Mail\Listener\AddressCollectionListener;
 use OCA\Mail\Listener\DeleteDraftListener;
 use OCA\Mail\Listener\DraftMailboxCreatorListener;
 use OCA\Mail\Listener\FlagRepliedMessageListener;
+use OCA\Mail\Listener\MessageDeletedCacheUpdaterListener;
 use OCA\Mail\Listener\SaveSentMessageListener;
 use OCA\Mail\Listener\TrashMailboxCreatorListener;
 use OCA\Mail\Service\Attachment\AttachmentService;
@@ -125,6 +126,7 @@ class BootstrapSingleton {
 
 		$dispatcher->addServiceListener(BeforeMessageDeletedEvent::class, TrashMailboxCreatorListener::class);
 		$dispatcher->addServiceListener(DraftSavedEvent::class, DeleteDraftListener::class);
+		$dispatcher->addServiceListener(MessageDeletedEvent::class, MessageDeletedCacheUpdaterListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, AddressCollectionListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, DeleteDraftListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, FlagRepliedMessageListener::class);

--- a/lib/Events/MessageDeletedEvent.php
+++ b/lib/Events/MessageDeletedEvent.php
@@ -1,9 +1,9 @@
 <?php declare(strict_types=1);
 
 /**
- * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
- * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -24,23 +24,26 @@
 namespace OCA\Mail\Events;
 
 use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
 use OCP\EventDispatcher\Event;
 
-class BeforeMessageDeletedEvent extends Event {
+class MessageDeletedEvent extends Event {
 
 	/** @var Account */
 	private $account;
 
-	/** @var string */
-	private $folderId;
+	/** @var Mailbox */
+	private $mailbox;
 
 	/** @var int */
 	private $messageId;
 
-	public function __construct(Account $account, string $mailbox, int $messageId) {
+	public function __construct(Account $account,
+								Mailbox $mailbox,
+								int $messageId) {
 		parent::__construct();
 		$this->account = $account;
-		$this->folderId = $mailbox;
+		$this->mailbox = $mailbox;
 		$this->messageId = $messageId;
 	}
 
@@ -48,8 +51,8 @@ class BeforeMessageDeletedEvent extends Event {
 		return $this->account;
 	}
 
-	public function getFolderId(): string {
-		return $this->folderId;
+	public function getMailbox(): Mailbox {
+		return $this->mailbox;
 	}
 
 	public function getMessageId(): int {

--- a/lib/Listener/MessageDeletedCacheUpdaterListener.php
+++ b/lib/Listener/MessageDeletedCacheUpdaterListener.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Listener;
+
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Events\MessageDeletedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+class MessageDeletedCacheUpdaterListener implements IEventListener {
+
+	/** @var MessageMapper */
+	private $mapper;
+
+	public function __construct(MessageMapper $mapper) {
+		$this->mapper = $mapper;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof MessageDeletedEvent)) {
+			// Unrelated
+			return;
+		}
+
+		$this->mapper->deleteByUid(
+			$event->getMailbox(),
+			$event->getMessageId()
+		);
+	}
+
+}

--- a/tests/Unit/Listener/MessageDeletedCacheUpdaterListenerTest.php
+++ b/tests/Unit/Listener/MessageDeletedCacheUpdaterListenerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Events\MessageDeletedEvent;
+use OCA\Mail\Listener\MessageDeletedCacheUpdaterListener;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+class MessageDeletedCacheUpdaterListenerTest extends TestCase {
+
+	/** @var ServiceMockObject */
+	private $serviceMock;
+
+	/** @var IEventListener */
+	private $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceMock = $this->createServiceMock(MessageDeletedCacheUpdaterListener::class);
+		$this->listener = $this->serviceMock->getService();
+	}
+
+	public function testHandleUnrelated() {
+		$event = new Event();
+		$this->serviceMock->getParameter('mapper')
+			->expects($this->never())
+			->method('deleteByUid');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandle() {
+		$event = $this->createMock(MessageDeletedEvent::class);
+		$this->serviceMock->getParameter('mapper')
+			->expects($this->once())
+			->method('deleteByUid')
+			->with($event->getMailbox(), $event->getMessageId());
+
+		$this->listener->handle($event);
+	}
+
+}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -34,9 +34,6 @@ use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\IMAP\MessageMapper;
-use OCA\Mail\IMAP\Sync\Request;
-use OCA\Mail\IMAP\Sync\Response;
-use OCA\Mail\IMAP\Sync\Synchronizer;
 use OCA\Mail\Service\MailManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -206,12 +203,8 @@ class MailManagerTest extends TestCase {
 		$inbox->setName('INBOX');
 		$trash = new Mailbox();
 		$trash->setName('Trash');
-		$this->eventDispatcher->expects($this->once())
-			->method('dispatch')
-			->with(
-				$this->equalTo(BeforeMessageDeletedEvent::class),
-				$this->anything()
-			);
+		$this->eventDispatcher->expects($this->exactly(2))
+			->method('dispatch');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
@@ -247,12 +240,8 @@ class MailManagerTest extends TestCase {
 		$source->setName('Trash');
 		$trash = new Mailbox();
 		$trash->setName('Trash');
-		$this->eventDispatcher->expects($this->once())
-			->method('dispatch')
-			->with(
-				$this->equalTo(BeforeMessageDeletedEvent::class),
-				$this->anything()
-			);
+		$this->eventDispatcher->expects($this->exactly(2))
+			->method('dispatch');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'Trash')


### PR DESCRIPTION
While strictly speaking we get inconsistent with the IMAP mailbox due to bypassing the sync machanism, this will show the user a more up-to-date representation of the mailbox, and making the sync a tiny bit faster (one row less to delete).

Fixes https://github.com/nextcloud/mail/issues/2622