### PR TITLE
Fix vertical space between sections in priority inbox

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -417,4 +417,13 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+// Fix vertical space between sections in priority inbox
+.nameimportant,
+.namestarred {
+	::v-deep #load-more-mail-messages {
+		margin-top: 0;
+		margin-bottom: 8px;
+	}
+}
+</style>


### PR DESCRIPTION
Before | After
-|-
![vertical space before](https://user-images.githubusercontent.com/925062/81461130-f5f20180-91a9-11ea-89b3-bc1cad3597a8.png) | ![vertical space after](https://user-images.githubusercontent.com/925062/81461110-dfe44100-91a9-11ea-9310-403758f78775.png)
