### PR TITLE
Update the message cache when a message is flagged

### DIFF
--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -32,6 +32,7 @@ use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Events\DraftSavedEvent;
 use OCA\Mail\Events\MessageDeletedEvent;
+use OCA\Mail\Events\MessageFlaggedEvent;
 use OCA\Mail\Events\MessageSentEvent;
 use OCA\Mail\Events\SaveDraftEvent;
 use OCA\Mail\Http\Middleware\ErrorMiddleware;
@@ -41,7 +42,7 @@ use OCA\Mail\Listener\DeleteDraftListener;
 use OCA\Mail\Listener\DraftMailboxCreatorListener;
 use OCA\Mail\Listener\FlagRepliedMessageListener;
 use OCA\Mail\Listener\InteractionListener;
-use OCA\Mail\Listener\MessageDeletedCacheUpdaterListener;
+use OCA\Mail\Listener\MessageCacheUpdaterListener;
 use OCA\Mail\Listener\SaveSentMessageListener;
 use OCA\Mail\Listener\TrashMailboxCreatorListener;
 use OCA\Mail\Service\Attachment\AttachmentService;
@@ -125,7 +126,8 @@ class BootstrapSingleton {
 
 		$dispatcher->addServiceListener(BeforeMessageDeletedEvent::class, TrashMailboxCreatorListener::class);
 		$dispatcher->addServiceListener(DraftSavedEvent::class, DeleteDraftListener::class);
-		$dispatcher->addServiceListener(MessageDeletedEvent::class, MessageDeletedCacheUpdaterListener::class);
+		$dispatcher->addServiceListener(MessageFlaggedEvent::class, MessageCacheUpdaterListener::class);
+		$dispatcher->addServiceListener(MessageDeletedEvent::class, MessageCacheUpdaterListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, AddressCollectionListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, DeleteDraftListener::class);
 		$dispatcher->addServiceListener(MessageSentEvent::class, FlagRepliedMessageListener::class);

--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Db;
 use JsonSerializable;
 use OCA\Mail\AddressList;
 use OCP\AppFramework\Db\Entity;
+use function in_array;
 
 /**
  * @method void setUid(int $uid)
@@ -64,6 +65,17 @@ use OCP\AppFramework\Db\Entity;
  * @method int getUpdatedAt()
  */
 class Message extends Entity implements JsonSerializable {
+
+	private const MUTABLE_FLAGS = [
+		'answered',
+		'deleted',
+		'draft',
+		'flagged',
+		'seen',
+		'forwarded',
+		'junk',
+		'notjunk',
+	];
 
 	protected $uid;
 	protected $messageId;
@@ -170,6 +182,18 @@ class Message extends Entity implements JsonSerializable {
 	 */
 	public function setBcc(AddressList $bcc): void {
 		$this->bcc = $bcc;
+	}
+
+	public function setFlag(string $flag, bool $value = true) {
+		if (!in_array($flag, self::MUTABLE_FLAGS, true)) {
+			// Ignore
+			return;
+		}
+
+		$this->setter(
+			$this->columnToProperty("flag_$flag"),
+			[$value]
+		);
 	}
 
 	public function jsonSerialize() {

--- a/lib/Events/MessageFlaggedEvent.php
+++ b/lib/Events/MessageFlaggedEvent.php
@@ -23,32 +23,60 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace OCA\Mail\Listener;
+namespace OCA\Mail\Events;
 
-use OCA\Mail\Db\MessageMapper;
-use OCA\Mail\Events\MessageDeletedEvent;
+use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
 use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\IEventListener;
 
-class MessageDeletedCacheUpdaterListener implements IEventListener {
+class MessageFlaggedEvent extends Event {
 
-	/** @var MessageMapper */
-	private $mapper;
+	/** @var Account */
+	private $account;
 
-	public function __construct(MessageMapper $mapper) {
-		$this->mapper = $mapper;
+	/** @var Mailbox */
+	private $mailbox;
+
+	/** @var int */
+	private $uid;
+
+	/** @var string */
+	private $flag;
+
+	/** @var bool */
+	private $set;
+
+	public function __construct(Account $account,
+								Mailbox $mailbox,
+								int $uid,
+								string $flag,
+								bool $set) {
+		parent::__construct();
+		$this->account = $account;
+		$this->mailbox = $mailbox;
+		$this->uid = $uid;
+		$this->flag = $flag;
+		$this->set = $set;
 	}
 
-	public function handle(Event $event): void {
-		if (!($event instanceof MessageDeletedEvent)) {
-			// Unrelated
-			return;
-		}
+	public function getAccount(): Account {
+		return $this->account;
+	}
 
-		$this->mapper->deleteByUid(
-			$event->getMailbox(),
-			$event->getMessageId()
-		);
+	public function getMailbox(): Mailbox {
+		return $this->mailbox;
+	}
+
+	public function getUid(): int {
+		return $this->uid;
+	}
+
+	public function getFlag(): string {
+		return $this->flag;
+	}
+
+	public function isSet(): bool {
+		return $this->set;
 	}
 
 }

--- a/lib/Listener/MessageCacheUpdaterListener.php
+++ b/lib/Listener/MessageCacheUpdaterListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Listener;
+
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Events\MessageDeletedEvent;
+use OCA\Mail\Events\MessageFlaggedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\ILogger;
+
+class MessageCacheUpdaterListener implements IEventListener {
+
+	/** @var MessageMapper */
+	private $mapper;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(MessageMapper $mapper,
+								ILogger $logger) {
+		$this->mapper = $mapper;
+		$this->logger = $logger;
+	}
+
+	public function handle(Event $event): void {
+		if ($event instanceof MessageFlaggedEvent) {
+			$messages = $this->mapper->findByUids($event->getMailbox(), [$event->getUid()]);
+			$message = reset($messages);
+
+			if ($message === false) {
+				$this->logger->warning("Flagged message is not cached");
+				return;
+			}
+
+			$message->setFlag($event->getFlag(), $event->isSet());
+
+			$this->mapper->update($message);
+		} elseif ($event instanceof MessageDeletedEvent) {
+			$this->mapper->deleteByUid(
+				$event->getMailbox(),
+				$event->getMessageId()
+			);
+		}
+	}
+
+}

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -31,6 +31,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Events\MessageDeletedEvent;
+use OCA\Mail\Events\MessageFlaggedEvent;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
@@ -303,6 +304,17 @@ class MailManager implements IMailManager {
 				throw new ServiceException("Could not set message flag on IMAP: " . $e->getMessage(), $e->getCode(), $e);
 			}
 		}
+
+		$this->eventDispatcher->dispatch(
+			MessageFlaggedEvent::class,
+			new MessageFlaggedEvent(
+				$account,
+				$mb,
+				$uid,
+				$flag,
+				$value
+			)
+		);
 	}
 
 }


### PR DESCRIPTION
When a message is flagged in the front-end (marked as seen, starred, etc) we send the change to IMAP, but the local cache is not updated directly. Hence there is a small time frame where the displayed information or search is incorrect.

To test, open the app and mark a message as unseen. Then quickly reload the page.

On master: the flagged message is shows as seen again. Wait for the sync or press <kbd>r</kbd> to see the cache catch up

On this PR: flag change is persisted immediately in the DB, hence after a reload you directly get the "correct" state.

@nextcloud/mail for review & test :)