### PR TITLE
Reset cache for mailbox on resetCache call

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -174,6 +174,11 @@ class ImapToDbSynchronizer {
 		$id = $account->getId() . ":" . $mailbox->getName();
 		$this->messageMapper->deleteAll($mailbox);
 		$this->logger->debug("All messages of $id cleared");
+		$clientCache = $this->clientFactory->getClient($account)->getCache();
+		if ($clientCache) {
+			// Clear cached data for mailbox
+			$clientCache->deleteMailbox($mailbox->getName());
+		}
 		$mailbox->setSyncNewToken(null);
 		$mailbox->setSyncChangedToken(null);
 		$mailbox->setSyncVanishedToken(null);


### PR DESCRIPTION
After pressing resetCache in the frontend for a mailbox i had messages that disappeared from nextcloud mail after some time. When i disabled caching the issue was gone. I think PR might fix the cause

Signed-off-by: Patrick Bender <patrick@bender-it-services.de>