### PR TITLE
Fix unseen messages loading infinitely

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -206,7 +206,7 @@ export default {
 				logger.debug(`message ${this.envelope.databaseId} fetched`, { message })
 
 				if (!this.envelope.flags.seen) {
-					return this.$store.dispatch('toggleEnvelopeSeen', this.envelope)
+					this.$store.dispatch('toggleEnvelopeSeen', this.envelope)
 				}
 
 				this.loading = false


### PR DESCRIPTION
When an unseen message is opened, we flag it as seen. So far, so good.
But in this code path we returned early from the `fetchMessage`
function, meaning that `this.loading` remained set to `true` and the
loading spinner never vanished.

My guess is that this is a leftover from the migration from promises to
async-await.

And of course the reason I was hardly able to trigger this locally is that my test account has only read emails …

Fixes https://github.com/nextcloud/mail/issues/3624