### PR TITLE
Fix signature settings layout, simplify HTML

### DIFF
--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -25,22 +25,18 @@
 		<p class="settings-hint">
 			{{ t('mail', 'A signature is added to the text of new messages and replies.') }}
 		</p>
-		<p>
-			<TextEditor v-model="signature" :html="true" :placeholder="t('mail', 'Signature …')" :bus="bus" />
-		</p>
-		<p>
-			<button
-				class="primary"
-				:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
-				:disabled="loading"
-				@click="saveSignature"
-			>
-				{{ t('mail', 'Save signature') }}
-			</button>
-			<button v-if="signature" class="button-text" @click="deleteSignature">
-				{{ t('mail', 'Delete') }}
-			</button>
-		</p>
+		<TextEditor v-model="signature" :html="true" :placeholder="t('mail', 'Signature …')" :bus="bus" />
+		<button
+			class="primary"
+			:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
+			:disabled="loading"
+			@click="saveSignature"
+		>
+			{{ t('mail', 'Save signature') }}
+		</button>
+		<button v-if="signature" class="button-text" @click="deleteSignature">
+			{{ t('mail', 'Delete') }}
+		</button>
 	</div>
 </template>
 
@@ -109,12 +105,13 @@ export default {
 	color: var(--color-text-maxcontrast);
 }
 
-textarea {
-	display: block;
+.ck.ck-editor__editable_inline {
 	width: 400px;
-	max-width: 85vw;
+	max-width: 78vw;
 	height: 100px;
-	resize: none;
+	border-radius: var(--border-radius) !important;
+	border: 1px solid var(--color-border) !important;
+	box-shadow: none !important;
 }
 
 .primary {

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -60,7 +60,7 @@ export default {
 	data() {
 		return {
 			loading: false,
-			signature: this.account.signature ? toHtml(detect(this.account.signature)) : html(''),
+			signature: this.account.signature ? toHtml(detect(this.account.signature)).value : '',
 			bus: new Vue(),
 		}
 	},


### PR DESCRIPTION
Before:
- Not obvious that it’s a text field
- Field way too narrow and not high enough
- Unnecessary containers in the HTML

We could still improve it by adding autosize back so the field will always be as high as what is in it, but not sure this works with CKEditor? @ChristophWurst 

![signature before](https://user-images.githubusercontent.com/925062/78552693-399ec780-7808-11ea-9888-d4853c3fe674.png)

After:
![signature after](https://user-images.githubusercontent.com/925062/78552695-3a375e00-7808-11ea-8827-f9c62a73cf27.png)
