### PR TITLE
Refactor message flag logic into a service method

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -115,4 +115,16 @@ interface IMailManager {
 	 */
 	public function markFolderAsRead(Account $account, string $folderId): void;
 
+	/**
+	 * @param Account $account
+	 * @param string $mailbox
+	 * @param int $uid
+	 * @param string $flag
+	 * @param bool $value
+	 *
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function flagMessage(Account $account, string $mailbox, int $uid, string $flag, bool $value): void;
+
 }

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -235,6 +235,8 @@ class AccountsController extends Controller {
 	 * @param int $id
 	 *
 	 * @return JSONResponse
+	 *
+	 * @throws ClientException
 	 */
 	public function destroy($id): JSONResponse {
 		$this->accountService->delete($this->currentUserId, $id);

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -449,7 +449,7 @@ class MessagesController extends Controller {
 	 * @throws ServiceException
 	 */
 	public function setFlags(int $accountId, string $folderId, int $messageId, array $flags): JSONResponse {
-		$mailBox = $this->getFolder($accountId, $folderId);
+		$account = $this->accountService->find($this->currentUserId, $accountId);
 
 		foreach ($flags as $flag => $value) {
 			$value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
@@ -457,7 +457,7 @@ class MessagesController extends Controller {
 				$flag = 'seen';
 				$value = !$value;
 			}
-			$mailBox->setMessageFlag($messageId, '\\' . $flag, $value);
+			$this->mailManager->flagMessage($account, base64_decode($folderId), $messageId, $flag, $value);
 		}
 		return new JSONResponse();
 	}
@@ -493,6 +493,7 @@ class MessagesController extends Controller {
 	 * @param string $folderId
 	 *
 	 * @return IMailBox
+	 * @deprecated
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -47,6 +47,8 @@ class MailAccountMapper extends QBMapper {
 	 * @param int $accountId
 	 *
 	 * @return MailAccount
+	 *
+	 * @throws DoesNotExistException
 	 */
 	public function find(string $userId, int $accountId): MailAccount {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -260,6 +260,22 @@ class MessageMapper {
 	}
 
 	/**
+	 * @throws Horde_Imap_Client_Exception
+	 */
+	public function removeFlag(Horde_Imap_Client_Socket $client,
+							Mailbox $mailbox,
+							int $uid,
+							string $flag): void {
+		$client->store(
+			$mailbox->getName(),
+			[
+				'ids' => new Horde_Imap_Client_Ids($uid),
+				'remove' => [$flag],
+			]
+		);
+	}
+
+	/**
 	 * @param Horde_Imap_Client_Socket $client
 	 * @param string $mailbox
 	 * @param int $id

--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -33,7 +33,6 @@ namespace OCA\Mail;
 
 use Horde_Imap_Client;
 use Horde_Imap_Client_Exception;
-use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Model\IMAPMessage;
@@ -321,32 +320,6 @@ class Mailbox implements IMailBox {
 		])->ids;
 
 		return reset($uids);
-	}
-
-	/**
-	 * @param int $uid
-	 * @param string $flag
-	 * @param boolean $add
-	 *
-	 * @return void
-	 */
-	public function setMessageFlag(int $uid, string $flag, $add) {
-		$options = [
-			'ids' => new Horde_Imap_Client_Ids($uid)
-		];
-		if ($add) {
-			$options['add'] = [$flag];
-		} else {
-			$options['remove'] = [$flag];
-		}
-		$this->conn->store($this->mailBox, $options);
-	}
-
-	/**
-	 * @return Horde_Imap_Client_Mailbox
-	 */
-	public function getHordeMailBox(): Horde_Imap_Client_Mailbox {
-		return $this->mailBox;
 	}
 
 }

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -101,14 +101,24 @@ class AccountService {
 			throw new ClientException("Account $accountId does not exist or you don\'t have permission to access it");
 		}
 
-		return new Account($this->mapper->find($uid, $accountId));
+		try {
+			return new Account($this->mapper->find($uid, $accountId));
+		} catch (DoesNotExistException $e) {
+			throw new ClientException("Account $accountId does not exist or you don\'t have permission to access it");
+		}
 	}
 
 	/**
 	 * @param int $accountId
+	 *
+	 * @throws ClientException
 	 */
 	public function delete(string $currentUserId, int $accountId): void {
-		$mailAccount = $this->mapper->find($currentUserId, $accountId);
+		try {
+			$mailAccount = $this->mapper->find($currentUserId, $accountId);
+		} catch (DoesNotExistException $e) {
+			throw new ClientException("Account $accountId does not exist", 0, $e);
+		}
 		$this->aliasesService->deleteAll($accountId);
 		$this->mapper->delete($mailAccount);
 	}

--- a/lib/Service/IMailBox.php
+++ b/lib/Service/IMailBox.php
@@ -54,13 +54,6 @@ interface IMailBox {
 	public function getAttachment(int $messageId, string $attachmentId): Attachment;
 
 	/**
-	 * @param int $messageId
-	 * @param string $flag
-	 * @param mixed $value
-	 */
-	public function setMessageFlag(int $messageId, string $flag, $value);
-
-	/**
 	 * @param int $flags
 	 * @return array
 	 */

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -129,7 +129,7 @@ class MessagesControllerTest extends TestCase {
 			->method('getTime')
 			->willReturn(10000);
 		$this->oldFactory = \OC::$server->offsetGet(ITimeFactory::class);
-		\OC::$server->registerService(ITimeFactory::class, function() use ($timeFactory) {
+		\OC::$server->registerService(ITimeFactory::class, function () use ($timeFactory) {
 			return $timeFactory;
 		});
 
@@ -372,17 +372,17 @@ class MessagesControllerTest extends TestCase {
 			->method('find')
 			->with($this->equalTo($this->userId), $this->equalTo($accountId))
 			->will($this->returnValue($this->account));
-		$this->account->expects($this->once())
-			->method('getMailbox')
-			->with(base64_decode($folderId))
-			->will($this->returnValue($this->mailbox));
-		$this->mailbox->expects($this->once())
-			->method('setMessageFlag')
-			->with($messageId, '\\seen', true);
+		$this->mailManager->expects($this->once())
+			->method('flagMessage')
+			->with($this->account, 'my folder', $messageId, 'seen', true);
 
 		$expected = new JSONResponse();
-		$response = $this->controller->setFlags($accountId, $folderId, $messageId,
-			$flags);
+		$response = $this->controller->setFlags(
+			$accountId,
+			$folderId,
+			$messageId,
+			$flags
+		);
 
 		$this->assertEquals($expected, $response);
 	}
@@ -399,17 +399,17 @@ class MessagesControllerTest extends TestCase {
 			->method('find')
 			->with($this->equalTo($this->userId), $this->equalTo($accountId))
 			->will($this->returnValue($this->account));
-		$this->account->expects($this->once())
-			->method('getMailbox')
-			->with(base64_decode($folderId))
-			->will($this->returnValue($this->mailbox));
-		$this->mailbox->expects($this->once())
-			->method('setMessageFlag')
-			->with($messageId, '\\flagged', true);
+		$this->mailManager->expects($this->once())
+			->method('flagMessage')
+			->with($this->account, 'my folder', $messageId, 'flagged', true);
 
 		$expected = new JSONResponse();
-		$response = $this->controller->setFlags($accountId, $folderId, $messageId,
-			$flags);
+		$response = $this->controller->setFlags(
+			$accountId,
+			$folderId,
+			$messageId,
+			$flags
+		);
 
 		$this->assertEquals($expected, $response);
 	}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -269,4 +269,58 @@ class MailManagerTest extends TestCase {
 		);
 	}
 
+	public function testSetCustomFlag(): void {
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$account = $this->createMock(Account::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$this->messageMapper->expects($this->never())
+			->method('addFlag');
+		$this->messageMapper->expects($this->never())
+			->method('removeFlag');
+
+		$this->manager->flagMessage($account, 'INBOX', 123, 'important', true);
+	}
+
+	public function testCaseInsensitiveFlag(): void {
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$account = $this->createMock(Account::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$mb = $this->createMock(Mailbox::class);
+		$this->mailboxMapper->expects($this->once())
+			->method('find')
+			->with($account, 'INBOX')
+			->willReturn($mb);
+		$this->messageMapper->expects($this->once())
+			->method('addFlag')
+			->with($client, $mb, 123, '\\seen');
+		$this->messageMapper->expects($this->never())
+			->method('removeFlag');
+
+		$this->manager->flagMessage($account, 'INBOX', 123, 'SeEn', true);
+	}
+
+	public function testRemoveFlag(): void {
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$account = $this->createMock(Account::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$mb = $this->createMock(Mailbox::class);
+		$this->mailboxMapper->expects($this->once())
+			->method('find')
+			->with($account, 'INBOX')
+			->willReturn($mb);
+		$this->messageMapper->expects($this->never())
+			->method('addFlag');
+		$this->messageMapper->expects($this->once())
+			->method('removeFlag')
+			->with($client, $mb, 123, '\\seen');
+
+		$this->manager->flagMessage($account, 'INBOX', 123, 'seen', false);
+	}
+
 }


### PR DESCRIPTION
Required for

* https://github.com/nextcloud/mail/pull/2796 -> don't send custom flags to server
* a new event to update the message cache immediately (PR coming shortly)