### PR TITLE
Fix the size of the source of raw msg

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -53,7 +53,7 @@
 							{{ t('mail', 'Delete') }}
 						</ActionButton>
 					</Actions>
-					<Modal v-if="showSource" @close="onCloseSource">
+					<Modal v-if="showSource" :size="isMobile ? 'large' : 'full'" @close="onCloseSource">
 						<div class="section">
 							<h2>{{ t('mail', 'Message source') }}</h2>
 							<pre class="message-source">{{ rawMessage }}</pre>
@@ -98,6 +98,7 @@ import MessagePlainTextBody from './MessagePlainTextBody'
 import Loading from './Loading'
 import logger from '../logger'
 import MessageAttachments from './MessageAttachments'
+import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 
 export default {
 	name: 'Message',
@@ -115,6 +116,7 @@ export default {
 		Modal,
 		Popover,
 	},
+	mixins: [isMobile],
 	data() {
 		return {
 			loading: true,


### PR DESCRIPTION
Now it looks like this. The close button doesnt show. We need to fix that, but how, should we put it inside container?
The large version only makes it taller so no big difference.
![source](https://user-images.githubusercontent.com/12728974/78789148-08133100-79ad-11ea-83ab-5db7fa5cfb0d.png)
