### PR TITLE
Break the recursion when fetching the next page

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -270,7 +270,7 @@ export default {
 			)
 		)(accountId, folderId, query)
 	},
-	fetchNextEnvelopePage({commit, getters, dispatch}, {accountId, folderId, query}) {
+	fetchNextEnvelopePage({commit, getters, dispatch}, {accountId, folderId, query, rec = true}) {
 		const folder = getters.getFolder(accountId, folderId)
 
 		if (folder.isUnified) {
@@ -308,10 +308,9 @@ export default {
 					findIndividualFolders(getters.getFolders, folder.specialRole),
 					filter(needsFetch(query, nextLocalUnifiedEnvelopePage(accounts)))
 				)(accounts)
-
 			const fs = foldersToFetch(getters.accounts)
 
-			if (fs.length) {
+			if (rec && fs.length) {
 				return pipe(
 					map((f) =>
 						dispatch('fetchNextEnvelopePage', {
@@ -326,6 +325,7 @@ export default {
 							accountId,
 							folderId,
 							query,
+							rec: false,
 						})
 					)
 				)(fs)
@@ -355,6 +355,7 @@ export default {
 		}
 
 		return fetchEnvelopes(accountId, folderId, query, lastEnvelope.dateInt).then((envelopes) => {
+			logger.debug(`fetched ${envelopes.length} messages for the next page of ${accountId}:${folderId}`)
 			envelopes.forEach((envelope) =>
 				commit('addEnvelope', {
 					accountId,


### PR DESCRIPTION
The unified inbox uses individual inbox pages to build the next unified
page. When there isn't enough data available for the next unified page,
individual pages are fetched, and the action is re-dispatched
afterwards.

This can lead to an endless recursion. A new parameter breaks this.

For testing open your unified inbox. Then scroll down so the next page is loaded.

On master: this never stops. it loads just everything page after page.
Here: only the next page is loaded, then it stops until you scroll down further and reach the bottom of the list again.