### PR TITLE
Fix format for aliases

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -527,7 +527,7 @@ export default {
 			}
 
 			return html(body)
-				.append('<br>--<br>')
+				.append(html('<br>--<br>'))
 				.append(toHtml(detect(alias.signature)))
 		},
 	},


### PR DESCRIPTION
Append expects an object, we pass in a string.

```
return html(body)
.append('<br>--<br>')
```
