### PR TITLE
Add back accidentally removed prop

### DIFF
--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -110,6 +110,11 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+		filter: {
+			type: String,
+			default: '',
+			required: false,
+		},
 		forceMenu: {
 			type: Boolean,
 			default: false,


### PR DESCRIPTION
@GretaD apparently you overwrote my change of the new prop with your own new prop at https://github.com/nextcloud/mail/pull/2686/files#diff-de3f9d25eae4ce26cfab9a0673499f70L112-R115, hence the starred inbox vanished.

To reproduce open the app. On master you'll see two indivisual inboxes per account. On this branch it's one inbox and one favorites inbox.

@nextcloud/mail 