### PR TITLE
In cron always sync mailboxes before sync'ing their messages

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -151,7 +151,7 @@ class ImapToDbSynchronizer {
 			// Just rethrow, don't wrap into another exception
 			throw $e;
 		} catch (Throwable $e) {
-			throw new ServiceException('Sync failed: ' . $e->getMessage(), 0, $e);
+			throw new ServiceException('Sync failed for ' . $account->getId() . ':' . $mailbox->getName() . ': ' . $e->getMessage(), 0, $e);
 		} finally {
 			if ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS) {
 				$this->mailboxMapper->unlockFromVanishedSync($mailbox);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2913
And https://github.com/nextcloud/mail/issues/2908#issuecomment-614368860

It makes sense to always ensure we have the absolute latest list of mailboxes before we iterate over it to sync the messages.

This even caused a bug: we recently removed the special `INBOX/FLAGGED` mailbox in #2706 and reset the last mailbox sync to 0 to trigger a sync once the user opens the app again. Now, since also cron sync's, it could pick up the old list of mailboxes and thus run into an error.

@ovv 