### PR TITLE
Refactor 'deleteMessage'-action to take just ids

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -137,7 +137,11 @@ export default {
 		},
 		onDelete() {
 			this.$emit('delete', {envelope: this.data})
-			this.$store.dispatch('deleteMessage', this.data)
+			this.$store.dispatch('deleteMessage', {
+				accountId: this.data.accountId,
+				folderId: this.data.folderId,
+				id: this.data.id,
+			})
 		},
 	},
 }

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -265,7 +265,7 @@ export default {
 					logger.debug('deleting', {env})
 					this.onDelete({envelope: env})
 					this.$store
-						.dispatch('deleteMessage', env)
+						.dispatch('deleteMessage', {accountId: env.accountId, folderId: env.folderId, id: env.id})
 						.catch(error => logger.error('could not delete envelope', {env, error}))
 
 					break

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -237,7 +237,11 @@ export default {
 				envelope: this.envelope,
 				message: this.message,
 			})
-			this.$store.dispatch('deleteMessage', this.message)
+			this.$store.dispatch('deleteMessage', {
+				accountId: this.message.accountId,
+				folderId: this.message.folderId,
+				id: this.message.id,
+			})
 		},
 	},
 }


### PR DESCRIPTION
Refactors the action `deleteMessage` to take `actionId`, `folderId`, and `id` instead of a full envelope. This paves the way for #2701 by allowing drafts to be deleted without access to the related envelope.