### PR TITLE
Fix missing UID on fetched envelope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       run: composer install
     - name: Run tests
       working-directory: nextcloud/apps/mail
-      run: composer run test:unit
+      run: composer run test:unit:dev
     - name: Upload coverage to Scrutinizer
       working-directory: nextcloud/apps/mail
       run: |

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -174,7 +174,7 @@ export default {
 				this.message = message
 
 				if (envelope === undefined || message === undefined) {
-					logger.info('message could not be found', {messageUid})
+					logger.info('message could not be found', {messageUid, envelope, message})
 					this.errorMessage = getRandomMessageErrorMessage()
 					this.loading = false
 					return

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -22,7 +22,7 @@ export function fetchEnvelope(accountId, folderId, id) {
 
 	return axios
 		.get(url)
-		.then((resp) => resp.data)
+		.then((resp) => amendEnvelopeWithIds(accountId, folderId, resp.data))
 		.catch((error) => {
 			if (error.response && error.response.status === 404) {
 				return undefined

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -184,6 +184,7 @@ export default {
 
 		const cached = getters.getEnvelope(accountId, folderId, id)
 		if (cached) {
+			logger.debug(`using cached value for envelope ${uid}`)
 			return cached
 		}
 


### PR DESCRIPTION
The store code expects a `uid` prop to be set, but this transformation was missing in the message service.

This causes an endless loading spinner when you open a deep URL for a message that is not in the first message page.

So, to reproduce, open the app, scroll down in the message list until the second page is loaded. Open one of those message. Then reload the page.

On master: loading spinner of eternity, js error in console
On this branch: message is loaded correctly

@nextcloud/mail