### PR TITLE
Collapse quoted text in plain text messages

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<div id="mail-content" v-html="nl2br(body)" />
+		<div id="mail-content" v-html="nl2br(enhancedBody)" />
 		<details v-if="signature" class="mail-signature">
 			<summary>{{ signatureSummaryAndBody.summary }}</summary>
 			<span v-html="nl2br(signatureSummaryAndBody.body)" />
@@ -24,6 +24,11 @@ export default {
 		},
 	},
 	computed: {
+		enhancedBody() {
+			return this.body.replace(/(&gt;.+\n?)+/g, (match) => {
+				return `<details class="quoted-text"><summary>${t('mail', 'Quoted text')}</summary>${match}</details>`
+			})
+		},
 		signatureSummaryAndBody() {
 			const matches = this.signature.match(regFirstParagraph)
 
@@ -54,11 +59,16 @@ export default {
 }
 </script>
 
+<style lang="scss">
+.quoted-text {
+	color: var(--color-text-maxcontrast)
+}
+</style>
 <style lang="scss" scoped>
 #mail-content, .mail-signature {
 	white-space: pre;
 }
-.mail-signature {
+.mail-signature, .quoted {
 	color: var(--color-text-maxcontrast)
 }
 </style>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3639

The logic is very simple. It will collapse all quoted text. As a future enhancement we can try to detect inline replies and don't collapse there.

---

### Before

![Bildschirmfoto von 2020-09-24 10-55-07](https://user-images.githubusercontent.com/1374172/94124084-e1f72580-fe54-11ea-81f0-4110c57820dd.png)

### After

![Bildschirmfoto von 2020-09-24 10-54-51](https://user-images.githubusercontent.com/1374172/94124114-eb808d80-fe54-11ea-87be-ca6292b0b2f3.png)
