### PR TITLE
Add TLS host verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,9 @@ before_script:
   - php -f core/occ app:enable mail
   # Enable app twice to check occ errors of registered commands
   - php -f core/occ app:enable mail
+  # Turn off TLS verification here as the test server is not trusted
+  - php -f core/occ config:system:set app.mail.verify-tls-peer --type bool --value false
+
   - cd core/apps/mail
   - sh -c "if [ '$TEST_SUITE' = 'TEST-JS' ]; then npm install -g npm@latest; fi"
   - sh -c "if [ '$TEST_SUITE' = 'TEST-JS' ]; then make dev-setup; fi"

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -136,6 +136,12 @@ class Account implements JsonSerializable {
 				'port' => $port,
 				'secure' => $ssl_mode,
 				'timeout' => (int) $this->config->getSystemValue('app.mail.imap.timeout', 20),
+				'context' => [
+					'ssl' => [
+						'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+						'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+					],
+				],
 			];
 			if ($this->config->getSystemValue('debug', false)) {
 				$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -77,6 +77,12 @@ class IMAPClientFactory {
 				'port' => $port,
 				'secure' => $sslMode,
 				'timeout' => (int)$this->config->getSystemValue('app.mail.imap.timeout', 5),
+				'context' => [
+					'ssl' => [
+						'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+						'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+					],
+				],
 			];
 			if ($this->cacheFactory->isAvailable()) {
 				$params['cache'] = [

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -76,7 +76,13 @@ class SmtpClientFactory {
 			'port' => $mailAccount->getOutboundPort(),
 			'username' => $mailAccount->getOutboundUser(),
 			'secure' => $security === 'none' ? false : $security,
-			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 5)
+			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 5),
+			'context' => [
+				'ssl' => [
+					'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+					'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+				],
+			],
 		];
 		if ($this->config->getSystemValue('debug', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -83,18 +83,17 @@ class SmtpClientFactoryTest extends TestCase {
 			'smtpPassword' => 'obenc',
 		]);
 		$account = new Account($mailAccount);
-		$this->config->expects($this->at(0))
+		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->with('app.mail.transport', 'smtp')
-			->willReturn('smtp');
-		$this->config->expects($this->at(2))
-			->method('getSystemValue')
-			->with('debug', false)
-			->willReturn(false);
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('app.mail.smtp.timeout', 5)
-			->willReturn(2);
+			->willReturnMap([
+				['app.mail.transport', 'smtp', 'smtp'],
+				['debug', false, false],
+				['app.mail.smtp.timeout', 5, 2],
+			]);
+		$this->config->expects($this->any())
+			->method('getSystemValueBool')
+			->with('app.mail.verify-tls-peer', true)
+			->willReturn(true);
 		$this->crypto->expects($this->once())
 			->method('decrypt')
 			->with('obenc')
@@ -110,6 +109,12 @@ class SmtpClientFactoryTest extends TestCase {
 			'secure' => false,
 			'timeout' => 2,
 			'localhost' => 'cloud.example.com',
+			'context' => [
+				'ssl' => [
+					'verify_peer' => true,
+					'verify_peer_name' => true,
+				],
+			],
 		]);
 
 		$transport = $this->factory->create($account);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/308

- [x] Fix context param upstream https://github.com/horde/Socket_Client/pull/3
- [x] Verify hosts by default
- [x] Option to disable verification system-wide (for CI)

Follow-ups:
* User/account-based option to disable verification https://github.com/nextcloud/mail/issues/2785