### PR TITLE
Improve thread header hover design and align text

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -175,7 +175,7 @@ export default {
 #mail-thread-header-fields {
 	// initial width
 	width: 0;
-	padding-left: 38px;
+	padding-left: 60px;
 	// grow and try to fill 100%
 	flex: 1 1 auto;
 	h2,
@@ -206,7 +206,7 @@ export default {
 }
 
 #mail-content, .mail-signature {
-	margin: 10px 38px 50px 38px;
+	margin: 10px 38px 50px 60px;
 
 	.mail-message-body-html & {
 		margin-bottom: -44px; // accounting for the sticky attachment button

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -364,7 +364,13 @@ export default {
 	}
 	.envelope--header {
 		display: flex;
-		padding-bottom: 20px
+		padding: 10px;
+		margin-bottom: 3px;
+		border-radius: var(--border-radius);
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
 	}
 	.left {
 		flex-grow: 1;


### PR DESCRIPTION
It's a nice little touch to show a light background color for the
hovered thread header, as suggested by Marco.

Moreover this aligns the email text with the thread subject and the
header text.

Fixes https://github.com/nextcloud/mail/issues/3634

![Bildschirmfoto von 2020-09-24 11-37-15](https://user-images.githubusercontent.com/1374172/94128783-dad31600-fe5a-11ea-938b-d88b7a267451.png)
