### PR TITLE
Fix more layout of message list until we move to component, ref #2827

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -184,12 +184,29 @@ export default {
 
 // Fix layout of messages in list until we move to component
 
-.app-content-list-item-line-two,
-.app-content-list-item-menu {
-	margin-top: -8px;
-}
+.app-content-list .app-content-list-item {
+	padding-right: 0;
 
-.app-content-list-item-menu {
-	margin-right: -2px;
+	.app-content-list-item-line-two {
+		padding-right: 0;
+		margin-top: -8px;
+	}
+
+	.app-content-list-item-menu {
+		margin-right: -2px;
+		margin-top: -8px;
+
+		::v-deep .action-item__menu {
+			right: 7px !important;
+
+			.action-item__menu_arrow {
+				right: 6px !important;
+			}
+		}
+	}
+
+	.app-content-list-item-details {
+		padding-right: 7px;
+	}
 }
 </style>


### PR DESCRIPTION
- Remove padding-right from the whole entry
- Add padding-right: 7px; to the date in the top right
- Remove padding-right from the subline

You can already see that even though it’s a tiny change only, the action icon looks much nicer aligned, there’s some more space for the text, and the menu click issue is fixed.

### Current
![Vue component message list currently](https://user-images.githubusercontent.com/925062/78006748-ab28d280-733d-11ea-9f67-132924f6a2a6.png)
### This pull request
![app content list item new](https://user-images.githubusercontent.com/925062/78006747-aa903c00-733d-11ea-8a0e-07b2dead03a8.png)

Easy review @nextcloud/mail :)