### PR TITLE
Fixed possible nullpointer exception in ImportantMessagesExtractor

### DIFF
--- a/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
@@ -51,7 +51,7 @@ class ImportantMessagesExtractor implements IExtractor {
 							array $outgoingMailboxes,
 							array $messages): bool {
 		$senders = array_unique(array_map(function (Message $message) {
-			return $message->getFrom()->first()->getEmail();
+			return is_null($message->getFrom()->first()) ? '' : $message->getFrom()->first()->getEmail();
 		}, $messages));
 		$this->totalMessages = $this->statisticsDao->getNumberOfMessagesGrouped($incomingMailboxes, $senders);
 		$this->flaggedMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'important', $senders);


### PR DESCRIPTION

Sometimes one of my emails account does not load the latest emails. The log is then full of this message "Call to a member function getEmail() on null" [error.log](https://github.com/nextcloud/mail/files/4861634/error.log). This PR fixes the nullpointer exception. The issue seems to have the same cause as #851