### PR TITLE
Do not combine threads with identical subjects

### DIFF
--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -211,13 +211,12 @@ class ThreadBuilder {
 				&& $container->hasMessage() && $container->getMessage()->hasReSubject()) {
 				$container->setParent($subjectContainer);
 				$subjectTable[$subject];
-			} else {
-				$new = Container::empty();
-				$container->setParent($new);
-				$subjectContainer->setParent($new);
-				$new->setParent($root);
-				$subjectTable[$subject] = $new;
 			}
+			/*
+			 * According to RFC5256 we would have to combine two messages with the same subject
+			 * to a thread. But this will also group unrelated messages, so we deliberately omit
+			 * this, just like most other clients do.
+			 */
 		}
 	}
 

--- a/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
+++ b/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
@@ -489,4 +489,87 @@ class ThreadBuilderTest extends TestCase {
 			$this->abstract($result)
 		);
 	}
+
+	/**
+	 * This is a test case from real-world data, compared to how Evolution renders the thread
+	 *
+	 * Message IDs and subject were obfuscated because they don't matter much
+	 */
+	public function testRealWorldTwoSimilarThreads(): void {
+		$messages = [
+			new Message('Sub', '<o1@mail.host>', []),
+			new Message('Re: Sub', '<o1re1@mail.host>', ['<o1@mail.host>']),
+			new Message('Re: Sub', '<o1re2@mail.host>', ['<o1@mail.host>']),
+			new Message('Re: Sub', '<o1re11@mail.host>', ['<o1@mail.host>', '<o1re1@mail.host>']),
+			new Message('Re: Sub', '<o1re111@mail.host>', ['<o1@mail.host>', '<o1re1@mail.host>', '<o1re11@mail.host>']),
+			new Message('Re: Sub', '<o1re1111@mail.host>', ['<o1@mail.host>', '<o1re11@mail.host>', '<o1re111@mail.host>']),
+			new Message('Re: Sub', '<o1re3@mail.host>', ['<o1@mail.host>']),
+			new Message('Re: Sub', '<o1re4@mail.host>', ['<o1@mail.host>']),
+			new Message('Re: Sub', '<o1re5@mail.host>', ['<o1@mail.host>']),
+			new Message('Re: Sub', '<o1re6@mail.host>', ['<o1@mail.host>']),
+			new Message('Sub', '<o2@mail.host>', []),
+			new Message('Re: Sub', '<o2re1@mail.host>', ['<o2@mail.host>']),
+		];
+
+		$result = $this->builder->build($messages);
+
+		$this->assertEquals(
+			[
+				[
+					'id' => '<o1@mail.host>',
+					'children' => [
+						[
+							'id' => '<o1re1@mail.host>',
+							'children' => [
+								[
+									'id' => '<o1re11@mail.host>',
+									'children' => [
+										[
+											'id' => '<o1re111@mail.host>',
+											'children' => [
+												[
+													'id' => '<o1re1111@mail.host>',
+													'children' => [],
+												],
+											],
+										],
+									],
+								],
+							],
+						],
+						[
+							'id' => '<o1re2@mail.host>',
+							'children' => [],
+						],
+						[
+							'id' => '<o1re3@mail.host>',
+							'children' => [],
+						],
+						[
+							'id' => '<o1re4@mail.host>',
+							'children' => [],
+						],
+						[
+							'id' => '<o1re5@mail.host>',
+							'children' => [],
+						],
+						[
+							'id' => '<o1re6@mail.host>',
+							'children' => [],
+						],
+					],
+				],
+				[
+					'id' => '<o2@mail.host>',
+					'children' => [
+						[
+							'id' => '<o2re1@mail.host>',
+							'children' => [],
+						],
+					],
+				],
+			],
+			$this->abstract($result)
+		);
+	}
 }


### PR DESCRIPTION
~~The current version does not look like the result in Evolution. In Evolution the two threads are separate. And I think that should be the expected output. @nextcloud/mail what do you think?~~ After reading things like http://kb.mozillazine.org/Stop_threading_by_subject and https://wiki.mozilla.org/MailNews:Message_Threading#Preferences_Controlling_Threading we concluded that those should be separate threads. Thunderbird, KMail and Apple Mail also keep them separate.

The algorithm was adjusted to this, but will still merge re subjects with the base subjects for the clients that just don't send headers.