### PR TITLE
Add tooltip for important filter

### DIFF
--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -19,7 +19,18 @@
 					:bus="bus"
 				/>
 				<template v-else>
-					<SectionTitle class="app-content-list-item important" :name="t('mail', 'Important')" />
+					<li class="app-content-list-item">
+						<SectionTitle class="important" :name="t('mail', 'Important')" />
+						<Popover trigger="hover focus">
+							<button slot="trigger" class="button icon-info"></button>
+							{{
+								t(
+									'mail',
+									'Messages will automatically be marked as important based on which messages you interacted with or marked as important. In the beginning you might have to manually change the importance to teach the system, but it will improve over time.'
+								)
+							}}
+						</Popover>
+					</li>
 					<Mailbox
 						class="nameimportant"
 						:account="unifiedAccount"
@@ -63,6 +74,7 @@
 <script>
 import AppContent from '@nextcloud/vue/dist/Components/AppContent'
 import AppContentList from '@nextcloud/vue/dist/Components/AppContentList'
+import Popover from '@nextcloud/vue/dist/Components/Popover'
 import infiniteScroll from 'vue-infinite-scroll'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import SectionTitle from './SectionTitle'
@@ -84,6 +96,7 @@ export default {
 	},
 	components: {
 		AppContent,
+		Popover,
 		AppContentList,
 		AppDetailsToggle,
 		Mailbox,
@@ -212,4 +225,26 @@ export default {
 }
 </script>
 
-<style scoped></style>
+<style lang="scss" scoped>
+.v-popover > .trigger > {
+	z-index: 1;
+}
+.icon-info {
+	background-image: var(--icon-info-000);
+}
+.app-content-list-item:hover {
+	background: transparent;
+}
+.button {
+	background-color: var(--color-main-background);
+	width: 44px;
+	height: 44px;
+	border: 0;
+	margin-bottom: 17px;
+
+	&:hover,
+	&:focus {
+		background-color: var(--color-background-dark);
+	}
+}
+</style>


### PR DESCRIPTION
fixes #3134 
![info1](https://user-images.githubusercontent.com/12728974/82424076-f5e4e200-9a84-11ea-9f05-8244b0ebf7cb.png)


----
![info2](https://user-images.githubusercontent.com/12728974/82434311-f8e6cf00-9a92-11ea-8f00-271f2c0e5c11.png)




a simple ~~div~~ popover to add the tooltip, @jancborchardt please send me a more accurate text for the tooltip :) @ChristophWurst ~~I hope you're fine with the div ;)~~ i changed to popover