### PR TITLE
Add debug output to sync processes triggered via the CLI

### DIFF
--- a/lib/Events/SynchronizationEvent.php
+++ b/lib/Events/SynchronizationEvent.php
@@ -27,19 +27,29 @@ namespace OCA\Mail\Events;
 
 use OCA\Mail\Account;
 use OCP\EventDispatcher\Event;
+use Psr\Log\LoggerInterface;
 
 class SynchronizationEvent extends Event {
 
 	/** @var Account */
 	private $account;
 
-	public function __construct(Account $account) {
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(Account $account,
+								LoggerInterface $logger) {
 		parent::__construct();
 
 		$this->account = $account;
+		$this->logger = $logger;
 	}
 
 	public function getAccount(): Account {
 		return $this->account;
+	}
+
+	public function getLogger(): LoggerInterface {
+		return $this->logger;
 	}
 }

--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Mail\IMAP\Threading;
 
 use OCA\Mail\Support\PerformanceLogger;
+use Psr\Log\LoggerInterface;
 use function array_key_exists;
 use function count;
 
@@ -43,8 +44,11 @@ class ThreadBuilder {
 	 *
 	 * @return Container[]
 	 */
-	public function build(array $messages): array {
-		$log = $this->performanceLogger->start('Threading ' . count($messages) . ' messages');
+	public function build(array $messages, LoggerInterface $logger): array {
+		$log = $this->performanceLogger->startWithLogger(
+			'Threading ' . count($messages) . ' messages',
+			$logger
+		);
 
 		// Step 1
 		$idTable = $this->buildIdTable($messages);

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -39,7 +39,7 @@ use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class DeleteDraftListener implements IEventListener {
 
@@ -55,14 +55,14 @@ class DeleteDraftListener implements IEventListener {
 	/** @var MailboxSync */
 	private $mailboxSync;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(IMAPClientFactory $imapClientFactory,
 								MailboxMapper $mailboxMapper,
 								MessageMapper $messageMapper,
 								MailboxSync $mailboxSync,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
@@ -94,16 +94,16 @@ class DeleteDraftListener implements IEventListener {
 				Horde_Imap_Client::FLAG_DELETED
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Could not flag draft as deleted'
+			$this->logger->error('Could not flag draft as deleted', [
+				'exception' => $e,
 			]);
 		}
 
 		try {
 			$client->expunge($draftsMailbox->getName());
 		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Could not expunge drafts folder'
+			$this->logger->error('Could not expunge drafts folder', [
+				'exception' => $e,
 			]);
 		}
 	}
@@ -134,12 +134,12 @@ class DeleteDraftListener implements IEventListener {
 				]
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Could not create drafts mailbox',
+			$this->logger->error('Could not create drafts mailbox', [
+				'exception' => $e,
 			]);
 		}
 
 		// TODO: find a more elegant solution for updating the mailbox cache
-		$this->mailboxSync->sync($account, true);
+		$this->mailboxSync->sync($account, $this->logger,true);
 	}
 }

--- a/lib/Listener/DraftMailboxCreatorListener.php
+++ b/lib/Listener/DraftMailboxCreatorListener.php
@@ -34,7 +34,7 @@ use OCA\Mail\IMAP\MailboxSync;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class DraftMailboxCreatorListener implements IEventListener {
 
@@ -47,13 +47,13 @@ class DraftMailboxCreatorListener implements IEventListener {
 	/** @var MailboxSync */
 	private $mailboxSync;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(MailboxMapper $mailboxMapper,
 								IMAPClientFactory $imapClientFactory,
 								MailboxSync $mailboxSync,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->mailboxMapper = $mailboxMapper;
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxSync = $mailboxSync;
@@ -88,12 +88,12 @@ class DraftMailboxCreatorListener implements IEventListener {
 				]
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Could not create drafts mailbox',
+			$this->logger->error('Could not create drafts mailbox', [
+				'exception' => $e,
 			]);
 		}
 
 		// TODO: find a more elegant solution for updating the mailbox cache
-		$this->mailboxSync->sync($account, true);
+		$this->mailboxSync->sync($account, $this->logger,true);
 	}
 }

--- a/lib/Listener/TrashMailboxCreatorListener.php
+++ b/lib/Listener/TrashMailboxCreatorListener.php
@@ -34,7 +34,7 @@ use OCA\Mail\IMAP\MailboxSync;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class TrashMailboxCreatorListener implements IEventListener {
 
@@ -47,13 +47,13 @@ class TrashMailboxCreatorListener implements IEventListener {
 	/** @var MailboxSync */
 	private $mailboxSync;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(MailboxMapper $mailboxMapper,
 								IMAPClientFactory $imapClientFactory,
 								MailboxSync $mailboxSync,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->mailboxMapper = $mailboxMapper;
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxSync = $mailboxSync;
@@ -92,10 +92,10 @@ class TrashMailboxCreatorListener implements IEventListener {
 			);
 
 			// TODO: find a more elegant solution for updating the mailbox cache
-			$this->mailboxSync->sync($account, true);
+			$this->mailboxSync->sync($account, $this->logger,true);
 		} catch (Horde_Imap_Client_Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Could not creat trash mailbox',
+			$this->logger->error('Could not creat trash mailbox', [
+				'exception' => $e,
 			]);
 		}
 	}

--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -37,7 +37,7 @@ use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\Classification\FeatureExtraction\CompositeExtractor;
 use OCA\Mail\Support\PerformanceLogger;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Rubix\ML\Classifiers\GaussianNB;
 use Rubix\ML\CrossValidation\Reports\MulticlassBreakdown;
 use Rubix\ML\Datasets\Labeled;
@@ -151,7 +151,7 @@ class ImportanceClassifier {
 	 *
 	 * @param Account $account
 	 */
-	public function train(Account $account, ILogger $logger): void {
+	public function train(Account $account, LoggerInterface $logger): void {
 		$perf = $this->performanceLogger->start('importance classifier training');
 		$incomingMailboxes = $this->getIncomingMailboxes($account);
 		$logger->debug('found ' . count($incomingMailboxes) . ' incoming mailbox(es)');
@@ -205,8 +205,8 @@ class ImportanceClassifier {
 				$logger
 			);
 		} catch (ClassifierTrainingException $e) {
-			$logger->logException($e, [
-				'message' => 'Importance classifier training failed: ' . $e->getMessage(),
+			$logger->error('Importance classifier training failed: ' . $e->getMessage(), [
+				'exception' => $e,
 			]);
 			$perf->end();
 			return;
@@ -351,7 +351,7 @@ class ImportanceClassifier {
 	private function validateClassifier(Estimator $estimator,
 										array $trainingSet,
 										array $validationSet,
-										ILogger $logger): Classifier {
+										LoggerInterface $logger): Classifier {
 		$predictedValidationLabel = $estimator->predict(Unlabeled::build(
 			array_column($validationSet, 'features')
 		));

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -46,6 +46,7 @@ use OCA\Mail\IMAP\MessageMapper as ImapMessageMapper;
 use OCA\Mail\Model\IMAPMessage;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
 use function array_map;
 use function array_values;
 
@@ -84,6 +85,10 @@ class MailManager implements IMailManager {
 
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
+	/**
+	 * @var LoggerInterface
+	 */
+	private $logger;
 
 	public function __construct(IMAPClientFactory $imapClientFactory,
 								MailboxMapper $mailboxMapper,
@@ -91,7 +96,8 @@ class MailManager implements IMailManager {
 								FolderMapper $folderMapper,
 								ImapMessageMapper $messageMapper,
 								DbMessageMapper $dbMessageMapper,
-								IEventDispatcher $eventDispatcher) {
+								IEventDispatcher $eventDispatcher,
+								LoggerInterface $logger) {
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->mailboxSync = $mailboxSync;
@@ -99,6 +105,7 @@ class MailManager implements IMailManager {
 		$this->imapMessageMapper = $messageMapper;
 		$this->dbMessageMapper = $dbMessageMapper;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->logger = $logger;
 	}
 
 	public function getMailbox(string $uid, int $id): Mailbox {
@@ -116,7 +123,7 @@ class MailManager implements IMailManager {
 	 * @throws ServiceException
 	 */
 	public function getMailboxes(Account $account): array {
-		$this->mailboxSync->sync($account);
+		$this->mailboxSync->sync($account, $this->logger);
 
 		return $this->mailboxMapper->findAll($account);
 	}
@@ -139,7 +146,7 @@ class MailManager implements IMailManager {
 		}
 		$this->folderMapper->detectFolderSpecialUse([$folder]);
 
-		$this->mailboxSync->sync($account, true);
+		$this->mailboxSync->sync($account, $this->logger,true);
 
 		return $this->mailboxMapper->find($account, $name);
 	}
@@ -324,7 +331,7 @@ class MailManager implements IMailManager {
 		/**
 		 * 2. Pull changes into the mailbox database cache
 		 */
-		$this->mailboxSync->sync($account, true);
+		$this->mailboxSync->sync($account, $this->logger,true);
 
 		/**
 		 * 3. Return the updated object
@@ -424,7 +431,7 @@ class MailManager implements IMailManager {
 		/**
 		 * 2. Get the IMAP changes into our database cache
 		 */
-		$this->mailboxSync->sync($account, true);
+		$this->mailboxSync->sync($account, $this->logger,true);
 
 		/**
 		 * 3. Return the cached object with the new ID

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -38,6 +38,7 @@ use OCA\Mail\IMAP\PreviewEnhancer;
 use OCA\Mail\IMAP\Sync\Response;
 use OCA\Mail\Service\Search\FilterStringParser;
 use OCA\Mail\Service\Search\SearchQuery;
+use Psr\Log\LoggerInterface;
 use function array_diff;
 use function array_map;
 
@@ -58,16 +59,21 @@ class SyncService {
 	/** @var PreviewEnhancer */
 	private $previewEnhancer;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	public function __construct(ImapToDbSynchronizer $synchronizer,
 								FilterStringParser $filterStringParser,
 								MailboxMapper $mailboxMapper,
 								MessageMapper $messageMapper,
-								PreviewEnhancer $previewEnhancer) {
+								PreviewEnhancer $previewEnhancer,
+								LoggerInterface $logger) {
 		$this->synchronizer = $synchronizer;
 		$this->filterStringParser = $filterStringParser;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->previewEnhancer = $previewEnhancer;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -109,6 +115,7 @@ class SyncService {
 		$this->synchronizer->sync(
 			$account,
 			$mailbox,
+			$this->logger,
 			$criteria,
 			$this->messageMapper->findUidsForIds($mailbox, $knownIds),
 			!$partialOnly

--- a/lib/Support/ConsoleLoggerDecorator.php
+++ b/lib/Support/ConsoleLoggerDecorator.php
@@ -25,81 +25,74 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Support;
 
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Throwable;
 
-class ConsoleLoggerDecorator implements ILogger {
+class ConsoleLoggerDecorator implements LoggerInterface {
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $inner;
 
 	/** @var OutputInterface */
 	private $consoleOutput;
 
-	public function __construct(ILogger $inner,
+	public function __construct(LoggerInterface $inner,
 								OutputInterface $consoleOutput) {
 		$this->inner = $inner;
 		$this->consoleOutput = $consoleOutput;
 	}
 
-	public function emergency(string $message, array $context = []) {
+	public function emergency($message, array $context = []) {
 		$this->consoleOutput->writeln("<error>[emergency] $message</error>");
 
-		return $this->inner->emergency($message, $context);
+		$this->inner->emergency($message, $context);
 	}
 
-	public function alert(string $message, array $context = []) {
+	public function alert($message, array $context = []) {
 		$this->consoleOutput->writeln("<error>[alert] $message</error>");
 
-		return $this->inner->alert($message, $context);
+		$this->inner->alert($message, $context);
 	}
 
-	public function critical(string $message, array $context = []) {
+	public function critical($message, array $context = []) {
 		$this->consoleOutput->writeln("<error>[critical] $message</error>");
 
-		return $this->inner->critical($message, $context);
+		$this->inner->critical($message, $context);
 	}
 
-	public function error(string $message, array $context = []) {
+	public function error($message, array $context = []) {
 		$this->consoleOutput->writeln("<error>[error] $message</error>");
 
-		return $this->inner->error($message, $context);
+		$this->inner->error($message, $context);
 	}
 
-	public function warning(string $message, array $context = []) {
+	public function warning($message, array $context = []) {
 		$this->consoleOutput->writeln("[warning] $message");
 
-		return $this->inner->warning($message, $context);
+		$this->inner->warning($message, $context);
 	}
 
-	public function notice(string $message, array $context = []) {
+	public function notice($message, array $context = []) {
 		$this->consoleOutput->writeln("<info>[notice] $message</info>");
 
-		return $this->inner->notice($message, $context);
+		$this->inner->notice($message, $context);
 	}
 
-	public function info(string $message, array $context = []) {
+	public function info($message, array $context = []) {
 		$this->consoleOutput->writeln("<info>[info] $message</info>");
 
-		return $this->inner->info($message, $context);
+		$this->inner->info($message, $context);
 	}
 
-	public function debug(string $message, array $context = []) {
+	public function debug($message, array $context = []) {
 		$this->consoleOutput->writeln("[debug] $message");
 
-		return $this->inner->debug($message, $context);
+		$this->inner->debug($message, $context);
 	}
 
-	public function log(int $level, string $message, array $context = []) {
+	public function log($level, $message, array $context = []) {
 		$this->consoleOutput->writeln("<info>[log] $message</info>");
 
-		return $this->inner->log($level, $message, $context);
-	}
-
-	public function logException(Throwable $exception, array $context = []) {
-		$this->consoleOutput->writeln("<error>[exception] {$exception->getMessage()}</error>");
-
-		$this->inner->logException($exception, $context);
+		$this->inner->log($level, $message, $context);
 	}
 }

--- a/lib/Support/PerformanceLogger.php
+++ b/lib/Support/PerformanceLogger.php
@@ -26,27 +26,34 @@ declare(strict_types=1);
 namespace OCA\Mail\Support;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class PerformanceLogger {
 
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(ITimeFactory $timeFactory,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->timeFactory = $timeFactory;
 		$this->logger = $logger;
 	}
 
 	public function start(string $task): PerformanceLoggerTask {
+		return $this->startWithLogger(
+			$task,
+			$this->logger
+		);
+	}
+
+	public function startWithLogger(string $task, LoggerInterface $logger): PerformanceLoggerTask {
 		return new PerformanceLoggerTask(
 			$task,
 			$this->timeFactory,
-			$this->logger
+			$logger
 		);
 	}
 }

--- a/lib/Support/PerformanceLoggerTask.php
+++ b/lib/Support/PerformanceLoggerTask.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Support;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
 
 class PerformanceLoggerTask {
 
@@ -36,7 +36,7 @@ class PerformanceLoggerTask {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var ILogger */
+	/** @var LoggerInterface */
 	private $logger;
 
 	/** @var int */
@@ -47,7 +47,7 @@ class PerformanceLoggerTask {
 
 	public function __construct(string $task,
 								ITimeFactory $timeFactory,
-								ILogger $logger) {
+								LoggerInterface $logger) {
 		$this->task = $task;
 		$this->timeFactory = $timeFactory;
 		$this->logger = $logger;

--- a/tests/Integration/Framework/ImapTestAccount.php
+++ b/tests/Integration/Framework/ImapTestAccount.php
@@ -26,6 +26,7 @@ use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\Service\AccountService;
+use Psr\Log\NullLogger;
 
 trait ImapTestAccount {
 
@@ -63,7 +64,7 @@ trait ImapTestAccount {
 
 		/** @var MailboxSync $mbSync */
 		$mbSync = OC::$server->query(MailboxSync::class);
-		$mbSync->sync(new Account($mailAccount));
+		$mbSync->sync(new Account($mailAccount), new NullLogger());
 
 		return $acc;
 	}

--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -35,8 +38,8 @@ use OCA\Mail\IMAP\FolderMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MailboxSync;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
 
 class MailboxSyncTest extends TestCase {
 
@@ -55,9 +58,6 @@ class MailboxSyncTest extends TestCase {
 	/** @var TimeFactory|MockObject */
 	private $timeFactory;
 
-	/** @var ILogger|MockObject */
-	private $logger;
-
 	/** @var MailboxSync */
 	private $sync;
 
@@ -69,15 +69,13 @@ class MailboxSyncTest extends TestCase {
 		$this->mailAccountMapper = $this->createMock(MailAccountMapper::class);
 		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->logger = $this->createMock(ILogger::class);
 
 		$this->sync = new MailboxSync(
 			$this->mailboxMapper,
 			$this->folderMapper,
 			$this->mailAccountMapper,
 			$this->imapClientFactory,
-			$this->timeFactory,
-			$this->logger
+			$this->timeFactory
 		);
 	}
 
@@ -90,7 +88,7 @@ class MailboxSyncTest extends TestCase {
 		$this->imapClientFactory->expects($this->never())
 			->method('getClient');
 
-		$this->sync->sync($account);
+		$this->sync->sync($account, new NullLogger());
 	}
 
 	public function testSync() {
@@ -119,6 +117,6 @@ class MailboxSyncTest extends TestCase {
 			->method('detectFolderSpecialUse')
 			->with($folders);
 
-		$this->sync->sync($account);
+		$this->sync->sync($account, new NullLogger());
 	}
 }

--- a/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
+++ b/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
@@ -31,11 +31,16 @@ use OCA\Mail\IMAP\Threading\Message;
 use OCA\Mail\IMAP\Threading\ThreadBuilder;
 use OCA\Mail\Support\PerformanceLogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ThreadBuilderTest extends TestCase {
 
 	/** @var PerformanceLogger|MockObject */
 	private $performanceLogger;
+
+	/** @var LoggerInterface */
+	private $logger;
 
 	/** @var ThreadBuilder */
 	private $builder;
@@ -44,6 +49,7 @@ class ThreadBuilderTest extends TestCase {
 		parent::setUp();
 
 		$this->performanceLogger = $this->createMock(PerformanceLogger::class);
+		$this->logger = new NullLogger();
 
 		$this->builder = new ThreadBuilder(
 			$this->performanceLogger
@@ -67,7 +73,7 @@ class ThreadBuilderTest extends TestCase {
 	public function testBuildEmpty(): void {
 		$messages = [];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals([], $result);
 	}
@@ -79,7 +85,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('s3', 'id3', []),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -106,7 +112,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s1', 'id2', ['id1']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -130,7 +136,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('s2', 'id2', ['id1']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -154,7 +160,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s1', 'id2', []),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -184,7 +190,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('s3', 'id3', ['id2']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -222,7 +228,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s1', 'id4', ['id3']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -266,7 +272,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s1', 'id7', ['id1', 'id3']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -322,7 +328,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s1', 'id7', ['id3']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -368,7 +374,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('s2', 'id2', ['id1']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -393,7 +399,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('s3', 'id3', ['id1']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -421,7 +427,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re:s2', 'id3', ['id1']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -457,7 +463,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re: Sub', '<msg5@mail.host>', ['<msg1@mail.host>', '<msg2@mail.host>', '<msg3@mail.host>', '<msg4@mail.host>']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[
@@ -511,7 +517,7 @@ class ThreadBuilderTest extends TestCase {
 			new Message('Re: Sub', '<o2re1@mail.host>', ['<o2@mail.host>']),
 		];
 
-		$result = $this->builder->build($messages);
+		$result = $this->builder->build($messages, $this->logger);
 
 		$this->assertEquals(
 			[

--- a/tests/Unit/Listener/DeleteDraftListenerTest.php
+++ b/tests/Unit/Listener/DeleteDraftListenerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -39,8 +42,8 @@ use OCA\Mail\Model\RepliedMessageData;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class DeleteDraftListenerTest extends TestCase {
 
@@ -56,7 +59,7 @@ class DeleteDraftListenerTest extends TestCase {
 	/** @var MailboxSync|MockObject */
 	private $mailboxSync;
 
-	/** @var ILogger|MockObject */
+	/** @var LoggerInterface|MockObject */
 	private $logger;
 
 	/** @var IEventListener */
@@ -69,7 +72,7 @@ class DeleteDraftListenerTest extends TestCase {
 		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
 		$this->messageMapper = $this->createMock(MessageMapper::class);
 		$this->mailboxSync = $this->createMock(MailboxSync::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new DeleteDraftListener(
 			$this->imapClientFactory,
@@ -101,7 +104,7 @@ class DeleteDraftListenerTest extends TestCase {
 		$this->messageMapper->expects($this->never())
 			->method('addFlag');
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}
@@ -143,7 +146,7 @@ class DeleteDraftListenerTest extends TestCase {
 			);
 		$this->mailboxSync->expects($this->once())
 			->method('sync')
-			->with($account, true);
+			->with($account, $this->logger, true);
 		$this->mailboxMapper->expects($this->at(1))
 			->method('findSpecial')
 			->with($account, 'drafts')
@@ -160,7 +163,7 @@ class DeleteDraftListenerTest extends TestCase {
 			->method('expunge')
 			->with('Drafts');
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}
@@ -178,7 +181,7 @@ class DeleteDraftListenerTest extends TestCase {
 		$this->messageMapper->expects($this->never())
 			->method('addFlag');
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}
@@ -229,7 +232,7 @@ class DeleteDraftListenerTest extends TestCase {
 			->method('expunge')
 			->with('Drafts');
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}

--- a/tests/Unit/Listener/DraftMailboxCreatorListenerTest.php
+++ b/tests/Unit/Listener/DraftMailboxCreatorListenerTest.php
@@ -37,8 +37,8 @@ use OCA\Mail\Listener\DraftMailboxCreatorListener;
 use OCA\Mail\Model\NewMessageData;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
-use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class DraftMailboxCreatorListenerTest extends TestCase {
 
@@ -51,7 +51,7 @@ class DraftMailboxCreatorListenerTest extends TestCase {
 	/** @var MailboxSync|MockObject */
 	private $mailboxSync;
 
-	/** @var ILogger|MockObject */
+	/** @var LoggerInterface|MockObject */
 	private $logger;
 
 	/** @var DraftMailboxCreatorListener */
@@ -63,7 +63,7 @@ class DraftMailboxCreatorListenerTest extends TestCase {
 		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
 		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
 		$this->mailboxSync = $this->createMock(MailboxSync::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new DraftMailboxCreatorListener(
 			$this->mailboxMapper,
@@ -106,7 +106,7 @@ class DraftMailboxCreatorListenerTest extends TestCase {
 			->with($account, 'drafts')
 			->willReturn($mailbox);
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}
@@ -147,9 +147,9 @@ class DraftMailboxCreatorListenerTest extends TestCase {
 			);
 		$this->mailboxSync->expects($this->once())
 			->method('sync')
-			->with($account, true);
+			->with($account, $this->logger, true);
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}

--- a/tests/Unit/Listener/TrashMailboxCreatorListenerTest.php
+++ b/tests/Unit/Listener/TrashMailboxCreatorListenerTest.php
@@ -35,8 +35,8 @@ use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\Listener\TrashMailboxCreatorListener;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
-use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class TrashMailboxCreatorListenerTest extends TestCase {
 
@@ -49,7 +49,7 @@ class TrashMailboxCreatorListenerTest extends TestCase {
 	/** @var MailboxSync|MockObject */
 	private $mailboxSync;
 
-	/** @var ILogger|MockObject */
+	/** @var LoggerInterface|MockObject */
 	private $logger;
 
 	/** @var TrashMailboxCreatorListener */
@@ -61,7 +61,7 @@ class TrashMailboxCreatorListenerTest extends TestCase {
 		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
 		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
 		$this->mailboxSync = $this->createMock(MailboxSync::class);
-		$this->logger = $this->createMock(ILogger::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->listener = new TrashMailboxCreatorListener(
 			$this->mailboxMapper,
@@ -125,7 +125,7 @@ class TrashMailboxCreatorListenerTest extends TestCase {
 			)
 			->willThrowException(new \Horde_Imap_Client_Exception());
 		$this->logger->expects($this->once())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}
@@ -157,12 +157,11 @@ class TrashMailboxCreatorListenerTest extends TestCase {
 					],
 				]
 			);
-		$mailbox = new Mailbox();
 		$this->mailboxSync->expects($this->once())
 			->method('sync')
-			->with($account, true);
+			->with($account, $this->logger, true);
 		$this->logger->expects($this->never())
-			->method('logException');
+			->method('error');
 
 		$this->listener->handle($event);
 	}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -41,6 +41,7 @@ use OCA\Mail\Service\MailManager;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class MailManagerTest extends TestCase {
 
@@ -68,6 +69,9 @@ class MailManagerTest extends TestCase {
 	/** @var MailManager */
 	private $manager;
 
+	/** @var MockObject|LoggerInterface */
+	private $logger;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -78,6 +82,7 @@ class MailManagerTest extends TestCase {
 		$this->dbMessageMapper = $this->createMock(DbMessageMapper::class);
 		$this->mailboxSync = $this->createMock(MailboxSync::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->manager = new MailManager(
 			$this->imapClientFactory,
@@ -86,7 +91,8 @@ class MailManagerTest extends TestCase {
 			$this->folderMapper,
 			$this->imapMessageMapper,
 			$this->dbMessageMapper,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
Just like a CLI priority inbox model training gives all the details, we
want to have the same to diagnose slow/faulty account syncs. This
changes the console logger adapter for the PSR logger and adds it to the
sync process.