### PR TITLE
Fix routing for the reply and forward actions

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -219,6 +219,7 @@ export default {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
 					messageUid: 'reply',
+					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
 				},
 				query: {
 					uid: this.message.uid,
@@ -232,6 +233,7 @@ export default {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
 					messageUid: 'replyAll',
+					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
 				},
 				query: {
 					uid: this.message.uid,
@@ -245,6 +247,7 @@ export default {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
 					messageUid: 'new',
+					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
 				},
 				query: {
 					uid: this.message.uid,


### PR DESCRIPTION
As discovered by @GretaD in https://github.com/nextcloud/mail/pull/2838#issuecomment-607177771 we lose the filter section in the URL when you reply or forward a message from the fav inbox.

Steps to reproduce
* Open the app
* Open the fav mailbox
* Reply to a message

On master: you get to reply, but the inbox is loaded
Here: you get to reply, but the mailbox does not change