### PR TITLE
Fix distinct select in strict mode

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -254,6 +254,7 @@ class MessageMapper extends QBMapper {
 
 		$select = $qb
 			->selectDistinct('m.uid')
+			->addSelect('sent_at')
 			->from($this->getTableName(), 'm');
 
 		if (!empty($query->getFrom())) {


### PR DESCRIPTION
When MySQL runs in strict mode, you can't order by a column that isn't
part of the select.
