### PR TITLE
Treat temporary IMAP errors as warnings

### DIFF
--- a/lib/Service/SyncService.php
+++ b/lib/Service/SyncService.php
@@ -88,7 +88,7 @@ class SyncService {
 				$response = $this->runPartialSync($account, $mailbox, $criteria, $knownUids);
 			}
 		} catch (Throwable $e) {
-			throw new ServiceException('Sync failed', 0, $e);
+			throw new ServiceException('Sync failed: ' . $e->getMessage(), 0, $e);
 		} finally {
 			if ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS) {
 				$this->mailboxMapper->unlockFromVanishedSync($mailbox);


### PR DESCRIPTION
We can then detect this in the js code. For some operation a retry policy could make sense.

In any case these "errors" shouldn't end in the log or Sentry when the min log levels are set to *errors*. They are not application errors.