### PR TITLE
Use a naive bayes algorithm to find important messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Composer
 composer.phar
+/lib/Vendor
 /vendor/
 
 # Mac OS

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.4.0</version>
+	<version>1.4.0-alpha1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Roeland Jago Douma</author>
@@ -36,7 +36,7 @@
 	<repair-steps>
 		<post-migration>
 			<step>OCA\Mail\Migration\FixCollectedAddresses</step>
-			<step>OCA\Mail\Migration\FixAccountSyncs</step>
+			<step>OCA\Mail\Migration\FixBackgroundJobs</step>
 			<step>OCA\Mail\Migration\MakeItineraryExtractorExecutable</step>
 			<step>OCA\Mail\Migration\MigrateProvisioningConfig</step>
 			<step>OCA\Mail\Migration\ProvisionAccounts</step>
@@ -48,6 +48,7 @@
 		<command>OCA\Mail\Command\DiagnoseAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>
 		<command>OCA\Mail\Command\SyncAccount</command>
+		<command>OCA\Mail\Command\TrainAccount</command>
 	</commands>
 	<settings>
 		<admin>OCA\Mail\Settings\AdminSettings</admin>

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,14 @@
 		"pear-pear.horde.org/horde_text_flowed": "^2.0.3@stable",
 		"pear-pear.horde.org/horde_util": "^2.5.8@stable",
 		"pear-pear.horde.org/horde_smtp": "^1.9.5@stable",
-		"psr/log": "^1"
+		"psr/log": "^1",
+		"php-ai/php-ml": "^0.8.0"
 	},
 	"require-dev": {
 		"roave/security-advisories": "dev-master",
 		"christophwurst/nextcloud": "^v18.0.0",
 		"christophwurst/nextcloud_testing": "0.10.0",
+		"coenjacobs/mozart": "^0.5.0",
 		"nextcloud/coding-standard": "^0.3.0",
 		"phan/phan": "^3.0",
 		"vimeo/psalm": "^3.9"
@@ -52,9 +54,28 @@
 		"cs:fix": "php-cs-fixer fix",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -exec php -l \"{}\" \\;",
 		"phan": "phan --allow-polyfill-parser -k .phan/config.php",
+		"post-install-cmd": [
+			"\"vendor/bin/mozart\" compose",
+			"composer dump-autoload"
+		],
+		"post-update-cmd": [
+			"\"vendor/bin/mozart\" compose",
+			"composer dump-autoload"
+		],
 		"test:integration": "phpunit -c tests/phpunit.integration.xml tests/Integration --fail-on-warning",
 		"test:integration:dev": "phpunit -c tests/phpunit.integration.xml tests/Integration --no-coverage --fail-on-warning --stop-on-error --stop-on-failure",
 		"test:unit": "phpunit -c tests/phpunit.unit.xml tests/Unit --fail-on-warning",
 		"test:unit:dev": "phpunit -c tests/phpunit.unit.xml tests/Unit --no-coverage --fail-on-warning --stop-on-error --stop-on-failure"
+	},
+	"extra": {
+		"mozart": {
+			"dep_namespace": "OCA\\Mail\\Vendor\\",
+			"dep_directory": "/lib/Vendor/",
+			"classmap_directory": "/lib/autoload/",
+			"classmap_prefix": "NEXTCLOUDMAIL_",
+			"packages": [
+				"php-ai/php-ml"
+			]
+		}
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36b7d4e49de8aca75589276654db27d1",
+    "content-hash": "9635cb2f6f89ea9161013f41b909ec58",
     "packages": [
         {
             "name": "arthurhoaro/favicon",
@@ -966,6 +966,61 @@
             "description": "A library that provides functionality useful for all kind of applications."
         },
         {
+            "name": "php-ai/php-ml",
+            "version": "0.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-ai/php-ml.git",
+                "reference": "5e02b893e904761cd7e2415b11778cd421494c07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-ai/php-ml/zipball/5e02b893e904761cd7e2415b11778cd421494c07",
+                "reference": "5e02b893e904761cd7e2415b11778cd421494c07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.14.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpstan/phpstan-shim": "^0.10",
+                "phpstan/phpstan-strict-rules": "^0.10",
+                "phpunit/phpunit": "^7.0.0",
+                "symplify/coding-standard": "^5.1",
+                "symplify/easy-coding-standard": "^5.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Phpml\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Arkadiusz Kondas",
+                    "email": "arkadiusz.kondas@gmail.com"
+                }
+            ],
+            "description": "PHP-ML - Machine Learning library for PHP",
+            "homepage": "https://github.com/php-ai/php-ml",
+            "keywords": [
+                "Neural network",
+                "artificial intelligence",
+                "computational learning theory",
+                "data science",
+                "feature extraction",
+                "machine learning",
+                "pattern recognition"
+            ],
+            "time": "2019-03-20T22:22:45+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.3",
             "source": {
@@ -1234,6 +1289,51 @@
             "time": "2020-01-20T13:20:58+00:00"
         },
         {
+            "name": "coenjacobs/mozart",
+            "version": "0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/coenjacobs/mozart.git",
+                "reference": "4bdde231f3309d9299c87b2246166e87acc93653"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/4bdde231f3309d9299c87b2246166e87acc93653",
+                "reference": "4bdde231f3309d9299c87b2246166e87acc93653",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^1.0",
+                "php": "^7.2",
+                "symfony/console": "^4|^5",
+                "symfony/finder": "^4|^5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/mozart"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CoenJacobs\\Mozart\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Coen Jacobs",
+                    "email": "coenjacobs@gmail.com"
+                }
+            ],
+            "description": "Composes all dependencies as a package inside a WordPress plugin",
+            "time": "2019-12-23T12:24:56+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "1.5.1",
             "source": {
@@ -1335,6 +1435,12 @@
             "keywords": [
                 "Xdebug",
                 "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
             ],
             "time": "2020-03-01T12:26:26+00:00"
         },
@@ -1702,7 +1808,103 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "funding": [
+                {
+                    "url": "https://github.com/keradus",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-15T18:51:10+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.0.67",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
+                "reference": "5b1f36c75c4bdde981294c2a0ebdb437ee6f275e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7.26"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "funding": [
+                {
+                    "url": "https://offset.earth/frankdejonge",
+                    "type": "other"
+                }
+            ],
+            "time": "2020-04-16T13:21:26+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
@@ -2907,6 +3109,16 @@
                 "testing",
                 "xunit"
             ],
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-23T04:39:42+00:00"
         },
         {
@@ -3975,6 +4187,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-30T11:41:10+00:00"
         },
         {
@@ -4045,6 +4271,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4153,6 +4393,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-12T14:39:55+00:00"
         },
         {
@@ -4202,6 +4456,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -4255,6 +4523,20 @@
                 "config",
                 "configuration",
                 "options"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-06T10:16:26+00:00"
         },
@@ -4313,6 +4595,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-08T16:50:20+00:00"
         },
@@ -4373,6 +4669,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-08T16:50:20+00:00"
         },
         {
@@ -4432,6 +4742,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-02T14:56:09+00:00"
         },
         {
@@ -4486,6 +4810,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-08T17:28:34+00:00"
         },
@@ -4545,6 +4883,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-02T14:56:09+00:00"
         },
         {
@@ -4594,6 +4946,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-15T15:56:18+00:00"
         },
         {
@@ -4702,6 +5068,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -5010,5 +5390,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.2"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\BackgroundJob;
+
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Classification\ImportanceClassifier;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\TimedJob;
+use OCP\ILogger;
+use Throwable;
+
+class TrainImportanceClassifierJob extends TimedJob {
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var ImportanceClassifier */
+	private $classifier;
+
+	/** @var IJobList */
+	private $jobList;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(ITimeFactory $time,
+								AccountService $accountService,
+								ImportanceClassifier $classifier,
+								IJobList $jobList,
+								ILogger $logger) {
+		parent::__construct($time);
+
+		$this->accountService = $accountService;
+		$this->classifier = $classifier;
+		$this->jobList = $jobList;
+		$this->logger = $logger;
+
+		$this->setInterval(3600);
+	}
+
+	protected function run($argument) {
+		$accountId = (int)$argument['accountId'];
+
+		try {
+			$account = $this->accountService->findById($accountId);
+		} catch (DoesNotExistException $e) {
+			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->jobList->remove(self::class, $argument);
+			return;
+		}
+
+		try {
+			$this->classifier->train($account);
+		} catch (Throwable $e) {
+			$this->logger->logException($e, [
+				'message' => 'Cron importance classifier training failed: ' . $e->getMessage(),
+			]);
+		}
+	}
+}

--- a/lib/Db/Classifier.php
+++ b/lib/Db/Classifier.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method int getAccountId()
+ * @method void setAccountId(int $accountId)
+ *
+ * @method string getType()
+ * @method void setType(string $type)
+ *
+ * @method string getEstimator()
+ * @method void setEstimator(string $estimator)
+ *
+ * @method string getAppVersion()
+ * @method void setAppVersion(string $version)
+ *
+ * @method int getTrainingSetSize()
+ * @method void setTrainingSetSize(int $size)
+ *
+ * @method int getValidationSetSize()
+ * @method void setValidationSetSize(int $size)
+ *
+ * @method float getRecallImportant()
+ * @method void setRecallImportant(float $recall)
+ *
+ * @method float getPrecisionImportant()
+ * @method void setPrecisionImportant(float $precision)
+ *
+ * @method float getF1ScoreImportant()
+ * @method void setF1ScoreImportant(float $precision)
+ *
+ * @method int getDuration()
+ * @method void setDuration(int $layers)
+ *
+ * @method int getActive()
+ * @method void setActive(bool $active)
+ *
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ */
+class Classifier extends Entity {
+	public const TYPE_IMPORTANCE = 'importance';
+
+	/** @var int */
+	protected $accountId;
+
+	/** @var string */
+	protected $type;
+
+	/** @var string */
+	protected $estimator;
+
+	/** @var string */
+	protected $appVersion;
+
+	/** @var int */
+	protected $trainingSetSize;
+
+	/** @var int */
+	protected $validationSetSize;
+
+	/** @var float */
+	protected $recallImportant;
+
+	/** @var float */
+	protected $precisionImportant;
+
+	/** @var float */
+	protected $f1ScoreImportant;
+
+	/** @var int */
+	protected $duration;
+
+	/** @var bool */
+	protected $active;
+
+	/** @var int */
+	protected $createdAt;
+
+	public function __construct() {
+		$this->addType('accountId', 'int');
+		$this->addType('type', 'string');
+		$this->addType('appVersion', 'string');
+		$this->addType('trainingSetSize', 'int');
+		$this->addType('validationSetSize', 'int');
+		$this->addType('recallImportant', 'float');
+		$this->addType('precisionImportant', 'float');
+		$this->addType('f1ScoreImportant', 'float');
+		$this->addType('duration', 'int');
+		$this->addType('active', 'bool');
+		$this->addType('createdAt', 'int');
+	}
+}

--- a/lib/Db/ClassifierMapper.php
+++ b/lib/Db/ClassifierMapper.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class ClassifierMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'mail_classifiers');
+	}
+
+	/**
+	 * @param int $id
+	 *
+	 * @return Classifier
+	 * @throws DoesNotExistException
+	 */
+	public function findLatest(int $id): Classifier {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('account_id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+				$qb->expr()->eq('active', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL)
+			)
+			->orderBy('created_at', 'asc')
+			->setMaxResults(1);
+
+		return $this->findEntity($select);
+	}
+}

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -470,6 +470,29 @@ class MessageMapper extends QBMapper {
 		return $this->findRecipients($this->findEntities($select));
 	}
 
+	/**
+	 * @param array $mailboxIds
+	 * @param int $limit
+	 *
+	 * @return string[]
+	 */
+	public function findLatestMessages(array $mailboxIds, int $limit): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb
+			->select('m.*')
+			->from($this->getTableName(), 'm')
+			->join('m', 'mail_recipients', 'r', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where(
+				$qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+				$qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
+			)
+			->orderBy('sent_at', 'desc')
+			->setMaxResults($limit);
+
+		return $this->findRecipients($this->findEntities($select));
+	}
+
 	public function deleteOrphans(): void {
 		$qb1 = $this->db->getQueryBuilder();
 		$idsQuery = $qb1->select('m.id')

--- a/lib/Db/StatisticsDao.php
+++ b/lib/Db/StatisticsDao.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCA\Mail\Address;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use function array_column;
+use function array_combine;
+use function array_map;
+
+class StatisticsDao {
+
+	/** @var IDBConnection */
+	private $db;
+
+	public function __construct(IDBConnection $db) {
+		$this->db = $db;
+	}
+
+	private function emailCountResultToIndexedArray(array $rows): array {
+		return array_combine(
+			array_column($rows, 'email'),
+			array_map(function (string $val) {
+				return (int)$val;
+			}, array_column($rows, 'count'))
+		);
+	}
+
+	public function getMessagesTotal(Mailbox ...$mb): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$mailboxIds = array_map(function (Mailbox $mb) {
+			return $mb->getId();
+		}, $mb);
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id'))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+
+	public function getMessagesSentTo(Mailbox $mb, string $email): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_TO), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)))
+			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+
+	public function getMessagesSentToGrouped(array $mailboxes, array $emails): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$mailboxIds = array_map(function (Mailbox $mb) {
+			return $mb->getId();
+		}, $mailboxes);
+		$select = $qb->selectAlias('r.email', 'email')
+			->selectAlias($qb->func()->count('*'), 'count')
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_TO), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->groupBy('r.email');
+		$result = $select->execute();
+		$rows = $result->fetchAll();
+		$data = $this->emailCountResultToIndexedArray($rows);
+		$result->closeCursor();
+		return $data;
+	}
+
+	public function getNrOfImportantMessages(Mailbox $mb, string $email): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('m.flag_important', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+
+	public function getNumberOfMessages(Mailbox $mb, string $email): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+
+	/**
+	 * @param Mailbox[] $mailboxes
+	 * @param string[] $emails
+	 *
+	 * @return int[]
+	 */
+	public function getNumberOfMessagesGrouped(array $mailboxes, array $emails): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$mailboxIds = array_map(function (Mailbox $mb) {
+			return $mb->getId();
+		}, $mailboxes);
+		$select = $qb->selectAlias('r.email', 'email')
+			->selectAlias($qb->func()->count('*'), 'count')
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
+			->groupBy('r.email');
+		$result = $select->execute();
+		$rows = $result->fetchAll();
+		$data = $this->emailCountResultToIndexedArray($rows);
+		$result->closeCursor();
+		return $data;
+	}
+
+	public function getNrOfReadMessages(Mailbox $mb, string $email): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('m.flag_seen', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+
+	/**
+	 * @param Mailbox[] $mailboxes
+	 * @param string $flag
+	 * @param string[] $emails
+	 *
+	 * @return int[]
+	 */
+	public function getNumberOfMessagesWithFlagGrouped(array $mailboxes, string $flag, array $emails): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$mailboxIds = array_map(function (Mailbox $mb) {
+			return $mb->getId();
+		}, $mailboxes);
+		$select = $qb->selectAlias('r.email', 'email')
+			->selectAlias($qb->func()->count('*'), 'count')
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->eq("m.flag_$flag", $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
+			->groupBy('r.email');
+		$result = $select->execute();
+		$rows = $result->fetchAll();
+		$data = $this->emailCountResultToIndexedArray($rows);
+		$result->closeCursor();
+		return $data;
+	}
+
+	public function getNrOfRepliedMessages(Mailbox $mb, string $email): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select($qb->func()->count('*'))
+			->from('mail_recipients', 'r')
+			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
+			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('m.flag_answered', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
+		$result = $select->execute();
+		$cnt = $result->fetchColumn();
+		$result->closeCursor();
+		return (int)$cnt;
+	}
+}

--- a/lib/Exception/ClassifierTrainingException.php
+++ b/lib/Exception/ClassifierTrainingException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Exception;
+
+use Throwable;
+
+class ClassifierTrainingException extends ServiceException {
+	public function __construct($message = "Classifier training failed",
+								$code = 0,
+								Throwable $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/Migration/FixBackgroundJobs.php
+++ b/lib/Migration/FixBackgroundJobs.php
@@ -26,13 +26,14 @@ declare(strict_types=1);
 namespace OCA\Mail\Migration;
 
 use OCA\Mail\BackgroundJob\SyncJob;
+use OCA\Mail\BackgroundJob\TrainImportanceClassifierJob;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
 use OCP\BackgroundJob\IJobList;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
-class FixAccountSyncs implements IRepairStep {
+class FixBackgroundJobs implements IRepairStep {
 
 	/** @var IJobList */
 	private $jobList;
@@ -45,7 +46,7 @@ class FixAccountSyncs implements IRepairStep {
 	}
 
 	public function getName(): string {
-		return 'Insert sync background job for all accounts';
+		return 'Insert background jobs for all accounts';
 	}
 
 	public function run(IOutput $output) {
@@ -53,12 +54,11 @@ class FixAccountSyncs implements IRepairStep {
 		$accounts = $this->mapper->getAllAccounts();
 
 		$output->startProgress(count($accounts));
-
 		foreach ($accounts as $account) {
 			$this->jobList->add(SyncJob::class, ['accountId' => $account->getId()]);
+			$this->jobList->add(TrainImportanceClassifierJob::class, ['accountId' => $account->getId()]);
 			$output->advance();
 		}
-
 		$output->finishProgress();
 	}
 }

--- a/lib/Migration/Version1040Date20200506111214.php
+++ b/lib/Migration/Version1040Date20200506111214.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1040Date20200506111214 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->createTable('mail_classifiers');
+		$table->addColumn('id', 'integer', [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('account_id', 'integer', [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('type', 'string', [
+			'notnull' => true,
+			'length' => 255,
+		]);
+		$table->addColumn('estimator', 'string', [
+			'notnull' => true,
+			'length' => 255,
+		]);
+		$table->addColumn('app_version', 'string', [
+			'notnull' => true,
+			'length' => 31,
+		]);
+		$table->addColumn('training_set_size', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$table->addColumn('validation_set_size', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$table->addColumn('recall_important', 'decimal', [
+			'notnull' => true,
+			'precision' => 10,
+			'scale' => 5,
+		]);
+		$table->addColumn('precision_important', 'decimal', [
+			'notnull' => true,
+			'precision' => 10,
+			'scale' => 5,
+		]);
+		$table->addColumn('f1_score_important', 'decimal', [
+			'notnull' => true,
+			'precision' => 10,
+			'scale' => 5,
+		]);
+		$table->addColumn('duration', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$table->addColumn('active', 'boolean', [
+			'notnull' => true,
+			'default' => false,
+		]);
+		$table->addColumn('created_at', 'integer', [
+			'notnull' => true,
+			'length' => 4,
+		]);
+
+		$table->setPrimaryKey(['id']);
+		$table->addIndex(['account_id', 'type'], 'mail_clssfr_accnt_id_type');
+
+		return $schema;
+	}
+}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Service;
 
 use OCA\Mail\Account;
 use OCA\Mail\BackgroundJob\SyncJob;
+use OCA\Mail\BackgroundJob\TrainImportanceClassifierJob;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Exception\ClientException;
@@ -131,8 +132,9 @@ class AccountService {
 	public function save(MailAccount $newAccount): MailAccount {
 		$newAccount = $this->mapper->save($newAccount);
 
-		// Insert a background sync job for this account
+		// Insert background jobs for this account
 		$this->jobList->add(SyncJob::class, ['accountId' => $newAccount->getId()]);
+		$this->jobList->add(TrainImportanceClassifierJob::class, ['accountId' => $newAccount->getId()]);
 
 		return $newAccount;
 	}

--- a/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Classification\FeatureExtraction;
+
+use OCA\Mail\Account;
+use function array_filter;
+
+/**
+ * Combines a set of DI'ed extractors so they can be used as one class
+ */
+class CompositeExtractor {
+
+	/** @var IExtractor[] */
+	private $extractors;
+
+	/** @var IExtractor[] */
+	private $applicableExtractors;
+
+	public function __construct(ImportantMessagesExtractor $ex1,
+								ReadMessagesExtractor $ex2,
+								RepliedMessagesExtractor $ex3,
+								SentMessagesExtractor $ex4) {
+		$this->extractors = [
+			$ex1,
+			$ex2,
+			$ex3,
+			$ex4,
+		];
+	}
+
+	public function prepare(Account $account,
+							array $incomingMailboxes,
+							array $outgoingMailboxes,
+							array $messages): void {
+		$this->applicableExtractors = array_filter(
+			$this->extractors,
+			function (IExtractor $extractor) use ($account, $incomingMailboxes, $outgoingMailboxes, $messages) {
+				return $extractor->prepare($account, $incomingMailboxes, $outgoingMailboxes, $messages);
+			}
+		);
+	}
+
+	public function extract(string $email): array {
+		return array_map(function (IExtractor $extractor) use ($email) {
+			return $extractor->extract($email);
+		}, $this->applicableExtractors);
+	}
+}

--- a/lib/Service/Classification/FeatureExtraction/IExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/IExtractor.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Classification\FeatureExtraction;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\Message;
+
+interface IExtractor {
+
+	/**
+	 * Initialize any data that is used for all messages and return whether the
+	 * extractor is applicable for this account
+	 *
+	 * @param Account $account
+	 * @param Mailbox[] $incomingMailboxes
+	 * @param Mailbox[] $outgoingMailboxes
+	 * @param Message[] $messages
+	 *
+	 * @return bool
+	 */
+	public function prepare(Account $account,
+							array $incomingMailboxes,
+							array $outgoingMailboxes,
+							array $messages): bool;
+
+	/**
+	 * Return the feature value for the given sender address
+	 *
+	 * @param string $email
+	 *
+	 * @return float
+	 */
+	public function extract(string $email): float;
+}

--- a/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Classification\FeatureExtraction;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\StatisticsDao;
+use function array_map;
+use function array_unique;
+
+class RepliedMessagesExtractor implements IExtractor {
+
+	/** @var StatisticsDao */
+	private $statisticsDao;
+
+	/** @var int[] */
+	private $totalMessages;
+
+	/** @var int[] */
+	private $repliedMessages;
+
+	public function __construct(StatisticsDao $statisticsDao) {
+		$this->statisticsDao = $statisticsDao;
+	}
+
+	public function prepare(Account $account,
+							array $incomingMailboxes,
+							array $outgoingMailboxes,
+							array $messages): bool {
+		$senders = array_unique(array_map(function (Message $message) {
+			return $message->getFrom()->first()->getEmail();
+		}, $messages));
+
+		$this->totalMessages = $this->statisticsDao->getNumberOfMessagesGrouped($incomingMailboxes, $senders);
+		$this->repliedMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'answered', $senders);
+
+		return true;
+	}
+
+	public function extract(string $email): float {
+		$total = $this->totalMessages[$email] ?? 0;
+
+		// Prevent division by zero and just say no emails are read
+		if ($total === 0) {
+			return 0;
+		}
+
+		return ($this->repliedMessages[$email] ?? 0) / $total;
+	}
+}

--- a/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
@@ -23,46 +23,45 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace OCA\Mail\Service\Classification;
+namespace OCA\Mail\Service\Classification\FeatureExtraction;
 
 use OCA\Mail\Account;
-use OCA\Mail\Db\Mailbox;
-use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\StatisticsDao;
-use OCP\AppFramework\Db\DoesNotExistException;
+use function array_map;
+use function array_unique;
 
-class OftenReadSenderClassifier extends AClassifier {
-	use SafeRatio;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
+class SentMessagesExtractor implements IExtractor {
 
 	/** @var StatisticsDao */
 	private $statisticsDao;
 
-	public function __construct(MailboxMapper $mailboxMapper,
-								StatisticsDao $statisticsDao) {
-		$this->mailboxMapper = $mailboxMapper;
+	/** @var int */
+	private $messagesSentTotal = 0;
+
+	/** @var int[] */
+	private $messagesSent;
+
+	public function __construct(StatisticsDao $statisticsDao) {
 		$this->statisticsDao = $statisticsDao;
 	}
 
-	public function isImportant(Account $account, Mailbox $mailbox, Message $message): bool {
-		$sender = $message->getTo()->first();
-		if ($sender === null) {
-			return false;
-		}
+	public function prepare(Account $account,
+							array $incomingMailboxes,
+							array $outgoingMailboxes,
+							array $messages): bool {
+		$senders = array_unique(array_map(function (Message $message) {
+			return $message->getFrom()->first()->getEmail();
+		}, $messages));
 
-		try {
-			$mb = $this->mailboxMapper->findSpecial($account, 'inbox');
-		} catch (DoesNotExistException $e) {
-			return false;
-		}
+		$this->messagesSentTotal = $this->statisticsDao->getMessagesTotal(...$outgoingMailboxes);
+		$this->messagesSent = $this->statisticsDao->getMessagesSentToGrouped($outgoingMailboxes, $senders);
 
-		return $this->greater(
-			$this->statisticsDao->getNrOfReadMessages($mb, $sender->getEmail()),
-			$this->statisticsDao->getNumberOfMessages($mb, $sender->getEmail()),
-			0.7
-		);
+		// This extractor is only applicable if there are sent messages
+		return $this->messagesSentTotal > 0;
+	}
+
+	public function extract(string $email): float {
+		return ($this->messagesSent[$email] ?? 0) / $this->messagesSentTotal;
 	}
 }

--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Classification;
+
+use Horde_Imap_Client;
+use OCA\Mail\Account;
+use OCA\Mail\Db\Classifier;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Exception\ClassifierTrainingException;
+use OCA\Mail\Service\Classification\FeatureExtraction\CompositeExtractor;
+use OCA\Mail\Support\PerformanceLogger;
+use OCA\Mail\Vendor\Phpml\Classification\NaiveBayes;
+use OCA\Mail\Vendor\Phpml\Estimator;
+use OCA\Mail\Vendor\Phpml\Metric\ClassificationReport;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\ILogger;
+use RuntimeException;
+use function array_column;
+use function array_combine;
+use function array_filter;
+use function array_map;
+use function array_slice;
+use function json_encode;
+
+class ImportanceClassifier {
+
+	/**
+	 * Mailbox special uses to exclude from the training
+	 */
+	private const EXEMPT_FROM_TRAINING = [
+		Horde_Imap_Client::SPECIALUSE_ALL,
+		Horde_Imap_Client::SPECIALUSE_DRAFTS,
+		Horde_Imap_Client::SPECIALUSE_FLAGGED,
+		Horde_Imap_Client::SPECIALUSE_JUNK,
+		Horde_Imap_Client::SPECIALUSE_SENT,
+		Horde_Imap_Client::SPECIALUSE_TRASH,
+	];
+
+	/**
+	 * @var string label for data sets that are classified as important
+	 */
+	private const LABEL_IMPORTANT = 'i';
+
+	/**
+	 * @var string label for data sets that are classified as not important
+	 */
+	private const LABEL_NOT_IMPORTANT = 'ni';
+
+	/**
+	 * The maximum number of data sets to train the classifier with
+	 */
+	private const MAX_TRAINING_SET_SIZE = 1000;
+
+	/** @var MailboxMapper */
+	private $mailboxMapper;
+
+	/** @var MessageMapper */
+	private $messageMapper;
+
+	/** @var CompositeExtractor */
+	private $extractor;
+
+	/** @var PersistenceService */
+	private $persistenceService;
+
+	/** @var PerformanceLogger */
+	private $performanceLogger;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(MailboxMapper $mailboxMapper,
+								MessageMapper $messageMapper,
+								CompositeExtractor $extractor,
+								PersistenceService $persistenceService,
+								PerformanceLogger $performanceLogger,
+								ILogger $logger) {
+		$this->mailboxMapper = $mailboxMapper;
+		$this->messageMapper = $messageMapper;
+		$this->extractor = $extractor;
+		$this->persistenceService = $persistenceService;
+		$this->performanceLogger = $performanceLogger;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Train an account's classifier of important messages
+	 *
+	 * Train a classifier based on a user's existing messages to be able to derive
+	 * importance markers for new incoming messages.
+	 *
+	 * To factor in (server-side) filtering into multiple mailboxes, the algorithm
+	 * will not only look for messages in the inbox but also other non-special
+	 * mailboxes.
+	 *
+	 * To prevent memory exhaustion, the process will only load a fixed maximum
+	 * number of messages per account.
+	 *
+	 * @param Account $account
+	 */
+	public function train(Account $account): void {
+		$perf = $this->performanceLogger->start('importance classifier training');
+		$incomingMailboxes = $this->getIncomingMailboxes($account);
+		$perf->step('find incoming mailboxes');
+		$outgoingMailboxes = $this->getOutgoingMailboxes($account);
+		$perf->step('find outgoing mailboxes');
+
+		$mailboxIds = array_map(function (Mailbox $mailbox) {
+			return $mailbox->getId();
+		}, $incomingMailboxes);
+		$messages = array_filter(
+			$this->messageMapper->findLatestMessages($mailboxIds, self::MAX_TRAINING_SET_SIZE),
+			function (Message $message) {
+				return $message->getFrom()->first() !== null;
+			}
+		);
+		$importantMessages = array_filter($messages, function (Message $message) {
+			return $message->getFlagImportant();
+		});
+		if (empty($importantMessages)) {
+			$this->logger->warning('not enough messages to train a classifier');
+			$perf->end();
+			return;
+		}
+		$perf->step('find latest ' . self::MAX_TRAINING_SET_SIZE . ' messages');
+
+		$dataSet = $this->getFeaturesAndImportance($account, $incomingMailboxes, $outgoingMailboxes, $messages);
+		$perf->step('extract features from messages');
+
+		/**
+		 * How many of the most recent messages are excluded from training?
+		 */
+		$validationThreshold = max(
+			5,
+			(int)(count($dataSet) * 0.1)
+		);
+		$validationSet = array_slice($dataSet, 0, $validationThreshold);
+		$trainingSet = array_slice($dataSet, $validationThreshold);
+		if (empty($validationSet) || empty($trainingSet)) {
+			$this->logger->warning('not enough messages to train a classifier');
+			$perf->end();
+			return;
+		}
+		$validationEstimator = $this->trainClassifier($trainingSet);
+		try {
+			$classifier = $this->validateClassifier($validationEstimator, $trainingSet, $validationSet);
+		} catch (ClassifierTrainingException $e) {
+			$this->logger->logException($e, [
+				'message' => 'Importance classifier training failed: ' . $e->getMessage(),
+			]);
+			$perf->end();
+			return;
+		}
+		$perf->step("train and validate classifier with training and validation sets");
+
+		$estimator = $this->trainClassifier($dataSet);
+		$perf->step("train classifier with full data set");
+
+		$classifier->setAccountId($account->getId());
+		$classifier->setDuration($perf->end());
+		$this->persistenceService->persist($classifier, $estimator);
+	}
+
+	/**
+	 * @param Account $account
+	 *
+	 * @return Mailbox[]
+	 */
+	private function getIncomingMailboxes(Account $account): array {
+		return array_filter($this->mailboxMapper->findAll($account), function (Mailbox $mailbox) {
+			foreach (self::EXEMPT_FROM_TRAINING as $excluded) {
+				if ($mailbox->isSpecialUse($excluded)) {
+					return false;
+				}
+			}
+			return true;
+		});
+	}
+
+	/**
+	 * @param Account $account
+	 *
+	 * @return Mailbox[]
+	 * @todo allow more than one outgoing mailbox
+	 */
+	private function getOutgoingMailboxes(Account $account): array {
+		try {
+			return [
+				$this->mailboxMapper->findSpecial($account, 'sent')
+			];
+		} catch (DoesNotExistException $e) {
+			return [];
+		}
+	}
+
+	/**
+	 * Get the feature vector of every message
+	 *
+	 * @param Account $account
+	 * @param Mailbox[] $incomingMailboxes
+	 * @param Mailbox[] $outgoingMailboxes
+	 * @param Message[] $messages
+	 *
+	 * @return array
+	 */
+	private function getFeaturesAndImportance(Account $account,
+											  array $incomingMailboxes,
+											  array $outgoingMailboxes,
+											  array $messages): array {
+		$this->extractor->prepare($account, $incomingMailboxes, $outgoingMailboxes, $messages);
+
+		return array_map(function (Message $message) {
+			$sender = $message->getFrom()->first();
+			if ($sender === null) {
+				throw new RuntimeException("This should not happen");
+			}
+
+			return [
+				'features' => $this->extractor->extract($sender->getEmail()),
+				'label' => $message->getFlagImportant() ? self::LABEL_IMPORTANT : self::LABEL_NOT_IMPORTANT,
+				'sender' => $sender->getEmail(),
+			];
+		}, $messages);
+	}
+
+	/**
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 * @param Message[] $messages
+	 *
+	 * @return array
+	 */
+	public function classifyImportance(Account $account, Mailbox $mailbox, array $messages): array {
+		$estimator = $this->persistenceService->loadLatest($account);
+		if ($estimator === null) {
+			// TODO: fallback to rules-based classification
+			return [];
+		}
+
+		$features = $this->getFeaturesAndImportance(
+			$account,
+			$this->getIncomingMailboxes($account),
+			$this->getOutgoingMailboxes($account),
+			$messages
+		);
+		$predictions = $estimator->predict(array_column($features, 'features'));
+		return array_combine(
+			array_map(function (Message $m) {
+				return $m->getUid();
+			}, $messages),
+			array_map(function ($p) {
+				return $p === self::LABEL_IMPORTANT;
+			}, $predictions)
+		);
+	}
+
+	private function trainClassifier(array $trainingSet): Estimator {
+		$classifier = new NaiveBayes();
+		$classifier->train(
+			array_column($trainingSet, 'features'),
+			array_column($trainingSet, 'label')
+		);
+		return $classifier;
+	}
+
+	/**
+	 * @param Estimator $estimator
+	 * @param array $trainingSet
+	 * @param array $validationSet
+	 *
+	 * @return Classifier
+	 * @throws ClassifierTrainingException
+	 */
+	private function validateClassifier(Estimator $estimator,
+										array $trainingSet,
+										array $validationSet): Classifier {
+		$predictedValidationLabel = $estimator->predict(array_column($validationSet, 'features'));
+		$report = new ClassificationReport($predictedValidationLabel, array_column($validationSet, 'label'));
+		/**
+		 * What we care most is the percentage of messages classified as important in relation to the truly important messages
+		 * as we want to have a classification that rather flags too much as important that too little.
+		 *
+		 * The f1 score tells us how balanced the results are, as in, if the classifier blindly detects messages as important
+		 * or if there is some a pattern it.
+		 *
+		 * Ref https://en.wikipedia.org/wiki/Precision_and_recall
+		 * Ref https://en.wikipedia.org/wiki/F1_score
+		 */
+		$this->logger->debug("classification report: " . json_encode([
+			'recall' => $report->getRecall(),
+			'precision' => $report->getPrecision(),
+			'f1Score' => $report->getF1score(),
+		]));
+		if (($recallImportant = $report->getRecall()[self::LABEL_IMPORTANT] ?? null) === null) {
+			throw new ClassifierTrainingException("Importance recall is null");
+		}
+		if (($precisionImportant = $report->getPrecision()[self::LABEL_IMPORTANT] ?? null) === null) {
+			throw new ClassifierTrainingException("Importance recall is null");
+		}
+		if (($f1ScoreImportant = $report->getF1score()[self::LABEL_IMPORTANT] ?? null) === null) {
+			throw new ClassifierTrainingException("Importance recall is null");
+		}
+		$this->logger->debug("classifier validated: recall(important)=$recallImportant, precision(important)=$precisionImportant f1(important)=$f1ScoreImportant");
+
+		$classifier = new Classifier();
+		$classifier->setType(Classifier::TYPE_IMPORTANCE);
+		$classifier->setTrainingSetSize(count($trainingSet));
+		$classifier->setValidationSetSize(count($validationSet));
+		$classifier->setRecallImportant($recallImportant);
+		$classifier->setPrecisionImportant($precisionImportant);
+		$classifier->setF1ScoreImportant($f1ScoreImportant);
+		return $classifier;
+	}
+}

--- a/lib/Service/Classification/OftenImportantSenderClassifier.php
+++ b/lib/Service/Classification/OftenImportantSenderClassifier.php
@@ -26,13 +26,11 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Classification;
 
 use OCA\Mail\Account;
-use OCA\Mail\Address;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\StatisticsDao;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
 
 class OftenImportantSenderClassifier extends AClassifier {
 	use SafeRatio;
@@ -40,13 +38,13 @@ class OftenImportantSenderClassifier extends AClassifier {
 	/** @var MailboxMapper */
 	private $mailboxMapper;
 
-	/** @var IDBConnection */
-	private $db;
+	/** @var StatisticsDao */
+	private $statisticsDao;
 
 	public function __construct(MailboxMapper $mailboxMapper,
-								IDBConnection $db) {
+								StatisticsDao $statisticsDao) {
 		$this->mailboxMapper = $mailboxMapper;
-		$this->db = $db;
+		$this->statisticsDao = $statisticsDao;
 	}
 
 	public function isImportant(Account $account, Mailbox $mailbox, Message $message): bool {
@@ -62,42 +60,9 @@ class OftenImportantSenderClassifier extends AClassifier {
 		}
 
 		return $this->greater(
-			$this->getNrOfImportantMessages($mb, $sender->getEmail()),
-			$this->getNumberOfMessages($mb, $sender->getEmail()),
+			$this->statisticsDao->getNrOfImportantMessages($mb, $sender->getEmail()),
+			$this->statisticsDao->getNumberOfMessages($mb, $sender->getEmail()),
 			0.3
 		);
-	}
-
-	private function getNrOfImportantMessages(Mailbox $mb, string $email): int {
-		$qb = $this->db->getQueryBuilder();
-
-		$select = $qb->select($qb->func()->count('*'))
-			->from('mail_recipients', 'r')
-			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
-			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', $qb->expr()->castColumn('m.mailbox_id', IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('m.flag_important', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
-			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
-		$cnt = $result->fetchColumn();
-		$result->closeCursor();
-		return (int)$cnt;
-	}
-
-	private function getNumberOfMessages(Mailbox $mb, string $email): int {
-		$qb = $this->db->getQueryBuilder();
-
-		$select = $qb->select($qb->func()->count('*'))
-			->from('mail_recipients', 'r')
-			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
-			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', $qb->expr()->castColumn('m.mailbox_id', IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
-		$cnt = $result->fetchColumn();
-		$result->closeCursor();
-		return (int)$cnt;
 	}
 }

--- a/lib/Service/Classification/OftenRepliedSenderClassifier.php
+++ b/lib/Service/Classification/OftenRepliedSenderClassifier.php
@@ -26,13 +26,11 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Classification;
 
 use OCA\Mail\Account;
-use OCA\Mail\Address;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\StatisticsDao;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\DB\QueryBuilder\IQueryBuilder;
-use OCP\IDBConnection;
 
 class OftenRepliedSenderClassifier extends AClassifier {
 	use SafeRatio;
@@ -40,13 +38,13 @@ class OftenRepliedSenderClassifier extends AClassifier {
 	/** @var MailboxMapper */
 	private $mailboxMapper;
 
-	/** @var IDBConnection */
-	private $db;
+	/** @var StatisticsDao */
+	private $statisticsDao;
 
 	public function __construct(MailboxMapper $mailboxMapper,
-								IDBConnection $db) {
+								StatisticsDao $statisticsDao) {
 		$this->mailboxMapper = $mailboxMapper;
-		$this->db = $db;
+		$this->statisticsDao = $statisticsDao;
 	}
 
 	public function isImportant(Account $account, Mailbox $mailbox, Message $message): bool {
@@ -62,42 +60,9 @@ class OftenRepliedSenderClassifier extends AClassifier {
 		}
 
 		return $this->greater(
-			$this->getNrOfRepliedMessages($mb, $sender->getEmail()),
-			$this->getNumberOfMessages($mb, $sender->getEmail()),
+			$this->statisticsDao->getNrOfRepliedMessages($mb, $sender->getEmail()),
+			$this->statisticsDao->getNumberOfMessages($mb, $sender->getEmail()),
 			0.1
 		);
-	}
-
-	private function getNrOfRepliedMessages(Mailbox $mb, string $email): int {
-		$qb = $this->db->getQueryBuilder();
-
-		$select = $qb->select($qb->func()->count('*'))
-			->from('mail_recipients', 'r')
-			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
-			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', $qb->expr()->castColumn('m.mailbox_id', IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('m.flag_answered', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
-			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
-		$cnt = $result->fetchColumn();
-		$result->closeCursor();
-		return (int)$cnt;
-	}
-
-	private function getNumberOfMessages(Mailbox $mb, string $email): int {
-		$qb = $this->db->getQueryBuilder();
-
-		$select = $qb->select($qb->func()->count('*'))
-			->from('mail_recipients', 'r')
-			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
-			->join('r', 'mail_mailboxes', 'mb', $qb->expr()->eq('mb.id', $qb->expr()->castColumn('m.mailbox_id', IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->eq('mb.id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
-		$cnt = $result->fetchColumn();
-		$result->closeCursor();
-		return (int)$cnt;
 	}
 }

--- a/lib/Service/Classification/PersistenceService.php
+++ b/lib/Service/Classification/PersistenceService.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Classification;
+
+use OCA\Mail\Account;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\Db\Classifier;
+use OCA\Mail\Db\ClassifierMapper;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Vendor\Phpml\Estimator;
+use OCA\Mail\Vendor\Phpml\Exception\FileException;
+use OCA\Mail\Vendor\Phpml\Exception\SerializeException;
+use OCA\Mail\Vendor\Phpml\ModelManager;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\ICacheFactory;
+use OCP\ITempManager;
+use function file_get_contents;
+use function file_put_contents;
+use function get_class;
+
+class PersistenceService {
+	private const ADD_DATA_FOLDER = 'classifiers';
+
+	/** @var ClassifierMapper */
+	private $mapper;
+
+	/** @var IAppData */
+	private $appData;
+
+	/** @var ITempManager */
+	private $tempManager;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/** @var ModelManager */
+	private $modelManager;
+
+	/** @var IAppManager */
+	private $appManager;
+
+	/** @var ICacheFactory */
+	private $cacheFactory;
+
+	public function __construct(ClassifierMapper $mapper,
+								IAppData $appData,
+								ITempManager $tempManager,
+								ITimeFactory $timeFactory,
+								ModelManager $modelManager,
+								IAppManager $appManager,
+								ICacheFactory $cacheFactory) {
+		$this->mapper = $mapper;
+		$this->appData = $appData;
+		$this->tempManager = $tempManager;
+		$this->timeFactory = $timeFactory;
+		$this->modelManager = $modelManager;
+		$this->appManager = $appManager;
+		$this->cacheFactory = $cacheFactory;
+	}
+
+	/**
+	 * Persist the classifier data to the database and the estimator to storage
+	 *
+	 * @param Classifier $classifier
+	 * @param Estimator $estimator
+	 *
+	 * @throws ServiceException
+	 */
+	public function persist(Classifier $classifier, Estimator $estimator): void {
+		/*
+		 * First we have to insert the row to get the unique ID, but disable
+		 * it until the model is persisted as well. Otherwise another process
+		 * might try to load the model in the meantime and run into an error
+		 * due to the missing data in app data.
+		 */
+		$classifier->setAppVersion($this->appManager->getAppVersion(Application::APP_ID));
+		$classifier->setEstimator(get_class($estimator));
+		$classifier->setActive(false);
+		$classifier->setCreatedAt($this->timeFactory->getTime());
+		$this->mapper->insert($classifier);
+
+		/*
+		 * Then we serialize the estimator into a temporary file
+		 */
+		$tmpPath = $this->tempManager->getTemporaryFile();
+		try {
+			$this->modelManager->saveToFile($estimator, $tmpPath);
+		} catch (FileException|SerializeException $e) {
+			throw new ServiceException("Could not serialize classifier: " . $e->getMessage(), 0, $e);
+		}
+
+		/*
+		 * Then we store the serialized model to app data
+		 */
+		try {
+			try {
+				$folder = $this->appData->getFolder(self::ADD_DATA_FOLDER);
+			} catch (NotFoundException $e) {
+				$folder = $this->appData->newFolder(self::ADD_DATA_FOLDER);
+			}
+			$folder->newFile($classifier->getId(), file_get_contents($tmpPath));
+		} catch (NotPermittedException $e) {
+			throw new ServiceException("Could not create classifiers directory: " . $e->getMessage(), 0, $e);
+		}
+
+		/*
+		 * Now we set the model active so it can be used by the next request
+		 */
+		$classifier->setActive(true);
+		$this->mapper->update($classifier);
+	}
+
+	public function loadLatest(Account $account): ?Estimator {
+		try {
+			$latestModel = $this->mapper->findLatest($account->getId());
+		} catch (DoesNotExistException $e) {
+			return null;
+		}
+		return $this->load($latestModel->getId());
+	}
+
+	public function load(int $id): Estimator {
+		$cached = $this->getCached($id);
+		if ($cached !== null) {
+			$serialized = $cached;
+		} else {
+			try {
+				$modelsFolder = $this->appData->getFolder(self::ADD_DATA_FOLDER);
+				$modelFile = $modelsFolder->getFile((string)$id);
+			} catch (NotFoundException $e) {
+				throw new ServiceException("Could not load classifier $id: " . $e->getMessage(), 0, $e);
+			}
+
+			$serialized = $modelFile->getContent();
+
+			$this->cache($id, $serialized);
+		}
+
+		$tmpPath = $this->tempManager->getTemporaryFile();
+		file_put_contents($tmpPath, $serialized);
+
+		try {
+			$estimator = $this->modelManager->restoreFromFile($tmpPath);
+		} catch (SerializeException $e) {
+			throw new ServiceException("Could not deserialize persisted classifier $id: " . $e->getMessage(), 0, $e);
+		}
+
+		return $estimator;
+	}
+
+	private function getCacheKey(int $id): string {
+		return "mail_classifier_$id";
+	}
+
+	private function getCached(int $id): ?string {
+		if (!$this->cacheFactory->isLocalCacheAvailable()) {
+			return null;
+		}
+		$cache = $this->cacheFactory->createLocal();
+
+		return $cache->get(
+			$this->getCacheKey($id)
+		);
+	}
+
+	private function cache(int $id, string $serialized): void {
+		if (!$this->cacheFactory->isLocalCacheAvailable()) {
+			return;
+		}
+		$cache = $this->cacheFactory->createLocal();
+		$cache->set($this->getCacheKey($id), $serialized);
+	}
+}

--- a/lib/Support/PerformanceLoggerTask.php
+++ b/lib/Support/PerformanceLoggerTask.php
@@ -64,10 +64,12 @@ class PerformanceLoggerTask {
 		$this->rel = $now;
 	}
 
-	public function end(): void {
+	public function end(): int {
 		$now = $this->timeFactory->getTime();
 		$passed = $now - $this->start;
 
 		$this->logger->debug($this->task . " took ${passed}s");
+
+		return $passed;
 	}
 }


### PR DESCRIPTION
This is the ML-based importance classifier discussed in the previous dev calls. It does classify your latest 1000 messages of any *incoming* mailboxes (no draft, sent, junk, "all").

This version still has the problem of the *cold start*, as in it will not learn any useful patterns as long as you have few or no important messages. As you tag more of them manually, the system will adapt to your preferences. The cold start workaround will come in a follow-up PR because this one is already quite a beast.