### PR TITLE
Add a CLI command to export thread data

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -47,6 +47,7 @@
 		<command>OCA\Mail\Command\CreateAccount</command>
 		<command>OCA\Mail\Command\DiagnoseAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>
+		<command>OCA\Mail\Command\ExportAccountThreads</command>
 		<command>OCA\Mail\Command\SyncAccount</command>
 		<command>OCA\Mail\Command\TrainAccount</command>
 	</commands>

--- a/lib/Command/ExportAccountThreads.php
+++ b/lib/Command/ExportAccountThreads.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function json_encode;
+
+class ExportAccountThreads extends Command {
+	private const ARGUMENT_ACCOUNT_ID = 'account-id';
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var MessageMapper */
+	private $messageMapper;
+
+	public function __construct(AccountService $service,
+								MessageMapper $messageMapper) {
+		parent::__construct();
+
+		$this->accountService = $service;
+		$this->messageMapper = $messageMapper;
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:account:export-threads');
+		$this->setDescription('Exports a user\'s account threads');
+		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
+
+		try {
+			$account = $this->accountService->findById($accountId);
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Account $accountId does not exist</error>");
+			return 1;
+		}
+
+		$output->writeln(
+			json_encode(
+				$this->messageMapper->findThreadingData($account),
+				JSON_PRETTY_PRINT
+			)
+		);
+
+		return 0;
+	}
+}

--- a/lib/IMAP/Threading/DatabaseMessage.php
+++ b/lib/IMAP/Threading/DatabaseMessage.php
@@ -25,9 +25,11 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP\Threading;
 
+use JsonSerializable;
+use function array_merge;
 use function json_decode;
 
-class DatabaseMessage extends Message {
+class DatabaseMessage extends Message implements JsonSerializable {
 
 	/** @var int */
 	private $databaseId;
@@ -87,5 +89,14 @@ class DatabaseMessage extends Message {
 
 	public function isDirty(): bool {
 		return $this->dirty;
+	}
+
+	public function jsonSerialize(): array {
+		return array_merge(
+			parent::jsonSerialize(),
+			[
+				'databaseId' => $this->databaseId,
+			]
+		);
 	}
 }

--- a/lib/IMAP/Threading/Message.php
+++ b/lib/IMAP/Threading/Message.php
@@ -25,10 +25,11 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP\Threading;
 
+use JsonSerializable;
 use function str_replace;
 use function strpos;
 
-class Message {
+class Message implements JsonSerializable {
 
 	/** @var string */
 	private $subject;
@@ -71,5 +72,13 @@ class Message {
 	 */
 	public function getReferences(): array {
 		return $this->references;
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'subject' => $this->subject,
+			'id' => $this->id,
+			'references' => $this->references,
+		];
 	}
 }


### PR DESCRIPTION
Because at some point we need to debug this. This format should be importable as well. That part will follow in another PR.

Example output

```
$ occ mail:account:export-threads 1227 --redact | head -n 30
[
    {
        "subject": "76d3434eef7593f94b3bf9c1ca64d76a@redacted",
        "id": "3fa00abd20dd8acf8ab42bb6a4d16919@redacted",
        "references": [],
        "databaseId": 138302
    },
    {
        "subject": "ca81be64aff1c8d223e4b9843429dcd9@redacted",
        "id": "783621fe05c62aa935c7c9c9149037a6@redacted",
        "references": [],
        "databaseId": 138303
    },
    {
        "subject": "4787464870eb08b3457b92e8b78ecf22@redacted",
        "id": "de30397a7f54212e61c392d6b53b303d@redacted",
        "references": [],
        "databaseId": 138304
    },
    {
        "subject": "71e1e09d3c23453612746dc6f7a9cf22@redacted",
        "id": "f8d1731b5bfe505b785f8743a8ba6196@redacted",
        "references": [],
        "databaseId": 138305
    },
    {
        "subject": "289c30d20f231994452684a8d01d6a1e@redacted",
        "id": "91458aed59f54d7efa50212c638a8341@redacted",
        "references": [],
        "databaseId": 138306
```