### PR TITLE
partial fix to #3435

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -65,7 +65,7 @@
 					data.flags.junk ? t('mail', 'Mark not spam') : t('mail', 'Mark as spam')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-checkmark" :close-after-click="true" @click.prevent="onSelect">
+			<ActionButton icon="icon-checkmark" :close-after-click="true" @click.prevent="toggleSelected">
 				{{
 					selected ? t('mail', 'Unselect') : t('mail', 'Select')
 				}}
@@ -180,9 +180,6 @@ export default {
 		},
 	},
 	methods: {
-		onSelect() {
-			this.$emit('update:selected', true)
-		},
 		toggleSelected() {
 			this.$emit('update:selected', !this.selected)
 		},
@@ -199,6 +196,11 @@ export default {
 			this.$store.dispatch('toggleEnvelopeJunk', this.data)
 		},
 		onDelete() {
+			// Remove from selection first
+			if (this.selected) {
+				this.$emit('update:selected', false)
+			}
+			// Delete
 			this.$emit('delete')
 			this.$store.dispatch('deleteMessage', {
 				id: this.data.databaseId,


### PR DESCRIPTION
Fixes the following issues from https://github.com/nextcloud/mail/issues/3435

- It was not possible to unselect an envelope from its action menu
- When a selected envelope was deleted, the next envelope in the envelopes' list got erroneously automaticaly selected