### PR TITLE
Fix "post-message deletion"-navigation

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -131,10 +131,7 @@ export default {
 		onToggleSeen() {
 			this.$store.dispatch('toggleEnvelopeSeen', this.data)
 		},
-		onDelete(e) {
-			// Don't navigate to the deleted message
-			e.preventDefault()
-
+		onDelete() {
 			this.$emit('delete', this.data)
 			this.$store.dispatch('deleteMessage', this.data)
 		},

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -132,7 +132,7 @@ export default {
 			this.$store.dispatch('toggleEnvelopeSeen', this.data)
 		},
 		onDelete() {
-			this.$emit('delete', this.data)
+			this.$emit('delete', {envelope: this.data})
 			this.$store.dispatch('deleteMessage', this.data)
 		},
 	},

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -7,7 +7,7 @@
 				:key="env.uid"
 				:data="env"
 				:folder="folder"
-				@delete="$emit('delete', env)"
+				@delete="$emit('delete', {envelope: env})"
 			/>
 			<div id="load-more-mail-messages" key="loadingMore" :class="{'icon-loading-small': loadingMore}" />
 		</transition-group>

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -317,7 +317,6 @@ export default {
 			}
 		},
 		onDelete({envelope}) {
-			const envelopes = this.envelopes
 			const idx = findIndex(propEq('uid', envelope.uid), this.envelopes)
 			if (idx === -1) {
 				logger.debug('envelope to delete does not exist in envelope list')
@@ -329,13 +328,7 @@ export default {
 				return
 			}
 
-			let next
-			if (idx === 0) {
-				next = envelopes[idx + 1]
-			} else {
-				next = envelopes[idx - 1]
-			}
-
+			const next = this.envelopes[idx === 0 ? idx : idx - 1]
 			if (!next) {
 				logger.debug('no next/previous envelope, not navigating')
 				return


### PR DESCRIPTION
This PR contains two adjacent but ultimately disconnected bugs. Sorry! If y'all prefer harder separation in the future let me know.

This fixes 1) navigating to the wrong message (one step too far down in the list) after deleting a message, and 2) not navigating at all.

I also threw in some minor clean-up for good measure/bad GitHub etiquette. At least the commits are separate 😇

Edit: I'm not sure if there's an issue related to this. I stumbled upon the bugs when trying to understand enough to fix #2492 (getting there). I tried finding a related issue, but couldn't..

Edit 2:
Fixes #2154 