### PR TITLE
Fix displaying of mails with empty from field

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -32,7 +32,7 @@
 				event=""
 				class="left"
 				@click.native.prevent="$emit('toggleExpand', $event)">
-				<span class="sender">{{ envelope.from[0].label }}</span>
+				<span class="sender">{{ envelope.from && envelope.from[0] ? envelope.from[0].label : '' }}</span>
 				<div class="subject">
 					<span class="preview">
 						<!-- TODO: instead of subject it should be shown the first line of the message #2666 -->


### PR DESCRIPTION
Signed-off-by: Patrick Bender <patrick@bender-it-services.de>

For example my ubuntu server sends such emails with empty from field when it sends mails for cron jobs that ran