### PR TITLE
Collapse plain text signatures into a detail element

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -1,11 +1,16 @@
 <template>
 	<div>
-		<div id="mail-content" v-html="htmlBody" />
-		<div v-if="signature" class="mail-signature" v-html="htmlSignature" />
+		<div id="mail-content" v-html="nl2br(body)" />
+		<details v-if="signature" class="mail-signature">
+			<summary>{{ signatureSummaryAndBody.summary }}</summary>
+			<span v-html="nl2br(signatureSummaryAndBody.body)" />
+		</details>
 	</div>
 </template>
 
 <script>
+const regFirstParagraph = /(.+\n\r?)+(\n\r?)+/
+
 export default {
 	name: 'MessagePlainTextBody',
 	props: {
@@ -19,11 +24,26 @@ export default {
 		},
 	},
 	computed: {
-		htmlBody() {
-			return this.nl2br(this.body)
+		signatureSummaryAndBody() {
+			const matches = this.signature.match(regFirstParagraph)
+
+			if (matches[0]) {
+				return {
+					summary: matches[0],
+					body: this.signature.substring(matches[0].length),
+				}
+			}
+
+			const lines = this.signature.trim().split(/\r?\n/)
+			return {
+				summary: lines[0],
+				body: lines.slice(1).join('\n'),
+			}
 		},
-		htmlSignature() {
-			return this.nl2br(this.signature)
+		signatureSummary() {
+			console.info(this.signature.match(regFirstParagraph))
+
+			return this.signatureSummaryAndBody.summary
 		},
 	},
 	methods: {
@@ -34,7 +54,10 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+#mail-content, .mail-signature {
+	white-space: pre;
+}
 .mail-signature {
 	color: var(--color-text-maxcontrast)
 }


### PR DESCRIPTION
Signatures are a bit of clutter when you view a conversation. So let's
collapse them and only show on click.

The logic is that we try to find the first *paragraph* in the signature. Because I found you can't assume the first line to be too meaningful. Ideally this would be the name, but some have a greeting followed by the name.

If this doesn't work we fall back to the first non-empty line. This should still be okay-ish.

Luckily there is an HTML element we can use for this: `<details>`.

If the design should be improved then let's do a follow-up. This PR
focuses on the splittig logic.

Ref https://github.com/nextcloud/mail/issues/3639

---

### Before

![Bildschirmfoto von 2020-09-24 08-46-48](https://user-images.githubusercontent.com/1374172/94115584-3ba62280-fe4a-11ea-8281-1ad5a87d1436.png)

### Now

![Bildschirmfoto von 2020-09-24 09-26-03](https://user-images.githubusercontent.com/1374172/94115683-5e383b80-fe4a-11ea-956e-bca378ee72c0.png)

![Bildschirmfoto von 2020-09-24 09-26-11](https://user-images.githubusercontent.com/1374172/94115739-7019de80-fe4a-11ea-9571-fa7389226d6a.png)
