### PR TITLE
Open inbox when clicking on account item

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -33,6 +33,7 @@
 					v-if="group.account"
 					:key="group.account.id"
 					:account="group.account"
+					:first-folder="group.folders[0]"
 					:is-first="isFirst(group.account)"
 					:is-last="isLast(group.account)"
 				/>

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -27,7 +27,8 @@
 		:icon="iconError"
 		:menu-open.sync="menuOpen"
 		:title="account.emailAddress"
-		:to="settingsRoute"
+		:to="firstFolderRoute"
+		exact="true"
 	>
 		<!-- Color dot -->
 		<AppNavigationIconBullet v-if="bulletColor" slot="icon" :color="bulletColor" />
@@ -87,6 +88,10 @@ export default {
 			type: Object,
 			required: true,
 		},
+		firstFolder: {
+			type: Object,
+			required: true,
+		},
 		isFirst: {
 			type: Boolean,
 			default: false,
@@ -114,6 +119,15 @@ export default {
 				name: 'accountSettings',
 				params: {
 					accountId: this.account.id,
+				},
+			}
+		},
+		firstFolderRoute() {
+			return {
+				name: 'folder',
+				params: {
+					accountId: this.account.id,
+					folderId: this.firstFolder.id,
 				},
 			}
 		},


### PR DESCRIPTION
This changes the account item to open the inbox (or technically the first folder) in the list instead of the settings screen.

The only quirk that it currently has is that the account is also marked as active with the inbox. Not sure why, any suggeestion or edits to fix that are welcome.

Closes #2731 