### PR TITLE
Make the initial mailbox sync interruptable and resumable

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -56,7 +56,7 @@ return [
 		[
 			'name' => 'folders#sync',
 			'url' => '/api/accounts/{accountId}/folders/{folderId}/sync',
-			'verb' => 'GET'
+			'verb' => 'POST'
 		],
 		[
 			'name' => 'folders#markAllAsRead',

--- a/lib/Controller/FoldersController.php
+++ b/lib/Controller/FoldersController.php
@@ -125,6 +125,10 @@ class FoldersController extends Controller {
 				}, $uids),
 				!$init
 			);
+
+			if ($syncResponse->isIncomplete()) {
+				return \OCA\Mail\Http\JsonResponse::fail([], Http::STATUS_ACCEPTED);
+			}
 		} catch (MailboxNotCachedException $e) {
 			return new JSONResponse(null, Http::STATUS_PRECONDITION_REQUIRED);
 		}

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -62,6 +62,23 @@ class MessageMapper extends QBMapper {
 		return $uids;
 	}
 
+	public function findHighestUid(Mailbox $mailbox): ?int {
+		$query = $this->db->getQueryBuilder();
+
+		$query->select($query->createFunction('MAX(' . $query->getColumnName('uid') .  ')'))
+			->from($this->getTableName())
+			->where($query->expr()->eq('mailbox_id', $query->createNamedParameter($mailbox->getId())));
+
+		$result = $query->execute();
+		$max = (int) $result->fetchColumn(0);
+		$result->closeCursor();
+
+		if ($max === 0) {
+			return null;
+		}
+		return $max;
+	}
+
 	public function insertBulk(Message ...$messages): void {
 		$this->db->beginTransaction();
 

--- a/lib/IMAP/Sync/Response.php
+++ b/lib/IMAP/Sync/Response.php
@@ -37,17 +37,27 @@ class Response implements JsonSerializable {
 	/** @var int[] */
 	private $vanishedMessageUids;
 
+	/** @var bool */
+	private $incomplete;
+
 	/**
 	 * @param string $syncToken
 	 * @param IMAPMessage[] $newMessages
 	 * @param IMAPMessage[] $changedMessages
 	 * @param int[] $vanishedMessageUids
 	 */
-	public function __construct(array $newMessages = [], array $changedMessages = [],
-								array $vanishedMessageUids = []) {
+	public function __construct(array $newMessages = [],
+								array $changedMessages = [],
+								array $vanishedMessageUids = [],
+								bool $incomplete = false) {
 		$this->newMessages = $newMessages;
 		$this->changedMessages = $changedMessages;
 		$this->vanishedMessageUids = $vanishedMessageUids;
+		$this->incomplete = $incomplete;
+	}
+
+	public static function incomplete(): self {
+		return new self([], [], [], true);
 	}
 
 	/**
@@ -85,6 +95,10 @@ class Response implements JsonSerializable {
 			array_merge($this->getChangedMessages(), $other->getChangedMessages()),
 			array_merge($this->getVanishedMessageUids(), $other->getVanishedMessageUids())
 		);
+	}
+
+	public function isIncomplete(): bool {
+		return $this->incomplete;
 	}
 
 }

--- a/src/errors/SyncIncompleteError.js
+++ b/src/errors/SyncIncompleteError.js
@@ -1,0 +1,32 @@
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default class SyncIncompleteError extends Error {
+	constructor(message) {
+		super(message)
+		this.name = SyncIncompleteError.getName()
+		this.message = message
+	}
+
+	static getName() {
+		return 'SyncIncompleteError'
+	}
+}


### PR DESCRIPTION
Fixes #2578 

With large mailboxes the initial sync is slow. Therefore it's prone to run into timeouts. I was hoping cron to be my last resort, but it turns out we can't rely on it as the instance might not use system cron but web cron. Then the same timeout rules apply as for any other AJAX requests. Thus we need an alternative.

I've changed the sync logic to limit the cache population to x (currently 1000 but I'll increase) message per run. Then it just stops without setting the syn tokens. The next sync attempt will detect the missing cache and start over. However, it will also check for the highest known UID in the database, and only fetch the ones that are newer than this message. It relies on the fact that the previous inital sync attempt did not leave any holes. But that shouldn't happen usually. Messages are also inserted in ascending order and both messages and recipients are inserted in the same transaction. Thus this should be a save way to resume the operation with the previous progress. Eventually one of the attempts will finish and no more messages can be fetched. Then the tokens will be set. From then on, partial sync can be used.

This also fixes the /sync request to be a POST. It was okay-ish to do it as GET for the old Horde sync as it was indeed stateless. But now it's changing server state, thus POST seems more appropriate. Moreover we send the list of known UIDs as parameter and AFAIK there are limits in URL length while with POST body we can send more data.

Steps to test

* Close the app
* Run `update oc_mail_mailboxes set sync_new_token=null, sync_new_lock=null, sync_changed_token=null, sync_changed_lock=null, sync_vanished_token=null, sync_vanished_lock=null;`, `delete from oc_mail_messages;` and `delete from oc_mail_recipients;`
* Open the app and browse to a large inbox

You should then see the "indexing … might take longer … " message. and in the browser network tab you see /sync requests. lots of 202s and then finally a 200. then the mailbox content should show.

Todo

- [x] A bit more testing
- [x] Find sweet spot of messages per request to optimize performance and still avoid timeouts
- [x] Ask @nickvergessen for a test run on his large mailbox(es)