### PR TITLE
Fix favorite/important ranking and typos

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -45,14 +45,14 @@
 			<Moment :timestamp="data.dateInt" />
 		</div>
 		<Actions class="app-content-list-item-menu" menu-align="right">
-			<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
-				{{
-					data.flags.flagged ? t('mail', 'Unfavorite') : t('mail', 'Favorite')
-				}}
-			</ActionButton>
 			<ActionButton icon="icon-important" @click.prevent="onToggleImportant">
 				{{
 					data.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
+				}}
+			</ActionButton>
+			<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
+				{{
+					data.flags.flagged ? t('mail', 'Mark unfavorite') : t('mail', 'Mark favorite')
 				}}
 			</ActionButton>
 			<ActionButton icon="icon-mail" @click.prevent="onToggleSeen">

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -38,14 +38,14 @@
 						<ActionButton icon="icon-forward" @click="forwardMessage">
 							{{ t('mail', 'Forward') }}
 						</ActionButton>
-						<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
-							{{
-								envelope.flags.flagged ? t('mail', 'Unfavorite') : t('mail', 'Favorite')
-							}}
-						</ActionButton>
 						<ActionButton icon="icon-important" @click.prevent="onToggleImportant">
 							{{
 								envelope.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
+							}}
+						</ActionButton>
+						<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
+							{{
+								envelope.flags.flagged ? t('mail', 'Mark unfavorite') : t('mail', 'Mark favorite')
 							}}
 						</ActionButton>
 						<ActionButton icon="icon-mail" @click="onToggleSeen">

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -39,7 +39,7 @@
 				{{ quotaText }}
 			</ActionText>
 			<ActionRouter :to="settingsRoute" icon="icon-settings">
-				{{ t('mail', 'Edit account') }}
+				{{ t('mail', 'Account settings') }}
 			</ActionRouter>
 			<ActionCheckbox
 				:checked="account.showSubscribedOnly"
@@ -55,7 +55,7 @@
 				{{ t('mail', 'Saving') }}
 			</ActionText>
 			<ActionButton v-if="!isFirst" icon="icon-triangle-n" @click="changeAccountOrderUp">
-				{{ t('mail', 'Move Up') }}
+				{{ t('mail', 'Move up') }}
 			</ActionButton>
 			<ActionButton v-if="!isLast" icon="icon-triangle-s" @click="changeAccountOrderDown">
 				{{ t('mail', 'Move down') }}

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -43,7 +43,7 @@
 				</ActionText>
 
 				<ActionButton
-					v-if="mailbox.specialRole !== 'flagged'"
+					v-if="mailbox.specialRole !== 'flagged' && !account.isUnified"
 					icon="icon-mail"
 					:title="t('mail', 'Mark all as read')"
 					:disabled="loadingMarkAsRead"


### PR DESCRIPTION
This PR fix:

- [x] Favorite/important ranking, putting important first

- [x] Change "Edit account" to "Account settings"

- [x] Move UP to Move up

- [x] Change "Favorite" into "Mark favorite"