### PR TITLE
Make sure the e-mail is valid UTF-8

### DIFF
--- a/lib/Address.php
+++ b/lib/Address.php
@@ -74,7 +74,8 @@ class Address implements JsonSerializable {
 	 * @return string|null
 	 */
 	public function getEmail(): ?string {
-		return $this->wrapped->bare_address;
+		// Lets make sure the e-mail is valid UTF-8 at all times
+		return iconv("UTF-8","UTF-8//IGNORE", $this->wrapped->bare_address);
 	}
 
 	/**


### PR DESCRIPTION
Sometimes (I'm looking at you SPAM mails) the e-mail address will
contain invalid UTF-8. This will make sure we only return valid UTF-8 by
just stripping the invalid parts.

Hacky: for sure
Works: for me

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>