### PR TITLE
Do not compare apples and pears during the mailbox sync

### DIFF
--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -145,13 +145,15 @@ class SyncService {
 
 		if ($query !== null) {
 			// Filter new messages to those that also match the current filter
-			$newIds = $this->messageMapper->findIdsByQuery($mailbox, $query, null, $newIds);
+			$newUids = $this->messageMapper->findUidsForIds($mailbox, $newIds);
+			$newIds = $this->messageMapper->findIdsByQuery($mailbox, $query, null, $newUids);
 		}
 		$new = $this->messageMapper->findByIds($newIds);
 
 		// TODO: $changed = $this->messageMapper->findChanged($mailbox, $uids);
 		if ($query !== null) {
-			$changedIds = $this->messageMapper->findIdsByQuery($mailbox, $query, null, $knownIds);
+			$changedUids = $this->messageMapper->findUidsForIds($mailbox, $knownIds);
+			$changedIds = $this->messageMapper->findIdsByQuery($mailbox, $query, null, $changedUids);
 		} else {
 			$changedIds = $knownIds;
 		}


### PR DESCRIPTION
The sync was comparing IDs with message UIDs, hence it occasionally told
the client that all known messages vanished. On the next sync request it
said everything that just vanished was suddenly a new message.

To test open the priority inbox. Optionally send yourself a message from another email client.

On master: first all messages disappear, then the browser hangs.
Here: all smoooooth :boat: 

Regression of #3439

(it should be :apple:s and :orange_circle:s but UID and ID are so similar I figured :apple: and :pear: makes more sense :wink:)