### PR TITLE
Label recipients correctly in Composer.vue

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -290,7 +290,9 @@ export default {
 			return this.$store.getters.accounts.filter(a => !a.isUnified)
 		},
 		selectableRecipients() {
-			return this.newRecipients.concat(this.autocompleteRecipients)
+			return this.newRecipients
+				.concat(this.autocompleteRecipients)
+				.map(recipient => ({...recipient, label: recipient.label || recipient.email}))
 		},
 		isReply() {
 			return this.to.length > 0


### PR DESCRIPTION
I was getting some juicy errors when trying to add recipients, so I dug into it. Turns out `vue-multiselect` wasn't a huge fan of their default `customLabel` returning `null` with our data, so I wrote our own. It's very recipient specific - assuming there will be a `.email` - but also somewhat lenient - falling back on hoping `option` is a string (which maybe could blow up if it's a truthy non-string); worst of both worlds? Anyway, here's more code to review 🤷

#### Juicy errors 🧃
![errors](https://user-images.githubusercontent.com/3090888/75496611-fc9e1480-59c1-11ea-9447-566afabb5791.png)
