### PR TITLE
Escape the subject search term for the LIKE clause

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -326,7 +326,7 @@ class MessageMapper extends QBMapper {
 			$select->andWhere(
 				$qb->expr()->iLike(
 					'subject',
-					$qb->createNamedParameter('%' . $query->getSubject() . '%', IQueryBuilder::PARAM_STR),
+					$qb->createNamedParameter('%' . $this->db->escapeLikeParameter($query-> $query->getSubject()) . '%', IQueryBuilder::PARAM_STR),
 					IQueryBuilder::PARAM_STR
 				)
 			);


### PR DESCRIPTION
For https://github.com/nextcloud/mail/pull/3156#discussion_r431765893

We do not want users to use placeholders in the search string.