### PR TITLE
Do not try to run the training job for provisioned accounts

### DIFF
--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -74,6 +74,12 @@ class TrainImportanceClassifierJob extends TimedJob {
 			return;
 		}
 
+		$dbAccount = $account->getMailAccount();
+		if ($dbAccount->getProvisioned() && $dbAccount->getInboundPassword() === null) {
+			$this->logger->info("Ignoring cron training for provisioned account that has no password set yet");
+			return;
+		}
+
 		try {
 			$this->classifier->train(
 				$account,


### PR DESCRIPTION
Noticed on our instance. Not needed to do anything if there is no password.