### PR TITLE
Fix handling of service exceptions

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -147,6 +147,9 @@ class ImapToDbSynchronizer {
 			} else {
 				$this->runPartialSync($account, $mailbox, $criteria, $knownUids);
 			}
+		} catch (ServiceException $e) {
+			// Just rethrow, don't wrap into another exception
+			throw $e;
 		} catch (Throwable $e) {
 			throw new ServiceException('Sync failed: ' . $e->getMessage(), 0, $e);
 		} finally {
@@ -189,7 +192,7 @@ class ImapToDbSynchronizer {
 			// We might need more attempts to fill the cache
 			$perf->end();
 
-			throw new IncompleteSyncException();
+			throw new IncompleteSyncException('Initial sync is not complete for ' . $account->getId() . ':' . $mailbox->getName());
 		}
 
 		$mailbox->setSyncNewToken($client->getSyncToken($mailbox->getName()));


### PR DESCRIPTION
We have special handling for IncompleteSyncException in the controller,
but since the exception handling always wrapped the original exception
in a service exception, the type cast to the incomplete sync exception
didn't work. Now, it just doesn't wrap unless it's something other than
a service exception.

How to test: open a very large mailbox for the first time.

On master: sync returns HTTP 500 due to unhandled exception
Here: 202 is returned, client code knows it just has to send another request. Everything works flawless.

Fixes https://github.com/nextcloud/mail/issues/2910
Fixes https://github.com/nextcloud/mail/issues/2908