### PR TITLE
Make menus automaticaly close after clicking on an action button 

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -48,32 +48,44 @@
 			menu-align="right"
 			event=""
 			@click.native.prevent>
-			<ActionButton icon="icon-important" @click.prevent="onToggleImportant">
+			<ActionButton icon="icon-important"
+				:close-after-click="true"
+				@click.prevent="onToggleImportant">
 				{{
 					data.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
+			<ActionButton icon="icon-starred"
+				:close-after-click="true"
+				@click.prevent="onToggleFlagged">
 				{{
 					data.flags.flagged ? t('mail', 'Mark unfavorite') : t('mail', 'Mark favorite')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-mail" @click.prevent="onToggleSeen">
+			<ActionButton icon="icon-mail"
+				:close-after-click="true"
+				@click.prevent="onToggleSeen">
 				{{
 					data.flags.seen ? t('mail', 'Mark unread') : t('mail', 'Mark read')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-junk" @click.prevent="onToggleJunk">
+			<ActionButton icon="icon-junk"
+				:close-after-click="true"
+				@click.prevent="onToggleJunk">
 				{{
 					data.flags.junk ? t('mail', 'Mark not spam') : t('mail', 'Mark as spam')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-checkmark" :close-after-click="true" @click.prevent="toggleSelected">
+			<ActionButton icon="icon-checkmark"
+				:close-after-click="true"
+				@click.prevent="toggleSelected">
 				{{
 					selected ? t('mail', 'Unselect') : t('mail', 'Select')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-delete" @click.prevent="onDelete">
+			<ActionButton icon="icon-delete"
+				:close-after-click="true"
+				@click.prevent="onDelete">
 				{{ t('mail', 'Delete') }}
 			</ActionButton>
 		</Actions>

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -10,17 +10,23 @@
 					}}</span>
 				</div>
 				<Actions class="app-content-list-item-menu" menu-align="right">
-					<ActionButton icon="icon-starred" @click.prevent="favoriteOrUnfavoriteAll">
+					<ActionButton icon="icon-starred"
+						:close-after-click="true"
+						@click.prevent="favoriteOrUnfavoriteAll">
 						{{
 							areAllSelectedFavorite
 								? t('mail', 'Unfavorite ' + selection.length)
 								: t('mail', 'Favorite ' + selection.length)
 						}}
 					</ActionButton>
-					<ActionButton icon="icon-close" @click.prevent="unselectAll">
+					<ActionButton icon="icon-close"
+						:close-after-click="true"
+						@click.prevent="unselectAll">
 						{{ t('mail', 'Unselect ' + selection.length) }}
 					</ActionButton>
-					<ActionButton icon="icon-delete" @click.prevent="deleteAllSelected">
+					<ActionButton icon="icon-delete"
+						:close-after-click="true"
+						@click.prevent="deleteAllSelected">
 						{{ t('mail', 'Delete ' + selection.length) }}
 					</ActionButton>
 				</Actions>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -53,42 +53,59 @@
 					<span class="action-label">{{ t('mail', 'Reply') }}</span>
 				</div>
 				<Actions class="app-content-list-item-menu" menu-align="right">
-					<ActionButton v-if="hasMultipleRecipients" icon="icon-reply" @click="replyMessage">
+					<ActionButton v-if="hasMultipleRecipients"
+						icon="icon-reply"
+						:close-after-click="true"
+						@click="replyMessage">
 						{{ t('mail', 'Reply to sender only') }}
 					</ActionButton>
-					<ActionButton icon="icon-forward" @click="forwardMessage">
+					<ActionButton icon="icon-forward"
+						:close-after-click="true"
+						@click="forwardMessage">
 						{{ t('mail', 'Forward') }}
 					</ActionButton>
-					<ActionButton icon="icon-important" @click.prevent="onToggleImportant">
+					<ActionButton icon="icon-important"
+						:close-after-click="true"
+						@click.prevent="onToggleImportant">
 						{{
 							envelope.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
 						}}
 					</ActionButton>
-					<ActionButton icon="icon-starred" @click.prevent="onToggleFlagged">
+					<ActionButton icon="icon-starred"
+						:close-after-click="true"
+						click.prevent="onToggleFlagged">
 						{{
 							envelope.flags.flagged ? t('mail', 'Mark unfavorite') : t('mail', 'Mark favorite')
 						}}
 					</ActionButton>
-					<ActionButton icon="icon-mail" @click="onToggleSeen">
+					<ActionButton icon="icon-mail"
+						:close-after-click="true"
+						@click.prevent="onToggleSeen">
 						{{ envelope.flags.seen ? t('mail', 'Mark unread') : t('mail', 'Mark read') }}
 					</ActionButton>
 
-					<ActionButton icon="icon-junk" @click="onToggleJunk">
+					<ActionButton icon="icon-junk"
+						:close-after-click="true"
+						@click.prevent="onToggleJunk">
 						{{ envelope.flags.junk ? t('mail', 'Mark not spam') : t('mail', 'Mark as spam') }}
 					</ActionButton>
 					<ActionButton
 						:icon="sourceLoading ? 'icon-loading-small' : 'icon-details'"
 						:disabled="sourceLoading"
-						@click="onShowSource">
+						:close-after-click="true"
+						@click.prevent="onShowSource">
 						{{ t('mail', 'View source') }}
 					</ActionButton>
 					<ActionLink v-if="debug"
 						icon="icon-download"
 						:download="threadingFileName"
-						:href="threadingFile">
+						:href="threadingFile"
+						:close-after-click="true">
 						{{ t('mail', 'Download thread data for debugging') }}
 					</ActionLink>
-					<ActionButton icon="icon-delete" @click.prevent="onDelete">
+					<ActionButton icon="icon-delete"
+						:close-after-click="true"
+						@click.prevent="onDelete">
 						{{ t('mail', 'Delete') }}
 					</ActionButton>
 				</Actions>


### PR DESCRIPTION
Fix to https://github.com/nextcloud/mail/issues/3597

Though I couldn't reproduce the issue here above, I've experienced this issue in the ThreadEnvelope component.

This PR makes the menu automaticaly close after clicking on **any** action button in ThreadEnvelope, EnvelopeList, and Envelope.

Signed-off-by: Cyrille Bollu <cyrpub@bollu.be>