### PR TITLE
Do not navigate from a message to just the folder

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -150,6 +150,17 @@ export default {
 	},
 	watch: {
 		$route(to, from) {
+			if (
+				from.name === to.name &&
+				Number.parseInt(from.params.accountId, 10) === Number.parseInt(to.params.accountId, 10) &&
+				from.params.folderId === to.params.folderId &&
+				from.params.messageUid === to.params.messageUid &&
+				from.params.filter === to.params.filter
+			) {
+				logger.debug('navigated but the message is still the same')
+				return
+			}
+			logger.debug('navigated to another message', {to, from})
 			this.fetchMessage()
 		},
 	},

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -30,6 +30,23 @@ export default {
 			return this.buildMenu()
 		},
 	},
+	watch: {
+		$route(to, from) {
+			if (
+				from.name === 'message' &&
+				to.name === 'folder' &&
+				Number.parseInt(from.params.accountId, 10) === Number.parseInt(to.params.accountId, 10) &&
+				from.params.folderId === to.params.folderId &&
+				from.params.filter === to.params.filter
+			) {
+				logger.warn("navigation from a message to just the folder. we don't want that, do we? let's go back", {
+					to,
+					from,
+				})
+				this.$router.replace(from)
+			}
+		},
+	},
 	created() {
 		const accounts = this.$store.getters.accounts
 


### PR DESCRIPTION
As discovered by @jancborchardt the router navigated from a *message route* to the *folder route*.

Let me elaborate. We have deep links for folders and messages. When a folder is opened we automagically redirect to the first message in the list once that got loaded. If you then click on the folder, the app routed back to just the folder. The active message was reset and a "No message selected" appeared. This was not desired by @jancborchardt.

To test

* Open the app and wait until the first message is shown
* Click the folder name

On master: message is unselected, you see placeholder text
Here: you still see your message. The URL might flash shortly but it doesn't have an effect logically.

The solution is merely a hack. If anyone know a better way please shoot.