### PR TITLE
Set file picker to copy mode.

### DIFF
--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -148,6 +148,7 @@ export default {
 				.addMimeTypeFilter('httpd/unix-directory')
 				.setModal(true)
 				.setType(1)
+				.allowDirectories(true)
 				.build()
 
 			return picker

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -81,6 +81,7 @@ export default {
 				.addMimeTypeFilter('httpd/unix-directory')
 				.setModal(true)
 				.setType(1)
+				.allowDirectories(true)
 				.build()
 
 			const saveAttachments = (id) => (directory) => {


### PR DESCRIPTION
Fixes #2922 by using the file picker using COPY type.