### PR TITLE
Migrate mail_messages.mailbox_id to an INT

### DIFF
--- a/lib/Migration/Version1034Date20200422124709.php
+++ b/lib/Migration/Version1034Date20200422124709.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1034Date20200422124709 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+		$messagesTable->addColumn('mailbox_id_int', 'integer', [
+			'notnull' => false,
+			'length' => 20,
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$qb = $this->connection->getQueryBuilder();
+
+		$update = $qb
+			->update('mail_messages')
+			->set('mailbox_id_int', $qb->expr()->castColumn('mailbox_id', IQueryBuilder::PARAM_INT));
+
+		$update->execute();
+	}
+}

--- a/lib/Migration/Version1034Date20200422125734.php
+++ b/lib/Migration/Version1034Date20200422125734.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1034Date20200422125734 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+
+		$messagesTable->dropColumn('mailbox_id');
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version1034Date20200422131751.php
+++ b/lib/Migration/Version1034Date20200422131751.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1034Date20200422131751 extends SimpleMigrationStep {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+		$messagesTable->addColumn('mailbox_id', 'integer', [
+			'notnull' => false,
+			'length' => 20,
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		$qb = $this->connection->getQueryBuilder();
+
+		$update = $qb
+			->update('mail_messages')
+			->set('mailbox_id', $qb->getColumnName('mailbox_id_int'));
+
+		$update->execute();
+	}
+
+}

--- a/lib/Migration/Version1034Date20200422133143.php
+++ b/lib/Migration/Version1034Date20200422133143.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1034Date20200422133143 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+		$messagesTable->dropColumn('mailbox_id_int');
+		$messagesTable->getColumn('mailbox_id')->setNotnull(true);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2963

TODO
- [ ] Basis migrations structure
- [ ] Drop the original unique index on [uid, mailbox_id]
- [ ] Create a new unique index
- [ ] Handle migration errors if possible