### PR TITLE
Fix missing padding-top of composer

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -601,7 +601,6 @@ export default {
 	width: 100%;
 	margin: 0;
 	padding: 12px;
-	padding-top: 0;
 	border: none !important;
 	outline: none !important;
 	box-shadow: none !important;


### PR DESCRIPTION
The composer was missing the 12px padding-top, which were removed before for some reason and probably the move to CKEditor makes this necessary again.

Before the message text is stuck to the divider line, now everything is fine:
![composer before](https://user-images.githubusercontent.com/925062/78554913-4cb39680-780c-11ea-9a49-d5ffada12286.png) ![composer after](https://user-images.githubusercontent.com/925062/78554915-4d4c2d00-780c-11ea-9603-22bec802c1d0.png)

Easy and quick review @nextcloud/mail 