### PR TITLE
Remove bountysource references

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-custom: https://www.bountysource.com/teams/nextcloud/issues?tracker_ids=44154351
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![PHP Coverage](https://scrutinizer-ci.com/g/nextcloud/mail/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/mail/?branch=master)
 [![JavaScript Coverage](https://coveralls.io/repos/github/nextcloud/mail/badge.svg)](https://coveralls.io/github/nextcloud/mail)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=nextcloud/mail)](https://dependabot.com)
-[![Bountysource](https://img.shields.io/bountysource/team/nextcloud/activity.svg?maxAge=2592000)](https://www.bountysource.com/teams/nextcloud/issues?tracker_ids=44154351)
 
 **💌 A mail app for [Nextcloud](https://nextcloud.com)**
 


### PR DESCRIPTION
Due to the many issues we've been having with the platform, we should try to keep this off the radar of people new to the project. The problem of existing bounties is still to handle. But we must not advertise this anymore for new tickets.

cc @karlitschek @jospoortvliet @nextcloud/mail 