### PR TITLE
Fix message source view wrapping and selection

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -54,7 +54,10 @@
 						</ActionButton>
 					</Actions>
 					<Modal v-if="showSource" @close="onCloseSource">
-						<pre class="message-source">{{ rawMessage }}</pre>
+						<div class="section">
+							<h2>{{ t('mail', 'Message source') }}</h2>
+							<pre class="message-source">{{ rawMessage }}</pre>
+						</div>
 					</Modal>
 				</div>
 			</div>
@@ -410,8 +413,9 @@ export default {
 	}
 }
 
-pre.message-source {
+.message-source {
 	font-family: monospace;
-	margin: 15px;
+	white-space: pre-wrap;
+	user-select: text;
 }
 </style>


### PR DESCRIPTION
Before, the message source was horizontally overflowing, and it wasn’t possible to select anything.

Now, that’s all fixed and there’s a nice descriptive header. :)
![Mail message source](https://user-images.githubusercontent.com/925062/77677096-845e4b00-6f8f-11ea-9a22-52a45061c3cd.png)

Please check @nextcloud/mail 