### PR TITLE
Do not use `this` in a Vue template

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -11,7 +11,7 @@
 			/>
 			<div
 				v-if="collapsible && envelopes.length > collapseThreshold"
-				:key="'list-collapse-' + this.searchQuery"
+				:key="'list-collapse-' + searchQuery"
 				class="collapse-expand"
 				@click="$emit('update:collapsed', !collapsed)"
 			>


### PR DESCRIPTION
Fixes linter warning as seen in https://github.com/nextcloud/mail/pull/3136/files and IIRC there was also a Vue warning about a duplicatekey `list-collapse-undefined`. This explains it.

@nextcloud/mail 