### PR TITLE
Add the missing `References` header for sent messages

### DIFF
--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -147,8 +147,9 @@ class MailTransmission implements IMailTransmission {
 			'Subject' => $message->getSubject(),
 		];
 
-		if ($message->getInReplyTo() !== null) {
-			$headers['In-Reply-To'] = $message->getInReplyTo();
+		if (($inReplyTo = $message->getInReplyTo()) !== null) {
+			$headers['References'] = $inReplyTo;
+			$headers['In-Reply-To'] = $inReplyTo;
 		}
 
 		$mail = new Horde_Mime_Mail();


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3298

cc @nextcloud/mail for review