### PR TITLE
Appease ESLint

### DIFF
--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -15,9 +15,12 @@ export default {
 	props: {
 		hint: {
 			type: String,
+			default: '',
+			required: false,
 		},
 		slowHint: {
 			type: String,
+			default: '',
 			required: false,
 		},
 	},


### PR DESCRIPTION
Kept seeing ESLint complain about these lines in different PRs.

I'm not sure about setting the default value to `undefined`. It's either that or an empty string, but I have a hard time deciding which aspect of JavaScript's typing system I dislike the least 😅 🧂