### PR TITLE
Match header-padding with AppDetailsToggle-width

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -269,7 +269,7 @@ export default {
 #mail-message-header-fields {
 	// initial width
 	width: 0;
-	padding-left: 38px;
+	padding-left: 44px;
 	// grow and try to fill 100%
 	flex: 1 1 auto;
 	h2,


### PR DESCRIPTION
Fixes problem with `AppsDetailsToggle`-button overlapping part of the message header on narrow screens.
![unfixed](https://user-images.githubusercontent.com/3090888/75344295-a3879100-589a-11ea-9b88-ab14ac7d7fb7.png)
![fixed](https://user-images.githubusercontent.com/3090888/75344283-9f5b7380-589a-11ea-8e92-525fc5234363.png)
