### PR TITLE
Store the `references`, `in-reply-to` and the thread root id

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.5.0-alpha1</version>
+	<version>1.5.0-alpha2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Roeland Jago Douma</author>

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -93,6 +93,9 @@ class MessageMapper extends QBMapper {
 		$qb1->insert($this->getTableName());
 		$qb1->setValue('uid', $qb1->createParameter('uid'));
 		$qb1->setValue('message_id', $qb1->createParameter('message_id'));
+		$qb1->setValue('references', $qb1->createParameter('references'));
+		$qb1->setValue('in_reply_to', $qb1->createParameter('in_reply_to'));
+		$qb1->setValue('thread_root_id', $qb1->createParameter('thread_root_id'));
 		$qb1->setValue('mailbox_id', $qb1->createParameter('mailbox_id'));
 		$qb1->setValue('subject', $qb1->createParameter('subject'));
 		$qb1->setValue('sent_at', $qb1->createParameter('sent_at'));
@@ -116,6 +119,12 @@ class MessageMapper extends QBMapper {
 		foreach ($messages as $message) {
 			$qb1->setParameter('uid', $message->getUid(), IQueryBuilder::PARAM_INT);
 			$qb1->setParameter('message_id', $message->getMessageId(), IQueryBuilder::PARAM_STR);
+			$inReplyTo = $message->getInReplyTo();
+			$qb1->setParameter('in_reply_to', $inReplyTo, $inReplyTo === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);
+			$references = $message->getReferences();
+			$qb1->setParameter('references', $references, $references === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);
+			$threadRootId = $message->getThreadRootId();
+			$qb1->setParameter('thread_root_id', $threadRootId,$threadRootId === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);
 			$qb1->setParameter('mailbox_id', $message->getMailboxId(), IQueryBuilder::PARAM_INT);
 			$qb1->setParameter('subject', $message->getSubject(), IQueryBuilder::PARAM_STR);
 			$qb1->setParameter('sent_at', $message->getSentAt(), IQueryBuilder::PARAM_INT);

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -200,6 +200,16 @@ class MessageMapper {
 		$query->flags();
 		$query->uid();
 		$query->imapDate();
+		$query->headers(
+			'references',
+			[
+				'references',
+			],
+			[
+				'cache' => true,
+				'peek' => true,
+			]
+		);
 
 		$fetchResults = iterator_to_array($client->fetch($mailbox, $query, [
 			'ids' => new Horde_Imap_Client_Ids($ids),

--- a/lib/Migration/Version1050Date20200624101359.php
+++ b/lib/Migration/Version1050Date20200624101359.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version1050Date20200624101359 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$messagesTable = $schema->getTable('mail_messages');
+		$messagesTable->getColumn('message_id')->setLength(1023);
+		$messagesTable->addColumn('references', 'text', [
+			'notnull' => false,
+		]);
+		$messagesTable->addColumn('in_reply_to', 'string', [
+			'notnull' => false,
+			'length' => 1023,
+		]);
+		$messagesTable->addColumn('thread_root_id', 'string', [
+			'notnull' => false,
+			'length' => 1023,
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -38,6 +38,7 @@ use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Mailbox;
 use Horde_Imap_Client_Socket;
+use Horde_Mime_Headers;
 use Horde_Mime_Part;
 use JsonSerializable;
 use OC;
@@ -161,6 +162,20 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 */
 	public function getEnvelope() {
 		return $this->fetch->getEnvelope();
+	}
+
+	private function getRawReferences(): string {
+		/** @var Horde_Mime_Headers $headers */
+		$headers = $this->fetch->getHeaders('references', Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
+		$header = $headers->getHeader('references');
+		if ($header === null) {
+			return '';
+		}
+		return $header->value_single;
+	}
+
+	private function getRawInReplyTo(): string {
+		return $this->fetch->getEnvelope()->in_reply_to;
 	}
 
 	/**
@@ -630,6 +645,9 @@ class IMAPMessage implements IMessage, JsonSerializable {
 
 		$msg->setUid($this->getUid());
 		$msg->setMessageId($this->getMessageId());
+		$msg->setReferences($this->getRawReferences());
+		$msg->setThreadRootId($this->getMessageId());
+		$msg->setInReplyTo($this->getRawInReplyTo());
 		$msg->setMailboxId($mailboxId);
 		$msg->setFrom($this->getFrom());
 		$msg->setTo($this->getTo());


### PR DESCRIPTION
For #17, extracted from https://github.com/nextcloud/mail/pull/2125.

This stores the raw values of `In-Reply-To` and `References` in the database as well as the `Message-ID` of the root element of a message thread. The default is the own (but parsed) message-id, like if the message was its own root. In a follow-up PR I'll finish the algorithm (possibly in #2125) to update this reference if a new root is found. The goal is to have the root as stable as possible and the threading algorithm should make that possible in most cases, we we only have to update this field once.

@nextcloud/mail please review

Steps to test
1) Check out the branch
2) Run the migration
3) See that new messages have these three attributes populated