### PR TITLE
Add missing trim of plain text signature and handle no matches

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -2,7 +2,7 @@
 	<div>
 		<div id="mail-content" v-html="nl2br(enhancedBody)" />
 		<details v-if="signature" class="mail-signature">
-			<summary>{{ signatureSummaryAndBody.summary }}</summary>
+			<summary v-html="nl2br(signatureSummaryAndBody.summary)" />
 			<span v-html="nl2br(signatureSummaryAndBody.body)" />
 		</details>
 	</div>

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -30,9 +30,9 @@ export default {
 			})
 		},
 		signatureSummaryAndBody() {
-			const matches = this.signature.match(regFirstParagraph)
+			const matches = this.signature.trim().match(regFirstParagraph)
 
-			if (matches[0]) {
+			if (matches && matches[0]) {
 				return {
 					summary: matches[0],
 					body: this.signature.substring(matches[0].length),


### PR DESCRIPTION
This fixes two bugs:

1) When the signature was prepended with some whitespaces (like tabs) or
   a single line ending, we didn't remove it, hence the first line
   showed below the triangle icon.
2) When no paragraph matches the regex, `null` is returned, not an empty
   array, therefore the previous code failed when it accessed index 0 on
   null. There is another check now.

Fixes https://github.com/nextcloud/mail/issues/3667