### PR TITLE
Make mark all as read, usable for unified account

### DIFF
--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -24,6 +24,7 @@
 		:id="genId(folder)"
 		:key="genId(folder)"
 		:allow-collapse="true"
+		:force-menu="forceMenu"
 		:icon="icon"
 		:title="title"
 		:to="to"
@@ -42,7 +43,7 @@
 
 				<!-- TODO: make *mark as read* available for all folders once there is more than one action -->
 				<ActionButton
-					v-if="!account.isUnified && folder.specialRole !== 'flagged'"
+					v-if="folder.specialRole !== 'flagged'"
 					icon="icon-checkmark"
 					:title="t('mail', 'Mark all as read')"
 					:disabled="loadingMarkAsRead"
@@ -109,10 +110,9 @@ export default {
 			type: Boolean,
 			default: true,
 		},
-		filter: {
-			type: String,
-			default: '',
-			required: false,
+		forceMenu: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {
@@ -234,7 +234,7 @@ export default {
 
 			this.$store
 				.dispatch('markFolderRead', {
-					account: this.account,
+					accountId: this.account.id,
 					folderId: this.folder.id,
 				})
 				.then(() => logger.info(`folder ${this.folder.id} marked as read`))

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -171,10 +171,25 @@ export default {
 			})
 		)
 	},
-	markFolderRead({dispatch}, {account, folderId}) {
-		return markFolderRead(account.id, folderId).then(
+	markFolderRead({getters, dispatch}, {accountId, folderId}) {
+		const folder = getters.getFolder(accountId, folderId)
+
+		if (folder.isUnified) {
+			const findIndividual = findIndividualFolders(getters.getFolders, folder.specialRole)
+			const individualFolders = findIndividual(getters.accounts)
+			return Promise.all(
+				individualFolders.map((f) =>
+					dispatch('markFolderRead', {
+						accountId: f.accountId,
+						folderId: f.id,
+					})
+				)
+			)
+		}
+
+		return markFolderRead(accountId, folderId).then(
 			dispatch('syncEnvelopes', {
-				accountId: account.id,
+				accountId: accountId,
 				folderId: folderId,
 			})
 		)


### PR DESCRIPTION
Make 'mark all as read' usable for unified account

Fixes #2526 

- [x] Requires https://github.com/nextcloud/nextcloud-vue/pull/887