### PR TITLE
Add mime type to attachments

### DIFF
--- a/lib/Contracts/IAttachmentService.php
+++ b/lib/Contracts/IAttachmentService.php
@@ -32,7 +32,7 @@ interface IAttachmentService {
 	/**
 	 * Save an uploaded file
 	 */
-	public function addFile(string $userId, UploadedFile $file): LocalAttachment;
+	public function addFile(string $userId, UploadedFile $file, string $mimType): LocalAttachment;
 
 	/**
 	 * Try to get an attachment by id

--- a/lib/Controller/LocalAttachmentsController.php
+++ b/lib/Controller/LocalAttachmentsController.php
@@ -30,6 +30,7 @@ use OCA\Mail\Service\Attachment\UploadedFile;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\ILogger;
 use OCP\IRequest;
 
 class LocalAttachmentsController extends Controller {
@@ -40,6 +41,9 @@ class LocalAttachmentsController extends Controller {
 	/** @var string */
 	private $userId;
 
+	/** @var ILogger */
+	private $logger;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -47,9 +51,10 @@ class LocalAttachmentsController extends Controller {
 	 * @param string $UserId
 	 */
 	public function __construct(string $appName, IRequest $request,
-								IAttachmentService $attachmentService, $UserId) {
+					IAttachmentService $attachmentService, ILogger $logger, $UserId) {
 		parent::__construct($appName, $request);
 		$this->attachmentService = $attachmentService;
+		$this->logger = $logger;
 		$this->userId = $UserId;
 	}
 
@@ -67,7 +72,12 @@ class LocalAttachmentsController extends Controller {
 		}
 
 		$uploadedFile = new UploadedFile($file);
-		$attachment = $this->attachmentService->addFile($this->userId, $uploadedFile);
+
+		$finfo = finfo_open(FILEINFO_MIME_TYPE);
+		$mimeType = finfo_file($finfo, $uploadedFile->getTempPath());
+		unset($finfo);
+
+		$attachment = $this->attachmentService->addFile($this->userId, $uploadedFile, $mimeType);
 
 		return new JSONResponse($attachment, Http::STATUS_CREATED);
 	}

--- a/lib/Db/LocalAttachment.php
+++ b/lib/Db/LocalAttachment.php
@@ -30,6 +30,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setUserId(string $userId)
  * @method string getFileName()
  * @method void setFileName(string $fileName)
+ * @method string getMimeType()
+ * @method void setMimeType(string $mimeType)
  * @method int getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  */
@@ -40,6 +42,9 @@ class LocalAttachment extends Entity implements JsonSerializable {
 
 	/** @var string */
 	protected $fileName;
+
+	/** @var string */
+	protected $mimeType;
 
 	/** @var mixed */
 	protected $createdAt;

--- a/lib/Migration/Version1060Date20200921141700.php
+++ b/lib/Migration/Version1060Date20200921141700.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1060Date20200921141700 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_attachments');
+		$accountsTable->addColumn('mime_type', 'string', [
+			'notnull' => true,
+			'length' => 255, // RFC 4288 defines max size
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -48,13 +48,15 @@ class AttachmentService implements IAttachmentService {
 	/**
 	 * @param string $userId
 	 * @param UploadedFile $file
+	 * @param string $mimeType
 	 * @return LocalAttachment
 	 * @throws UploadException
 	 */
-	public function addFile(string $userId, UploadedFile $file): LocalAttachment {
+	public function addFile(string $userId, UploadedFile $file, string $mimeType): LocalAttachment {
 		$attachment = new LocalAttachment();
 		$attachment->setUserId($userId);
 		$attachment->setFileName($file->getFileName());
+		$attachment->setMimeType($mimeType);
 
 		$persisted = $this->mapper->insert($attachment);
 		try {


### PR DESCRIPTION
Fix for #3297 

TODO:
- [x] Get mime type of uploaded files
- [ ] Get mime type of files attached from Files;
- [x] Update DB to store mime type in table oc_mail_attachments;
- [ ] Actually make use of that mime type information in the composed email.

I would like to have a confirmation of this approach as I believe I've to touch the DB 'schema

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>