### PR TITLE
Fix missing but expected accountId and mailboxId on message JSON

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -233,6 +233,8 @@ class MessagesController extends Controller {
 				$a
 			);
 		}, $json['attachments']);
+		$json['accountId'] = $account->getId();
+		$json['mailboxId'] = $mailbox->getId();
 		$json['databaseId'] = $message->getId();
 
 		return new JSONResponse($json);


### PR DESCRIPTION
This caused two bugs
* Reply all did not work (the account lookup failed because `undefined`
  was used as ID)
* The preselected account in the reply composer was not automatically
  set to the one from the original message