### PR TITLE
Fix capitalization of Re, Fwd, Cc and Bcc

### DIFF
--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -138,7 +138,7 @@ export const buildReplySubject = (original) => {
 		return original
 	}
 
-	return `RE: ${original}`
+	return `Re: ${original}`
 }
 
 // TODO: https://en.wikipedia.org/wiki/List_of_email_subject_abbreviations#Abbreviations_in_other_languages
@@ -173,5 +173,5 @@ export const buildForwardSubject = (original) => {
 		return original
 	}
 
-	return `FWD: ${original}`
+	return `Fwd: ${original}`
 }

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -40,12 +40,12 @@
 				@search-change="onAutocomplete"
 			/>
 			<a v-if="!showCC" class="copy-toggle" href="#" @click.prevent="showCC = true">
-				{{ t('mail', '+ CC/BCC') }}
+				{{ t('mail', '+ Cc/Bcc') }}
 			</a>
 		</div>
 		<div v-if="showCC" class="composer-fields">
 			<label for="cc" class="cc-label">
-				{{ t('mail', 'CC') }}
+				{{ t('mail', 'Cc') }}
 			</label>
 			<Multiselect
 				id="cc"
@@ -68,7 +68,7 @@
 		</div>
 		<div v-if="showCC" class="composer-fields">
 			<label for="bcc" class="bcc-label">
-				{{ t('mail', 'BCC') }}
+				{{ t('mail', 'Bcc') }}
 			</label>
 			<Multiselect
 				id="bcc"

--- a/src/tests/unit/ReplyBuilder.spec.js
+++ b/src/tests/unit/ReplyBuilder.spec.js
@@ -230,7 +230,7 @@ describe('ReplyBuilder', () => {
 
 		const replySubject = buildReplySubject(orig)
 
-		expect(replySubject).to.equal('RE: Hello')
+		expect(replySubject).to.equal('Re: Hello')
 	})
 
 	it("does not stack subject re:'s", () => {


### PR DESCRIPTION
They should _not_ be all-caps as it looks shouty and regular mail apps (like e.g. Gmail) do not do this either. It’s also how we used to have it but got changed along the way.

Please review @nextcloud/mail 