### PR TITLE
Update the authors list after v1.5

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,9 +15,10 @@
 	<version>1.5.0</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
-	<author>Roeland Jago Douma</author>
 	<author>Greta Doçi</author>
+	<author>Julius Härtl</author>
 	<author>Cyrille Bollu</author>
+	<author>Holger Dehnhardt</author>
 	<author>Jan-Christoph Borchardt</author>
 	<namespace>Mail</namespace>
 	<documentation>


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/graphs/contributors?from=2020-06-16&to=2020-10-03&type=c

This was originally based on that data, so let's keep it up to date. @rullzer you should contribute more :P