### PR TITLE
Fix the return type hint for IMailManager::getThread

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -121,7 +121,7 @@ interface IMailManager {
 	 * @param Account $account
 	 * @param int $messageId database message ID
 	 *
-	 * @return IMAPMessage[]
+	 * @return Message[]
 	 */
 	public function getThread(Account $account, int $messageId): array;
 


### PR DESCRIPTION
It returns DB messages, not IMAP messages.