### PR TITLE
Optimize the background sync logic

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -131,7 +131,6 @@ export default {
 		this.bus.$on('delete', this.onDelete)
 		this.bus.$on('shortcut', this.handleShortcut)
 		this.loadMailboxInterval = setInterval(this.loadMailbox, 60000)
-		window.addEventListener('focus', this.onWindowFocus)
 	},
 	async mounted() {
 		return await this.loadEnvelopes()
@@ -141,7 +140,6 @@ export default {
 		this.bus.$off('delete', this.onDelete)
 		this.bus.$off('shortcut', this.handleShortcut)
 		this.stopInterval()
-		window.removeEventListener('focus', this.onWindowFocus)
 	},
 	methods: {
 		initializeCache() {
@@ -335,12 +333,8 @@ export default {
 					logger.warn('shortcut ' + e.srcKey + ' is unknown. ignoring.')
 			}
 		},
-		async onWindowFocus() {
-			if (!this.refreshing) {
-				await this.sync()
-			}
-		},
 		async sync() {
+			logger.debug("mailbox sync'ing")
 			this.refreshing = true
 
 			try {
@@ -393,7 +387,7 @@ export default {
 			})
 		},
 		async loadMailbox() {
-			//when the account is unified or inbox, return nothing, else sync the mailbox
+			// When the account is unified or inbox, return nothing, else sync the mailbox
 			if (this.account.isUnified || this.folder.specialRole === 'inbox') {
 				return
 			}


### PR DESCRIPTION
Sooo this is what I whined about in the dev channel today

![Bildschirmfoto von 2020-05-07 19-29-55](https://user-images.githubusercontent.com/1374172/81325813-344bcb80-9099-11ea-9c25-773a9f93b49a.png)

Long story short: keeping inboxes up to date is a non-trivial task. Current master does too many sync's IMO, so this reduces the number of (unnecessary) roundtrips a bit.

Most noticeable is that when you lose focus and go back to the Mail window/tab it does not trigger a sync. But only periodically in the background.

The background jobs does these consecutive steps:
* Sync all individual inboxes
* Sync priority inbox sections
* Show the notification

So when you, as a user, see the notification and switch to Mail, the messages will be there already.

Fixes https://github.com/nextcloud/mail/issues/2982 for me. There might still be edge cases but this seems to make it a lot better on  my dev instance.

@nextcloud/mail please give this a test :pray: 