### PR TITLE
Fix onsistency of "important" icon

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -325,6 +325,9 @@
 .icon-inbox {
 	@include icon-color('inbox', 'mail', $color-black);
 }
+.icon-important {
+	@include icon-color('important', 'mail', $color-black);
+}
 .icon-flagged {
 	@include icon-color('star', 'mail', $color-black);
 }

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -177,18 +177,33 @@ export default {
 	z-index: 1;
 }
 
-.app-content-list-item-star.icon-important {
-	left: 7px;
-	top: 13px;
-	opacity: 1;
-	&:hover {
-		opacity: 0.5;
-	}
+.icon-important {
 	::v-deep path {
 		fill: #ffcc00;
 		stroke: var(--color-main-background);
 	}
+	.app-content-list-item:hover &,
+	.app-content-list-item:focus &,
+	.app-content-list-item.active & {
+		::v-deep path {
+			stroke: var(--color-background-dark);
+		}
+	}
+
+	// In message list, but not the one in the action menu
+	&.app-content-list-item-star {
+		background-image: none;
+		left: 7px;
+		top: 13px;
+		opacity: 1;
+
+		&:hover,
+		&:focus {
+			opacity: 0.5;
+		}
+	}
 }
+
 .app-content-list-item.unseen {
 	font-weight: bold;
 }

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -39,7 +39,7 @@
 			<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">{{
 				data.flags.flagged ? t('mail', 'Unfavorite') : t('mail', 'Favorite')
 			}}</ActionButton>
-			<ActionButton icon="icon-info" @click.prevent="onToggleImportant">{{
+			<ActionButton icon="icon-important" @click.prevent="onToggleImportant">{{
 				data.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
 			}}</ActionButton>
 			<ActionButton icon="icon-mail" @click.prevent="onToggleSeen">{{

--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -19,7 +19,7 @@
 					:bus="bus"
 				/>
 				<template v-else>
-					<SectionTitle class="app-content-list-item important" :name="t('mail', 'Priority')" />
+					<SectionTitle class="app-content-list-item important" :name="t('mail', 'Important')" />
 					<Mailbox
 						class="nameimportant"
 						:account="unifiedAccount"

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -152,7 +152,7 @@ export default {
 			if (this.filter === 'starred') {
 				return 'icon-flagged'
 			} else if (this.folder.specialRole === 'priority') {
-				return 'icon-category-monitoring'
+				return 'icon-important'
 			}
 			return this.folder.specialRole ? 'icon-' + this.folder.specialRole : 'icon-folder'
 		},


### PR DESCRIPTION
Fix #2990

- Consistent wording, heading 'Priority' to 'Important'
- Fix important icon border being visible on hover/focus/active
- Use relevant icon-important for the action

Before | After
-|-
![Important icon](https://user-images.githubusercontent.com/925062/80227561-18ced280-864e-11ea-818a-6e633fe04fde.png) | ![important new](https://user-images.githubusercontent.com/925062/81460902-921b0900-91a8-11ea-8d27-86d3d0835ea1.png)

