### PR TITLE
Change important section to allow favorites too

### DIFF
--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -25,7 +25,7 @@
 						:account="unifiedAccount"
 						:folder="unifiedInbox"
 						:paginate="false"
-						:search-query="appendToSearch('is:important not:starred')"
+						:search-query="appendToSearch('is:important')"
 						:bus="bus"
 					/>
 					<SectionTitle class="app-content-list-item starred" :name="t('mail', 'Favorites')" />


### PR DESCRIPTION
Priority section should show the messages that are both marked as important and favorite.