### PR TITLE
Fix 'Important' info popover design

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -21,7 +21,9 @@
 						<SectionTitle class="important" :name="t('mail', 'Important')" />
 						<Popover trigger="hover focus">
 							<button slot="trigger" :aria-label="t('mail', 'Important info')" class="button icon-info" />
-							{{ importantInfo }}
+							<p class="important-info">
+								{{ importantInfo }}
+							</p>
 						</Popover>
 					</div>
 					<Mailbox
@@ -215,12 +217,20 @@ export default {
 .v-popover > .trigger > {
 	z-index: 1;
 }
+
 .icon-info {
 	background-image: var(--icon-info-000);
 }
+
+.important-info {
+	max-width: 230px;
+	padding: 16px;
+}
+
 .app-content-list-item:hover {
 	background: transparent;
 }
+
 .button {
 	background-color: var(--color-main-background);
 	width: 44px;

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -30,10 +30,10 @@
 		<Popover v-if="message.attachments[0]" class="attachment-popover">
 			<Actions slot="trigger">
 				<ActionButton icon="icon-public icon-attachment">
-					{{t('mail', 'Attachments')}}
+					{{ t('mail', 'Attachments') }}
 				</ActionButton>
 			</Actions>
-			<MessageAttachments :attachments="message.attachments" v-close-popover="true" />
+			<MessageAttachments v-close-popover="true" :attachments="message.attachments" />
 		</Popover>
 		<div id="reply-composer" />
 	</div>


### PR DESCRIPTION
Now looks nice:
![image](https://user-images.githubusercontent.com/925062/94578860-7bb93b00-0278-11eb-98cb-eda047dae3b7.png)
