### PR TITLE
Fix number of coverage reports per build

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,4 +20,4 @@ imports:
 tools:
     external_code_coverage:
         timeout: 1200 # Timeout in seconds. 20 minutes
-        runs: 4
+        runs: 1


### PR DESCRIPTION
There is only one job, not four.

That is why Scrutinizer got stuck so often recently.