### PR TITLE
Add important AND favorite to the same section

### DIFF
--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -25,7 +25,7 @@
 						:account="unifiedAccount"
 						:folder="unifiedInbox"
 						:paginate="false"
-						:search-query="appendToSearch('is:important not:starred')"
+						:search-query="appendToSearch('is:important')"
 						:is-priority-inbox="true"
 						:collapsible="true"
 						:bus="bus"


### PR DESCRIPTION
When an email is marks as important AND favorite it should be shown at the Important section.