### PR TITLE
Extract js translation strings with gettext and commit them

### DIFF
--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -1,0 +1,19 @@
+name: Lint
+on: pull_request
+
+jobs:
+  l10n-extract-check:
+    runs-on: ubuntu-latest
+    name: L10n check
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: npm install
+      run: npm ci
+    - name: extract l10n files
+      run: npm run l10n:extract
+    - name: Check webpack build changes
+      run: bash -c "[[ ! \"`git status --porcelain translationfiles/templates`\" ]] || ( echo 'Uncommited l10n changes. Run `npm l10n:extract`.' && git status && exit 1 )"

--- a/.github/workflows/l10n.yml
+++ b/.github/workflows/l10n.yml
@@ -15,5 +15,5 @@ jobs:
       run: npm ci
     - name: extract l10n files
       run: npm run l10n:extract
-    - name: Check webpack build changes
+    - name: Check l10n file changes
       run: bash -c "[[ ! \"`git status --porcelain translationfiles/templates`\" ]] || ( echo 'Uncommited l10n changes. Run `npm l10n:extract`.' && git status && exit 1 )"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Composer
 composer.phar
 /vendor/
+/translationfiles/templates/mail.pot
+/translationfiles/templates/src.pot
 
 # Mac OS
 .DS_Store

--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -31,6 +31,7 @@
 .scrutinizer.yml
 /src
 /tests
+/translationfiles
 .travis.yml
 /vendor/bin
 /webpack.*

--- a/build/extract-l10n.js
+++ b/build/extract-l10n.js
@@ -1,0 +1,25 @@
+const { GettextExtractor, JsExtractors } = require('gettext-extractor');
+
+let extractor = new GettextExtractor();
+
+extractor
+    .createJsParser([
+        JsExtractors.callExpression('t', {
+            arguments: {
+                text: 1,
+                context: 1
+            }
+        }),
+        JsExtractors.callExpression('n', {
+            arguments: {
+                text: 1,
+                textPlural: 2,
+                context: 3
+            }
+        })
+    ])
+    .parseFilesGlob('./src/**/*.@(ts|js|vue)');
+
+extractor.savePotFile('./translationfiles/templates/mail-js.pot');
+
+extractor.printStats();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8492,15 +8492,6 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
-    "i18next": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.1.0.tgz",
-      "integrity": "sha512-ISbmukX4L6Dz0QoH9+EW1AnBw7j+NRLoMu9uLPMaNSSTP9Eie9/oUL0dOyWX15baB3gYOpkHJpGZRHOqcnl0ew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.3.1"
-      }
-    },
     "ical.js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-1.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3691,6 +3691,14 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.1.tgz",
           "integrity": "sha512-186WjSik2iTGfDjfdCZAxv2ormxtKgemjC3SI6PL31qOA0j5LhTDVjHChccoc7brwLvpvLPiMyRlcO88C4l1QQ=="
+        },
+        "i18next": {
+          "version": "19.0.2",
+          "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.0.2.tgz",
+          "integrity": "sha512-fBa43Ann2udP1CQAz3IQpOZ1dGAkmi3mMfzisOhH17igneSRbvZ7P2RNbL+L1iRYKMufBmVwnC7G3gqcyviZ9g==",
+          "requires": {
+            "@babel/runtime": "^7.3.1"
+          }
         }
       }
     },
@@ -3818,6 +3826,12 @@
       "version": "12.7.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.8.tgz",
       "integrity": "sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A=="
+    },
+    "@types/parse5": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.2.tgz",
+      "integrity": "sha512-BOl+6KDs4ItndUWUFchy3aEqGdHhw0BC4Uu+qoDonN/f0rbUnJbm71Ulj8Tt9jLFRaAxPLKvdS1bBLfx1qXR9g==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.2",
@@ -5915,6 +5929,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+    },
+    "css-selector-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
+      "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s=",
+      "dev": true
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -8044,6 +8064,29 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gettext-extractor": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/gettext-extractor/-/gettext-extractor-3.5.2.tgz",
+      "integrity": "sha512-4fJViJvAkWBUV8BHwAaY2T1oirsIEAYgYfYm/+x/gF2xWxOXgn4f7Cjsdq+xuuoA9HZga+fx2PIDP+07zbmP6g==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "5 - 7",
+        "@types/parse5": "^5",
+        "css-selector-parser": "^1.3",
+        "glob": "5 - 7",
+        "parse5": "^5",
+        "pofile": "1.0.x",
+        "typescript": "2 - 3"
+      },
+      "dependencies": {
+        "pofile": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pofile/-/pofile-1.0.11.tgz",
+          "integrity": "sha512-Vy9eH1dRD9wHjYt/QqXcTz+RnX/zg53xK+KljFSX30PvdDMb2z+c6uDUeblUGqqJgz3QFsdlA0IJvHziPmWtQg==",
+          "dev": true
+        }
+      }
+    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -8450,9 +8493,10 @@
       "dev": true
     },
     "i18next": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.0.2.tgz",
-      "integrity": "sha512-fBa43Ann2udP1CQAz3IQpOZ1dGAkmi3mMfzisOhH17igneSRbvZ7P2RNbL+L1iRYKMufBmVwnC7G3gqcyviZ9g==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.1.0.tgz",
+      "integrity": "sha512-ISbmukX4L6Dz0QoH9+EW1AnBw7j+NRLoMu9uLPMaNSSTP9Eie9/oUL0dOyWX15baB3gYOpkHJpGZRHOqcnl0ew==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
@@ -13619,6 +13663,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "eslint-plugin-vue": "^6.1.2",
     "file-loader": "^5.0.2",
     "gettext-extractor": "^3.5.2",
-    "i18next": "^19.1.0",
     "jsdom": "^16.1.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js",
     "dev": "NODE_ENV=development webpack --config webpack.dev.js",
-    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js",
+    "l10n:extract": "node build/extract-l10n.js",
     "lint": "eslint --ext .js,.vue src",
     "lint:autofix": "eslint --ext .js,.vue src --fix",
     "test": "mochapack --webpack-config webpack.test.js --require src/tests/setup.js \"src/tests/**/*.spec.js\"",
-    "test:watch": "mochapack -w --webpack-config webpack.test.js --require src/tests/setup.js \"src/tests/**/*.spec.js\""
+    "test:watch": "mochapack -w --webpack-config webpack.test.js --require src/tests/setup.js \"src/tests/**/*.spec.js\"",
+    "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js"
   },
   "dependencies": {
     "@bundle-analyzer/webpack-plugin": "^0.5.1",
@@ -88,6 +89,8 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-vue": "^6.1.2",
     "file-loader": "^5.0.2",
+    "gettext-extractor": "^3.5.2",
+    "i18next": "^19.1.0",
     "jsdom": "^16.1.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^6.2.2",

--- a/translationfiles/templates/mail-js.pot
+++ b/translationfiles/templates/mail-js.pot
@@ -1,0 +1,634 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+
+#: src/components/NavigationFolder.vue:140
+msgid "{total} message"
+msgid_plural "{total} messages"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/components/NavigationFolder.vue:144
+msgid "{unread} unread of {total}"
+msgid_plural "{unread} unread of {total}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/service/NotificationService.js:80
+msgid ""
+"%n new message \n"
+"from {from}"
+msgid_plural ""
+"%n new messages \n"
+"from {from}"
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/service/NotificationService.js:75
+msgctxt ""
+"{from}\n"
+"{subject}"
+msgid ""
+"{from}\n"
+"{subject}"
+msgstr ""
+
+#: src/components/itinerary/TrainReservation.vue:98
+msgctxt "{trainNr} from {depStation} to {arrStation}"
+msgid "{trainNr} from {depStation} to {arrStation}"
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:246
+msgctxt "* %USERID% and %EMAIL% will be replaced with the user's UID and email"
+msgid "* %USERID% and %EMAIL% will be replaced with the user's UID and email"
+msgstr ""
+
+#: src/components/Composer.vue:43
+msgctxt "+ CC/BCC"
+msgid "+ CC/BCC"
+msgstr ""
+
+#: src/components/SignatureSettings.vue:26
+msgctxt "A signature is added to the text of new messages and replies."
+msgid "A signature is added to the text of new messages and replies."
+msgstr ""
+
+#: src/views/AccountSettings.vue:6
+msgctxt "Account settings"
+msgid "Account settings"
+msgstr ""
+
+#: src/components/Composer.vue:145
+msgctxt "Add attachment from Files"
+msgid "Add attachment from Files"
+msgstr ""
+
+#: src/components/NavigationAccount.vue:41
+msgctxt "Add folder"
+msgid "Add folder"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:4
+msgctxt "Add mail account"
+msgid "Add mail account"
+msgstr ""
+
+#: src/components/NavigationFolder.vue:55
+msgctxt "Add subfolder"
+msgid "Add subfolder"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:27
+msgctxt "All"
+msgid "All"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:44
+msgctxt "All inboxes"
+msgid "All inboxes"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:10
+msgctxt "Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally."
+msgid "Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally."
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:31
+msgctxt "Archive"
+msgid "Archive"
+msgstr ""
+
+#: src/components/Envelope.vue:105
+msgctxt "Blind copy recipients only"
+msgid "Blind copy recipients only"
+msgstr ""
+
+#: src/components/ComposerAttachments.vue:129
+#: src/components/ComposerAttachments.vue:132
+msgctxt "Choose a file to add as attachment"
+msgid "Choose a file to add as attachment"
+msgstr ""
+
+#: src/components/MessageAttachment.vue:150
+msgctxt "Choose a folder to store the attachment in"
+msgid "Choose a folder to store the attachment in"
+msgstr ""
+
+#: src/components/MessageAttachments.vue:82
+msgctxt "Choose a folder to store the attachments in"
+msgid "Choose a folder to store the attachments in"
+msgstr ""
+
+#: src/components/NavigationAccountExpandCollapse.vue:45
+msgctxt "Collapse folders"
+msgid "Collapse folders"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:13
+msgctxt "Compose new message"
+msgid "Compose new message"
+msgstr ""
+
+#: src/components/AccountForm.vue:295
+msgctxt "Connect"
+msgid "Connect"
+msgstr ""
+
+#: src/views/Setup.vue:6
+msgctxt "Connect your mail account"
+msgid "Connect your mail account"
+msgstr ""
+
+#: src/components/itinerary/EventReservation.vue:136
+#: src/components/itinerary/FlightReservation.vue:129
+#: src/components/itinerary/TrainReservation.vue:141
+msgctxt "Could not create event"
+msgid "Could not create event"
+msgstr ""
+
+#: src/util/ErrorMessageFactory.js:35
+#: src/util/ErrorMessageFactory.js:38
+msgctxt "Could not load {tag}{name}{endtag}"
+msgid "Could not load {tag}{name}{endtag}"
+msgstr ""
+
+#: src/components/NewMessageDetail.vue:233
+msgctxt "Could not load original message"
+msgid "Could not load original message"
+msgstr ""
+
+#: src/util/ErrorMessageFactory.js:56
+msgctxt "Could not load the desired message"
+msgid "Could not load the desired message"
+msgstr ""
+
+#: src/util/ErrorMessageFactory.js:57
+msgctxt "Could not load the message"
+msgid "Could not load the message"
+msgstr ""
+
+#: src/components/NewMessageDetail.vue:190
+msgctxt "Could not load your draft"
+msgid "Could not load your draft"
+msgstr ""
+
+#: src/components/Message.vue:186
+#: src/util/ErrorMessageFactory.js:55
+msgctxt "Could not load your message"
+msgid "Could not load your message"
+msgstr ""
+
+#: src/components/Envelope.vue:34
+#: src/components/Message.vue:50
+#: src/components/SignatureSettings.vue:41
+#: src/views/KeyboardShortcuts.vue:34
+msgctxt "Delete"
+msgid "Delete"
+msgstr ""
+
+#: src/components/NavigationAccount.vue:50
+msgctxt "Delete account"
+msgid "Delete account"
+msgstr ""
+
+#: src/components/Composer.vue:138
+msgctxt "Draft saved"
+msgid "Draft saved"
+msgstr ""
+
+#: src/components/Envelope.vue:23
+msgctxt "Draft: "
+msgid "Draft: "
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:35
+msgctxt "Drafts"
+msgid "Drafts"
+msgstr ""
+
+#: src/components/NavigationAccount.vue:38
+msgctxt "Edit account"
+msgid "Edit account"
+msgstr ""
+
+#: src/components/settings/ProvisionPreview.vue:29
+msgctxt "Email: {email}"
+msgid "Email: {email}"
+msgstr ""
+
+#: src/components/MessageAttachment.vue:121
+#: src/components/MessageAttachment.vue:127
+msgctxt "Embedded message"
+msgid "Embedded message"
+msgstr ""
+
+#: src/components/Composer.vue:152
+msgctxt "Enable formatting"
+msgid "Enable formatting"
+msgstr ""
+
+#: src/components/Composer.vue:170
+msgctxt "Error sending your message"
+msgid "Error sending your message"
+msgstr ""
+
+#: src/components/itinerary/EventReservation.vue:132
+#: src/components/itinerary/FlightReservation.vue:125
+#: src/components/itinerary/TrainReservation.vue:137
+msgctxt "Event imported into {calendar}"
+msgid "Event imported into {calendar}"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:39
+msgctxt "Favorites"
+msgid "Favorites"
+msgstr ""
+
+#: src/components/itinerary/FlightReservation.vue:100
+msgctxt "Flight {flightNr} from {depAirport} to {arrAirport}"
+msgid "Flight {flightNr} from {depAirport} to {arrAirport}"
+msgstr ""
+
+#: src/components/Message.vue:44
+msgctxt "Forward"
+msgid "Forward"
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:48
+msgctxt "General"
+msgid "General"
+msgstr ""
+
+#: src/components/Composer.vue:172
+msgctxt "Go back"
+msgid "Go back"
+msgstr ""
+
+#: src/components/settings/AdminSettings.vue:28
+msgctxt "Here you can find instance-wide settings. User specific settings are found in the app itself (bottom-left corner)."
+msgid "Here you can find instance-wide settings. User specific settings are found in the app itself (bottom-left corner)."
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:62
+msgctxt "IMAP"
+msgid "IMAP"
+msgstr ""
+
+#: src/components/AccountForm.vue:66
+msgctxt "IMAP Security"
+msgid "IMAP Security"
+msgstr ""
+
+#: src/components/AccountForm.vue:56
+msgctxt "IMAP Settings"
+msgid "IMAP Settings"
+msgstr ""
+
+#: src/components/settings/ProvisionPreview.vue:31
+msgctxt "IMAP: {user} on {host}:{port} ({ssl} encryption)"
+msgid "IMAP: {user} on {host}:{port} ({ssl} encryption)"
+msgstr ""
+
+#: src/components/itinerary/CalendarImport.vue:29
+msgctxt "Import into {calendar}"
+msgid "Import into {calendar}"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:46
+msgctxt "Inbox"
+msgid "Inbox"
+msgstr ""
+
+#: src/components/Itinerary.vue:26
+msgctxt "Itinerary for {type} is not supported yet"
+msgid "Itinerary for {type} is not supported yet"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:51
+msgctxt "Junk"
+msgid "Junk"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:53
+#: src/views/KeyboardShortcuts.vue:6
+msgctxt "Keyboard shortcuts"
+msgid "Keyboard shortcuts"
+msgstr ""
+
+#: src/components/NavigationFolder.vue:156
+msgctxt "Loading …"
+msgid "Loading …"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:59
+msgctxt "Looking for a way to encrypt your emails? Install the Mailvelope browser extension!"
+msgid "Looking for a way to encrypt your emails? Install the Mailvelope browser extension!"
+msgstr ""
+
+#: src/components/settings/AdminSettings.vue:24
+msgctxt "Mail app"
+msgid "Mail app"
+msgstr ""
+
+#: src/views/AccountSettings.vue:20
+msgctxt "Mail server"
+msgid "Mail server"
+msgstr ""
+
+#: src/components/NavigationFolder.vue:51
+msgctxt "Mark all messages of this folder as read"
+msgid "Mark all messages of this folder as read"
+msgstr ""
+
+#: src/components/Envelope.vue:32
+#: src/components/Message.vue:47
+msgctxt "Mark read"
+msgid "Mark read"
+msgstr ""
+
+#: src/components/Envelope.vue:32
+#: src/components/Message.vue:47
+msgctxt "Mark unread"
+msgid "Mark unread"
+msgstr ""
+
+#: src/components/Composer.vue:176
+msgctxt "Message sent!"
+msgid "Message sent!"
+msgstr ""
+
+#: src/components/NavigationAccount.vue:47
+msgctxt "Move down"
+msgid "Move down"
+msgstr ""
+
+#: src/components/NavigationAccount.vue:44
+msgctxt "Move Up"
+msgid "Move Up"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:17
+msgctxt "Newer message"
+msgid "Newer message"
+msgstr ""
+
+#: src/service/NotificationService.js:88
+msgctxt "Nextcloud Mail"
+msgid "Nextcloud Mail"
+msgstr ""
+
+#: src/components/Composer.vue:66
+#: src/components/Composer.vue:88
+msgctxt "No contacts found."
+msgid "No contacts found."
+msgstr ""
+
+#: src/components/NoMessageSelected.vue:25
+msgctxt "No message selected"
+msgid "No message selected"
+msgstr ""
+
+#: src/components/EmptyFolder.vue:4
+msgctxt "No messages in this folder"
+msgid "No messages in this folder"
+msgstr ""
+
+#: src/components/AccountForm.vue:167
+#: src/components/AccountForm.vue:81
+#: src/components/settings/ProvisioningSettings.vue:112
+#: src/components/settings/ProvisioningSettings.vue:196
+msgctxt "None"
+msgid "None"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:21
+msgctxt "Older message"
+msgid "Older message"
+msgstr ""
+
+#: src/components/EditorSettings.vue:26
+msgctxt "Preferred writing mode for new messages and replies."
+msgid "Preferred writing mode for new messages and replies."
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:47
+msgctxt "Refresh"
+msgid "Refresh"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:48
+msgctxt "Register as application for mail links"
+msgid "Register as application for mail links"
+msgstr ""
+
+#: src/components/Message.vue:37
+msgctxt "Reply"
+msgid "Reply"
+msgstr ""
+
+#: src/components/Composer.vue:177
+msgctxt "Reply sent!"
+msgid "Reply sent!"
+msgstr ""
+
+#: src/components/Message.vue:41
+msgctxt "Reply to sender only"
+msgid "Reply to sender only"
+msgstr ""
+
+#: src/components/Error.vue:27
+msgctxt "Report this bug"
+msgid "Report this bug"
+msgstr ""
+
+#: src/components/itinerary/FlightReservation.vue:12
+msgctxt "Reservation {id}"
+msgid "Reservation {id}"
+msgstr ""
+
+#: src/components/Composer.vue:173
+msgctxt "Retry"
+msgid "Retry"
+msgstr ""
+
+#: src/components/AccountForm.vue:295
+msgctxt "Save"
+msgid "Save"
+msgstr ""
+
+#: src/components/MessageAttachments.vue:45
+msgctxt "Save all to Files"
+msgid "Save all to Files"
+msgstr ""
+
+#: src/components/SignatureSettings.vue:38
+msgctxt "Save signature"
+msgid "Save signature"
+msgstr ""
+
+#: src/components/Composer.vue:137
+msgctxt "Saving draft …"
+msgid "Saving draft …"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:39
+msgctxt "Search"
+msgid "Search"
+msgstr ""
+
+#: src/components/Composer.vue:274
+#: src/views/KeyboardShortcuts.vue:43
+msgctxt "Send"
+msgid "Send"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:55
+msgctxt "Sent"
+msgid "Sent"
+msgstr ""
+
+#: src/components/NavigationAccountExpandCollapse.vue:45
+msgctxt "Show all folders"
+msgid "Show all folders"
+msgstr ""
+
+#: src/components/MessageHTMLBody.vue:6
+msgctxt "Show images from this\tsender"
+msgid "Show images from this\tsender"
+msgstr ""
+
+#: src/components/SignatureSettings.vue:24
+msgctxt "Signature"
+msgid "Signature"
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:146
+msgctxt "SMTP"
+msgid "SMTP"
+msgstr ""
+
+#: src/components/AccountForm.vue:152
+msgctxt "SMTP Security"
+msgid "SMTP Security"
+msgstr ""
+
+#: src/components/AccountForm.vue:142
+msgctxt "SMTP Settings"
+msgid "SMTP Settings"
+msgstr ""
+
+#: src/components/settings/ProvisionPreview.vue:39
+msgctxt "SMTP: {user} on {host}:{port} ({ssl} encryption)"
+msgid "SMTP: {user} on {host}:{port} ({ssl} encryption)"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:8
+msgctxt "Speed up your Mail experience with these quick shortcuts."
+msgid "Speed up your Mail experience with these quick shortcuts."
+msgstr ""
+
+#: src/components/AccountForm.vue:182
+#: src/components/AccountForm.vue:96
+#: src/components/settings/ProvisioningSettings.vue:126
+#: src/components/settings/ProvisioningSettings.vue:210
+msgctxt "SSL/TLS"
+msgid "SSL/TLS"
+msgstr ""
+
+#: src/components/AccountForm.vue:111
+#: src/components/AccountForm.vue:197
+#: src/components/settings/ProvisioningSettings.vue:140
+#: src/components/settings/ProvisioningSettings.vue:224
+msgctxt "STARTTLS"
+msgid "STARTTLS"
+msgstr ""
+
+#: src/components/MessageHTMLBody.vue:4
+msgctxt "The images have been blocked to protect your privacy."
+msgid "The images have been blocked to protect your privacy."
+msgstr ""
+
+#: src/components/settings/AdminSettings.vue:25
+msgctxt "The mail app allows users to read mails on their IMAP accounts."
+msgid "The mail app allows users to read mails on their IMAP accounts."
+msgstr ""
+
+#: src/util/ErrorMessageFactory.js:41
+msgctxt "There was a problem loading {tag}{name}{endtag}"
+msgid "There was a problem loading {tag}{name}{endtag}"
+msgstr ""
+
+#: src/components/Composer.vue:107
+msgctxt "This message came from a noreply address so your reply will probably not be read."
+msgid "This message came from a noreply address so your reply will probably not be read."
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:33
+msgctxt "This setting only makes most sense if you use the same user back-end for your organization's Nextcloud and mail server."
+msgid "This setting only makes most sense if you use the same user back-end for your organization's Nextcloud and mail server."
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:26
+msgctxt "Toggle star"
+msgid "Toggle star"
+msgstr ""
+
+#: src/views/KeyboardShortcuts.vue:30
+msgctxt "Toggle unread"
+msgid "Toggle unread"
+msgstr ""
+
+#: src/components/itinerary/TrainReservation.vue:107
+msgctxt "Train from {depStation} to {arrStation}"
+msgid "Train from {depStation} to {arrStation}"
+msgstr ""
+
+#: src/l10n/MailboxTranslator.js:59
+msgctxt "Trash"
+msgid "Trash"
+msgstr ""
+
+#: src/views/Setup.vue:64
+msgctxt "Unexpected error during account creation"
+msgid "Unexpected error during account creation"
+msgstr ""
+
+#: src/components/MessageAttachment.vue:82
+msgctxt "Unnamed"
+msgid "Unnamed"
+msgstr ""
+
+#: src/components/Composer.vue:142
+msgctxt "Upload attachment"
+msgid "Upload attachment"
+msgstr ""
+
+#: src/components/ComposerAttachments.vue:33
+msgctxt "Uploading {percent}% …"
+msgid "Uploading {percent}% …"
+msgstr ""
+
+#: src/components/AppSettingsMenu.vue:34
+msgctxt "Use Gravatar and favicon avatars"
+msgid "Use Gravatar and favicon avatars"
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:255
+msgctxt "With the settings above, the app will create account settings in the following way:"
+msgid "With the settings above, the app will create account settings in the following way:"
+msgstr ""
+
+#: src/components/Composer.vue:179
+msgctxt "Write another message"
+msgid "Write another message"
+msgstr ""
+
+#: src/components/EditorSettings.vue:24
+msgctxt "Writing mode"
+msgid "Writing mode"
+msgstr ""
+
+#: src/components/settings/ProvisioningSettings.vue:27
+msgctxt "You can configure a template for account settings, from which all users will get an account provisioned from."
+msgid "You can configure a template for account settings, from which all users will get an account provisioned from."
+msgstr ""


### PR DESCRIPTION
Not sure if this actually works, but it looks like we can have .pot files in `translationfiles/templates` and they will be picked up by the l10n bot: https://github.com/nextcloud/docker-ci/blob/8f896e1b82051c9c863496cd680935a011e05daf/translations/handleAppTranslations.sh#L44-L48

For #2530 