### PR TITLE
Fix icon color in dark theme

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -318,31 +318,18 @@
 }
 
 /* icons */
-.icon-inbox {
-	@include icon-color('inbox', 'mail', $color-black);
-}
-.icon-important {
-	@include icon-color('important', 'mail', $color-black);
-}
+@include icon-black-white('inbox', 'mail', 1);
+@include icon-black-white('important', 'mail', 1);
+
 .icon-flagged {
 	@include icon-color('star', 'mail', $color-black);
 }
-.icon-drafts {
-	@include icon-color('drafts', 'mail', $color-black);
-}
-.icon-sent {
-	@include icon-color('sent', 'mail', $color-black);
-}
-.icon-archive {
-	@include icon-color('archive', 'mail', $color-black);
-}
-.icon-junk {
-	@include icon-color('junk', 'mail', $color-black);
-}
-.icon-trash {
-	@include icon-color('trash', 'mail', $color-black);
-}
 
+@include icon-black-white('drafts', 'mail', 1);
+@include icon-black-white('sent', 'mail', 1);
+@include icon-black-white('archive', 'mail', 1);
+@include icon-black-white('junk', 'mail', 1);
+@include icon-black-white('trash', 'mail', 1);
 @include icon-black-white('reply', 'mail', 1);
 @include icon-black-white('reply-all', 'mail', 1);
 @include icon-black-white('forward', 'mail', 1);

--- a/img/inbox.svg
+++ b/img/inbox.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.0" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
- <path d="m8 1.0306-8 7.9694h3v6.0001h10v-6h3l-3-3.0306v-3.9695h-3v1.0812l-2-2.0505z" fill-rule="evenodd"/>
+ <path fill="#000000" d="m8 1.0306-8 7.9694h3v6.0001h10v-6h3l-3-3.0306v-3.9695h-3v1.0812l-2-2.0505z" fill-rule="evenodd"/>
 </svg>

--- a/img/trash.svg
+++ b/img/trash.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" height="16" width="16" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
- <path d="m6.5 1-0.5 1h-3c-0.554 0-1 0.446-1 1v1h12v-1c0-0.554-0.446-1-1-1h-3l-0.5-1zm-3.5 4 0.875 9c0.061 0.549 0.5729 1 1.125 1h6c0.55232 0 1.064-0.45102 1.125-1l0.875-9z" fill-rule="evenodd"/>
+ <path fill="#000000" d="m6.5 1-0.5 1h-3c-0.554 0-1 0.446-1 1v1h12v-1c0-0.554-0.446-1-1-1h-3l-0.5-1zm-3.5 4 0.875 9c0.061 0.549 0.5729 1 1.125 1h6c0.55232 0 1.064-0.45102 1.125-1l0.875-9z" fill-rule="evenodd"/>
 </svg>


### PR DESCRIPTION
fixes #3224 
// The problem is caused because of this regression here: https://github.com/nextcloud/server/blob/892589746dd0f758358adbc66a1bd729a8374e55/lib/private/Template/IconsCacher.php#L198 
@skjnldsv should we maybe change it to check only for fill and not fill-rule?