### PR TITLE
Fix collapsing of quoted text with empty lines

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -25,7 +25,7 @@ export default {
 	},
 	computed: {
 		enhancedBody() {
-			return this.body.replace(/(&gt;.+\n?)+/g, (match) => {
+			return this.body.replace(/(&gt;.*\n?)+/g, (match) => {
 				return `<details class="quoted-text"><summary>${t('mail', 'Quoted text')}</summary>${match}</details>`
 			})
 		},


### PR DESCRIPTION
An empty line in a quote looks like ">". The regex didn't match that,
hence every paragraph became a quoted text element of its own. Now the
whole text is combined.

---

### Example email

![Bildschirmfoto von 2020-09-29 15-52-59](https://user-images.githubusercontent.com/1374172/94568024-532b4400-026c-11eb-917f-e3f91e6471ff.png)

### What it looked like before

![Bildschirmfoto von 2020-09-29 15-53-46](https://user-images.githubusercontent.com/1374172/94568023-532b4400-026c-11eb-889b-9e3f5b6eccd1.png)

### How it looks now

![Bildschirmfoto von 2020-09-29 15-56-01](https://user-images.githubusercontent.com/1374172/94568022-5292ad80-026c-11eb-953c-09f3ad7562f6.png)
