### PR TITLE
Delete all user's accounts when the user is deleted

### DIFF
--- a/lib/AppInfo/BootstrapSingleton.php
+++ b/lib/AppInfo/BootstrapSingleton.php
@@ -49,6 +49,7 @@ use OCA\Mail\Listener\MessageCacheUpdaterListener;
 use OCA\Mail\Listener\NewMessageClassificationListener;
 use OCA\Mail\Listener\SaveSentMessageListener;
 use OCA\Mail\Listener\TrashMailboxCreatorListener;
+use OCA\Mail\Listener\UserDeletedListener;
 use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\AvatarService;
 use OCA\Mail\Service\MailManager;
@@ -57,6 +58,7 @@ use OCA\Mail\Service\MailTransmission;
 use OCA\Mail\Service\UserPreferenceSevice;
 use OCP\AppFramework\IAppContainer;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
 
 class BootstrapSingleton {
@@ -133,5 +135,6 @@ class BootstrapSingleton {
 		$dispatcher->addServiceListener(MessageSentEvent::class, SaveSentMessageListener::class);
 		$dispatcher->addServiceListener(NewMessagesSynchronized::class, NewMessageClassificationListener::class);
 		$dispatcher->addServiceListener(SaveDraftEvent::class, DraftMailboxCreatorListener::class);
+		$dispatcher->addServiceListener(UserDeletedEvent::class, UserDeletedListener::class);
 	}
 }

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Listener;
+
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Service\AccountService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\ILogger;
+use OCP\User\Events\BeforeUserDeletedEvent;
+
+class UserDeletedListener implements IEventListener {
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(AccountService $accountService,
+								ILogger $logger) {
+		$this->accountService = $accountService;
+		$this->logger = $logger;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeUserDeletedEvent)) {
+			// Unrelated
+			return;
+		}
+
+		$user = $event->getUser();
+		foreach ($this->accountService->findByUserId($user->getUID()) as $account) {
+			try {
+				$this->accountService->delete(
+					$user->getUID(),
+					$account->getId()
+				);
+			} catch (ClientException $e) {
+				$this->logger->logException($e, [
+					'message' => 'Could not delete user\'s Mail account: ' . $e->getMessage(),
+					'level' => ILogger::ERROR,
+				]);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/1501

When a Nextcloud user is deleted, the Mail accounts remained. This shall help clean up their data.

- [x] Requires 18+

@nextcloud/mail 