### PR TITLE
fix a bug when navigating away from a draft that's not yet loaded

### DIFF
--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -145,7 +145,7 @@ export default {
 				return
 			}
 			logger.debug('the  draft ID changed, we have to fetch the draft', {
-				currentId: this.draft.databaseId,
+				currentId: this?.draft?.databaseId ?? 'no draft currently loaded',
 				newId: to.params.draftId,
 			})
 


### PR DESCRIPTION
If you navigate away from a draft that's currently loading, but not loaded yet, an error is thrown on the browser console.

This PR fixes that

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>