### PR TITLE
Cache no avatar available in memcache as well

### DIFF
--- a/lib/Service/Avatar/Cache.php
+++ b/lib/Service/Avatar/Cache.php
@@ -66,7 +66,7 @@ class Cache {
 	/**
 	 * @param string $email
 	 * @param string $uid
-	 * @return Avatar|null avatar URL
+	 * @return Avatar|null|false the avatar if cached, false if cached but no value and null if not cached
 	 */
 	public function get(string $email, string $uid) {
 		$cached = $this->cache->get($this->buildUrlKey($email, $uid));
@@ -74,23 +74,26 @@ class Cache {
 		if (is_null($cached)) {
 			return null;
 		}
+		if ($cached === false) {
+			return false;
+		}
 
 		if ($cached['isExternal']) {
 			return $this->avatarFactory->createExternal($cached['url'], $cached['mime']);
-		} else {
-			return $this->avatarFactory->createInternal($cached['url'], $cached['mime']);
 		}
+
+		return $this->avatarFactory->createInternal($cached['url'], $cached['mime']);
 	}
 
 	/**
 	 * @param string $email
 	 * @param string $uid
-	 * @param Avatar $avatar
+	 * @param Avatar|null $avatar
 	 *
 	 * @return void
 	 */
-	public function add(string $email, string $uid, Avatar $avatar): void {
-		$this->cache->set($this->buildUrlKey($email, $uid), $avatar->jsonSerialize(), self::CACHE_TTL);
+	public function add(string $email, string $uid, ?Avatar $avatar): void {
+		$this->cache->set($this->buildUrlKey($email, $uid), $avatar === null ? false : $avatar->jsonSerialize(), self::CACHE_TTL);
 	}
 
 	/**

--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -107,13 +107,20 @@ class AvatarService implements IAvatarService {
 	 */
 	public function getAvatar(string $email, string $uid) {
 		$cachedAvatar = $this->cache->get($email, $uid);
-		if (!is_null($cachedAvatar)) {
+		if ($cachedAvatar) {
 			return $cachedAvatar;
+		}
+		if ($cachedAvatar === false) {
+			// We know there is no avatar
+			return null;
 		}
 
 		$avatar = $this->source->fetch($email, $this->avatarFactory, $this->externalAvatarsAllowed());
 		if (is_null($avatar) || !$this->hasAllowedMime($avatar)) {
 			// Cannot locate any avatar -> nothing to do here
+
+			$this->cache->add($email, $uid, null);
+
 			return null;
 		}
 

--- a/tests/Unit/Service/AvatarServiceTest.php
+++ b/tests/Unit/Service/AvatarServiceTest.php
@@ -102,8 +102,9 @@ class AvatarServiceTest extends TestCase {
 			->method('fetch')
 			->with($email, $this->avatarFactory, true)
 			->willReturn(null);
-		$this->cache->expects($this->never())
-			->method('add');
+		$this->cache->expects($this->once())
+			->method('add')
+			->with($email, $uid, null);
 
 		$url = $this->avatarService->getAvatar($email, $uid);
 
@@ -126,8 +127,9 @@ class AvatarServiceTest extends TestCase {
 			->method('fetch')
 			->with($email, $this->avatarFactory, true)
 			->willReturn($avatar);
-		$this->cache->expects($this->never())
-			->method('add');
+		$this->cache->expects($this->once())
+			->method('add')
+			->with($email, $uid, null);
 
 		$url = $this->avatarService->getAvatar($email, $uid);
 


### PR DESCRIPTION
We cache the HTTP response for when no avatar is available, so the same
browser won't ask for this for the next few hours. However, this doesn't
work across devices, so a tiny bit of work is spent on a task that can
be cached.

This is most noticeable in dev setup where the HTTP cache is disabled.
The server had to always check if avatars are available. This is quite
slow and causes lots of requests to queue.