### PR TITLE
Fix display of previous and successive threads

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -189,12 +189,12 @@ export default {
 		previousThread() {
 			// Only show younger messages, not the current one
 			return this.$store.getters.getMessageThread(this.message.databaseId)
-				.filter(m => m.dateInt > this.message.dateInt)
+				.filter(m => m.dateInt < this.message.dateInt)
 		},
 		successiveThread() {
 			// Only show older messages, not the current one
 			return this.$store.getters.getMessageThread(this.message.databaseId)
-				.filter(m => m.dateInt < this.message.dateInt)
+				.filter(m => m.dateInt > this.message.dateInt)
 		},
 	},
 	watch: {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultTo, head } from 'ramda'
+import { defaultTo, head, sortBy, prop } from 'ramda'
 
 import { UNIFIED_ACCOUNT_ID } from './constants'
 import { normalizedEnvelopeListId } from './normalization'
@@ -62,6 +62,6 @@ export const getters = {
 		return state.messages[id]
 	},
 	getMessageThread: (state) => (id) => {
-		return state.messages[id]?.thread ?? []
+		return sortBy(prop('dateInt'), state.messages[id]?.thread ?? [])
 	},
 }


### PR DESCRIPTION
* The list should show oldest on top, newest at bottom
* Above should be the older ones, below the newer ones

Before it showed the newer ones on top, but sorted in the wrong order.