### PR TITLE
Fix php notice about undinfed index in importance classifier

### DIFF
--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -361,9 +361,9 @@ class ImportanceClassifier {
 			$predictedValidationLabel,
 			array_column($validationSet, 'label')
 		);
-		$recallImportant = $report['classes'][self::LABEL_IMPORTANT]['recall'];
-		$precisionImportant = $report['classes'][self::LABEL_IMPORTANT]['precision'];
-		$f1ScoreImportant = $report['classes'][self::LABEL_IMPORTANT]['f1_score'];
+		$recallImportant = $report['classes'][self::LABEL_IMPORTANT]['recall'] ?? 0;
+		$precisionImportant = $report['classes'][self::LABEL_IMPORTANT]['precision'] ?? 0;
+		$f1ScoreImportant = $report['classes'][self::LABEL_IMPORTANT]['f1_score'] ?? 0;
 
 		/**
 		 * What we care most is the percentage of messages classified as important in relation to the truly important messages


### PR DESCRIPTION
In extreme cases the classifier only learn non-important messages and
thus the values for important are not present, hence the array index is
missing.

We just fall back to 0, this should be fine.