### PR TITLE
Make it possible to filter messages for the important flag

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -345,6 +345,7 @@ class MessageMapper extends QBMapper {
 			Horde_Imap_Client::FLAG_FORWARDED,
 			Horde_Imap_Client::FLAG_JUNK,
 			Horde_Imap_Client::FLAG_NOTJUNK,
+			'\\important',
 		] as $flag) {
 			if (in_array($flag, $flagKeys, true)) {
 				$key = ltrim($flag, '\\');

--- a/lib/Service/Search/FilterStringParser.php
+++ b/lib/Service/Search/FilterStringParser.php
@@ -33,6 +33,7 @@ class FilterStringParser {
 		'read' => [Horde_Imap_Client::FLAG_SEEN, true],
 		'starred' => [Horde_Imap_Client::FLAG_FLAGGED, true],
 		'unread' => [Horde_Imap_Client::FLAG_SEEN, false],
+		'important' => ['\\important', true],
 	];
 
 	public function parse(?string $filter): SearchQuery {


### PR DESCRIPTION
This makes it possible to search for `is:important` and `not:important` as we need that for the priority inbox.

To test you can simple search `is:important`. On master you get nothing or same random results, and the query takes a bit longer. Here it returns faster and only important messages.