### PR TITLE
Add search by subject

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -322,6 +322,16 @@ class MessageMapper extends QBMapper {
 			);
 		}
 
+		if ($query->getSubject() !== null) {
+			$select->andWhere(
+				$qb->expr()->iLike(
+					'subject',
+					$qb->createNamedParameter('%' . $query->getSubject() . '%', IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR
+				)
+			);
+		}
+
 		if ($query->getCursor() !== null) {
 			$select->andWhere(
 				$qb->expr()->lt('sent_at', $qb->createNamedParameter($query->getCursor(), IQueryBuilder::PARAM_INT))


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2989

To reproduce try to search with `subject:something` where `something` is part of a known email in the current mailbox. On master you won't get any matching result. Here you will.