### PR TITLE
Fix user data cleanup after user deletion

### DIFF
--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -30,7 +30,7 @@ use OCA\Mail\Service\AccountService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\ILogger;
-use OCP\User\Events\BeforeUserDeletedEvent;
+use OCP\User\Events\UserDeletedEvent;
 
 class UserDeletedListener implements IEventListener {
 
@@ -47,7 +47,7 @@ class UserDeletedListener implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof BeforeUserDeletedEvent)) {
+		if (!($event instanceof UserDeletedEvent)) {
 			// Unrelated
 			return;
 		}


### PR DESCRIPTION
We expected the wrong type here, hence the early return kicked in and nullified the delete procedure.

The event is registered at https://github.com/nextcloud/mail/blob/84c804de6dfc5aa914572458b2976f0b268025fe/lib/AppInfo/BootstrapSingleton.php#L138.

Fixes https://github.com/nextcloud/mail/issues/3135