### PR TITLE
Fix popover attachment overlaping dialogs

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -30,10 +30,10 @@
 		<Popover v-if="message.attachments[0]" class="attachment-popover">
 			<Actions slot="trigger">
 				<ActionButton icon="icon-public icon-attachment">
-					Attachments
+					{{t('mail', 'Attachments')}}
 				</ActionButton>
 			</Actions>
-			<MessageAttachments :attachments="message.attachments" />
+			<MessageAttachments :attachments="message.attachments" v-close-popover="true" />
 		</Popover>
 		<div id="reply-composer" />
 	</div>

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -116,4 +116,7 @@ export default {
 	background-position: 9px center;
 	padding-left: 32px;
 }
+.oc-dialog {
+	z-index: 10000000;
+}
 </style>


### PR DESCRIPTION
ref #3675 
when we click _save to file_ the attachment preview should close.