### PR TITLE
Improve source modal scroll bar

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -125,9 +125,11 @@
 					</ActionButton>
 				</Actions>
 				<Modal v-if="showSource" class="source-modal" @close="onCloseSource">
-					<div class="section">
-						<h2>{{ t('mail', 'Message source') }}</h2>
-						<pre class="message-source">{{ rawMessage }}</pre>
+					<div class="source-modal-content">
+						<div class="section">
+							<h2>{{ t('mail', 'Message source') }}</h2>
+							<pre class="message-source">{{ rawMessage }}</pre>
+						</div>
 					</div>
 				</Modal>
 				<MoveModal
@@ -431,8 +433,16 @@ export default {
 	.left {
 		flex-grow: 1;
 	}
-	.source-modal ::v-deep .modal-container {
-		overflow-y: scroll !important;
+	.source-modal {
+		::v-deep .modal-container {
+			height: 800px;
+		}
+
+		.source-modal-content {
+			width: 100%;
+			height: 100%;
+			overflow-y: scroll;
+		}
 	}
 	.icon-important {
 		::v-deep path {


### PR DESCRIPTION
Improves the source modal scroll bar. The rounded corners on the right edge of the modal were overlapped by the scroll bar resulting in an ugly modal.

How it looks with my changes:
![scroll-bar](https://user-images.githubusercontent.com/1479486/96878402-17eef000-147b-11eb-837b-060db8da4c57.png)