### PR TITLE
Change the font weight to normal for threading

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -318,7 +318,6 @@ export default {
 
 <style lang="scss" scoped>
 	.sender {
-		font-weight: bold;
 		margin-left: 8px;
 	}
 


### PR DESCRIPTION
The font weight of sender for envelope is normal, while for threading is bold. Let have it the same everywhere. It also makes it easier to see the unread messages.