### PR TITLE
Add a CLI command to build threads for an account's exported data

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,6 +49,7 @@
 		<command>OCA\Mail\Command\ExportAccount</command>
 		<command>OCA\Mail\Command\SyncAccount</command>
 		<command>OCA\Mail\Command\TrainAccount</command>
+		<command>OCA\Mail\Command\Thread</command>
 	</commands>
 	<settings>
 		<admin>OCA\Mail\Settings\AdminSettings</admin>

--- a/lib/Command/Thread.php
+++ b/lib/Command/Thread.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\IMAP\Threading\DatabaseMessage;
+use OCA\Mail\IMAP\Threading\ThreadBuilder;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function array_map;
+use function file_exists;
+use function file_get_contents;
+use function json_decode;
+
+class Thread extends Command {
+	public const ARGUMENT_INPUT_FILE = 'thread-file';
+
+	/** @var ThreadBuilder */
+	private $builder;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(ThreadBuilder $builder,
+								LoggerInterface $logger) {
+		parent::__construct();
+		$this->builder = $builder;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function configure() {
+		$this->setName('mail:thread');
+		$this->setDescription('Build threads from the exported data of an account');
+		$this->addArgument(self::ARGUMENT_INPUT_FILE, InputArgument::REQUIRED);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$inputFile = $input->getArgument(self::ARGUMENT_INPUT_FILE);
+
+		if (!file_exists($inputFile)) {
+			$output->writeln("<error>File $inputFile does not exist</error>");
+			return 1;
+		}
+
+		$json = file_get_contents($inputFile);
+		if ($json === false) {
+			$output->writeln("<error>Could not read thread data</error>");
+			return 2;
+		}
+		$parsed = json_decode($json, true);
+		$threadData = array_map(function ($serialized) {
+			return new DatabaseMessage(
+				$serialized['databaseId'],
+				$serialized['subject'],
+				$serialized['id'],
+				$serialized['references'],
+				$serialized['threadRootId']
+			);
+		}, $parsed);
+
+		$threads = $this->builder->build($threadData, $this->logger);
+		$output->writeln(count($threads) . " threads built from " . count($threadData) . " messages");
+
+		return 0;
+	}
+}


### PR DESCRIPTION
This is the counterpart to https://github.com/nextcloud/mail/pull/3683.

@nextcloud/mail this means when someone has a problem with threading, we can ask them to export the data and we can then locally step through the code. We won't see the personalized info but just IDs.