### PR TITLE
Do not sync accounts that are provisioned and have no password set

### DIFF
--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -81,6 +81,12 @@ class SyncJob extends TimedJob {
 			return;
 		}
 
+		$dbAccount = $account->getMailAccount();
+		if ($dbAccount->getProvisioned() && $dbAccount->getInboundPassword() === null) {
+			$this->logger->info("Ignoring cron sync for provisioned account that has no password set yet");
+			return;
+		}
+
 		try {
 			$this->mailboxSync->sync($account, true);
 			$this->syncService->syncAccount($account);


### PR DESCRIPTION
Provisioned accounts have no password set when they are written to the DB. This is patched as soon as the user opens the app for the first time, so we can grab the login password.

If cron is faster (which is quite likely), it will try to sync the account when no password has been set, leading to an error logged.

This patch catches that case and just write an info log.