### PR TITLE
Fix race condition where one envelope object overwrites the other

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -136,7 +136,7 @@ export default {
 	},
 	addEnvelope(state, { query, envelope }) {
 		const mailbox = state.mailboxes[envelope.mailboxId]
-		Vue.set(state.envelopes, envelope.databaseId, envelope)
+		Vue.set(state.envelopes, envelope.databaseId, Object.assign({}, state.envelopes[envelope.databaseId] || {}, envelope))
 		Vue.set(envelope, 'accountId', mailbox.accountId)
 		const listId = normalizedEnvelopeListId(query)
 		const existing = mailbox.envelopeLists[listId] || []


### PR DESCRIPTION
On page load we have a lot of concurrent operations going on. This
includes:

1) Loading the list of envelopes
2) Loading the contents of the thread

Both of these might fetch the envelope/thread to be shown. Now, there is
some more logic going on that stores the thread of an envelope.

In the unlucky case, things followed this pattern

1) The envelope is fetched
2) The thread list is fetched and stored to the envelope
3) The envelope list is fetched and the envelope is added again,
   overwriting the other one
4) The thread list was thus empty -> the current message thread vanished

If the envelope is already known, it will be re-used. Thus this won't
happen on later navigation but just right after the page load.

---

To reproduce open the app. The first message will show but after a few seconds you see a blank third column. On this branch this won't happen.