### PR TITLE
Fix missing In-Reply-To and References header for replies

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -364,7 +364,6 @@ class AccountsController extends Controller {
 						 string $bcc,
 						 bool $isHtml = true,
 						 int $draftId = null,
-						 string $folderId = null,
 						 int $messageId = null,
 						 array $attachments = [],
 						 int $aliasId = null): JSONResponse {
@@ -377,8 +376,13 @@ class AccountsController extends Controller {
 
 		$messageData = NewMessageData::fromRequest($account, $expandedTo, $expandedCc, $expandedBcc, $subject, $body, $attachments, $isHtml);
 		$repliedMessageData = null;
-		if ($folderId !== null && $messageId !== null) {
-			$repliedMessageData = new RepliedMessageData($account, base64_decode($folderId), $messageId);
+		if ($messageId !== null) {
+			try {
+				$repliedMessage = $this->mailManager->getMessage($this->currentUserId, $messageId);
+			} catch (ClientException $e) {
+				$this->logger->info("Message in reply " . $messageId . " could not be loaded: " . $e->getMessage());
+			}
+			$repliedMessageData = new RepliedMessageData($account, $repliedMessage);
 		}
 
 		$draft = null;

--- a/lib/Db/MailboxMapper.php
+++ b/lib/Db/MailboxMapper.php
@@ -93,6 +93,32 @@ class MailboxMapper extends QBMapper {
 	 * @throws DoesNotExistException
 	 * @throws ServiceException
 	 */
+	public function findById(int $id): Mailbox {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
+			);
+
+		try {
+			return $this->findEntity($select);
+		} catch (MultipleObjectsReturnedException $e) {
+			// Not possible due to DB constraints
+			throw new ServiceException("The impossible has happened", 42, $e);
+		}
+	}
+
+	/**
+	 * @param int $id
+	 * @param string $uid
+	 *
+	 * @return Mailbox
+	 *
+	 * @throws DoesNotExistException
+	 * @throws ServiceException
+	 */
 	public function findByUid(int $id, string $uid): Mailbox {
 		$qb = $this->db->getQueryBuilder();
 

--- a/lib/Listener/FlagRepliedMessageListener.php
+++ b/lib/Listener/FlagRepliedMessageListener.php
@@ -67,9 +67,8 @@ class FlagRepliedMessageListener implements IEventListener {
 		}
 
 		try {
-			$mailbox = $this->mailboxMapper->find(
-				$event->getAccount(),
-				$event->getRepliedMessageData()->getFolderId()
+			$mailbox = $this->mailboxMapper->findById(
+				$event->getRepliedMessageData()->getMessage()->getMailboxId()
 			);
 		} catch (DoesNotExistException|ServiceException $e) {
 			$this->logger->logException($e, [
@@ -85,7 +84,7 @@ class FlagRepliedMessageListener implements IEventListener {
 			$this->messageMapper->addFlag(
 				$client,
 				$mailbox,
-				$event->getRepliedMessageData()->getId(),
+				$event->getRepliedMessageData()->getMessage()->getUid(),
 				Horde_Imap_Client::FLAG_ANSWERED
 			);
 		} catch (Horde_Imap_Client_Exception $e) {

--- a/lib/Model/RepliedMessageData.php
+++ b/lib/Model/RepliedMessageData.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Model;
 
 use OCA\Mail\Account;
+use OCA\Mail\Db\Message;
 
 /**
  * An immutable DTO that holds information about a message that is replied to
@@ -33,35 +34,19 @@ class RepliedMessageData {
 	/** @var Account */
 	private $account;
 
-	/** @var string */
-	private $folderId;
+	/** @var Message */
+	private $message;
 
-	/** @var int */
-	private $id;
-
-	/**
-	 * @param Account $account
-	 * @param string $folderId
-	 * @param int $id
-	 */
-	public function __construct(Account $account, string $folderId, int $id) {
+	public function __construct(Account $account, Message  $message) {
 		$this->account = $account;
-		$this->folderId = $folderId;
-		$this->id = $id;
+		$this->message = $message;
 	}
 
-	/**
-	 * @return Account
-	 */
 	public function getAccount(): Account {
 		return $this->account;
 	}
 
-	public function getFolderId(): string {
-		return $this->folderId;
-	}
-
-	public function getId(): int {
-		return $this->id;
+	public function getMessage(): Message {
+		return $this->message;
 	}
 }

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -25,7 +25,6 @@ namespace OCA\Mail\Service;
 
 use Horde_Exception;
 use Horde_Imap_Client;
-use Horde_Imap_Client_Exception;
 use Horde_Mail_Transport_Null;
 use Horde_Mime_Exception;
 use Horde_Mime_Headers_Date;
@@ -251,24 +250,8 @@ class MailTransmission implements IMailTransmission {
 		$message->setSubject($messageData->getSubject());
 		$message->setTo($messageData->getTo());
 
-		$client = $this->imapClientFactory->getClient($account);
-
-		try {
-			$repliedMessage = $this->messageMapper->find(
-				$client,
-				$replyData->getFolderId(),
-				$replyData->getId()
-			);
-
-			$message->setInReplyTo($repliedMessage->getMessageId());
-		} catch (DoesNotExistException $e) {
-			// Nothing to do
-		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'level' => ILogger::WARN,
-				'messages' => 'Could not find draft message: ' . $e->getMessage(),
-			]);
-		}
+		$rawMessageId = $replyData->getMessage()->getMessageId();
+		$message->setInReplyTo($rawMessageId);
 
 		return $message;
 	}

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -33,6 +33,7 @@ use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
@@ -45,6 +46,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IUser;
 use OCP\Security\ICrypto;
+use Psr\Log\NullLogger;
 
 class MailTransmissionIntegrationTest extends TestCase {
 	use ImapTest,
@@ -145,16 +147,25 @@ class MailTransmissionIntegrationTest extends TestCase {
 	}
 
 	public function testSendReply() {
-		$inbox = base64_encode('inbox');
 		$mb = $this->getMessageBuilder();
 		$originalMessage = $mb->from('from@domain.tld')
 			->to('to@domain.tld')
 			->subject('reply test')
 			->finish();
 		$originalUID = $this->saveMessage('inbox', $originalMessage);
+		/** @var MailboxSync $mbSync */
+		$mbSync = OC::$server->query(MailboxSync::class);
+		$mbSync->sync($this->account, new NullLogger(), true);
+		/** @var MailboxMapper $mailboxMapper */
+		$mailboxMapper = OC::$server->query(MailboxMapper::class);
+		$inbox = $mailboxMapper->find($this->account, 'INBOX');
+		$messageInReply = new Message();
+		$messageInReply->setUid($originalUID);
+		$messageInReply->setMessageId('message@server');
+		$messageInReply->setMailboxId($inbox->getId());
 
 		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
-		$reply = new RepliedMessageData($this->account, $inbox, $originalUID);
+		$reply = new RepliedMessageData($this->account, $messageInReply);
 		$this->transmission->sendMessage($message, $reply);
 
 		$this->assertMailboxExists('Sent');
@@ -162,16 +173,25 @@ class MailTransmissionIntegrationTest extends TestCase {
 	}
 
 	public function testSendReplyWithoutSubject() {
-		$inbox = base64_encode('inbox');
 		$mb = $this->getMessageBuilder();
 		$originalMessage = $mb->from('from@domain.tld')
 			->to('to@domain.tld')
 			->subject('reply test')
 			->finish();
 		$originalUID = $this->saveMessage('inbox', $originalMessage);
+		/** @var MailboxSync $mbSync */
+		$mbSync = OC::$server->query(MailboxSync::class);
+		$mbSync->sync($this->account, new NullLogger(), true);
+		/** @var MailboxMapper $mailboxMapper */
+		$mailboxMapper = OC::$server->query(MailboxMapper::class);
+		$inbox = $mailboxMapper->find($this->account, 'INBOX');
+		$messageInReply = new Message();
+		$messageInReply->setUid($originalUID);
+		$messageInReply->setMessageId('message@server');
+		$messageInReply->setMailboxId($inbox->getId());
 
 		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, '', 'hello there', []);
-		$reply = new RepliedMessageData($this->account, $inbox, $originalUID);
+		$reply = new RepliedMessageData($this->account, $messageInReply);
 		$this->transmission->sendMessage($message, $reply);
 
 		$this->assertMailboxExists('Sent');
@@ -179,16 +199,25 @@ class MailTransmissionIntegrationTest extends TestCase {
 	}
 
 	public function testSendReplyWithoutReplySubject() {
-		$inbox = base64_encode('inbox');
 		$mb = $this->getMessageBuilder();
 		$originalMessage = $mb->from('from@domain.tld')
 			->to('to@domain.tld')
 			->subject('reply test')
 			->finish();
 		$originalUID = $this->saveMessage('inbox', $originalMessage);
+		/** @var MailboxSync $mbSync */
+		$mbSync = OC::$server->query(MailboxSync::class);
+		$mbSync->sync($this->account, new NullLogger(), true);
+		/** @var MailboxMapper $mailboxMapper */
+		$mailboxMapper = OC::$server->query(MailboxMapper::class);
+		$inbox = $mailboxMapper->find($this->account, 'INBOX');
+		$messageInReply = new Message();
+		$messageInReply->setUid($originalUID);
+		$messageInReply->setMessageId('message@server');
+		$messageInReply->setMailboxId($inbox->getId());
 
 		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'Re: reply test', 'hello there', []);
-		$reply = new RepliedMessageData($this->account, $inbox, $originalUID);
+		$reply = new RepliedMessageData($this->account, $messageInReply);
 		$this->transmission->sendMessage($message, $reply);
 
 		$this->assertMailboxExists('Sent');

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -32,6 +32,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Controller\AccountsController;
 use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
@@ -439,13 +440,17 @@ class AccountsControllerTest extends TestCase {
 
 	public function testSendReply() {
 		$account = $this->createMock(Account::class);
-		$folderId = 'INBOX';
+		$replyMessage = new Message();
 		$messageId = 1234;
 		$this->accountService->expects($this->once())
 			->method('find')
 			->willReturn($account);
+		$this->mailManager->expects($this->once())
+			->method('getMessage')
+			->with($this->userId, $messageId)
+			->willReturn($replyMessage);
 		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod', []);
-		$replyData = new RepliedMessageData($account, $folderId, $messageId);
+		$replyData = new RepliedMessageData($account, $replyMessage);
 		$this->transmission->expects($this->once())
 			->method('sendMessage')
 			->with($messageData, $replyData, null, null);
@@ -460,7 +465,6 @@ class AccountsControllerTest extends TestCase {
 			'',
 			true,
 			null,
-			base64_encode($folderId),
 			$messageId,
 			[],
 			null);

--- a/tests/Unit/Model/RepliedMessageTest.php
+++ b/tests/Unit/Model/RepliedMessageTest.php
@@ -23,6 +23,7 @@ namespace OCA\Mail\Tests\Unit\Model;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
+use OCA\Mail\Db\Message;
 use OCA\Mail\Model\RepliedMessageData;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -30,26 +31,18 @@ class RepliedMessageTest extends TestCase {
 	public function testGetAccount() {
 		/** @var Account|MockObject $account */
 		$account = $this->createMock(Account::class);
-		$data = new RepliedMessageData($account, "abc", 123);
+		$message = new Message();
+		$data = new RepliedMessageData($account, $message);
 
 		$this->assertEquals($account, $data->getAccount());
 	}
 
-	public function testGetFolderId() {
+	public function testGetMessage() {
 		/** @var Account|MockObject $account */
 		$account = $this->createMock(Account::class);
-		$folderId = 'INBOX';
-		$data = new RepliedMessageData($account, $folderId, 123);
+		$message = new Message();
+		$data = new RepliedMessageData($account, $message);
 
-		$this->assertEquals($folderId, $data->getFolderId());
-	}
-
-	public function testGetId() {
-		/** @var Account|MockObject $account */
-		$account = $this->createMock(Account::class);
-		$messageId = 12;
-		$data = new RepliedMessageData($account, "abc", $messageId);
-
-		$this->assertEquals($messageId, $data->getId());
+		$this->assertEquals($message, $data->getMessage());
 	}
 }

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -34,7 +34,6 @@ use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
-use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Model\Message;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
@@ -194,22 +193,15 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getMailAccount')->willReturn($mailAccount);
 		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod');
 		$folderId = 'INBOX';
-		$repliedMessageId = 321;
-		$replyData = new RepliedMessageData($account, $folderId, $repliedMessageId);
+		$repliedMessageUid = 321;
+		$messageInReply = new \OCA\Mail\Db\Message();
+		$messageInReply->setUid($repliedMessageUid);
+		$messageInReply->setMessageId('message@server');
+		$replyData = new RepliedMessageData($account, $messageInReply);
 		$message = new Message();
 		$account->expects($this->once())
 			->method('newMessage')
 			->willReturn($message);
-		$client = $this->createMock(Horde_Imap_Client_Socket::class);
-		$this->imapClientFactory->expects($this->once())
-			->method('getClient')
-			->with($account)
-			->willReturn($client);
-		$repliedMessage = $this->createMock(IMAPMessage::class);
-		$this->messageMapper->expects($this->once())
-			->method('find')
-			->with($client, $folderId, $repliedMessageId)
-			->willReturn($repliedMessage);
 		$transport = $this->createMock(Horde_Mail_Transport::class);
 		$this->smtpClientFactory->expects($this->once())
 			->method('create')


### PR DESCRIPTION
To reproduce this, either inspect the message source of a reply written with our app, or see how the threading algorithm fails to associate messages of the same thread.