### PR TITLE
Fix leftover usage of mailbox.id when mailbox.name is required

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -243,7 +243,7 @@ export default {
 		async createMailbox(e) {
 			this.editing = true
 			const name = e.target.elements[1].value
-			const withPrefix = atob(this.mailbox.databaseId) + this.mailbox.delimiter + name
+			const withPrefix = this.mailbox.name + this.mailbox.delimiter + name
 			logger.info(`creating mailbox ${withPrefix} as submailbox of ${this.mailbox.databaseId}`)
 			this.menuOpen = false
 			try {

--- a/src/imap/MailboxSorter.js
+++ b/src/imap/MailboxSorter.js
@@ -31,7 +31,7 @@ export const sortMailboxes = (mailboxes) => {
 			const s2 = specialRolesOrder.indexOf(f2.specialUse[0])
 
 			if (s1 === s2) {
-				return atob(f1.id).localeCompare(atob(f2.id))
+				return f1.name.localeCompare(f2.name)
 			}
 
 			return s1 - s2
@@ -40,7 +40,7 @@ export const sortMailboxes = (mailboxes) => {
 		} else if (f2.specialUse.length) {
 			return 1
 		} else {
-			return atob(f1.id).localeCompare(atob(f2.id))
+			return f1.name.localeCompare(f2.name)
 		}
 	})
 	return c

--- a/src/tests/unit/i18n/MailboxTranslator.spec.js
+++ b/src/tests/unit/i18n/MailboxTranslator.spec.js
@@ -24,7 +24,7 @@ import { translate } from '../../../i18n/MailboxTranslator'
 describe('MailboxTranslator', () => {
 	it('translates the inbox', () => {
 		const mailbox = {
-			id: btoa('INBOX'),
+			name: 'INBOX',
 			specialUse: ['inbox'],
 		}
 
@@ -35,7 +35,7 @@ describe('MailboxTranslator', () => {
 
 	it('does not translate an arbitrary mailbox', () => {
 		const mailbox = {
-			id: btoa('Newsletters'),
+			name: 'Newsletters',
 			displayName: 'Newsletters',
 			specialUse: [],
 		}

--- a/src/tests/unit/imap/MailboxHierarchy.spec.js
+++ b/src/tests/unit/imap/MailboxHierarchy.spec.js
@@ -32,11 +32,11 @@ describe('mailboxHierarchyBuilder', () => {
 
 	it('builds a flat hierarchy', () => {
 		const mb1 = {
-			id: btoa('INBOX'),
+			name: 'INBOX',
 			delimiter: '.',
 		}
 		const mb2 = {
-			id: btoa('Sent'),
+			name: 'Sent',
 			delimiter: '.',
 		}
 		const mailboxes = [mb1, mb2]
@@ -45,12 +45,12 @@ describe('mailboxHierarchyBuilder', () => {
 
 		expect(hierarchy).to.deep.equal([
 			{
-				id: btoa('INBOX'),
+				name: 'INBOX',
 				delimiter: '.',
 				mailboxes: [],
 			},
 			{
-				id: btoa('Sent'),
+				name: 'Sent',
 				delimiter: '.',
 				mailboxes: [],
 			},
@@ -59,11 +59,11 @@ describe('mailboxHierarchyBuilder', () => {
 
 	it('builds a nested hierarchy with one level', () => {
 		const mb1 = {
-			id: btoa('Archive'),
+			name: 'Archive',
 			delimiter: '.',
 		}
 		const mb2 = {
-			id: btoa('Archive.Sent'),
+			name: 'Archive.Sent',
 			delimiter: '.',
 		}
 		const mailboxes = [mb1, mb2]
@@ -72,11 +72,11 @@ describe('mailboxHierarchyBuilder', () => {
 
 		expect(hierarchy).to.deep.equal([
 			{
-				id: btoa('Archive'),
+				name: 'Archive',
 				delimiter: '.',
 				mailboxes: [
 					{
-						id: btoa('Archive.Sent'),
+						name: 'Archive.Sent',
 						delimiter: '.',
 						mailboxes: [],
 					},
@@ -87,15 +87,15 @@ describe('mailboxHierarchyBuilder', () => {
 
 	it('builds a nested hierarchy with two levels', () => {
 		const mb1 = {
-			id: btoa('Archive'),
+			name: 'Archive',
 			delimiter: '.',
 		}
 		const mb2 = {
-			id: btoa('Archive.Sent'),
+			name: 'Archive.Sent',
 			delimiter: '.',
 		}
 		const mb3 = {
-			id: btoa('Archive.Sent.Old'),
+			name: 'Archive.Sent.Old',
 			delimiter: '.',
 		}
 		const mailboxes = [mb1, mb2, mb3]
@@ -104,16 +104,16 @@ describe('mailboxHierarchyBuilder', () => {
 
 		expect(hierarchy).to.deep.equal([
 			{
-				id: btoa('Archive'),
+				name: 'Archive',
 				delimiter: '.',
 				mailboxes: [
 					{
-						id: btoa('Archive.Sent'),
+						name: 'Archive.Sent',
 						delimiter: '.',
 						mailboxes: [],
 					},
 					{
-						id: btoa('Archive.Sent.Old'),
+						name: 'Archive.Sent.Old',
 						delimiter: '.',
 						mailboxes: [],
 					},
@@ -124,15 +124,15 @@ describe('mailboxHierarchyBuilder', () => {
 
 	it('does not use the flagged inbox as submailbox of inbox', () => {
 		const mb1 = {
-			id: btoa('INBOX'),
+			name: 'INBOX',
 			delimiter: '/',
 		}
 		const mb2 = {
-			id: btoa('INBOX/FLAGGED'),
+			name: 'INBOX/FLAGGED',
 			delimiter: '/',
 		}
 		const mb3 = {
-			id: btoa('Archive'),
+			name: 'Archive',
 			delimiter: '/',
 		}
 		const mailboxes = [mb1, mb2, mb3]
@@ -141,17 +141,17 @@ describe('mailboxHierarchyBuilder', () => {
 
 		expect(hierarchy).to.deep.equal([
 			{
-				id: btoa('INBOX'),
+				name: 'INBOX',
 				delimiter: '/',
 				mailboxes: [],
 			},
 			{
-				id: btoa('INBOX/FLAGGED'),
+				name: 'INBOX/FLAGGED',
 				delimiter: '/',
 				mailboxes: [],
 			},
 			{
-				id: btoa('Archive'),
+				name: 'Archive',
 				delimiter: '/',
 				mailboxes: [],
 			},
@@ -160,11 +160,11 @@ describe('mailboxHierarchyBuilder', () => {
 
 	it('builds a nested hierarchy with a prefix', () => {
 		const mb1 = {
-			id: btoa('INBOX.Archive'),
+			name: 'INBOX.Archive',
 			delimiter: '.',
 		}
 		const mb2 = {
-			id: btoa('INBOX.Archive.Sent'),
+			name: 'INBOX.Archive.Sent',
 			delimiter: '.',
 		}
 		const mailboxes = [mb1, mb2]
@@ -173,11 +173,11 @@ describe('mailboxHierarchyBuilder', () => {
 
 		expect(hierarchy).to.deep.equal([
 			{
-				id: btoa('INBOX.Archive'),
+				name: 'INBOX.Archive',
 				delimiter: '.',
 				mailboxes: [
 					{
-						id: btoa('INBOX.Archive.Sent'),
+						name: 'INBOX.Archive.Sent',
 						delimiter: '.',
 						mailboxes: [],
 					},

--- a/src/tests/unit/imap/MailboxPrefix.spec.js
+++ b/src/tests/unit/imap/MailboxPrefix.spec.js
@@ -25,11 +25,11 @@ describe('MailboxPrefix', () => {
 	it('does not find a prefix if there is none', () => {
 		const mailboxes = [
 			{
-				id: 'INBOX',
+				name: 'INBOX',
 				delimiter: '.',
 			},
 			{
-				id: 'Sent',
+				name: 'Sent',
 				delimiter: '.',
 			},
 		]
@@ -42,11 +42,11 @@ describe('MailboxPrefix', () => {
 	it('detects a prefix', () => {
 		const mailboxes = [
 			{
-				id: 'INBOX',
+				name: 'INBOX',
 				delimiter: '.',
 			},
 			{
-				id: 'INBOX.Sent',
+				name: 'INBOX.Sent',
 				delimiter: '.',
 			},
 		]

--- a/src/tests/unit/imap/MailboxSorter.spec.js
+++ b/src/tests/unit/imap/MailboxSorter.spec.js
@@ -24,11 +24,11 @@ import { sortMailboxes } from '../../../imap/MailboxSorter'
 describe('mailboxSorter', () => {
 	it('sorts ordinary mailboxes', () => {
 		const mb1 = {
-			id: btoa('Inbox 1'),
+			name: 'Inbox 1',
 			specialUse: [],
 		}
 		const mb2 = {
-			id: btoa('Inbox 2'),
+			name: 'Inbox 2',
 			specialUse: [],
 		}
 		const mailboxes = [mb2, mb1]
@@ -40,11 +40,11 @@ describe('mailboxSorter', () => {
 
 	it('lists special mailboxes first', () => {
 		const mb1 = {
-			id: btoa('Inbox 1'),
+			name: 'Inbox 1',
 			specialUse: [],
 		}
 		const mb2 = {
-			id: btoa('Inbox 2'),
+			name: 'Inbox 2',
 			specialUse: ['inbox'],
 		}
 		const mailboxes = [mb1, mb2]
@@ -56,11 +56,11 @@ describe('mailboxSorter', () => {
 
 	it('sorts equally special mailboxes', () => {
 		const mb1 = {
-			id: btoa('Inbox 1'),
+			name: 'Inbox 1',
 			specialUse: ['inbox'],
 		}
 		const mb2 = {
-			id: btoa('Inbox 2'),
+			name: 'Inbox 2',
 			specialUse: ['inbox'],
 		}
 		const mailboxes = [mb1, mb2]
@@ -72,27 +72,27 @@ describe('mailboxSorter', () => {
 
 	it('sorts real-world mailboxes', () => {
 		const mb1 = {
-			id: btoa('Drafts'),
+			name: 'Drafts',
 			specialUse: ['drafts'],
 		}
 		const mb2 = {
-			id: btoa('Inbox'),
+			name: 'Inbox',
 			specialUse: ['inbox'],
 		}
 		const mb3 = {
-			id: btoa('Other 2'),
+			name: 'Other 2',
 			specialUse: [],
 		}
 		const mb4 = {
-			id: btoa('Other 1'),
+			name: 'Other 1',
 			specialUse: [],
 		}
 		const mb5 = {
-			id: btoa('Sent'),
+			name: 'Sent',
 			specialUse: ['sent'],
 		}
 		const mb6 = {
-			id: btoa('Sent2'),
+			name: 'Sent2',
 			specialUse: ['sent'],
 		}
 		const mailboxes = [mb1, mb2, mb3, mb4, mb5, mb6]


### PR DESCRIPTION
Leftover from #3439, discovered in #3147. Mea culpa.