### PR TITLE
Catch importance classification exception during sync

### DIFF
--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -33,6 +33,7 @@ use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Exception\ClassifierTrainingException;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\Classification\FeatureExtraction\CompositeExtractor;
 use OCA\Mail\Support\PerformanceLogger;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -281,7 +282,8 @@ class ImportanceClassifier {
 	 * @param Mailbox $mailbox
 	 * @param Message[] $messages
 	 *
-	 * @return array
+	 * @return bool[]
+	 * @throws ServiceException
 	 */
 	public function classifyImportance(Account $account, Mailbox $mailbox, array $messages): array {
 		$estimator = $this->persistenceService->loadLatest($account);

--- a/lib/Service/Classification/PersistenceService.php
+++ b/lib/Service/Classification/PersistenceService.php
@@ -141,6 +141,12 @@ class PersistenceService {
 		$this->mapper->update($classifier);
 	}
 
+	/**
+	 * @param Account $account
+	 *
+	 * @return Estimator|null
+	 * @throws ServiceException
+	 */
 	public function loadLatest(Account $account): ?Estimator {
 		try {
 			$latestModel = $this->mapper->findLatest($account->getId());
@@ -150,6 +156,12 @@ class PersistenceService {
 		return $this->load($latestModel->getId());
 	}
 
+	/**
+	 * @param int $id
+	 *
+	 * @return Estimator
+	 * @throws ServiceException
+	 */
 	public function load(int $id): Estimator {
 		$cached = $this->getCached($id);
 		if ($cached !== null) {


### PR DESCRIPTION
The importance classifcation is not that important (pun intended), so it should not make the sync process fail hard. The user can't do anything about this error anyway.

This is best reviewed as https://github.com/nextcloud/mail/pull/3176/files?w=1