### PR TITLE
Fix flattening of threads for database update

### DIFF
--- a/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
+++ b/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
@@ -95,7 +95,7 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 
 			yield from $this->flattenThreads(
 				$thread->getChildren(),
-				$message === null ? null : $message->getId()
+				$threadId ?? ($message === null ? null : $message->getId())
 			);
 		}
 	}


### PR DESCRIPTION
There were some obvious flaws with threading, like some messages would
not group. But there was no pattern so far. I expected the threading
algorithm to be the problem, but it was on a different level: when we
flatten the thread trees into lists of messages to udpate the thread
root ID in the database.

The logic should flatten each of the trees. And all of those messages
that are of the same thread get the same root thread ID set. So far the
theory, but the code passed down the parent message's ID as thread root
ID, hence the (linear) threads broke into multiple.
