### PR TITLE
Add a debug-only file download for threading data

### DIFF
--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -30,12 +30,14 @@ use JsonSerializable;
 use OCA\Mail\AddressList;
 use OCP\AppFramework\Db\Entity;
 use function in_array;
+use function json_decode;
 use function json_encode;
 
 /**
  * @method void setUid(int $uid)
  * @method int getUid()
  * @method string getMessageId()
+ * @method void setReferences(string $references)
  * @method string|null getReferences()
  * @method string|null getInReplyTo()
  * @method string|null getThreadRootId()
@@ -146,7 +148,7 @@ class Message extends Entity implements JsonSerializable {
 		$this->setMessageIdFieldIfNotEmpty('messageId', $messageId);
 	}
 
-	public function setReferences(?string $references): void {
+	public function setRawReferences(?string $references): void {
 		$parsed = new Horde_Mail_Rfc822_Identification($references);
 		$this->setter('references', [json_encode($parsed->ids)]);
 	}
@@ -254,6 +256,10 @@ class Message extends Entity implements JsonSerializable {
 			'cc' => $this->getCc()->jsonSerialize(),
 			'bcc' => $this->getBcc()->jsonSerialize(),
 			'mailboxId' => $this->getMailboxId(),
+			'messageId' => $this->getMessageId(),
+			'inReplyTo' => $this->getInReplyTo(),
+			'references' => empty($this->getReferences()) ? null: json_decode($this->getReferences(), true),
+			'threadRootId' => $this->getThreadRootId(),
 		];
 	}
 }

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -642,7 +642,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 
 		$msg->setUid($this->getUid());
 		$msg->setMessageId($this->getMessageId());
-		$msg->setReferences($this->getRawReferences());
+		$msg->setRawReferences($this->getRawReferences());
 		$msg->setThreadRootId($this->getMessageId());
 		$msg->setInReplyTo($this->getRawInReplyTo());
 		$msg->setMailboxId($mailboxId);

--- a/src/components/Address.vue
+++ b/src/components/Address.vue
@@ -3,7 +3,8 @@
 		v-tooltip.bottom="email"
 		:to="newMessageRoute"
 		exact>
-		{{ label }}</router-link>
+		{{ label }}
+	</router-link>
 	<router-link v-else :to="newMessageRoute" exact>
 		{{ label }}
 	</router-link>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -82,6 +82,12 @@
 						@click="onShowSource">
 						{{ t('mail', 'View source') }}
 					</ActionButton>
+					<ActionLink v-if="debug"
+						icon="icon-download"
+						:download="threadingFileName"
+						:href="threadingFile">
+						{{ t('mail', 'Download thread data for debugging') }}
+					</ActionLink>
 					<ActionButton icon="icon-delete" @click.prevent="onDelete">
 						{{ t('mail', 'Delete') }}
 					</ActionButton>
@@ -105,6 +111,7 @@
 <script>
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import axios from '@nextcloud/axios'
 import Error from './Error'
 import Loading from './Loading'
@@ -121,6 +128,7 @@ export default {
 	components: {
 		Actions,
 		ActionButton,
+		ActionLink,
 		Error,
 		Loading,
 		Moment,
@@ -149,6 +157,7 @@ export default {
 	},
 	data() {
 		return {
+			debug: window?.OC?.debug || false,
 			loading: false,
 			error: undefined,
 			message: undefined,
@@ -158,6 +167,18 @@ export default {
 		}
 	},
 	computed: {
+		threadingFile() {
+			return `data:text/plain;base64,${btoa(JSON.stringify({
+				subject: this.envelope.subject,
+				messageId: this.envelope.messageId,
+				inReplyTo: this.envelope.inReplyTo,
+				references: this.envelope.references,
+				threadRootId: this.envelope.threadRootId,
+			}, null, 2))}`
+		},
+		threadingFileName() {
+			return `${this.envelope.databaseId}.json`
+		},
 		route() {
 			return {
 				name: 'message',


### PR DESCRIPTION
Threading still doesn't work for some messages. To debug this more
easily, especially for non devs, this adds a new action menu entry to
download all relevant threading data as a simple JSON. The maintainers
can then look at those files, put them into unit tests and see why they
messages don't group.

Again, this entry won't be shown on production instances but only if
debug mode is enabled.

![Bildschirmfoto von 2020-09-23 09-54-05](https://user-images.githubusercontent.com/1374172/93984281-e3a4e880-fd83-11ea-8c92-da704479c2a6.png)
![Bildschirmfoto von 2020-09-23 09-54-01](https://user-images.githubusercontent.com/1374172/93984283-e43d7f00-fd83-11ea-8599-d71296469d46.png)

Fixes https://github.com/nextcloud/mail/issues/3628

@nextcloud/mail in other words if we get bug reports with *threading doesn't work* we'll ask for the files of each of the messages that are expected to be shown in one thread. Then we take a closer look.