### PR TITLE
Use all available group services

### DIFF
--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -49,9 +49,6 @@ use OCA\Mail\Listener\SaveSentMessageListener;
 use OCA\Mail\Listener\TrashMailboxCreatorListener;
 use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\AvatarService;
-use OCA\Mail\Service\Group\IGroupService;
-use OCA\Mail\Service\Group\NextcloudGroupService;
-use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\MailManager;
 use OCA\Mail\Service\Search\MailSearch;
 use OCA\Mail\Service\MailTransmission;
@@ -117,9 +114,6 @@ class BootstrapSingleton {
 		$container->registerMiddleWare('ErrorMiddleware');
 		$container->registerAlias('ProvisioningMiddleware', ProvisioningMiddleware::class);
 		$container->registerMiddleWare('ProvisioningMiddleware');
-
-		$container->registerAlias(IGroupService::class, NextcloudGroupService::class);
-		$container->registerAlias(IGroupService::class, ContactsGroupService::class);
 	}
 
 	private function registerEvents(IAppContainer $container): void {

--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -23,7 +23,9 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service;
 
+use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\Group\IGroupService;
+use OCA\Mail\Service\Group\NextcloudGroupService;
 use OCA\Mail\Exception\ServiceException;
 
 class GroupsIntegration {
@@ -35,8 +37,11 @@ class GroupsIntegration {
 	 */
 	private $groupServices = [];
 
-	public function __construct(IGroupService $groupService) {
-		$this->groupServices[] = $groupService;
+	public function __construct(ContactsGroupService $contactsGroupService, NextcloudGroupService $nextcloudGroupService) {
+		$this->groupServices = [
+			$contactsGroupService,
+			$nextcloudGroupService,
+		];
 	}
 
 	/**

--- a/tests/Unit/Service/GroupsIntegrationTest.php
+++ b/tests/Unit/Service/GroupsIntegrationTest.php
@@ -22,6 +22,7 @@
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\GroupsIntegration;
 use OCA\Mail\Service\Group\NextcloudGroupService;
 use OCA\Mail\Exception\ServiceException;
@@ -38,12 +39,17 @@ class GroupsIntegrationTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->groupService1 = $this->createMock(NextcloudGroupService::class);
-		$this->groupService1->expects($this->any())
+		$this->groupService1 = $this->createMock(ContactsGroupService::class);
+		$this->groupService2 = $this->createMock(NextcloudGroupService::class);
+		$this->groupService1
 			->method('getNamespace')
 			->willReturn('Namespace1');
+		$this->groupService2
+			->method('getNamespace')
+			->willReturn('Namespace2');
 		$this->groupsIntegration = new GroupsIntegration(
-			$this->groupService1
+			$this->groupService1,
+			$this->groupService2
 		);
 	}
 


### PR DESCRIPTION
When we just had one implementation of a group service we could just
inject the implementation when the interface is used. However, as
another implementation was added, it is necessary to explicitly require
the implementations to be able to use all of them.

Before the patch the contacts group integration overwrote the nextcloud group integration.

Fixes https://github.com/nextcloud/mail/pull/810

@nextcloud/mail