### PR TITLE
Fix missing In-Reply-To header for replies

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -260,6 +260,10 @@ export default {
 			type: Function,
 			required: true,
 		},
+		replyTo: {
+			type: Object,
+			default: () => undefined,
+		},
 	},
 	data() {
 		return {
@@ -296,7 +300,7 @@ export default {
 				.map((recipient) => ({...recipient, label: recipient.label || recipient.email}))
 		},
 		isReply() {
-			return this.to.length > 0
+			return this.replyTo !== undefined
 		},
 		canSend() {
 			return this.selectTo.length > 0 || this.selectCc.length > 0 || this.selectBcc.length > 0


### PR DESCRIPTION
When a message is answered, we have to set the in-reply-to header, so other clients can build the correct message thread. Evolution, for example, builds threads only based on the header, thus @ma12-co's replies on company emails always show up as new messages for me.

Steps to reproduce
* Open app
* Open a message
* Reply to it
* Open the sent message and inspect the source (action menu on the top right #2264)

On master: no `In-Reply-To` header found
Here: `In-Reply-To` is set to the message ID of the previous message

This might be an unnoticed regression of https://github.com/nextcloud/mail/pull/1774