### PR TITLE
Discussion: what's the down side of caching email?

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -231,7 +231,11 @@ class MessagesController extends Controller {
 			return $this->enrichDownloadUrl($accountId, $folderId, $messageId, $a);
 		}, $json['attachments']);
 
-		return new JSONResponse($json);
+		$response = new JSONResponse($json);
+		$response->addHeader('Cache-Control', 'private, max-age=7776000');
+		$response->addHeader('Pragma', 'private');
+
+		return $response;
 	}
 
 	/**

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -402,6 +402,7 @@ export default {
 				const unifiedFolder = getters.getUnifiedFolder(folder.specialRole)
 
 				syncData.newMessages.forEach((envelope) => {
+					fetchMessage(accountId, folderId, envelope.id)
 					commit('addEnvelope', {
 						accountId,
 						folderId,


### PR DESCRIPTION
This PR is not to be merged but wonder what's the downside of doing this.
I cannot live without this change now as everything opens for me instantly now, but it is clearly just a hack as some parameters could be changed and doesn't match with the cached version.

But I'm wondering if we are actually using the changeable parameters (flags?) when showing the emails.