### PR TITLE
Paginate all priority inbox sections

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -27,7 +27,7 @@
 		<transition-group name="list">
 			<div id="list-refreshing" key="loading" class="icon-loading-small" :class="{refreshing: refreshing}" />
 			<Envelope
-				v-for="env in envelopesToShow"
+				v-for="env in envelopes"
 				:key="env.uid"
 				:data="env"
 				:folder="folder"
@@ -37,13 +37,12 @@
 				@update:selected="onEnvelopeSelectToggle(env, ...$event)"
 			/>
 			<div
-				v-if="collapsible && envelopes.length > collapseThreshold"
+				v-if="loadMoreButton && !loadingMore"
 				:key="'list-collapse-' + searchQuery"
-				class="collapse-expand"
-				@click="$emit('update:collapsed', !collapsed)"
+				class="load-more"
+				@click="$emit('loadMore')"
 			>
-				<template v-if="collapsed">{{ t('mail', 'Show all {nr} messages', {nr: envelopes.length}) }}</template>
-				<template v-else>{{ t('mail', 'Collapse messages') }}</template>
+				{{ t('mail', 'Load more') }}
 			</div>
 			<div id="load-more-mail-messages" key="loadingMore" :class="{'icon-loading-small': loadingMore}" />
 		</transition-group>
@@ -90,12 +89,7 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		collapsible: {
-			type: Boolean,
-			required: false,
-			default: false,
-		},
-		collapsed: {
+		loadMoreButton: {
 			type: Boolean,
 			required: false,
 			default: false,
@@ -104,16 +98,9 @@ export default {
 	data() {
 		return {
 			selection: [],
-			collapseThreshold: 5,
 		}
 	},
 	computed: {
-		envelopesToShow() {
-			if (this.collapsible && this.collapsed) {
-				return this.envelopes.slice(0, this.collapseThreshold)
-			}
-			return this.envelopes
-		},
 		selectMode() {
 			// returns true when in selection mode (where the user selects several emails at once)
 			return this.selection.length > 0
@@ -210,7 +197,7 @@ div {
 	position: relative;
 }
 
-.collapse-expand {
+.load-more {
 	text-align: center;
 	margin-top: 10px;
 	cursor: pointer;

--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -35,9 +35,10 @@
 						class="nameimportant"
 						:account="unifiedAccount"
 						:folder="unifiedInbox"
-						:paginate="false"
 						:search-query="appendToSearch('is:important')"
+						:paginate="'manual'"
 						:is-priority-inbox="true"
+						:initial-page-size="5"
 						:collapsible="true"
 						:bus="bus"
 					/>
@@ -46,10 +47,10 @@
 						class="namestarred"
 						:account="unifiedAccount"
 						:folder="unifiedInbox"
-						:paginate="false"
 						:search-query="appendToSearch('is:starred not:important')"
+						:paginate="'manual'"
 						:is-priority-inbox="true"
-						:collapsible="true"
+						:initial-page-size="5"
 						:bus="bus"
 					/>
 					<SectionTitle class="app-content-list-item other" :name="t('mail', 'Other')" />


### PR DESCRIPTION
For the first design we said pagination is only necessary for *Other messages* but as the number of messages in an inbox almost always grows this is not a real solution. The collapse thingy recently added helps with the vertical space consumed, but as soon as you expand the browser has to render lots of data, making the whole interface lag for a few secs.

@jancborchardt  and I decided to do pagination. Now *Important* and *Favorites* will have a *Load more* button, *Others* will still load more through scrolling.

TODO
- [x] Bug with hiding the button when the list end is reached -> button is hidden before already