### PR TITLE
Mapping "STARTTLS" to "tls" for autoconfig XML compatible with Thunderbird

### DIFF
--- a/lib/Service/AutoConfig/IspDbConfigurationDetector.php
+++ b/lib/Service/AutoConfig/IspDbConfigurationDetector.php
@@ -222,7 +222,6 @@ class IspDbConfigurationDetector {
 			$account->setOutboundPort($smtp['port']);
 			$account->setOutboundPassword($this->crypto->encrypt($password));
 			$account->setOutboundUser($user);
-			$account->setOutboundSslMode(strtolower($smtp['socketType']));
 
 			/** mapping 'STARTTLS' expected by e.g. Thunderbird to 'tls' used by mail app */
 			if (strtolower($smtp['socketType']) === 'starttls') {


### PR DESCRIPTION
As Thunderbird expects the string "STARTTLS" from the autoconfig XML*, but Mail App internally uses "tls", starttls is now being mapped to tls.

*source: https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat
