### PR TITLE
Add a flag that indicates whether an inbox should be sync'ed

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.5.0-beta2</version>
+	<version>1.5.0-beta3</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Roeland Jago Douma</author>

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -209,4 +209,15 @@ interface IMailManager {
 	public function updateSubscription(Account $account,
 									   Mailbox $mailbox,
 									   bool $subscribed): Mailbox;
+
+	/**
+	 * @param string $mailbox
+	 * @param bool $syncInBackground
+	 *
+	 * @return Mailbox
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function enableMailboxBackgroundSync(Mailbox $mailbox,
+												bool $syncInBackground): Mailbox;
 }

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -109,7 +109,8 @@ class MailboxesController extends Controller {
 	 */
 	public function patch(int $id,
 						  ?string $name = null,
-						  ?bool $subscribed = null): JSONResponse {
+						  ?bool $subscribed = null,
+						  ?bool $syncInBackground = null): JSONResponse {
 		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
 		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 
@@ -125,6 +126,12 @@ class MailboxesController extends Controller {
 				$account,
 				$mailbox,
 				$subscribed
+			);
+		}
+		if ($syncInBackground !== null) {
+			$mailbox = $this->mailManager->enableMailboxBackgroundSync(
+				$mailbox,
+				$syncInBackground
 			);
 		}
 

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -62,6 +62,8 @@ use function strtolower;
  * @method void setSelectable(bool $selectable)
  * @method string getSpecialUse()
  * @method void setSpecialUse(string $specialUse)
+ * @method bool getSyncInBackground()
+ * @method void setSyncInBackground(bool $sync)
  */
 class Mailbox extends Entity implements JsonSerializable {
 	protected $name;
@@ -78,6 +80,7 @@ class Mailbox extends Entity implements JsonSerializable {
 	protected $unseen;
 	protected $selectable;
 	protected $specialUse;
+	protected $syncInBackground;
 
 	public function __construct() {
 		$this->addType('accountId', 'integer');
@@ -87,6 +90,12 @@ class Mailbox extends Entity implements JsonSerializable {
 		$this->addType('syncChangedLock', 'integer');
 		$this->addType('syncVanishedLock', 'integer');
 		$this->addType('selectable', 'boolean');
+		$this->addType('syncInBackground', 'boolean');
+	}
+
+	public function isInbox(): bool {
+		// https://tools.ietf.org/html/rfc3501#section-5.1
+		return strtolower($this->getName()) === 'inbox';
 	}
 
 	private function getSpecialUseParsed(): array {
@@ -129,6 +138,7 @@ class Mailbox extends Entity implements JsonSerializable {
 			'specialUse' => $specialUse,
 			'specialRole' => $specialUse[0] ?? 0,
 			'mailboxes' => [],
+			'syncInBackground' => $this->getSyncInBackground(),
 		];
 	}
 }

--- a/lib/Migration/Version1050Date20200923180030.php
+++ b/lib/Migration/Version1050Date20200923180030.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1050Date20200923180030 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_mailboxes');
+		$accountsTable->addColumn('sync_in_background', 'boolean', [
+			'notnull' => true,
+			'default' => false,
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -339,6 +339,13 @@ class MailManager implements IMailManager {
 		return $this->mailboxMapper->find($account, $mailbox->getName());
 	}
 
+	public function enableMailboxBackgroundSync(Mailbox $mailbox,
+												bool $syncInBackground): Mailbox {
+		$mailbox->setSyncInBackground($syncInBackground);
+
+		return $this->mailboxMapper->update($mailbox);
+	}
+
 	public function flagMessage(Account $account, string $mailbox, int $uid, string $flag, bool $value): void {
 		$client = $this->imapClientFactory->getClient($account);
 		try {

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -112,6 +112,11 @@ class ImapToDbSynchronizer {
 								bool $force = false,
 								int $criteria = Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS): void {
 		foreach ($this->mailboxMapper->findAll($account) as $mailbox) {
+			if (!$mailbox->isInbox() && !$mailbox->getSyncInBackground()) {
+				$logger->debug("Skipping mailbox sync for " . $mailbox->getName());
+				continue;
+			}
+
 			$this->sync(
 				$account,
 				$mailbox,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -227,6 +227,22 @@ export default {
 			updated,
 		})
 	},
+	async patchMailbox({ commit }, { mailbox, attributes }) {
+		logger.debug('patching mailbox', {
+			mailbox,
+			attributes,
+		})
+
+		const updated = await patchMailbox(mailbox.databaseId, attributes)
+
+		commit('updateMailbox', {
+			mailbox: updated,
+		})
+		logger.debug(`mailbox ${mailbox.databaseId} patched`, {
+			mailbox,
+			updated,
+		})
+	},
 	async fetchEnvelope({ commit, getters }, id) {
 		const cached = getters.getEnvelope(id)
 		if (cached) {


### PR DESCRIPTION
The cron background sync can be expensive with accounts that have many
mailboxes. As it turns out other clients like Thunderbird also don't
look into *all* mailboxes to check for new email. Instead they only do
that for INBOX by default and let the user pick more mailboxes if they
wish. We should do the same.

This adds a simple flag. Only the inbox and mailboxes that have this
flag set will get a sync in background.

Any other mailbox can still be used, but the sync only happens if the
user has the mailbox open.

This will bring down the load on instances with many accounts,
especially if those have many mailboxes.

- [x] Requires https://github.com/nextcloud/mail/pull/3642