### PR TITLE
Allow toggeling of subscription status of folders

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -196,4 +196,17 @@ interface IMailManager {
 	 * @throws ServiceException
 	 */
 	public function deleteMailbox(Account $account, Mailbox $mailbox): void;
+
+	/**
+	 * @param Account $account
+	 * @param string $mailbox
+	 * @param bool $subscribed
+	 *
+	 * @return Mailbox
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function updateSubscription(Account $account,
+									   Mailbox $mailbox,
+									   bool $subscribed): Mailbox;
 }

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -108,7 +108,8 @@ class MailboxesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function patch(int $id,
-						  ?string $name = null): JSONResponse {
+						  ?string $name = null,
+						  ?bool $subscribed = null): JSONResponse {
 		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
 		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 
@@ -117,6 +118,13 @@ class MailboxesController extends Controller {
 				$account,
 				$mailbox,
 				$name
+			);
+		}
+		if ($subscribed !== null) {
+			$mailbox = $this->mailManager->updateSubscription(
+				$account,
+				$mailbox,
+				$subscribed
 			);
 		}
 

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -80,6 +80,15 @@
 					@click="clearCache">
 					{{ t('mail', 'Clear locally cached data, in case there are issues with synchronization.') }}
 				</ActionButton>
+
+				<ActionCheckbox
+					v-if="notVirtual"
+					:checked="isSubscribed"
+					:disabled="changeSubscription"
+					@update:checked="changeFolderSubscription">
+					{{ t('mail', 'Subscribed') }}
+				</ActionCheckbox>
+
 				<ActionButton v-if="!account.isUnified && !mailbox.specialRole && !hasSubMailboxes" icon="icon-delete" @click="deleteMailbox">
 					{{ t('mail', 'Delete folder') }}
 				</ActionButton>
@@ -103,6 +112,7 @@
 import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
 import AppNavigationCounter from '@nextcloud/vue/dist/Components/AppNavigationCounter'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 
@@ -120,6 +130,7 @@ export default {
 		AppNavigationCounter,
 		ActionText,
 		ActionButton,
+		ActionCheckbox,
 		ActionInput,
 	},
 	props: {
@@ -148,6 +159,7 @@ export default {
 			loadingMarkAsRead: false,
 			clearingCache: false,
 			showSaving: false,
+			changeSubscription: false,
 			editing: false,
 			showSubMailboxes: false,
 			menuOpen: false,
@@ -163,6 +175,9 @@ export default {
 				this.account.showSubscribedOnly === false
 				|| (this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed'))
 			)
+		},
+		notVirtual() {
+			return !this.account.isUnified && this.mailbox.specialRole !== 'flagged'
 		},
 		title() {
 			if (this.filter === 'starred') {
@@ -217,6 +232,9 @@ export default {
 				}
 			}
 			return t('mail', 'Loading …')
+		},
+		isSubscribed() {
+			return this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed')
 		},
 	},
 	methods: {
@@ -294,6 +312,21 @@ export default {
 				.then(() => logger.info(`mailbox ${this.mailbox.databaseId} marked as read`))
 				.catch((error) => logger.error(`could not mark mailbox ${this.mailbox.databaseId} as read`, { error }))
 				.then(() => (this.loadingMarkAsRead = false))
+		},
+		async changeFolderSubscription(subscribed) {
+			try {
+				this.changeSubscription = true
+
+				await this.$store.dispatch('changeMailboxSubscription', {
+					mailbox: this.mailbox,
+					subscribed,
+				})
+			} catch (error) {
+				logger.error(`could not update subscription of mailbox ${this.mailbox.databaseId}`, { error })
+				throw error
+			} finally {
+				this.changeSubscription = false
+			}
 		},
 		async clearCache() {
 			try {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -212,6 +212,21 @@ export default {
 			})
 		)
 	},
+	async changeMailboxSubscription({ commit }, { mailbox, subscribed }) {
+		logger.debug(`toggle subscription for mailbox ${mailbox.databaseId}`, {
+			mailbox,
+			subscribed,
+		})
+		const updated = await patchMailbox(mailbox.databaseId, { subscribed })
+
+		commit('updateMailbox', {
+			mailbox: updated,
+		})
+		logger.debug(`subscription for mailbox ${mailbox.databaseId} updated`, {
+			mailbox,
+			updated,
+		})
+	},
 	fetchEnvelope({ commit, getters }, id) {
 		const cached = getters.getEnvelope(id)
 		if (cached) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -113,6 +113,9 @@ export default {
 	addMailbox(state, { account, mailbox }) {
 		addMailboxToState(state, account, mailbox)
 	},
+	updateMailbox(state, { mailbox }) {
+		Vue.set(state.mailboxes, mailbox.databaseId, mailbox)
+	},
 	removeMailbox(state, { id }) {
 		const mailbox = state.mailboxes[id]
 		if (mailbox === undefined) {


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/mail/pull/3260 for the mailbox patch route

Now a properly squashed version of "Allow toggling subscription status for mailboxes".
@ChristophWurst: If at all possible, please merge it quickly. The merge conflicts have taken up a lot of time.