### PR TITLE
Fix folder creation design

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -49,9 +49,13 @@
 			>
 				{{ t('mail', 'Show only subscribed folders') }}
 			</ActionCheckbox>
-			<ActionInput icon="icon-add" @submit="createFolder">
+			<ActionButton v-if="!editing" icon="icon-folder" @click="openCreateFolder">
 				{{ t('mail', 'Add folder') }}
-			</ActionInput>
+			</ActionButton>
+			<ActionInput v-if="editing" icon="icon-folder" @submit.prevent.stop="createFolder" />
+			<ActionText v-if="showSaving" icon="icon-loading-small">
+				{{ t('mail', 'Saving') }}
+			</ActionText>
 			<ActionButton v-if="!isFirst" icon="icon-triangle-n" @click="changeAccountOrderUp">
 				{{ t('mail', 'Move Up') }}
 			</ActionButton>
@@ -117,6 +121,8 @@ export default {
 			},
 			savingShowOnlySubscribed: false,
 			quota: undefined,
+			editing: false,
+			showSaving: false,
 		}
 	},
 	computed: {
@@ -165,6 +171,7 @@ export default {
 	},
 	methods: {
 		createFolder(e) {
+			this.editing = true
 			const name = e.target.elements[1].value
 			logger.info('creating folder ' + name)
 			this.menuOpen = false
@@ -175,6 +182,12 @@ export default {
 					logger.error('could not create folder', {error})
 					throw error
 				})
+			this.editing = false
+			this.showSaving = false
+		},
+		openCreateFolder() {
+			this.editing = true
+			this.showSaving = false
 		},
 		removeAccount() {
 			const id = this.account.id

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -150,6 +150,7 @@ export default {
 		return createFolder(account.id, name).then((folder) => {
 			console.debug(`folder ${name} created for account ${account.id}`, {folder})
 			commit('addFolder', {account, folder})
+			commit('expandAccount', account.id)
 		})
 	},
 	moveAccount({commit, getters}, {account, up}) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -84,6 +84,9 @@ export default {
 	toggleAccountCollapsed(state, accountId) {
 		state.accounts[accountId].collapsed = !state.accounts[accountId].collapsed
 	},
+	expandAccount(state, accountId) {
+		state.accounts[accountId].collapsed = false
+	},
 	addFolder(state, {account, folder}) {
 		// Flatten the existing ones before updating the hierarchy
 		const existing = account.folders.map((id) => state.folders[id])


### PR DESCRIPTION
Fixes #2798 

- Change icon into icon-folder for

- [x] Folder

- [x] Subfolder

- By default, it should only show as normal entry

- [x] Folder

- [x] Subfolder

- [x] When the folders are collapsed and you add a folder, you don’t see any feedback. So in this case, the folders should automatically expand.