### PR TITLE
Add priority inbox "light"

### DIFF
--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -56,5 +56,5 @@ interface IMailSearch {
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function findMessages(Account $account, string $mailboxName, ?string $filter, ?int $cursor): array;
+	public function findMessages(Account $account, string $mailboxName, ?string $filter, ?int $cursor, ?int $limit): array;
 }

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -141,7 +141,7 @@ class MessagesController extends Controller {
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function index(int $accountId, string $folderId, int $cursor = null, string $filter = null): JSONResponse {
+	public function index(int $accountId, string $folderId, int $cursor = null, string $filter = null, int $limit = null): JSONResponse {
 		try {
 			$account = $this->accountService->find($this->currentUserId, $accountId);
 		} catch (DoesNotExistException $e) {
@@ -155,7 +155,8 @@ class MessagesController extends Controller {
 				$account,
 				base64_decode($folderId),
 				$filter === '' ? null : $filter,
-				$cursor
+				$cursor,
+				$limit
 			)
 		);
 	}

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -271,11 +271,12 @@ class MessageMapper extends QBMapper {
 	/**
 	 * @param Mailbox $mailbox
 	 * @param SearchQuery $query
+	 * @param int|null $limit
 	 * @param int[]|null $uids
 	 *
 	 * @return int[]
 	 */
-	public function findUidsByQuery(Mailbox $mailbox, SearchQuery $query, array $uids = null): array {
+	public function findUidsByQuery(Mailbox $mailbox, SearchQuery $query, ?int $limit, array $uids = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$select = $qb
@@ -352,8 +353,11 @@ class MessageMapper extends QBMapper {
 		}
 
 		$select = $select
-			->orderBy('sent_at', 'desc')
-			->setMaxResults(20);
+			->orderBy('sent_at', 'desc');
+
+		if ($limit !== null) {
+			$select = $select->setMaxResults($limit);
+		}
 
 		return array_map(function (Message $message) {
 			return $message->getUid();

--- a/lib/Service/Search/MailSearch.php
+++ b/lib/Service/Search/MailSearch.php
@@ -110,7 +110,8 @@ class MailSearch implements IMailSearch {
 	public function findMessages(Account $account,
 								 string $mailboxName,
 								 ?string $filter,
-								 ?int $cursor): array {
+								 ?int $cursor,
+								 ?int $limit): array {
 		try {
 			$mailbox = $this->mailboxMapper->find($account, $mailboxName);
 		} catch (DoesNotExistException $e) {
@@ -142,7 +143,7 @@ class MailSearch implements IMailSearch {
 			$mailbox,
 			$this->messageMapper->findByUids(
 				$mailbox,
-				$this->getUids($account, $mailbox, $query)
+				$this->getUids($account, $mailbox, $query, $limit)
 			)
 		);
 	}
@@ -152,9 +153,9 @@ class MailSearch implements IMailSearch {
 	 *
 	 * @throws ServiceException
 	 */
-	private function getUids(Account $account, Mailbox $mailbox, SearchQuery $query): array {
+	private function getUids(Account $account, Mailbox $mailbox, SearchQuery $query, ?int $limit): array {
 		if (empty($query->getTextTokens())) {
-			return $this->messageMapper->findUidsByQuery($mailbox, $query);
+			return $this->messageMapper->findUidsByQuery($mailbox, $query, $limit);
 		}
 
 		$fromImap = $this->imapSearchProvider->findMatches(
@@ -162,6 +163,6 @@ class MailSearch implements IMailSearch {
 			$mailbox,
 			$query
 		);
-		return $this->messageMapper->findUidsByQuery($mailbox, $query, $fromImap);
+		return $this->messageMapper->findUidsByQuery($mailbox, $query, $limit, $fromImap);
 	}
 }

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -152,13 +152,13 @@ class SyncService {
 
 		if ($query !== null) {
 			// Filter new messages to those that also match the current filter
-			$newUids = $this->messageMapper->findUidsByQuery($mailbox, $query, $newUids);
+			$newUids = $this->messageMapper->findUidsByQuery($mailbox, $query, null, $newUids);
 		}
 		$new = $this->messageMapper->findByUids($mailbox, $newUids);
 
 		// TODO: $changed = $this->messageMapper->findChanged($mailbox, $uids);
 		if ($query !== null) {
-			$changedUids = $this->messageMapper->findUidsByQuery($mailbox, $query, $knownUids);
+			$changedUids = $this->messageMapper->findUidsByQuery($mailbox, $query, null, $knownUids);
 		} else {
 			$changedUids = $knownUids;
 		}

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -151,6 +151,8 @@ export default {
 		icon() {
 			if (this.filter === 'starred') {
 				return 'icon-flagged'
+			} else if (this.folder.specialRole === 'priority') {
+				return 'icon-category-monitoring'
 			}
 			return this.folder.specialRole ? 'icon-' + this.folder.specialRole : 'icon-folder'
 		},

--- a/src/components/SectionTitle.vue
+++ b/src/components/SectionTitle.vue
@@ -1,0 +1,49 @@
+<!--
+  - @copyright 2020 Greta Doçi <gretadoci@gmail.com>
+  -
+  - @author 2020 Greta Doçi <gretadoci@gmail.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div id="priority">
+		<div class="app-content-list-item">
+			<h2>{{ name }}</h2>
+		</div>
+	</div>
+</template>
+<script>
+export default {
+	name: 'SectionTitle',
+	props: {
+		name: {
+			type: String,
+			required: true,
+		},
+	},
+}
+</script>
+
+<style scoped>
+#priority {
+	display: inline-block;
+}
+.app-content-list-item:hover {
+	background-color: transparent;
+	opacity: 0.8;
+}
+</style>

--- a/src/i18n/MailboxTranslator.js
+++ b/src/i18n/MailboxTranslator.js
@@ -46,6 +46,11 @@ const translateSpecial = (folder) => {
 			return t('mail', 'Inbox')
 		}
 	}
+	if (folder.specialUse.includes('priority')) {
+		if (folder.isPriorityInbox === true) {
+			return t('mail', 'Priority inbox')
+		}
+	}
 	if (folder.specialUse.includes('junk')) {
 		// TRANSLATORS: translated mail box name
 		return t('mail', 'Junk')

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -31,7 +31,7 @@ export function fetchEnvelope(accountId, folderId, id) {
 		})
 }
 
-export function fetchEnvelopes(accountId, folderId, query, cursor) {
+export function fetchEnvelopes(accountId, folderId, query, cursor, limit) {
 	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages', {
 		accountId,
 		folderId,
@@ -40,6 +40,9 @@ export function fetchEnvelopes(accountId, folderId, query, cursor) {
 
 	if (query) {
 		params.filter = query
+	}
+	if (limit) {
+		params.limit = limit
 	}
 	if (cursor) {
 		params.cursor = cursor

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -65,6 +65,8 @@ import {showNewMessagesNotification} from '../service/NotificationService'
 import {parseUid} from '../util/EnvelopeUidParser'
 import {matchError} from '../errors/match'
 import SyncIncompleteError from '../errors/SyncIncompleteError'
+import MailboxLockedError from '../errors/MailboxLockedError'
+import {wait} from '../util/wait'
 
 const PAGE_SIZE = 20
 
@@ -217,7 +219,7 @@ export default {
 			return getters.getEnvelope(accountId, folderId, id)
 		})
 	},
-	fetchEnvelopes({state, commit, getters, dispatch}, {accountId, folderId, query}) {
+	fetchEnvelopes({state, commit, getters, dispatch}, {accountId, folderId, query, paginate = true}) {
 		const folder = getters.getFolder(accountId, folderId)
 
 		if (folder.isUnified) {
@@ -227,16 +229,17 @@ export default {
 						accountId: f.accountId,
 						folderId: f.id,
 						query,
+						paginate,
 					})
 				),
 				Promise.all.bind(Promise),
-				andThen(map(sliceToPage))
+				andThen(paginate ? map(sliceToPage) : identity)
 			)
 			const fetchUnifiedEnvelopes = pipe(
 				findIndividualFolders(getters.getFolders, folder.specialRole),
 				fetchIndividualLists,
 				andThen(combineEnvelopeLists),
-				andThen(sliceToPage),
+				andThen(paginate ? sliceToPage : identity),
 				andThen(
 					tap(
 						map((envelope) =>
@@ -268,7 +271,7 @@ export default {
 					)
 				)
 			)
-		)(accountId, folderId, query)
+		)(accountId, folderId, query, undefined, paginate ? 20 : undefined)
 	},
 	fetchNextEnvelopePage({commit, getters, dispatch}, {accountId, folderId, query, rec = true}) {
 		const folder = getters.getFolder(accountId, folderId)
@@ -354,7 +357,7 @@ export default {
 			return Promise.reject(new Error('Cannot find last envelope. Required for the folder cursor'))
 		}
 
-		return fetchEnvelopes(accountId, folderId, query, lastEnvelope.dateInt).then((envelopes) => {
+		return fetchEnvelopes(accountId, folderId, query, lastEnvelope.dateInt, 20).then((envelopes) => {
 			logger.debug(`fetched ${envelopes.length} messages for the next page of ${accountId}:${folderId}`)
 			envelopes.forEach((envelope) =>
 				commit('addEnvelope', {
@@ -433,6 +436,10 @@ export default {
 					[SyncIncompleteError.getName()]() {
 						console.warn('(initial) sync is incomplete, retriggering')
 						return dispatch('syncEnvelopes', {accountId, folderId, query, init})
+					},
+					[MailboxLockedError.getName()](error) {
+						logger.info('Sync failed because the mailbox is locked, retriggering', {error})
+						return wait(1500).then(() => dispatch('syncEnvelopes', {accountId, folderId, query, init}))
 					},
 					default(error) {
 						console.error('Could not sync envelopes: ' + error.message, error)

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -23,3 +23,5 @@ import {normalizedFolderId} from './normalization'
 export const UNIFIED_ACCOUNT_ID = 0
 export const UNIFIED_INBOX_ID = btoa('inbox')
 export const UNIFIED_INBOX_UID = normalizedFolderId(UNIFIED_ACCOUNT_ID, UNIFIED_INBOX_ID)
+export const PRIORITY_INBOX_ID = btoa('priority')
+export const PRIORITY_INBOX_UID = UNIFIED_ACCOUNT_ID + '-' + PRIORITY_INBOX_ID

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -22,7 +22,13 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 
-import {UNIFIED_ACCOUNT_ID, UNIFIED_INBOX_ID, UNIFIED_INBOX_UID} from './constants'
+import {
+	UNIFIED_ACCOUNT_ID,
+	UNIFIED_INBOX_ID,
+	UNIFIED_INBOX_UID,
+	PRIORITY_INBOX_ID,
+	PRIORITY_INBOX_UID,
+} from './constants'
 import actions from './actions'
 import {getters} from './getters'
 import mutations from './mutations'
@@ -36,8 +42,9 @@ export default new Vuex.Store({
 		accounts: {
 			[UNIFIED_ACCOUNT_ID]: {
 				id: UNIFIED_ACCOUNT_ID,
+				accountId: UNIFIED_ACCOUNT_ID,
 				isUnified: true,
-				folders: [UNIFIED_INBOX_UID],
+				folders: [PRIORITY_INBOX_UID, UNIFIED_INBOX_UID],
 				collapsed: false,
 				emailAddress: '',
 				name: '',
@@ -51,6 +58,16 @@ export default new Vuex.Store({
 				isUnified: true,
 				specialUse: ['inbox'],
 				specialRole: 'inbox',
+				unread: 0,
+				folders: [],
+				envelopeLists: {},
+			},
+			[PRIORITY_INBOX_UID]: {
+				id: PRIORITY_INBOX_ID,
+				accountId: 0,
+				isPriorityInbox: true,
+				specialUse: ['priority'],
+				specialRole: 'priority',
 				unread: 0,
 				folders: [],
 				envelopeLists: {},

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -20,7 +20,7 @@
  */
 
 import orderBy from 'lodash/fp/orderBy'
-import sortedUniq from 'lodash/fp/sortedUniq'
+import sortedUniqBy from 'lodash/fp/sortedUniqBy'
 import Vue from 'vue'
 
 import {buildMailboxHierarchy} from '../imap/MailboxHierarchy'
@@ -109,11 +109,10 @@ export default {
 		Vue.set(state.envelopes, envelope.uid, envelope)
 		const listId = normalizedEnvelopeListId(query)
 		const existing = folder.envelopeLists[listId] || []
-		Vue.set(
-			folder.envelopeLists,
-			listId,
-			sortedUniq(orderBy((id) => state.envelopes[id].dateInt, 'desc', existing.concat([envelope.uid])))
-		)
+		const uidToDateInt = (uid) => state.envelopes[uid].dateInt
+		const sortedUniqByDateInt = sortedUniqBy(uidToDateInt)
+		const orderByDateInt = orderBy(uidToDateInt, 'desc')
+		Vue.set(folder.envelopeLists, listId, sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uid]))))
 
 		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
 		unifiedAccount.folders
@@ -124,7 +123,7 @@ export default {
 				Vue.set(
 					folder.envelopeLists,
 					listId,
-					sortedUniq(orderBy((id) => state.envelopes[id].dateInt, 'desc', existing.concat([envelope.uid])))
+					sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uid])))
 				)
 			})
 	},

--- a/tests/Unit/Service/Search/MailSearchTest.php
+++ b/tests/Unit/Service/Search/MailSearchTest.php
@@ -98,6 +98,7 @@ class MailSearchTest extends TestCase {
 			$account,
 			'INBOX',
 			null,
+			null,
 			null
 		);
 	}
@@ -114,6 +115,7 @@ class MailSearchTest extends TestCase {
 		$this->search->findMessages(
 			$account,
 			'INBOX',
+			null,
 			null,
 			null
 		);
@@ -132,6 +134,7 @@ class MailSearchTest extends TestCase {
 		$messages = $this->search->findMessages(
 			$account,
 			'INBOX',
+			null,
 			null,
 			null
 		);
@@ -156,7 +159,7 @@ class MailSearchTest extends TestCase {
 			->willReturn($query);
 		$this->messageMapper->expects($this->once())
 			->method('findUidsByQuery')
-			->with($mailbox, $query)
+			->with($mailbox, $query, null)
 			->willReturn([1, 2]);
 		$this->messageMapper->expects($this->once())
 			->method('findByUids')
@@ -174,6 +177,7 @@ class MailSearchTest extends TestCase {
 			$account,
 			'INBOX',
 			'my search',
+			null,
 			null
 		);
 
@@ -200,10 +204,9 @@ class MailSearchTest extends TestCase {
 			->method('findMatches')
 			->with($account, $mailbox, $query)
 			->willReturn([2, 3]);
-
 		$this->messageMapper->expects($this->once())
 			->method('findUidsByQuery')
-			->with($mailbox, $query, [2, 3])
+			->with($mailbox, $query, null, [2, 3])
 			->willReturn([1, 2]);
 		$this->messageMapper->expects($this->once())
 			->method('findByUids')
@@ -219,6 +222,7 @@ class MailSearchTest extends TestCase {
 			$account,
 			'INBOX',
 			'my search',
+			null,
 			null
 		);
 


### PR DESCRIPTION
For https://github.com/nextcloud/mail/projects/7#card-31900324

Done:

- [x] Add SectionTitle Component
- [x] Add starred section
- [x] Add other section

To do: 
- [ ] Add priority section

Bugs
- [x] https://github.com/nextcloud/mail/pull/2706 Refresh pulls in unrelated elements (non-starred ones into starred and the other way around)
- [x] Starred should show *all* messages. Only *other* is paginated
- [x] First message not opened correctly
- [x] Messages sync'ed in the background won't show in PI because we use the filtered envelope lists here
