### PR TITLE
Fix lower bound when fetching a range of IMAP messages for the sync

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -175,7 +175,12 @@ class ImapToDbSynchronizer {
 		$highestKnownUid = $this->dbMapper->findHighestUid($mailbox);
 		$client = $this->clientFactory->getClient($account);
 		try {
-			$imapMessages = $this->imapMapper->findAll($client, $mailbox, self::MAX_NEW_MESSAGES, $highestKnownUid);
+			$imapMessages = $this->imapMapper->findAll(
+				$client,
+				$mailbox->getName(),
+				self::MAX_NEW_MESSAGES,
+				$highestKnownUid ?? 0
+			);
 			$perf->step('fetch all messages from IMAP');
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException('Can not get messages from mailbox ' . $mailbox->getName() . ': ' . $e->getMessage(), 0, $e);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2909

When we fetch messages for the initial sync, we use a UID range. There is a bit of logic involved to only fetch roughly `$maxResults` messages, and we might have a known offset `$highestKnownUid` to take into account for resumed sync's. The code previously always set the lower range bound to `$highestKnownUid + 1`, so for the very first sync attempt the range was like `0:$maxResults`. If the UIDs of a mailbox start *after* `$maxResults`, no messages were returned. And the logic entered an infinite retry loop.

Now, the new logic starts at `$min`, the lowest known UID reported by the server or at `$highestKnownUid`, whichever is higher. The upper bound is calculated based on the lower bound.

If my train of thought is not derailing, this should give the correct range to fetch. I can still correctly sync all messages with my test accounts.

TODO
- [x] Fix the bug
- [x] Add tests to verify the fix
- [x] ~~Remove debug logs once we have the confirmation this works from https://github.com/nextcloud/mail/issues/2909#issuecomment-614690050~~ leaving them in case we have to debug this another time