### PR TITLE
Fix remaining psalm errors, add baseline and CI test matrix for all Nextcloud versions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,8 +4,11 @@ on: [push]
 
 jobs:
   static-psalm-analysis:
-      name: Static analysis with Psalm
       runs-on: ubuntu-latest
+      strategy:
+          matrix:
+              ocp-version: [ 'dev-master', 'v20.0.0' ]
+      name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout
             uses: actions/checkout@master
@@ -16,5 +19,7 @@ jobs:
                 coverage: none
           - name: Install dependencies
             run: composer i
+          - name: Install dependencies
+            run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
           - name: Run coding standards check
             run: composer run psalm

--- a/lib/BackgroundJob/CleanupJob.php
+++ b/lib/BackgroundJob/CleanupJob.php
@@ -42,7 +42,7 @@ class CleanupJob extends TimedJob {
 		$this->setInterval(24 * 60 * 60);
 	}
 
-	protected function run($argument) {
+	protected function run($argument): void {
 		$this->cleanupService->cleanUp();
 	}
 }

--- a/lib/Command/CreateAccount.php
+++ b/lib/Command/CreateAccount.php
@@ -105,13 +105,13 @@ class CreateAccount extends Command {
 		$account->setEmail($email);
 
 		$account->setInboundHost($imapHost);
-		$account->setInboundPort($imapPort);
+		$account->setInboundPort((int) $imapPort);
 		$account->setInboundSslMode($imapSslMode);
 		$account->setInboundUser($imapUser);
 		$account->setInboundPassword($this->crypto->encrypt($imapPassword));
 
 		$account->setOutboundHost($smtpHost);
-		$account->setOutboundPort($smtpPort);
+		$account->setOutboundPort((int) $smtpPort);
 		$account->setOutboundSslMode($smtpSslMode);
 		$account->setOutboundUser($smtpUser);
 		$account->setOutboundPassword($this->crypto->encrypt($smtpPassword));

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -93,14 +93,14 @@ interface IMailManager {
 
 	/**
 	 * @param Account $account
-	 * @param string $mb
+	 * @param string $mailbox
 	 * @param int $uid
 	 *
 	 * @return string
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function getSource(Account $account, string $mb, int $uid): ?string;
+	public function getSource(Account $account, string $mailbox, int $uid): ?string;
 
 	/**
 	 * @param Account $account

--- a/lib/Contracts/IMailTransmission.php
+++ b/lib/Contracts/IMailTransmission.php
@@ -34,17 +34,17 @@ interface IMailTransmission {
 	/**
 	 * Send a new message or reply to an existing one
 	 *
-	 * @param NewMessageData $message
-	 * @param RepliedMessageData|null $reply
+	 * @param NewMessageData $messageData
+	 * @param RepliedMessageData|null $replyData
 	 * @param Alias|null $alias
 	 * @param Message|null $draft
 	 *
 	 * @throws ServiceException
 	 */
-	public function sendMessage(NewMessageData $message,
-								RepliedMessageData $reply = null,
+	public function sendMessage(NewMessageData $messageData,
+								RepliedMessageData $replyData = null,
 								Alias $alias = null,
-								Message $draft = null);
+								Message $draft = null): void;
 
 	/**
 	 * Save a message draft

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -238,7 +238,7 @@ class AccountsController extends Controller {
 		$account = $this->accountService->find($this->currentUserId, $id);
 
 		if ($account === null) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$dbAccount = $account->getMailAccount();

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -168,7 +168,7 @@ class MailboxesController extends Controller {
 				$query
 			);
 		} catch (MailboxNotCachedException $e) {
-			return new JSONResponse(null, Http::STATUS_PRECONDITION_REQUIRED);
+			return new JSONResponse([], Http::STATUS_PRECONDITION_REQUIRED);
 		} catch (IncompleteSyncException $e) {
 			return \OCA\Mail\Http\JsonResponse::fail([], Http::STATUS_ACCEPTED);
 		}
@@ -191,7 +191,7 @@ class MailboxesController extends Controller {
 		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 
 		$this->syncService->clearCache($account, $mailbox);
-		return new JSONResponse(null);
+		return new JSONResponse([]);
 	}
 
 	/**
@@ -210,7 +210,7 @@ class MailboxesController extends Controller {
 
 		$this->mailManager->markFolderAsRead($account, $mailbox);
 
-		return new JSONResponse(null);
+		return new JSONResponse([]);
 	}
 
 	/**

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -180,7 +180,7 @@ class MailboxesController extends Controller {
 	 * @NoAdminRequired
 	 * @TrapError
 	 *
-	 * @param string $id
+	 * @param int $id
 	 *
 	 * @return JSONResponse
 	 * @throws ClientException

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -267,7 +267,7 @@ class MessagesController extends Controller {
 	 * @TrapError
 	 *
 	 * @param int $id
-	 * @param string $destFolderId
+	 * @param int $destFolderId
 	 *
 	 * @return JSONResponse
 	 *
@@ -398,7 +398,7 @@ class MessagesController extends Controller {
 	 * @param int $accountId
 	 * @param string $folderId
 	 * @param int $id
-	 * @param int $attachmentId
+	 * @param string $attachmentId
 	 *
 	 * @return Response
 	 *
@@ -439,7 +439,7 @@ class MessagesController extends Controller {
 	 * @TrapError
 	 *
 	 * @param int $id
-	 * @param int $attachmentId
+	 * @param string $attachmentId
 	 * @param string $targetPath
 	 *
 	 * @return JSONResponse
@@ -496,7 +496,7 @@ class MessagesController extends Controller {
 	 * @NoAdminRequired
 	 * @TrapError
 	 *
-	 * @param string $id
+	 * @param int $id
 	 * @param array $flags
 	 *
 	 * @return JSONResponse

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -147,7 +147,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $mailboxId);
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->logger->debug("loading messages of folder <$mailboxId>");
@@ -182,7 +182,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->logger->debug("loading message <$id>");
@@ -213,7 +213,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$json = $this->mailManager->getImapMessage(
@@ -256,7 +256,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		return new JSONResponse($this->mailManager->getThread($account, $id));
@@ -282,7 +282,7 @@ class MessagesController extends Controller {
 			$srcAccount = $this->accountService->find($this->currentUserId, $srcMailbox->getAccountId());
 			$dstAccount = $this->accountService->find($this->currentUserId, $dstMailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->mailManager->moveMessage(
@@ -313,7 +313,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$response = new JSONResponse([
@@ -412,7 +412,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 		$folder = $account->getMailbox($mailbox->getName());
 		$attachment = $folder->getAttachment($message->getUid(), $attachmentId);
@@ -455,7 +455,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 		$folder = $account->getMailbox($mailbox->getName());
 
@@ -510,7 +510,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		foreach ($flags as $flag => $value) {
@@ -539,7 +539,7 @@ class MessagesController extends Controller {
 			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
-			return new JSONResponse(null, Http::STATUS_FORBIDDEN);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->logger->debug("deleting message <$id>");

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -63,12 +63,12 @@ class SettingsController extends Controller {
 			$smtpSslMode
 		);
 
-		return new JSONResponse(null);
+		return new JSONResponse([]);
 	}
 
 	public function deprovision(): JSONResponse {
 		$this->provisioningManager->deprovision();
 
-		return new JSONResponse(null);
+		return new JSONResponse([]);
 	}
 }

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -774,7 +774,7 @@ class MessageMapper extends QBMapper {
 	 * @param Mailbox $mailbox
 	 * @param int $highest
 	 *
-	 * @return Message[]
+	 * @return int[]
 	 */
 	public function findNewIds(Mailbox $mailbox, array $ids): array {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -96,13 +96,13 @@ class Mailbox implements IMailBox {
 	}
 
 	/**
-	 * @param int $messageId
+	 * @param int $id
 	 * @param bool $loadHtmlMessageBody
 	 *
 	 * @return IMAPMessage
 	 */
-	public function getMessage(int $messageId, bool $loadHtmlMessageBody = false) {
-		return new IMAPMessage($this->conn, $this->mailBox, $messageId, null, $loadHtmlMessageBody);
+	public function getMessage(int $id, bool $loadHtmlMessageBody = false) {
+		return new IMAPMessage($this->conn, $this->mailBox, $id, null, $loadHtmlMessageBody);
 	}
 
 	/**

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -145,7 +145,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	}
 
 	/**
-	 * @param array $flags
+	 * @param string $flags
 	 *
 	 * @throws Exception
 	 *

--- a/lib/Model/IMessage.php
+++ b/lib/Model/IMessage.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Model;
 
+use Horde_Mime_Part;
 use OCA\Mail\AddressList;
 use OCA\Mail\Db\LocalAttachment;
 use OCP\Files\File;
@@ -45,7 +46,7 @@ interface IMessage {
 	public function getFlags(): array;
 
 	/**
-	 * @param array $flags
+	 * @param string $flags
 	 */
 	public function setFlags(array $flags);
 
@@ -120,12 +121,12 @@ interface IMessage {
 	public function setContent(string $content);
 
 	/**
-	 * @return File[]
+	 * @return Horde_Mime_Part[]
 	 */
 	public function getCloudAttachments(): array;
 
 	/**
-	 * @return int[]
+	 * @return Horde_Mime_Part[]
 	 */
 	public function getLocalAttachments(): array;
 

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -50,16 +50,16 @@ class Message implements IMessage {
 	/** @var string|null */
 	private $inReplyTo = null;
 
-	/** @var array */
+	/** @var string[] */
 	private $flags = [];
 
 	/** @var string */
 	private $content = '';
 
-	/** @var File[] */
+	/** @var Horde_Mime_Part[] */
 	private $cloudAttachments = [];
 
-	/** @var int[] */
+	/** @var Horde_Mime_Part[] */
 	private $localAttachments = [];
 
 	public function __construct() {
@@ -81,7 +81,7 @@ class Message implements IMessage {
 	/**
 	 * Get all flags set on this message
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function getFlags(): array {
 		return $this->flags;
@@ -209,14 +209,14 @@ class Message implements IMessage {
 	}
 
 	/**
-	 * @return File[]
+	 * @return Horde_Mime_Part[]
 	 */
 	public function getCloudAttachments(): array {
 		return $this->cloudAttachments;
 	}
 
 	/**
-	 * @return int[]
+	 * @return Horde_Mime_Part[]
 	 */
 	public function getLocalAttachments(): array {
 		return $this->localAttachments;

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -31,7 +31,6 @@ use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
-use OCA\mail\lib\Service\Quota;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\BackgroundJob\IJobList;
 use function array_map;
@@ -156,8 +155,5 @@ class AccountService {
 		$mailAccount = $account->getMailAccount();
 		$mailAccount->setSignature($signature);
 		$this->mapper->save($mailAccount);
-	}
-
-	public function getQuota(): Quota {
 	}
 }

--- a/lib/Service/AutoCompletion/AddressCollector.php
+++ b/lib/Service/AutoCompletion/AddressCollector.php
@@ -79,7 +79,7 @@ class AddressCollector {
 			}
 		} catch (Horde_Mail_Exception $ex) {
 			// Ignore it
-			$this->logger->debug("<$address> is not a valid RFC822 mail address");
+			$this->logger->debug("<" . $address->getEmail() . "> is not a valid RFC822 mail address");
 			return;
 		}
 		if ($address->getEmail() !== null && !$this->mapper->exists($this->userId, $address->getEmail())) {

--- a/lib/Service/AutoConfig/SmtpConnectivityTester.php
+++ b/lib/Service/AutoConfig/SmtpConnectivityTester.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\AutoConfig;
 
 use Exception;
+use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\SMTP\SmtpClientFactory;
@@ -135,6 +136,8 @@ class SmtpConnectivityTester {
 	protected function testStmtpConnection(MailAccount $mailAccount): void {
 		$account = new Account($mailAccount);
 		$smtp = $this->clientFactory->create($account);
-		$smtp->getSMTPObject();
+		if ($smtp instanceof Horde_Mail_Transport_Smtphorde) {
+			$smtp->getSMTPObject();
+		}
 	}
 }

--- a/lib/Service/Avatar/Downloader.php
+++ b/lib/Service/Avatar/Downloader.php
@@ -28,6 +28,8 @@ namespace OCA\Mail\Service\Avatar;
 
 use Exception;
 use OCP\Http\Client\IClientService;
+use function is_resource;
+use function stream_get_contents;
 
 class Downloader {
 
@@ -51,6 +53,10 @@ class Downloader {
 			return null;
 		}
 
-		return $resp->getBody();
+		$body = $resp->getBody();
+		if (is_resource($body)) {
+			return stream_get_contents($body);
+		}
+		return $body;
 	}
 }

--- a/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
@@ -34,7 +34,7 @@ use function array_unique;
 class ImportantMessagesExtractor implements IExtractor {
 
 	/** @var int[] */
-	private $totalMessages = 0;
+	private $totalMessages = [];
 
 	/** @var int[] */
 	private $flaggedMessages = [];
@@ -50,6 +50,7 @@ class ImportantMessagesExtractor implements IExtractor {
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
 							array $messages): bool {
+		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
 		}, array_filter($messages, function (Message $message) {
@@ -59,7 +60,7 @@ class ImportantMessagesExtractor implements IExtractor {
 		$this->flaggedMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'important', $senders);
 
 		// This extractor is only applicable if there are incoming messages
-		return $this->totalMessages > 0;
+		return !empty($this->totalMessages);
 	}
 
 	public function extract(string $email): float {

--- a/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
@@ -33,7 +33,7 @@ use function array_unique;
 
 class ImportantMessagesExtractor implements IExtractor {
 
-	/** @var int */
+	/** @var int[] */
 	private $totalMessages = 0;
 
 	/** @var int[] */

--- a/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
@@ -50,6 +50,7 @@ class ReadMessagesExtractor implements IExtractor {
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
 							array $messages): bool {
+		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
 		}, array_filter($messages, function (Message $message) {

--- a/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
@@ -50,6 +50,7 @@ class RepliedMessagesExtractor implements IExtractor {
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
 							array $messages): bool {
+		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
 		}, array_filter($messages, function (Message $message) {

--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -31,6 +31,7 @@ use Closure;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use HTMLPurifier_HTMLDefinition;
+use HTMLPurifier_URIDefinition;
 use HTMLPurifier_URISchemeRegistry;
 use Kwi\UrlLinker;
 use OCA\Mail\Service\HtmlPurify\CidURIScheme;
@@ -125,11 +126,13 @@ class Html {
 		$config->set('Cache.DefinitionImpl', null);
 
 		// Rewrite URL for redirection and proxying of content
+		/** @var HTMLPurifier_HTMLDefinition $html */
 		$html = $config->getDefinition('HTML');
 		$html->info_attr_transform_post['imagesrc'] = new TransformImageSrc($this->urlGenerator);
 		$html->info_attr_transform_post['cssbackground'] = new TransformCSSBackground($this->urlGenerator);
 		$html->info_attr_transform_post['htmllinks'] = new TransformHTMLLinks();
 
+		/** @var HTMLPurifier_URIDefinition $uri */
 		$uri = $config->getDefinition('URI');
 		$uri->addFilter(new TransformURLScheme($messageParameters, $mapCidToAttachmentId, $this->urlGenerator, $this->request), $config);
 

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -124,9 +124,14 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 		// otherwise it's an element that we send through our proxy
 		if ($element === 'href') {
 			$uri = new \HTMLPurifier_URI(
-				$this->request->getServerProtocol(), null, $this->request->getServerHost(), null,
+				$this->request->getServerProtocol(),
+				null,
+				$this->request->getServerHost(),
+				null,
 				$this->urlGenerator->linkToRoute('mail.proxy.redirect'),
-				'src=' . $originalURL, null);
+				'src=' . $originalURL,
+				null
+			);
 			return $uri;
 		} else {
 			$uri = new \HTMLPurifier_URI(

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -196,7 +196,7 @@ class MailManager implements IMailManager {
 
 	/**
 	 * @param Account $account
-	 * @param string $mb
+	 * @param string $mailbox
 	 * @param int $uid
 	 *
 	 * @return string
@@ -325,7 +325,7 @@ class MailManager implements IMailManager {
 		try {
 			$client->subscribeMailbox($mailbox->getName(), $subscribed);
 		} catch (Horde_Imap_Client_Exception $e) {
-			throw new ServiceException("Could not set subscription status for mailbox $mailbox on IMAP: " . $e->getMessage(), $e->getCode(), $e);
+			throw new ServiceException("Could not set subscription status for mailbox " . $mailbox->getId() . " on IMAP: " . $e->getMessage(), $e->getCode(), $e);
 		}
 
 		/**

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -102,13 +102,10 @@ class MailTransmission implements IMailTransmission {
 		$this->logger = $logger;
 	}
 
-	/**
-	 * @return void
-	 */
 	public function sendMessage(NewMessageData $messageData,
 								RepliedMessageData $replyData = null,
 								Alias $alias = null,
-								Message $draft = null) {
+								Message $draft = null): void {
 		$account = $messageData->getAccount();
 
 		if ($replyData !== null) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,5 +16,6 @@
     </projectFiles>
     <extraFiles>
         <directory name="vendor/christophwurst/nextcloud" />
+		<directory name="lib/Vendor" />
     </extraFiles>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="tests/psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="lib" />
@@ -15,7 +16,25 @@
         </ignoreFiles>
     </projectFiles>
     <extraFiles>
-        <directory name="vendor/christophwurst/nextcloud" />
+        <directory name="vendor" />
 		<directory name="lib/Vendor" />
+		<ignoreFiles>
+			<directory name="vendor/phpunit/php-code-coverage" />
+		</ignoreFiles>
     </extraFiles>
+	<issueHandlers>
+		<UndefinedClass>
+			<errorLevel type="suppress">
+				<referencedClass name="OC" />
+			</errorLevel>
+		</UndefinedClass>
+		<UndefinedDocblockClass>
+			<errorLevel type="suppress">
+				<referencedClass name="Doctrine\DBAL\Schema\Schema" />
+				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
+				<referencedClass name="Doctrine\DBAL\Driver\Statement" />
+				<referencedClass name="Doctrine\DBAL\Schema\Table" />
+			</errorLevel>
+		</UndefinedDocblockClass>
+	</issueHandlers>
 </psalm>

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -538,7 +538,7 @@ class MessagesControllerTest extends TestCase {
 			->with($this->equalTo($this->userId), $this->equalTo($accountId))
 			->will($this->throwException(new DoesNotExistException('')));
 
-		$expected = new JSONResponse(null, Http::STATUS_FORBIDDEN);
+		$expected = new JSONResponse([], Http::STATUS_FORBIDDEN);
 
 		$this->assertEquals($expected, $this->controller->destroy($id));
 	}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
+  <file src="lib/Controller/AvatarsController.php">
+    <InvalidArgument occurrences="1">
+      <code>$avatar</code>
+    </InvalidArgument>
+  </file>
+  <file src="lib/IMAP/MessageMapper.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>$mail-&gt;getRaw()</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="lib/IMAP/Sync/Synchronizer.php">
+    <InvalidArgument occurrences="2">
+      <code>$changedMessages</code>
+      <code>$newMessages</code>
+    </InvalidArgument>
+  </file>
+  <file src="lib/Model/IMAPMessage.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>array</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="lib/Service/AutoConfig/SmtpConnectivityTester.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>$smtp-&gt;getSMTPObject()</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="lib/Service/HtmlPurify/TransformURLScheme.php">
+    <NullArgument occurrences="3">
+      <code>null</code>
+      <code>null</code>
+      <code>null</code>
+    </NullArgument>
+  </file>
+  <file src="lib/Service/MailTransmission.php">
+    <InvalidArgument occurrences="2">
+      <code>$transport</code>
+      <code>$transport</code>
+    </InvalidArgument>
+  </file>
+</files>


### PR DESCRIPTION
@nickvergessen this is what we discussed a few week ago if all goes well. My OCP package will then only be required on CI. Here I'm leaving it for now because Scrutinizer still does our coverage tracking. But in general apps don't need to have it as default require anymore.