### PR TITLE
Remove debugging code that stops the threading process for some accounts

### DIFF
--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -114,9 +114,6 @@ class ThreadBuilder {
 			// Step 1.C
 			//$parentId = $message->getReferences()[count($message->getReferences()) - 1] ?? null;
 			//$container->setParent($idTable[$parentId] ?? null);
-			if ($parent === $container) {
-				throw new \Exception("about to run into a nasty endless loop");
-			}
 			if ($parent === null || !$parent->hasAncestor($container)) {
 				$container->setParent($parent);
 			}


### PR DESCRIPTION
I accidentally added this when I tried to help @violoncelloCH debug his account. This is not needed in production.