### PR TITLE
Fix CKEditor for stable1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2000,53 +2000,14 @@
       }
     },
     "@ckeditor/ckeditor5-link": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-19.0.1.tgz",
-      "integrity": "sha512-2W9F+G1Ulr7wbp9YkQaDT+ylBNn1u/++s19exJsa3QcTxtDN0OGq748Cp+X6pfBBb6AtttfDmfZc+qgDAcBHKA==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-19.0.0.tgz",
+      "integrity": "sha512-YvpSsUM2PDhTRAmZP2ar85HuPQZvSudyTfBD1lCgGiqLoP8CV3itPq1ntoo+7toKWXAQvHsfDYV5bSAMOGktWg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^19.0.1",
-        "@ckeditor/ckeditor5-engine": "^19.0.1",
-        "@ckeditor/ckeditor5-ui": "^19.0.1",
+        "@ckeditor/ckeditor5-core": "^19.0.0",
+        "@ckeditor/ckeditor5-engine": "^19.0.0",
+        "@ckeditor/ckeditor5-ui": "^19.0.0",
         "lodash-es": "^4.17.10"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-19.0.1.tgz",
-          "integrity": "sha512-HKuJp7XEmg8q6o8T2pIUCQDxLlgx2vtweJeDpgreLrX4IqreE0UQtz+TUyxvtlay55UhVpBP4zrnROxrq4Prng==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^19.0.1",
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-19.0.1.tgz",
-          "integrity": "sha512-dBE4bSpQzGhoyZaWdDaUJyWG0ltCmpXVkv5YG/x+4s+n3vJf9KKEQcXvj/XPCrMqLaWGKTNugKYfQIEJdOzTZA==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-19.0.1.tgz",
-          "integrity": "sha512-b5WpNmR75NeZ/5CxXWarYUAaomcoflQVjD8M0JHppJKMrBpfuaogRXIRiqsCq+d4mUKzkrEzBcGElI2MObE5dw==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^19.0.1",
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "19.0.2",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-19.0.2.tgz",
-          "integrity": "sha512-ZpoCbuyzujERC5WIjT5obrUyo9m4IoAEOgTxiKOyv9Cy8IGrcW1mG01111iwY/j2pWio0rY0kGRIsQaxqcZ+Ag==",
-          "requires": {
-            "lodash-es": "^4.17.10"
-          }
-        }
       }
     },
     "@ckeditor/ckeditor5-paragraph": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,51 +1684,12 @@
       }
     },
     "@ckeditor/ckeditor5-basic-styles": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-19.0.1.tgz",
-      "integrity": "sha512-3jpcBjClifbVdxYs+x5cw4If3GfOQ86D3pOJT/8vqNliWMpseIvJhrO+XiiBgcTuXynYuzuIVObdosSlK6PzUg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-19.0.0.tgz",
+      "integrity": "sha512-YH3AWD0b7GS4IN4igWVLYd98BQvoZIdSrRPEO5NYQKffQtLNMURr9qKHGJ/8wZ41M9eYxX/x9s9XCyh8zhU3EA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^19.0.1",
-        "@ckeditor/ckeditor5-ui": "^19.0.1"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-19.0.1.tgz",
-          "integrity": "sha512-HKuJp7XEmg8q6o8T2pIUCQDxLlgx2vtweJeDpgreLrX4IqreE0UQtz+TUyxvtlay55UhVpBP4zrnROxrq4Prng==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^19.0.1",
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-19.0.1.tgz",
-          "integrity": "sha512-dBE4bSpQzGhoyZaWdDaUJyWG0ltCmpXVkv5YG/x+4s+n3vJf9KKEQcXvj/XPCrMqLaWGKTNugKYfQIEJdOzTZA==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "19.0.1",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-19.0.1.tgz",
-          "integrity": "sha512-b5WpNmR75NeZ/5CxXWarYUAaomcoflQVjD8M0JHppJKMrBpfuaogRXIRiqsCq+d4mUKzkrEzBcGElI2MObE5dw==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^19.0.1",
-            "@ckeditor/ckeditor5-utils": "^19.0.1",
-            "lodash-es": "^4.17.10"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "19.0.2",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-19.0.2.tgz",
-          "integrity": "sha512-ZpoCbuyzujERC5WIjT5obrUyo9m4IoAEOgTxiKOyv9Cy8IGrcW1mG01111iwY/j2pWio0rY0kGRIsQaxqcZ+Ag==",
-          "requires": {
-            "lodash-es": "^4.17.10"
-          }
-        }
+        "@ckeditor/ckeditor5-core": "^19.0.0",
+        "@ckeditor/ckeditor5-ui": "^19.0.0"
       }
     },
     "@ckeditor/ckeditor5-block-quote": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@bundle-analyzer/webpack-plugin": "^0.5.1",
     "@ckeditor/ckeditor5-alignment": "^19.0.0",
-    "@ckeditor/ckeditor5-basic-styles": "^19.0.1",
+    "@ckeditor/ckeditor5-basic-styles": "^19.0.0",
     "@ckeditor/ckeditor5-block-quote": "^19.0.0",
     "@ckeditor/ckeditor5-build-balloon": "^19.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@ckeditor/ckeditor5-editor-balloon": "^19.0.0",
     "@ckeditor/ckeditor5-essentials": "^19.0.0",
     "@ckeditor/ckeditor5-heading": "^19.0.0",
-    "@ckeditor/ckeditor5-link": "^19.0.1",
+    "@ckeditor/ckeditor5-link": "^19.0.0",
     "@ckeditor/ckeditor5-paragraph": "^19.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^19.0.0",
     "@ckeditor/ckeditor5-vue": "^1.0.1",


### PR DESCRIPTION
Dependabot sneaked some PRs into https://github.com/nextcloud/mail/commits/stable1.4 that I did not want there and so it broke the front-end completely due to a CKEditor module mismatch. This reverts the two problematic commits, so the app renders again.

cc @nextcloud/mail 