### PR TITLE
Fix query in often contacted sender classifier

### DIFF
--- a/lib/Service/Classification/OftenContactedSenderClassifier.php
+++ b/lib/Service/Classification/OftenContactedSenderClassifier.php
@@ -76,7 +76,7 @@ class OftenContactedSenderClassifier extends AClassifier {
 			->from('mail_recipients', 'r')
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id'))
 			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', 'm.mailbox_id'))
-			->where($qb->expr()->eq('r.id', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)));
 		$result = $select->execute();
 		$cnt = $result->fetchColumn();
@@ -91,7 +91,7 @@ class OftenContactedSenderClassifier extends AClassifier {
 			->from('mail_recipients', 'r')
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
 			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', $qb->expr()->castColumn('m.mailbox_id', IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->eq('r.id', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)))
 			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)));
 		$result = $select->execute();


### PR DESCRIPTION
We want to compare the recipient type, not the ID.

@nextcloud/mail 

@jancborchardt I think that is the reason why all new messages are important.