### PR TITLE
Fix signature detection and signature design

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -96,7 +96,7 @@ class Html {
 	 */
 	public function parseMailBody(string $body): array {
 		$signature = null;
-		$parts = explode("-- \r\n", $body);
+		$parts = preg_split("/-- (\n|(\r\n))/", $body);
 		if (count($parts) > 1) {
 			$signature = array_pop($parts);
 			$body = implode("-- \r\n", $parts);

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -36,8 +36,6 @@ export default {
 
 <style scoped>
 .mail-signature {
-	font-family: monospace;
-	opacity: 0.5;
-	line-height: initial;
+	color: var(--color-text-maxcontrast)
 }
 </style>

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -205,7 +205,7 @@ export default {
 	text-align: left;
 }
 
-#mail-content {
+#mail-content, .mail-signature {
 	margin: 10px 38px 50px 38px;
 
 	.mail-message-body-html & {


### PR DESCRIPTION
We can't assume line endings of specific platforms but should be
flexible with that when detecting the signature part of an email.

Also this fixes the styling of signatures a bit. They looked quite off
now that the distinct styling came back.

Fine-tuning in terms of design can be done in follow-ups. This PR is
mainly about getting the detection back.

![Bildschirmfoto von 2020-09-24 08-46-48](https://user-images.githubusercontent.com/1374172/94110538-12ce5f00-fe43-11ea-9a93-4f95830f547e.png)
