### PR TITLE
Make loading spinner not move all messages

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -47,7 +47,12 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+div {
+	// So we can align the loading spinner in the Priority inbox
+	position: relative;
+}
+
 #load-more-mail-messages {
 	margin: 10px auto;
 	padding: 10px;
@@ -62,15 +67,24 @@ export default {
 }
 
 #list-refreshing {
-	overflow-y: hidden;
-	min-height: 0;
-	transition-property: all;
+	position: absolute;
+	left: calc(50% - 8px);
+	overflow: hidden;
+	padding: 12px;
+	background-color: var(--color-main-background);
+	z-index: 1;
+	border-radius: var(--border-radius-pill);
+	border: 1px solid var(--color-border);
+	top: -24px;
+	opacity: 0;
+	transition-property: top, opacity;
 	transition-duration: 0.5s;
 	transition-timing-function: ease-in-out;
-}
 
-#list-refreshing.refreshing {
-	min-height: 32px;
+	&.refreshing {
+		top: 4px;
+		opacity: 1;
+	}
 }
 
 .list-enter-active,


### PR DESCRIPTION
Use more of a Material-Design-ish approach here, simply overlapping the top message a bit.
This prevents any misclicks and also makes the app appear more stable because things don’t just move around:

## Before
![Nextcloud Mail spinner before](https://user-images.githubusercontent.com/925062/81224312-ceebd200-8fe7-11ea-8b4c-4e29091589e3.gif) ![Nextcloud Mail spinner priority before](https://user-images.githubusercontent.com/925062/81224317-d01cff00-8fe7-11ea-8d43-020902ab64d7.gif)

## After
![Nextcloud Mail spinner priority new](https://user-images.githubusercontent.com/925062/81224319-d0b59580-8fe7-11ea-848b-2c848a7ae602.gif) ![Nextcloud Mail spinner new](https://user-images.githubusercontent.com/925062/81224321-d1e6c280-8fe7-11ea-97e0-9a2aac2c0680.gif)
