### PR TITLE
Always return the own message when asking for a thread

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -437,13 +437,21 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->eq('id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
 			);
 
+		/**
+		 * Select the message with the given ID or any that has the same thread ID
+		 */
 		$selectMessages = $qb
 			->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->isNotNull('thread_root_id'),
-				$qb->expr()->in('thread_root_id', $qb->createFunction($threadRootIdsQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY),
-				$qb->expr()->in('mailbox_id', $qb->createFunction($mailboxIdsQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY)
+				$qb->expr()->in('mailbox_id', $qb->createFunction($mailboxIdsQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY),
+				$qb->expr()->orX(
+					$qb->expr()->eq('id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+					$qb->expr()->andX(
+						$qb->expr()->isNotNull('thread_root_id'),
+						$qb->expr()->in('thread_root_id', $qb->createFunction($threadRootIdsQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY)
+					)
+				)
 			)
 			->orderBy('sent_at', 'desc');
 


### PR DESCRIPTION
The front-end asks for the thread of a message by sending the message
ID. Now, after an upgrade from v1.4.x to v1.5 and no sync of the
mailbox, the `thread_root_id` will still be `NULL`, hence we can't find
related messages this way. But we don't have to look it up that way, we
can also allow matching by the ID.

This safes me from coming up with a complicated strategy to force a
resync after the upgrade. Messages will be able to show. The threads
will build deferred.

Steps to reproduce
* Open a message on latest master -> it's shown
* Run `update oc_mail_messages set thread_root_id=NULL where id=<threadid from URL>;`
* Open the message again -> blank details
* Switch to this branch
* Open the message again -> message is shown, yay