### PR TITLE
Fix URLs of embedded images

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -318,7 +318,7 @@ class MessagesController extends Controller {
 					base64_decode($folderId),
 					$messageId,
 					true
-				)->getHtmlBody($accountId, $folderId, $messageId)
+				)->getHtmlBody($accountId, base64_decode($folderId), $messageId)
 			);
 
 			// Harden the default security policy


### PR DESCRIPTION
Due to a missing decoding, the generated URL for embedded images was doubly-encoded and thus threw an error as an invalid IMAP mailbox was attempted to be opened.

Steps to test:
* Open a message with embedded images

On master: see image as attachment, but not inline
Here: image shows inline and as attachment

@nextcloud/mail