### PR TITLE
Fix/925/isp autoconfiguration server

### DIFF
--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -91,7 +91,7 @@ class IspDbConfigurationDetector {
 		// TODO: use horde libs for email address parsing
 		list(, $host) = explode("@", $email);
 
-		$ispdb = $this->ispDb->query($host);
+		$ispdb = $this->ispDb->query($host, $email);
 
 		if (empty($ispdb)) {
 			// Nothing to detect
@@ -157,9 +157,11 @@ class IspDbConfigurationDetector {
 			$user = $email;
 		} elseif ($imap['username'] === '%EMAILLOCALPART%') {
 			list($user,) = explode("@", $email);
-		} else {
-			$this->logger->info("Unknown username variable: " . $imap['username']);
+		} elseif (empty($imap['username'])) {
+			$this->logger->info("imap username is either an invalid placeholder or is empty");
 			return null;
+		} else {
+			$user = $imap['username'];
 		}
 
 		try {
@@ -209,9 +211,11 @@ class IspDbConfigurationDetector {
 				$user = $email;
 			} elseif ($smtp['username'] === '%EMAILLOCALPART%') {
 				list($user,) = explode("@", $email);
-			} else {
-				$this->logger->info("Unknown username variable: " . $smtp['username']);
+			} elseif (empty($smtp['username'])) {
+				$this->logger->info("smtp username is either an unknown placeholder or is empty");
 				return null;
+			} else {
+				$user = $smtp['username'];
 			}
 
 			$account->setOutboundHost($smtp['hostname']);

--- a/tests/Unit/Service/Autoconfig/IspDbTest.php
+++ b/tests/Unit/Service/Autoconfig/IspDbTest.php
@@ -39,8 +39,8 @@ class IspDbtest extends TestCase {
 
 	public function queryData() {
 		return [
-			['gmail.com'],
-			['outlook.com'],
+			['gmail.com', 'user@gmail.com',],
+			['outlook.com', 'user@outlook.com',],
 		];
 	}
 
@@ -48,19 +48,20 @@ class IspDbtest extends TestCase {
 	 * @dataProvider queryData
 	 *
 	 * @param string $domain
+	 * @param string $email
 	 */
-	public function testQueryRealServers($domain) {
+	public function testQueryRealServers(string $domain, string $email): void {
 		$this->markTestSkipped('does not work reliably');
 		return;
 
 		$ispDb = new IspDb($this->logger);
-		$result = $ispDb->query($domain);
+		$result = $ispDb->query($domain, $email);
 		$this->assertContainsIspData($result);
 	}
 
 	public function fakeAutoconfigData() {
 		return [
-			['freenet.de', true],
+			['freenet.de', 'user@freenet.de', true],
 			//['example.com', false], //should it fail?
 		];
 	}
@@ -68,13 +69,13 @@ class IspDbtest extends TestCase {
 	/**
 	 * @dataProvider fakeAutoconfigData
 	 */
-	public function testQueryFakeAutoconfig($domain, $shouldSucceed) {
+	public function testQueryFakeAutoconfig(string $domain, string $email, bool $shouldSucceed) {
 		$urls = [
 			dirname(__FILE__) . '/../../../resources/autoconfig-freenet.xml',
 		];
 		$ispDb = $this->getIspDbMock($urls);
 
-		$result = $ispDb->query($domain);
+		$result = $ispDb->query($domain, $email);
 
 		if ($shouldSucceed) {
 			$this->assertContainsIspData($result);


### PR DESCRIPTION
This should fix #925 by providing a better compliance with https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration.

Autodection will use the user's email when querying the isp autoconfiguration servers both with http and https.

