### PR TITLE
Show only subscribed folders

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.4.0-alpha1</version>
+	<version>1.4.0-alpha2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Roeland Jago Douma</author>

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -185,6 +185,7 @@ class AccountsController extends Controller {
 	 * @param int $accountId
 	 * @param string|null $editorMode
 	 * @param int|null $order
+	 * @param bool|null $showSubscribedOnly
 	 *
 	 * @return JSONResponse
 	 *
@@ -192,7 +193,8 @@ class AccountsController extends Controller {
 	 */
 	public function patchAccount(int $accountId,
 								 string $editorMode = null,
-								 int $order = null): JSONResponse {
+								 int $order = null,
+								 bool $showSubscribedOnly = null): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 
 		if ($account === null) {
@@ -205,6 +207,9 @@ class AccountsController extends Controller {
 		}
 		if ($order !== null) {
 			$dbAccount->setOrder($order);
+		}
+		if ($showSubscribedOnly !== null) {
+			$dbAccount->setShowSubscribedOnly($showSubscribedOnly);
 		}
 		return new JSONResponse(
 			$this->accountService->save($dbAccount)->toJson()

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -67,6 +67,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setProvisioned(bool $provisioned)
  * @method int getOrder()
  * @method void setOrder(int $order)
+ * @method bool getShowSubscribedOnly()
+ * @method void setShowSubscribedOnly(bool $showSubscribedOnly)
  */
 class MailAccount extends Entity {
 	protected $userId;
@@ -87,6 +89,7 @@ class MailAccount extends Entity {
 	protected $editorMode;
 	protected $provisioned;
 	protected $order;
+	protected $showSubscribedOnly;
 
 	/**
 	 * @param array $params
@@ -133,12 +136,16 @@ class MailAccount extends Entity {
 		if (isset($params['smtpPassword'])) {
 			$this->setOutboundPassword($params['smtpPassword']);
 		}
+		if (isset($params['showSubscribedOnly'])) {
+			$this->setShowSubscribedOnly($params['showSubscribedOnly']);
+		}
 
 		$this->addType('inboundPort', 'integer');
 		$this->addType('outboundPort', 'integer');
 		$this->addType('lastMailboxSync', 'integer');
 		$this->addType('provisioned', 'bool');
 		$this->addType('order', 'integer');
+		$this->addType('showSubscribedOnly', 'boolean');
 	}
 
 	/**
@@ -157,6 +164,7 @@ class MailAccount extends Entity {
 			'signature' => $this->getSignature(),
 			'editorMode' => $this->getEditorMode(),
 			'provisioned' => $this->getProvisioned(),
+			'showSubscribedOnly' => $this->getShowSubscribedOnly(),
 		];
 
 		if (!is_null($this->getOutboundHost())) {

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -56,7 +56,7 @@ class FolderMapper {
 	 */
 	public function getFolders(Account $account, Horde_Imap_Client_Socket $client,
 							   string $pattern = '*'): array {
-		$mailboxes = $client->listMailboxes($pattern, Horde_Imap_Client::MBOX_ALL, [
+		$mailboxes = $client->listMailboxes($pattern, Horde_Imap_Client::MBOX_ALL_SUBSCRIBED, [
 			'delimiter' => true,
 			'attributes' => true,
 			'special_use' => true,
@@ -82,7 +82,7 @@ class FolderMapper {
 								 string $name): Folder {
 		$client->createMailbox($name);
 
-		$list = $client->listMailboxes($name, Horde_Imap_Client::MBOX_ALL, [
+		$list = $client->listMailboxes($name, Horde_Imap_Client::MBOX_ALL_SUBSCRIBED, [
 			'delimiter' => true,
 			'attributes' => true,
 			'special_use' => true,

--- a/lib/Migration/Version1040Date20200515080614.php
+++ b/lib/Migration/Version1040Date20200515080614.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1040Date20200515080614 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+
+		$accountsTable->addColumn('show_subscribed_only', 'boolean', [
+			'notnull' => true,
+			'default' => false,
+		]);
+
+		return $schema;
+	}
+}

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -37,6 +37,13 @@
 			<ActionRouter :to="settingsRoute" icon="icon-settings">
 				{{ t('mail', 'Edit account') }}
 			</ActionRouter>
+			<ActionCheckbox
+				:checked="account.showSubscribedOnly"
+				:disabled="savingShowOnlySubscribed"
+				@update:checked="changeShowSubscribedOnly"
+			>
+				{{ t('mail', 'Show only subscribed folders') }}
+			</ActionCheckbox>
 			<ActionInput icon="icon-add" @submit="createFolder">
 				{{ t('mail', 'Add folder') }}
 			</ActionInput>
@@ -58,6 +65,7 @@ import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
 import AppNavigationIconBullet from '@nextcloud/vue/dist/Components/AppNavigationIconBullet'
 import ActionRouter from '@nextcloud/vue/dist/Components/ActionRouter'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import {generateUrl} from '@nextcloud/router'
 
@@ -71,6 +79,7 @@ export default {
 		AppNavigationIconBullet,
 		ActionRouter,
 		ActionButton,
+		ActionCheckbox,
 		ActionInput,
 	},
 	props: {
@@ -93,6 +102,7 @@ export default {
 			loading: {
 				delete: false,
 			},
+			savingShowOnlySubscribed: false,
 		}
 	},
 	computed: {
@@ -174,6 +184,25 @@ export default {
 			this.$store
 				.dispatch('moveAccount', {account: this.account})
 				.catch((error) => logger.error('could not move account down', {error}))
+		},
+		changeShowSubscribedOnly(onlySubscribed) {
+			this.savingShowOnlySubscribed = true
+			this.$store
+				.dispatch('patchAccount', {
+					account: this.account,
+					data: {
+						showSubscribedOnly: onlySubscribed,
+					},
+				})
+				.then(() => {
+					this.savingShowOnlySubscribed = false
+					logger.info('show only subscribed folders updated to ' + onlySubscribed)
+				})
+				.catch((error) => {
+					logger.error('could not update subscription mode', {error})
+					this.savingShowOnlySubscribed = false
+					throw error
+				})
 		},
 	},
 }

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -42,7 +42,12 @@ export default {
 			return 'collapse-' + this.account.id
 		},
 		title() {
-			return this.account.collapsed ? t('mail', 'Show all folders') : t('mail', 'Collapse folders')
+			if (this.account.collapsed && this.account.showSubscribedOnly) {
+				return t('mail', 'Show all subscribed folders')
+			} else if (this.account.collapsed && !this.account.showSubscribedOnly) {
+				return t('mail', 'Show all folders')
+			}
+			return t('mail', 'Collapse folders')
 		},
 	},
 	methods: {

--- a/src/components/NavigationFolder.vue
+++ b/src/components/NavigationFolder.vue
@@ -21,6 +21,7 @@
 
 <template>
 	<AppNavigationItem
+		v-if="visible"
 		:id="genId(folder)"
 		:key="genId(folder)"
 		:allow-collapse="true"
@@ -135,6 +136,12 @@ export default {
 		}
 	},
 	computed: {
+		visible() {
+			return (
+				this.account.showSubscribedOnly === false ||
+				(this.folder.attributes && this.folder.attributes.includes('\\subscribed'))
+			)
+		},
 		title() {
 			if (this.filter === 'starred') {
 				// Little hack to trick the translation logic into a different path

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -128,7 +128,7 @@ export default {
 	patchAccount({commit}, {account, data}) {
 		return patchAccount(account, data).then((account) => {
 			console.debug('account patched', account, data)
-			commit('editAccount', data)
+			commit('patchAccount', {account, data})
 			return account
 		})
 	},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -48,6 +48,7 @@ export default new Vuex.Store({
 				collapsed: false,
 				emailAddress: '',
 				name: '',
+				showSubscribedOnly: false,
 			},
 		},
 		accountList: [UNIFIED_ACCOUNT_ID],
@@ -55,6 +56,7 @@ export default new Vuex.Store({
 			[UNIFIED_INBOX_UID]: {
 				id: UNIFIED_INBOX_ID,
 				accountId: 0,
+				attributes: ['\\subscribed'],
 				isUnified: true,
 				specialUse: ['inbox'],
 				specialRole: 'inbox',
@@ -65,6 +67,7 @@ export default new Vuex.Store({
 			[PRIORITY_INBOX_UID]: {
 				id: PRIORITY_INBOX_ID,
 				accountId: 0,
+				attributes: ['\\subscribed'],
 				isPriorityInbox: true,
 				specialUse: ['inbox'],
 				specialRole: 'inbox',

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -70,6 +70,9 @@ export default {
 	editAccount(state, account) {
 		Vue.set(state.accounts, account.id, Object.assign({}, state.accounts[account.id], account))
 	},
+	patchAccount(state, {account, data}) {
+		Vue.set(state.accounts, account.id, Object.assign({}, state.accounts[account.id], data))
+	},
 	saveAccountsOrder(state, {account, order}) {
 		Vue.set(account, 'order', order)
 		Vue.set(

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -63,6 +63,7 @@ class MailAccountTest extends TestCase {
 			'editorMode' => 'html',
 			'provisioned' => false,
 			'order' => 13,
+			'showSubscribedOnly' => null,
 		], $a->toJson());
 	}
 
@@ -83,6 +84,7 @@ class MailAccountTest extends TestCase {
 			'editorMode' => null,
 			'provisioned' => false,
 			'order' => null,
+			'showSubscribedOnly' => null,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency


### PR DESCRIPTION
If there are many folders in a mail account, e.g. if there are shared folders, IMAP can be used to select which folders are displayed by subscribing to them.
This patch adds a setting in the mail account to show only subscribed folders.

From my point of view critical is the change in FolderMApper.php (getFolders() and createFolder() ).
Replacing MBOX_ALL with MBOX_ALL_SUBSCRIBED results in "Return all mailboxes regardless of subscription status, and ensure the '\subscribed' attribute is set if mailbox is subscribed (implies 'attributes' option is true)." as described in the Horde API. This works great under Dovecot but I can't try it with other IMAP servers.

For displaying the folder in the user interface the method findAll() in the MailboxMapper can't be used, because the synchronization doesn't work anymore if all mailboxes are not returned without exception, so I added a new method which returns only the list of subscribed folders.

- [x] adding flag to mailaccount table
- [x] add preference to mail account settings
- [x] fetching mailfolders with subscription flags from IMAP Server
- [x] fetching mailforders from database considering the subscription setting
- [x] reload all folders when changing the setting (don'tknow how)
- [ ] tests