### PR TITLE
Fix mailvelope integration by switching to the API version

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -316,10 +316,6 @@
 .mailaccount-list .actions {
 	opacity: .5;
 }
-.app-settings-hint {
-	margin-top: 15px;
-	color: #555;
-}
 
 /* icons */
 .icon-inbox {

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -48,12 +48,6 @@
 				{{ t('mail', 'Keyboard shortcuts') }}
 			</router-link>
 		</p>
-
-		<p class="app-settings-hint app-settings-link">
-			<a href="https://www.mailvelope.com/" target="_blank">{{
-				t('mail', 'Looking for a way to encrypt your emails? Install the Mailvelope browser extension!')
-			}}</a>
-		</p>
 	</div>
 </template>
 

--- a/src/components/MailvelopeEditor.vue
+++ b/src/components/MailvelopeEditor.vue
@@ -1,0 +1,82 @@
+<!--
+  - @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div id="mailvelope-composer"></div>
+</template>
+
+<script>
+import logger from '../logger'
+import {isPgpgMessage} from '../crypto/pgp'
+
+export default {
+	name: 'MailvelopeEditor',
+	props: {
+		value: {
+			type: String,
+			required: true,
+		},
+		recipients: {
+			type: Array,
+			required: true,
+		},
+		quotedText: {
+			type: Object,
+			required: false,
+			default: () => undefined,
+		},
+		isReplyOrForward: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			editor: undefined,
+		}
+	},
+	async mounted() {
+		const isEncrypted = this.quotedText ? isPgpgMessage(this.quotedText) : false
+		const quotedMail = this.isReplyOrForward ? this.quotedText?.value : undefined
+
+		this.editor = await window.mailvelope.createEditorContainer('#mailvelope-composer', undefined, {
+			quotedMail: isEncrypted ? quotedMail : undefined,
+		})
+	},
+	methods: {
+		async pull() {
+			const recipients = this.recipients.map((r) => r.email)
+			logger.info('encrypting message', {recipients})
+			const armored = await this.editor.encrypt(recipients)
+			logger.info('message encryted', {armored})
+
+			this.$emit('input', armored)
+		},
+	},
+}
+</script>
+
+<style scoped>
+#mailvelope-composer {
+	width: 100%;
+	height: 450px;
+}
+</style>

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -66,6 +66,7 @@
 					<Itinerary :entries="message.itineraries" :message-id="message.messageId" />
 				</div>
 				<MessageHTMLBody v-if="message.hasHtmlBody" :url="htmlUrl" />
+				<MessageEncryptedBody v-else-if="isEncrypted" :body="message.body" :from="from" />
 				<MessagePlainTextBody v-else :body="message.body" :signature="message.signature" />
 				<Popover v-if="message.attachments[0]" class="attachment-popover">
 					<Actions slot="trigger">
@@ -92,7 +93,10 @@ import AddressList from './AddressList'
 import {buildRecipients as buildReplyRecipients, buildReplySubject} from '../ReplyBuilder'
 import Error from './Error'
 import {getRandomMessageErrorMessage} from '../util/ErrorMessageFactory'
+import {html, plain} from '../util/text'
+import {isPgpgMessage} from '../crypto/pgp'
 import Itinerary from './Itinerary'
+import MessageEncryptedBody from './MessageEncryptedBody'
 import MessageHTMLBody from './MessageHTMLBody'
 import MessagePlainTextBody from './MessagePlainTextBody'
 import Loading from './Loading'
@@ -110,6 +114,7 @@ export default {
 		Itinerary,
 		Loading,
 		MessageAttachments,
+		MessageEncryptedBody,
 		MessageHTMLBody,
 		MessagePlainTextBody,
 		Modal,
@@ -130,6 +135,12 @@ export default {
 		}
 	},
 	computed: {
+		from() {
+			return this.message.from[0]?.email
+		},
+		isEncrypted() {
+			return isPgpgMessage(this.message.hasHtmlBody ? html(this.message.body) : plain(this.message.body))
+		},
 		htmlUrl() {
 			return generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{id}/html', {
 				accountId: this.message.accountId,

--- a/src/components/MessageEncryptedBody.vue
+++ b/src/components/MessageEncryptedBody.vue
@@ -1,0 +1,42 @@
+<template>
+	<div>
+		<div v-if="mailvelope" id="mail-content"></div>
+		<span v-else>{{ t('mail', 'This message is encrypted with PGP. Install Mailvelope to decrypt it.') }}</span>
+	</div>
+</template>
+
+<script>
+import {getMailvelope} from '../crypto/mailvelope'
+
+export default {
+	name: 'MessageEncryptedBody',
+	props: {
+		body: {
+			type: String,
+			required: true,
+		},
+		from: {
+			type: String,
+			required: false,
+			default: undefined,
+		},
+	},
+	data() {
+		return {
+			mailvelope: false,
+		}
+	},
+	async mounted() {
+		this.mailvelope = await getMailvelope()
+		this.mailvelope.createDisplayContainer('#mail-content', this.body, undefined, {
+			senderAddress: this.from,
+		})
+	},
+}
+</script>
+
+<style scoped>
+#mail-content {
+	height: 450px;
+}
+</style>

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -81,6 +81,7 @@ export default {
 						cc: [],
 						subject: buildReplySubject(message.subject),
 						body: this.originalBody,
+						originalBody: this.originalBody,
 						replyTo: message,
 					}
 				} else if (this.$route.params.messageUid === 'replyAll') {
@@ -97,6 +98,7 @@ export default {
 						cc: recipients.cc,
 						subject: buildReplySubject(message.subject),
 						body: this.originalBody,
+						originalBody: this.originalBody,
 						replyTo: message,
 					}
 				} else {
@@ -107,6 +109,7 @@ export default {
 						cc: [],
 						subject: buildForwardSubject(message.subject),
 						body: this.originalBody,
+						originalBody: this.originalBody,
 						forwardFrom: message,
 					}
 				}

--- a/src/crypto/mailvelope.js
+++ b/src/crypto/mailvelope.js
@@ -1,0 +1,48 @@
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import logger from '../logger'
+
+let mailvelope
+
+const loadMailvelopeStatically = () => window.mailvelope
+
+const loadMailvelopeDynamically = () =>
+	new Promise((res) => {
+		window.addEventListener('mailvelope', () => res(window.mailvelope), false)
+	})
+
+export const getMailvelope = async () => {
+	if (mailvelope) {
+		return mailvelope
+	}
+
+	mailvelope = loadMailvelopeStatically()
+	if (mailvelope) {
+		logger.debug('mailvelope found statically')
+		return mailvelope
+	}
+
+	logger.debug('loading mailvelope dynamically')
+	mailvelope = await loadMailvelopeDynamically()
+	logger.debug('mailvelope found dynamically')
+	return mailvelope
+}

--- a/src/crypto/pgp.js
+++ b/src/crypto/pgp.js
@@ -1,0 +1,29 @@
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import startsWith from 'lodash/fp/startsWith'
+
+/**
+ * @param {Text} message
+ * @return {boolean|*}
+ */
+export const isPgpgMessage = (message) =>
+	message.format === 'plain' && message.value.startsWith('-----BEGIN PGP MESSAGE-----')

--- a/src/tests/unit/crypto/mailvelope.spec.js
+++ b/src/tests/unit/crypto/mailvelope.spec.js
@@ -1,0 +1,49 @@
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {getMailvelope} from '../../../crypto/mailvelope'
+
+describe('mailvelope', () => {
+	afterEach(() => {
+		delete window.mailvelope
+	})
+
+	it('loads statically', async () => {
+		window.mailvelope = {
+			mock: 3,
+		}
+
+		const mailvelope = await getMailvelope()
+
+		expect(mailvelope).to.deep.equal(window.mailvelope)
+	})
+
+	it('loads dynamically', async () => {
+		const p = getMailvelope()
+		window.mailvelope = {
+			mock: 3,
+		}
+		window.dispatchEvent(new Event('mailvelope'))
+
+		const mailvelope = await p
+		expect(mailvelope).to.deep.equal(window.mailvelope)
+	})
+})

--- a/src/tests/unit/crypto/pgp.spec.js
+++ b/src/tests/unit/crypto/pgp.spec.js
@@ -1,0 +1,49 @@
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {isPgpgMessage} from '../../../crypto/pgp'
+import {html, plain} from '../../../util/text'
+
+describe('pgp', () => {
+	it('detects non-pgp messages', () => {
+		const messages = plain('Hi Alice')
+
+		const isPgp = isPgpgMessage(messages)
+
+		expect(isPgp).to.equal(false)
+	})
+
+	it('detects non-pgp HTML messages', () => {
+		const messages = html('Hi Alice')
+
+		const isPgp = isPgpgMessage(messages)
+
+		expect(isPgp).to.equal(false)
+	})
+
+	it('detects a pgp message', () => {
+		const message = plain('-----BEGIN PGP MESSAGE-----\nVersion: Mailvelope v4.3.1')
+
+		const isPgp = isPgpgMessage(message)
+
+		expect(isPgp).to.equal(true)
+	})
+})


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2745

- [x] Send new message
  - [x] Disable link attachments for encrypted email
  - [ ] ~~Disable unencrypted attachments?~~ let's leave them for now
- [x] Read encrypted message
- [x] Reply/forward encrypted message
- [x] Move Mailvelope hint from the settings menu to the composer actions