### PR TITLE
Add a unit test for another real-world linear thread

### DIFF
--- a/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
+++ b/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
@@ -583,7 +583,7 @@ class ThreadBuilderTest extends TestCase {
 		$messages = [
 			new Message('sub', '<454AF3B1-C642-4976-AA00-DB33B34225C1@bollu.be>', ['<1A0C073E-8D77-4F05-9853-4A576D33B819@acme.be>']),
 			new Message('sub', '<1A0C073E-8D77-4F05-9853-4A576D33B819@acme.be>', []),
-			new Message('sub', '<9009C4EE-C517-4EAE-B0E3-75FE5EA25207@acme.be>', ["<1A0C073E-8D77-4F05-9853-4A576D33B819@acme.be>","<454AF3B1-C642-4976-AA00-DB33B34225C1@bollu.be>"]),
+			new Message('sub', '<9009C4EE-C517-4EAE-B0E3-75FE5EA25207@acme.be>', ['<1A0C073E-8D77-4F05-9853-4A576D33B819@acme.be>','<454AF3B1-C642-4976-AA00-DB33B34225C1@bollu.be>']),
 		];
 
 		$result = $this->builder->build($messages, $this->logger);
@@ -599,6 +599,42 @@ class ThreadBuilderTest extends TestCase {
 								[
 									'id' => '<9009C4EE-C517-4EAE-B0E3-75FE5EA25207@acme.be>',
 									'children' => [],
+								],
+							],
+						],
+					],
+				],
+			],
+			$this->abstract($result)
+		);
+	}
+
+	public function testRealWorldLinearThreadReferencesAndInReplyTo(): void {
+		$messages = [
+			new Message('sub', '<testRealWorldLinearThreadReferencesAndInReplyTo1@host>', []),
+			new Message('sub', '<testRealWorldLinearThreadReferencesAndInReplyTo2@host>', ['<testRealWorldLinearThreadReferencesAndInReplyTo1@host>', '<testRealWorldLinearThreadReferencesAndInReplyTo1@host>']),
+			new Message('sub', '<testRealWorldLinearThreadReferencesAndInReplyTo3@host>', ['<testRealWorldLinearThreadReferencesAndInReplyTo1@host>', '<testRealWorldLinearThreadReferencesAndInReplyTo2@host>', '<testRealWorldLinearThreadReferencesAndInReplyTo2@host>']),
+			new Message('sub', '<testRealWorldLinearThreadReferencesAndInReplyTo4@host>', ['<testRealWorldLinearThreadReferencesAndInReplyTo1@host>','<testRealWorldLinearThreadReferencesAndInReplyTo2@host>', '<testRealWorldLinearThreadReferencesAndInReplyTo3@host>']),
+		];
+
+		$result = $this->builder->build($messages, $this->logger);
+
+		$this->assertEquals(
+			[
+				[
+					'id' => '<testRealWorldLinearThreadReferencesAndInReplyTo1@host>',
+					'children' => [
+						[
+							'id' => '<testRealWorldLinearThreadReferencesAndInReplyTo2@host>',
+							'children' => [
+								[
+									'id' => '<testRealWorldLinearThreadReferencesAndInReplyTo3@host>',
+									'children' => [
+										[
+											'id' => '<testRealWorldLinearThreadReferencesAndInReplyTo4@host>',
+											'children' => [],
+										],
+									],
 								],
 							],
 						],


### PR DESCRIPTION
I found a thread that breaks into two in production. Ironically the
problem isn't reproducible in isolation here, but we don't have tests
where both references and in-reply-to info is used (duplicate
reference) so I figured we can keep it :)
