### PR TITLE
Clean up mix up of ID, UID and UUID

### DIFF
--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -233,7 +233,8 @@ class Message extends Entity implements JsonSerializable {
 
 	public function jsonSerialize() {
 		return [
-			'id' => $this->getUid(), // Change to UID on front-end
+			'databaseId' => $this->getId(),
+			'uid' => $this->getUid(),
 			'subject' => $this->getSubject(),
 			'dateInt' => $this->getSentAt(),
 			'flags' => [

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -448,7 +448,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 */
 	public function jsonSerialize(): array {
 		return [
-			'id' => $this->getUid(),
+			'uid' => $this->getUid(),
 			'messageId' => $this->getMessageId(),
 			'from' => $this->getFrom()->jsonSerialize(),
 			'to' => $this->getTo()->jsonSerialize(),

--- a/src/components/Address.vue
+++ b/src/components/Address.vue
@@ -23,7 +23,7 @@ export default {
 				params: {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
-					messageUid: 'new',
+					messageUuid: 'new',
 				},
 				query: {
 					to: this.email,

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -394,7 +394,7 @@ export default {
 		},
 	},
 	watch: {
-		'$route.params.messageUid'(newID) {
+		'$route.params.messageUuid'() {
 			this.reset()
 		},
 		allRecipients() {
@@ -498,7 +498,7 @@ export default {
 				body: this.encrypt ? plain(this.bodyVal) : html(this.bodyVal),
 				attachments: this.attachments,
 				folderId: this.replyTo ? this.replyTo.folderId : undefined,
-				messageId: this.replyTo ? this.replyTo.id : undefined,
+				messageId: this.replyTo ? this.replyTo.uid : undefined,
 				isHtml: !this.editorPlainText,
 			}
 		},

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -124,7 +124,7 @@ export default {
 						accountId: this.$route.params.accountId,
 						folderId: this.$route.params.folderId,
 						filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-						messageUid: 'new',
+						messageUuid: 'new',
 						draftUid: this.data.uid,
 					},
 					exact: true,
@@ -136,7 +136,7 @@ export default {
 						accountId: this.$route.params.accountId,
 						folderId: this.$route.params.folderId,
 						filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-						messageUid: this.data.uid,
+						messageUuid: this.data.uuid,
 					},
 					exact: true,
 				}
@@ -194,7 +194,7 @@ export default {
 			this.$store.dispatch('deleteMessage', {
 				accountId: this.data.accountId,
 				folderId: this.data.folderId,
-				id: this.data.id,
+				uid: this.data.uid,
 			})
 		},
 	},

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -28,12 +28,12 @@
 			<div id="list-refreshing" key="loading" class="icon-loading-small" :class="{refreshing: refreshing}" />
 			<Envelope
 				v-for="env in envelopes"
-				:key="env.uid"
+				:key="env.uuid"
 				:data="env"
 				:folder="folder"
 				:selected="isEnvelopeSelected(envelopes.indexOf(env))"
 				:select-mode="selectMode"
-				@delete="$emit('delete', env.uid)"
+				@delete="$emit('delete', env.uuid)"
 				@update:selected="onEnvelopeSelectToggle(env, ...$event)"
 			/>
 			<div
@@ -144,8 +144,8 @@ export default {
 		},
 		deleteAllSelected() {
 			this.selection.forEach((envelopeId) => {
-				// Navigate if the message beeing deleted is the one currently viewed
-				if (this.envelopes[envelopeId].uid == this.$route.params.messageUid) {
+				// Navigate if the message being deleted is the one currently viewed
+				if (this.envelopes[envelopeId].uuid == this.$route.params.messageUuid) {
 					let next
 					if (envelopeId === 0) {
 						next = this.envelopes[envelopeId + 1]
@@ -159,7 +159,7 @@ export default {
 							params: {
 								accountId: this.$route.params.accountId,
 								folderId: this.$route.params.folderId,
-								messageUid: next.uid,
+								messageUuid: next.uuid,
 							},
 						})
 					}

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -207,7 +207,7 @@ export default {
 							accountId: this.$route.params.accountId,
 							folderId: this.$route.params.folderId,
 							filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-							messageUid: first.uid,
+							messageUuid: first.uuid,
 						},
 					})
 				}
@@ -268,14 +268,14 @@ export default {
 		},
 		handleShortcut(e) {
 			const envelopes = this.envelopes
-			const currentUid = this.$route.params.messageUid
+			const currentUuid = this.$route.params.messageUuid
 
-			if (!currentUid) {
+			if (!currentUuid) {
 				logger.debug('ignoring shortcut: no envelope selected')
 				return
 			}
 
-			const current = envelopes.filter((e) => e.uid === currentUid)
+			const current = envelopes.filter((e) => e.uuid === currentUuid)
 			if (current.length === 0) {
 				logger.debug('ignoring shortcut: currently displayed messages is not in current envelope list')
 				return
@@ -311,18 +311,18 @@ export default {
 							accountId: this.$route.params.accountId,
 							folderId: this.$route.params.folderId,
 							filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-							messageUid: next.uid,
+							messageUuid: next.uuid,
 						},
 					})
 					break
 				case 'del':
 					logger.debug('deleting', {env})
-					this.onDelete(env.uid)
+					this.onDelete(env.uuid)
 					this.$store
 						.dispatch('deleteMessage', {
 							accountId: env.accountId,
 							folderId: env.folderId,
-							id: env.id,
+							uid: env.uid,
 						})
 						.catch((error) =>
 							logger.error('could not delete envelope', {
@@ -384,14 +384,14 @@ export default {
 				this.refreshing = false
 			}
 		},
-		onDelete(uid) {
-			const idx = findIndex(propEq('uid', uid), this.envelopes)
+		onDelete(uuid) {
+			const idx = findIndex(propEq('uuid', uuid), this.envelopes)
 			if (idx === -1) {
 				logger.debug('envelope to delete does not exist in envelope list')
 				return
 			}
 			this.envelopes.splice(idx, 1)
-			if (uid !== this.$route.params.messageUid) {
+			if (uuid !== this.$route.params.messageUuid) {
 				logger.debug('other message open, not jumping to the next/previous message')
 				return
 			}
@@ -410,7 +410,7 @@ export default {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
 					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-					messageUid: next.uid,
+					messageUuid: next.uuid,
 				},
 			})
 		},

--- a/src/components/MailboxMessage.vue
+++ b/src/components/MailboxMessage.vue
@@ -164,9 +164,9 @@ export default {
 		},
 		newMessage() {
 			return (
-				this.$route.params.messageUid === 'new' ||
-				this.$route.params.messageUid === 'reply' ||
-				this.$route.params.messageUid === 'replyAll'
+				this.$route.params.messageUuid === 'new' ||
+				this.$route.params.messageUuid === 'reply' ||
+				this.$route.params.messageUuid === 'replyAll'
 			)
 		},
 	},

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -60,7 +60,7 @@ import {translate as t} from '@nextcloud/l10n'
 import {getFilePickerBuilder} from '@nextcloud/dialogs'
 import PopoverMenu from '@nextcloud/vue/dist/Components/PopoverMenu'
 
-import {parseUid} from '../util/EnvelopeUidParser'
+import {parseUuid} from '../util/EnvelopeUidParser'
 import Logger from '../logger'
 
 import {downloadAttachment, saveAttachmentToFiles} from '../service/AttachmentService'
@@ -146,7 +146,7 @@ export default {
 			const saveAttachment = (accountId, folderId, messageId, attachmentId) => (directory) => {
 				return saveAttachmentToFiles(accountId, folderId, messageId, attachmentId, directory)
 			}
-			const {accountId, folderId, id} = parseUid(this.$route.params.messageUid)
+			const {accountId, folderId, uid} = parseUuid(this.$route.params.messageUuid)
 			const picker = getFilePickerBuilder(t('mail', 'Choose a folder to store the attachment in'))
 				.setMultiSelect(false)
 				.addMimeTypeFilter('httpd/unix-directory')
@@ -160,7 +160,7 @@ export default {
 					this.savingToCloud = true
 					return dest
 				})
-				.then(saveAttachment(accountId, folderId, id, this.id))
+				.then(saveAttachment(accountId, folderId, uid, this.id))
 				.then(() => Logger.info('saved'))
 				.catch((e) => Logger.error('not saved', {error: e}))
 				.then(() => (this.savingToCloud = false))

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -50,7 +50,7 @@
 
 <script>
 import {getFilePickerBuilder} from '@nextcloud/dialogs'
-import {parseUid} from '../util/EnvelopeUidParser'
+import {parseUuid} from '../util/EnvelopeUidParser'
 import {saveAttachmentsToFiles} from '../service/AttachmentService'
 
 import MessageAttachment from './MessageAttachment'
@@ -89,7 +89,7 @@ export default {
 			const saveAttachments = (accountId, folderId, messageId) => (directory) => {
 				return saveAttachmentsToFiles(accountId, folderId, messageId, directory)
 			}
-			const {accountId, folderId, id} = parseUid(this.$route.params.messageUid)
+			const {accountId, folderId, uid} = parseUuid(this.$route.params.messageUuid)
 
 			return picker
 				.pick()
@@ -97,7 +97,7 @@ export default {
 					this.savingToCloud = true
 					return dest
 				})
-				.then(saveAttachments(accountId, folderId, id))
+				.then(saveAttachments(accountId, folderId, uid))
 				.then(() => Logger.info('saved'))
 				.catch((error) => Logger.error('not saved', {error}))
 				.then(() => (this.savingToCloud = false))

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -126,7 +126,10 @@ export default {
 
 			// FIXME: this assumes that there's at least one folder
 			const folderId = this.$route.params.folderId || this.$store.getters.getFolders(accountId)[0].id
-			if (this.$router.currentRoute.name === 'message' && this.$router.currentRoute.params.messageUid === 'new') {
+			if (
+				this.$router.currentRoute.name === 'message' &&
+				this.$router.currentRoute.params.messageUuid === 'new'
+			) {
 				// If we already show the composer, navigating to it would be pointless (and doesn't work)
 				// instead trigger an event to reset the composer
 				this.$root.$emit('newMessage')
@@ -140,7 +143,7 @@ export default {
 						accountId,
 						folderId,
 						filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-						messageUid: 'new',
+						messageUuid: 'new',
 					},
 				})
 				.catch((err) => {

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -67,12 +67,12 @@ export default {
 					subject: this.draft.subject,
 					body: this.draft.hasHtmlBody ? html(this.draft.body) : plain(this.draft.body),
 				}
-			} else if (this.$route.query.uid !== undefined) {
+			} else if (this.$route.query.uuid !== undefined) {
 				// Forward or reply to a message
 				const message = this.original
 				logger.debug('forwarding or replying to message', {message})
 
-				if (this.$route.params.messageUid === 'reply') {
+				if (this.$route.params.messageUuid === 'reply') {
 					logger.debug('simple reply')
 
 					return {
@@ -84,7 +84,7 @@ export default {
 						originalBody: this.originalBody,
 						replyTo: message,
 					}
-				} else if (this.$route.params.messageUid === 'replyAll') {
+				} else if (this.$route.params.messageUuid === 'replyAll') {
 					logger.debug('replying to all', {original: this.original})
 					const account = this.$store.getters.getAccount(message.accountId)
 					const recipients = buildReplyRecipients(message, {
@@ -164,8 +164,8 @@ export default {
 		fetchMessage() {
 			if (this.$route.params.draftUid !== undefined) {
 				return this.fetchDraftMessage(this.$route.params.draftUid)
-			} else if (this.$route.query.uid !== undefined) {
-				return this.fetchOriginalMessage(this.$route.query.uid)
+			} else if (this.$route.query.uuid !== undefined) {
+				return this.fetchOriginalMessage(this.$route.query.uuid)
 			}
 		},
 		fetchDraftMessage(draftUid) {
@@ -209,7 +209,7 @@ export default {
 
 			try {
 				const message = await this.$store.dispatch('fetchMessage', uid)
-				if (message.uid !== this.$route.query.uid) {
+				if (message.uuid !== this.$route.query.uuid) {
 					logger.debug("User navigated away, loaded original message won't be used")
 					return
 				}
@@ -221,10 +221,10 @@ export default {
 				if (message.hasHtmlBody) {
 					logger.debug('original message has HTML body')
 					const resp = await Axios.get(
-						generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{id}/html', {
+						generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{uid}/html', {
 							accountId: message.accountId,
 							folderId: message.folderId,
-							id: message.id,
+							uid: message.uid,
 						})
 					)
 
@@ -270,7 +270,7 @@ export default {
 							params: {
 								accountId: this.$route.params.accountId,
 								folderId: this.$route.params.folderId,
-								messageUid: 'new',
+								messageUuid: 'new',
 								draftUid: this.draft.uid,
 							},
 						})

--- a/src/router.js
+++ b/src/router.js
@@ -29,7 +29,7 @@ export default new Router({
 			component: Home,
 		},
 		{
-			path: '/accounts/:accountId/folders/:filter?/:folderId/message/:messageUid/:draftUid?',
+			path: '/accounts/:accountId/folders/:filter?/:folderId/message/:messageUuid/:draftUid?',
 			name: 'message',
 			component: Home,
 		},

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -9,15 +9,15 @@ import SyncIncompleteError from '../errors/SyncIncompleteError'
 const amendEnvelopeWithIds = curry((accountId, folderId, envelope) => ({
 	accountId,
 	folderId,
-	uid: `${accountId}-${folderId}-${envelope.id}`,
+	uuid: `${accountId}-${folderId}-${envelope.uid}`,
 	...envelope,
 }))
 
-export function fetchEnvelope(accountId, folderId, id) {
-	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{id}', {
+export function fetchEnvelope(accountId, folderId, uid) {
+	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{uid}', {
 		accountId,
 		folderId,
-		id,
+		uid,
 	})
 
 	return axios
@@ -104,11 +104,11 @@ export async function clearCache(accountId, folderId) {
 	}
 }
 
-export function setEnvelopeFlag(accountId, folderId, id, flag, value) {
-	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{id}/flags', {
+export function setEnvelopeFlag(accountId, folderId, uid, flag, value) {
+	const url = generateUrl('/apps/mail/api/accounts/{accountId}/folders/{folderId}/messages/{uid}/flags', {
 		accountId,
 		folderId,
-		id,
+		uid,
 	})
 
 	const flags = {}

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -52,8 +52,8 @@ export const getters = {
 				.filter((folder) => folder.specialRole === specialRole)
 		)
 	},
-	getEnvelope: (state) => (accountId, folderId, id) => {
-		return state.envelopes[normalizedMessageId(accountId, folderId, id)]
+	getEnvelope: (state) => (accountId, folderId, uid) => {
+		return state.envelopes[normalizedMessageId(accountId, folderId, uid)]
 	},
 	getEnvelopeById: (state) => (id) => {
 		return state.envelopes[id]
@@ -62,7 +62,7 @@ export const getters = {
 		const list = getters.getFolder(accountId, folderId).envelopeLists[normalizedEnvelopeListId(query)] || []
 		return list.map((msgId) => state.envelopes[msgId])
 	},
-	getMessage: (state) => (accountId, folderId, id) => {
-		return state.messages[normalizedMessageId(accountId, folderId, id)]
+	getMessage: (state) => (accountId, folderId, uid) => {
+		return state.messages[normalizedMessageId(accountId, folderId, uid)]
 	},
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -112,13 +112,13 @@ export default {
 	},
 	addEnvelope(state, {accountId, folderId, query, envelope}) {
 		const folder = state.folders[normalizedFolderId(accountId, folderId)]
-		Vue.set(state.envelopes, envelope.uid, envelope)
+		Vue.set(state.envelopes, envelope.uuid, envelope)
 		const listId = normalizedEnvelopeListId(query)
 		const existing = folder.envelopeLists[listId] || []
-		const uidToDateInt = (uid) => state.envelopes[uid].dateInt
-		const sortedUniqByDateInt = sortedUniqBy(uidToDateInt)
-		const orderByDateInt = orderBy(uidToDateInt, 'desc')
-		Vue.set(folder.envelopeLists, listId, sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uid]))))
+		const uuidToDateInt = (uuid) => state.envelopes[uuid].dateInt
+		const sortedUniqByDateInt = sortedUniqBy(uuidToDateInt)
+		const orderByDateInt = orderBy(uuidToDateInt, 'desc')
+		Vue.set(folder.envelopeLists, listId, sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uuid]))))
 
 		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
 		unifiedAccount.folders
@@ -129,7 +129,7 @@ export default {
 				Vue.set(
 					folder.envelopeLists,
 					listId,
-					sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uid])))
+					sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.uuid])))
 				)
 			})
 	},
@@ -143,18 +143,18 @@ export default {
 	flagEnvelope(state, {envelope, flag, value}) {
 		envelope.flags[flag] = value
 	},
-	removeEnvelope(state, {accountId, folderId, id}) {
+	removeEnvelope(state, {accountId, folderId, uid}) {
 		const folder = state.folders[normalizedFolderId(accountId, folderId)]
 		for (const listId in folder.envelopeLists) {
 			if (!Object.hasOwnProperty.call(folder.envelopeLists, listId)) {
 				continue
 			}
 			const list = folder.envelopeLists[listId]
-			const idx = list.indexOf(normalizedMessageId(accountId, folderId, id))
+			const idx = list.indexOf(normalizedMessageId(accountId, folderId, uid))
 			if (idx < 0) {
 				continue
 			}
-			console.debug('envelope removed from mailbox', accountId, folder.id, id, listId)
+			console.debug('envelope removed from mailbox', accountId, folder.id, uid, listId)
 			list.splice(idx, 1)
 		}
 
@@ -167,29 +167,29 @@ export default {
 						continue
 					}
 					const list = folder.envelopeLists[listId]
-					const idx = list.indexOf(normalizedMessageId(accountId, folderId, id))
+					const idx = list.indexOf(normalizedMessageId(accountId, folderId, uid))
 					if (idx < 0) {
 						console.warn(
 							'envelope does not exist in unified mailbox',
 							accountId,
 							folder.id,
-							id,
+							uid,
 							listId,
 							list
 						)
 						continue
 					}
-					console.debug('envelope removed from unified mailbox', accountId, folder.id, id, listId)
+					console.debug('envelope removed from unified mailbox', accountId, folder.id, uid, listId)
 					list.splice(idx, 1)
 				}
 			})
 	},
 	addMessage(state, {accountId, folderId, message}) {
-		const uid = normalizedMessageId(accountId, folderId, message.id)
+		const uuid = normalizedMessageId(accountId, folderId, message.uid)
 		message.accountId = accountId
 		message.folderId = folderId
-		message.uid = uid
-		Vue.set(state.messages, uid, message)
+		message.uuid = uuid
+		Vue.set(state.messages, uuid, message)
 	},
 	updateDraft(state, {draft, data, newUid}) {
 		// Update draft's UID
@@ -217,8 +217,8 @@ export default {
 		Vue.set(state.envelopes, uid, draft)
 		Vue.set(state.messages, uid, draft)
 	},
-	removeMessage(state, {accountId, folderId, id}) {
-		Vue.delete(state.messages, normalizedMessageId(accountId, folderId, id))
+	removeMessage(state, {accountId, folderId, uid}) {
+		Vue.delete(state.messages, normalizedMessageId(accountId, folderId, uid))
 	},
 	createAlias(state, {account, alias}) {
 		account.aliases.push(alias)

--- a/src/store/normalization.js
+++ b/src/store/normalization.js
@@ -25,8 +25,8 @@ export const normalizedFolderId = curry((accountId, folderId) => {
 	return `${accountId}-${folderId}`
 })
 
-export const normalizedMessageId = curry((accountId, folderId, messageId) => {
-	return `${accountId}-${folderId}-${messageId}`
+export const normalizedMessageId = curry((accountId, folderId, uid) => {
+	return `${accountId}-${folderId}-${uid}`
 })
 
 export const normalizedEnvelopeListId = defaultTo('')

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -29,12 +29,12 @@ import * as NotificationService from '../../../service/NotificationService'
 import {normalizedMessageId} from '../../../store/normalization'
 import {UNIFIED_ACCOUNT_ID, UNIFIED_INBOX_ID} from '../../../store/constants'
 
-const mockEnvelope = curry((accountId, folderId, id) => ({
+const mockEnvelope = curry((accountId, folderId, uid) => ({
 	accountId,
 	folderId,
-	id,
-	uid: normalizedMessageId(accountId, folderId, id),
-	dateInt: id * 10000,
+	uid,
+	uuid: normalizedMessageId(accountId, folderId, uid),
+	dateInt: uid * 10000,
 }))
 
 describe('Vuex store actions', () => {
@@ -154,8 +154,8 @@ describe('Vuex store actions', () => {
 			Promise.resolve(
 				reverse(
 					range(1, 21).map((n) => ({
-						id: n,
-						uid: normalizedMessageId(13, 'INBOX', n),
+						uid: n,
+						uuid: normalizedMessageId(13, 'INBOX', n),
 						dateInt: n * 10000,
 					}))
 				)
@@ -170,8 +170,8 @@ describe('Vuex store actions', () => {
 		expect(page).to.deep.equal(
 			reverse(
 				range(1, 21).map((n) => ({
-					id: n,
-					uid: normalizedMessageId(13, 'INBOX', n),
+					uid: n,
+					uuid: normalizedMessageId(13, 'INBOX', n),
 					dateInt: n * 10000,
 				}))
 			)

--- a/src/tests/unit/store/normalization.spec.js
+++ b/src/tests/unit/store/normalization.spec.js
@@ -36,7 +36,7 @@ describe('Vuex store normalization', () => {
 		const folderId = 'INBOX'
 		const messageId = 123
 
-		const id = normalizedMessageId(accountId, folderId, 123)
+		const id = normalizedMessageId(accountId, folderId, messageId)
 
 		expect(id).to.equal('13-INBOX-123')
 	})

--- a/src/tests/unit/util/EnvelopeUidParser.spec.js
+++ b/src/tests/unit/util/EnvelopeUidParser.spec.js
@@ -19,26 +19,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {parseUid} from '../../../util/EnvelopeUidParser'
+import {parseUuid} from '../../../util/EnvelopeUidParser'
 
 describe('EnvelopeUidParser', () => {
 	it('parses a simple UID', () => {
-		const uid = '1-SU5CT1g=-123'
+		const uuid = '1-SU5CT1g=-123'
 
-		const parsed = parseUid(uid)
+		const parsed = parseUuid(uuid)
 
 		expect(parsed.accountId).to.equal(1)
 		expect(parsed.folderId).to.equal('SU5CT1g=')
-		expect(parsed.id).to.equal(123)
+		expect(parsed.uid).to.equal(123)
 	})
 
 	it('parses the default account UID', () => {
-		const uid = '-2-SU5CT1g=-123'
+		const uuid = '-2-SU5CT1g=-123'
 
-		const parsed = parseUid(uid)
+		const parsed = parseUuid(uuid)
 
 		expect(parsed.accountId).to.equal(-2)
 		expect(parsed.folderId).to.equal('SU5CT1g=')
-		expect(parsed.id).to.equal(123)
+		expect(parsed.uid).to.equal(123)
 	})
 })

--- a/src/util/EnvelopeUidParser.js
+++ b/src/util/EnvelopeUidParser.js
@@ -21,7 +21,7 @@
 
 const reg = /^(-?\d+)-((?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4}))-(\d+)$/
 
-export const parseUid = (str) => {
+export const parseUuid = (str) => {
 	const match = reg.exec(str)
 
 	if (match === null) {
@@ -32,6 +32,6 @@ export const parseUid = (str) => {
 	return {
 		accountId: parseInt(match[1], 10),
 		folderId: match[2],
-		id: parseInt(match[3], 10),
+		uid: parseInt(match[3], 10),
 	}
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -91,7 +91,7 @@ export default {
 				params: {
 					accountId: firstAccount.id,
 					folderId: firstFolder.id,
-					messageUid: 'new',
+					messageUuid: 'new',
 				},
 				query: {
 					to: this.$route.query.to,
@@ -111,7 +111,7 @@ export default {
 				params: {
 					accountId: this.$route.params.accountId,
 					folderId: this.$route.params.folderId,
-					messageUid: 'new',
+					messageUuid: 'new',
 				},
 			})
 		},

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -88,6 +88,6 @@ class IMAPMessageTest extends TestCase {
 
 		$json = $m->jsonSerialize();
 
-		$this->assertEquals(1234, $json['id']);
+		$this->assertEquals(1234, $json['uid']);
 	}
 }


### PR DESCRIPTION
* ID is supposed to be the database ID
* UID is the IMAP UID
* UUID is the globally unique identifier used in the front-end

So this
* Moves the previous message.uid and envelope.uid to message.uuid and envelope.uuid.
* Changes the `messageUid` url param to `mesageUuid`.
* Moves the previous message.id and envelope.id to message.id and envelope.id.
* Adds a message.id and envelope.id that represent the unique ID from the database cache.

Required for the front-end changes of https://github.com/orgs/nextcloud/projects/4 and the integration of #3367 