### PR TITLE
Remove subfolders from Favorites

### DIFF
--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -51,7 +51,7 @@
 					{{ t('mail', 'Mark all messages of this folder as read') }}
 				</ActionButton>
 
-				<ActionInput v-if="!account.isUnified" icon="icon-add" @submit="createFolder">
+				<ActionInput v-if="!account.isUnified && folder.specialRole !== 'flagged'" icon="icon-add" @submit="createFolder">
 					{{ t('mail', 'Add subfolder') }}
 				</ActionInput>
 			</template>

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -42,7 +42,7 @@
 
 				<!-- TODO: make *mark as read* available for all folders once there is more than one action -->
 				<ActionButton
-					v-if="!account.isUnified"
+					v-if="!account.isUnified && folder.specialRole !== 'flagged'"
 					icon="icon-checkmark"
 					:title="t('mail', 'Mark all as read')"
 					:disabled="loadingMarkAsRead"
@@ -51,7 +51,11 @@
 					{{ t('mail', 'Mark all messages of this folder as read') }}
 				</ActionButton>
 
-				<ActionInput v-if="!account.isUnified && folder.specialRole !== 'flagged'" icon="icon-add" @submit="createFolder">
+				<ActionInput
+					v-if="!account.isUnified && folder.specialRole !== 'flagged'"
+					icon="icon-add"
+					@submit="createFolder"
+				>
 					{{ t('mail', 'Add subfolder') }}
 				</ActionInput>
 			</template>


### PR DESCRIPTION
fixes #2602
now it looks like in the pic below, since the only option is mark all as read. Is this ok? @ChristophWurst 

![favorite_subfolder](https://user-images.githubusercontent.com/12728974/74181406-8f5c5680-4c41-11ea-9bfa-9a19f2a1ab28.png)
