### PR TITLE
Do not trigger scroll event on page load

### DIFF
--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -5,6 +5,7 @@
 			<AppContentList
 				v-infinite-scroll="onScroll"
 				v-shortkey.once="shortkeys"
+				infinite-scroll-immediate-check="false"
 				:show-details="showMessage"
 				:infinite-scroll-disabled="false"
 				:infinite-scroll-distance="10"
@@ -27,6 +28,7 @@ import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import Vue from 'vue'
 
 import AppDetailsToggle from './AppDetailsToggle'
+import logger from '../logger'
 import Mailbox from './Mailbox'
 import Message from './Message'
 import NewMessageDetail from './NewMessageDetail'
@@ -127,7 +129,9 @@ export default {
 		deleteMessage(envelopeUid) {
 			this.bus.$emit('delete', envelopeUid)
 		},
-		onScroll() {
+		onScroll(event) {
+			logger.debug('scroll', {event})
+
 			this.bus.$emit('loadMore')
 		},
 		onShortcut(e) {


### PR DESCRIPTION
vue-infinite-scroll can detect when the element is too big to fit the
contents on first render. This is typically the case for us as the
message list is bigger than the container. However, we don't want to
trigger the loading of the next page yet, as we first have to fetch the
initial one.
Luckily there is an option to disable the immediate check https://github.com/ElemeFE/vue-infinite-scroll#options

To test open the app and check for errors.

On master: error because the list does not have a tail (misleading, shouldn't usually happen but the page is fetched too early)
Here: no error

As a user it always looked the same as the error did not cause any trouble.