### PR TITLE
Limit the size of recipient labels

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -36,6 +36,7 @@ use OCP\IDBConnection;
 use function array_combine;
 use function array_keys;
 use function array_map;
+use function mb_substr;
 
 class MessageMapper extends QBMapper {
 
@@ -146,7 +147,7 @@ class MessageMapper extends QBMapper {
 
 					$qb2->setParameter('message_id', $messageId, IQueryBuilder::PARAM_INT);
 					$qb2->setParameter('type', $type, IQueryBuilder::PARAM_INT);
-					$qb2->setParameter('label', $recipient->getLabel(), IQueryBuilder::PARAM_STR);
+					$qb2->setParameter('label', mb_substr($recipient->getLabel(), 0, 255), IQueryBuilder::PARAM_STR);
 					$qb2->setParameter('email', $recipient->getEmail(), IQueryBuilder::PARAM_STR);
 
 					$qb2->execute();


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/2930

This is more likely to be triggered by an invalid message header as in the ticket, but even if the real label is that long, we won't have the space to show it anyway. So let's just limit it to the width of the db table.