### PR TITLE
Inject styles for using native fonts in html mails

### DIFF
--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -32,6 +32,11 @@ class HtmlResponse extends Response {
 	/** @var string */
 	private $content;
 
+	private $injectedStyles = <<<EOF
+* { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; }
+EOF;
+
+
 	public function __construct(string $content) {
 		parent::__construct();
 		$this->content = $content;
@@ -43,6 +48,6 @@ class HtmlResponse extends Response {
 	 * @return string the file contents
 	 */
 	public function render(): string {
-		return $this->content;
+		return '<style>' . $this->injectedStyles . '</style>' . $this->content;
 	}
 }

--- a/tests/Unit/Http/HtmlResponseTest.php
+++ b/tests/Unit/Http/HtmlResponseTest.php
@@ -35,7 +35,8 @@ class HtmlResponseTest extends TestCase {
 	 */
 	public function testIt($content) {
 		$resp = new HtmlResponse($content);
-		$this->assertEquals($content, $resp->render());
+		$injectedStyles = "<style>* { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; }</style>";
+		$this->assertEquals($injectedStyles . $content, $resp->render());
 	}
 
 	public function providesResponseData() {


### PR DESCRIPTION
This will use our native font stack as default fonts in the HTML mail renderings, though it is kind of a hack it seems to work quite well and turns bad browser fonts into something nicer :wink: 

Before:
![image](https://user-images.githubusercontent.com/3404133/93336676-611ea500-f828-11ea-9f13-eab427487368.png)

After:
![image](https://user-images.githubusercontent.com/3404133/93336765-7d224680-f828-11ea-9a3e-e717d6b221f7.png)
