### PR TITLE
Add individually sync'ed new messages to the unified mailbox

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -114,6 +114,19 @@ export default {
 			listId,
 			sortedUniq(orderBy((id) => state.envelopes[id].dateInt, 'desc', existing.concat([envelope.uid])))
 		)
+
+		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
+		unifiedAccount.folders
+			.map((fId) => state.folders[fId])
+			.filter((f) => f.specialRole && f.specialRole === folder.specialRole)
+			.forEach((folder) => {
+				const existing = folder.envelopeLists[listId] || []
+				Vue.set(
+					folder.envelopeLists,
+					listId,
+					sortedUniq(orderBy((id) => state.envelopes[id].dateInt, 'desc', existing.concat([envelope.uid])))
+				)
+			})
 	},
 	updateEnvelope(state, {envelope}) {
 		const existing = state.envelopes[envelope.uid]
@@ -145,7 +158,7 @@ export default {
 		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
 		unifiedAccount.folders
 			.map((fId) => state.folders[fId])
-			.filter((f) => f.specialRole === folder.specialRole)
+			.filter((f) => f.specialRole && f.specialRole === folder.specialRole)
 			.forEach((folder) => {
 				const list = folder.envelopeLists[normalizedEnvelopeListId(query)]
 				if (!list) {

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -20,11 +20,18 @@
  */
 
 import mutations from '../../../store/mutations'
-import {UNIFIED_ACCOUNT_ID} from '../../../store/constants'
+import {UNIFIED_ACCOUNT_ID, UNIFIED_INBOX_UID} from '../../../store/constants'
 
 describe('Vuex store mutations', () => {
 	it('adds envelopes', () => {
 		const state = {
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					folders: [],
+				},
+			},
 			envelopes: {},
 			folders: {
 				'13-INBOX': {
@@ -48,6 +55,13 @@ describe('Vuex store mutations', () => {
 		})
 
 		expect(state).to.deep.equal({
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					folders: [],
+				},
+			},
 			envelopes: {
 				'13-INBOX-123': {
 					accountId: 13,
@@ -60,6 +74,77 @@ describe('Vuex store mutations', () => {
 			folders: {
 				'13-INBOX': {
 					id: 'INBOX',
+					envelopeLists: {
+						'': ['13-INBOX-123'],
+					},
+				},
+			},
+		})
+	})
+
+	it('adds new envelopes to the unified inbox as well', () => {
+		const state = {
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					folders: [UNIFIED_INBOX_UID],
+				},
+			},
+			envelopes: {},
+			folders: {
+				'13-INBOX': {
+					id: 'INBOX',
+					envelopeLists: {},
+					specialRole: 'inbox',
+				},
+				[UNIFIED_INBOX_UID]: {
+					specialRole: 'inbox',
+					envelopeLists: {},
+				},
+			},
+		}
+
+		mutations.addEnvelope(state, {
+			accountId: 13,
+			folderId: 'INBOX',
+			query: undefined,
+			envelope: {
+				accountId: 13,
+				folderId: 'INBOX',
+				id: 123,
+				subject: 'henlo',
+				uid: '13-INBOX-123',
+			},
+		})
+
+		expect(state).to.deep.equal({
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					folders: [UNIFIED_INBOX_UID],
+				},
+			},
+			envelopes: {
+				'13-INBOX-123': {
+					accountId: 13,
+					folderId: 'INBOX',
+					uid: '13-INBOX-123',
+					id: 123,
+					subject: 'henlo',
+				},
+			},
+			folders: {
+				'13-INBOX': {
+					id: 'INBOX',
+					specialRole: 'inbox',
+					envelopeLists: {
+						'': ['13-INBOX-123'],
+					},
+				},
+				[UNIFIED_INBOX_UID]: {
+					specialRole: 'inbox',
 					envelopeLists: {
 						'': ['13-INBOX-123'],
 					},


### PR DESCRIPTION
In the background we invoke the synchronization of all individual
inboxes. With a recent change in the Vuex logic we didn't push the new
message to the unified inbox as well. So you could see a notification
about new messages but when you switched to the Mail tab it wasn't
there. You first had to switch to the individual mailbox and then back
to get the latest entries.

Steps to test
* Open the app
* Open the unified inbox
* Go away
* Wait for emails to arrive or send one to you from another device or mail client
* See the notification and click it

On master: the new message was not in the list
Now: the new message shows up as expected

The change is also covered by a unit test to lower the risk of breaking again.