### PR TITLE
Fix redirect after moving thread envelope

### DIFF
--- a/src/components/MoveModal.vue
+++ b/src/components/MoveModal.vue
@@ -50,7 +50,6 @@ export default {
 					.map((envelope) => envelope.databaseId)
 
 				if (envelopeIds.length === 0) {
-					this.$emit('close')
 					return
 				}
 
@@ -64,6 +63,7 @@ export default {
 				}))
 
 				await this.$store.dispatch('syncEnvelopes', { mailboxId: this.destMailboxId })
+				this.$emit('move')
 			} catch (error) {
 				logger.error('could not move messages', {
 					error,

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -20,6 +20,7 @@
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
 				:expanded="expandedThreads.includes(env.databaseId)"
+				@move="onMove(env.databaseId)"
 				@toggleExpand="toggleExpand(env.databaseId)" />
 		</template>
 	</AppContentDetails>
@@ -54,8 +55,11 @@ export default {
 		}
 	},
 	computed: {
+		threadId() {
+			return parseInt(this.$route.params.threadId, 10)
+		},
 		thread() {
-			return this.$store.getters.getEnvelopeThread(this.$route.params.threadId)
+			return this.$store.getters.getEnvelopeThread(this.threadId)
 		},
 		threadParticipants() {
 			const recipients = this.thread.flatMap(envelope => {
@@ -84,11 +88,11 @@ export default {
 				return
 			}
 			logger.debug('navigated to another thread', { to, from })
-			this.fetchThread()
+			this.resetThread()
 		},
 	},
 	created() {
-		this.fetchThread()
+		this.resetThread()
 	},
 	methods: {
 		toggleExpand(threadId) {
@@ -100,12 +104,28 @@ export default {
 				this.expandedThreads = this.expandedThreads.filter(t => t !== threadId)
 			}
 		},
+		onMove(threadId) {
+			if (threadId === this.threadId) {
+				this.$router.replace({
+					name: 'mailbox',
+					params: {
+						mailboxId: this.$route.params.mailboxId,
+					},
+				})
+			} else {
+				this.expandedThreads = this.expandedThreads.filter((id) => id !== threadId)
+				this.fetchThread()
+			}
+		},
+		resetThread() {
+			this.expandedThreads = [this.threadId]
+			this.fetchThread()
+		},
 		async fetchThread() {
 			this.loading = true
 			this.errorMessage = ''
 			this.error = undefined
-			const threadId = parseInt(this.$route.params.threadId, 10)
-			this.expandedThreads = [threadId]
+			const threadId = this.threadId
 
 			try {
 				const thread = await this.$store.dispatch('fetchThread', threadId)

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -136,6 +136,7 @@
 					v-if="showMoveModal"
 					:account="account"
 					:envelopes="[envelope]"
+					@move="onMove"
 					@close="onCloseMoveModal" />
 			</div>
 		</div>
@@ -363,12 +364,9 @@ export default {
 		},
 		onCloseMoveModal() {
 			this.showMoveModal = false
-			this.$router.replace({
-				name: 'mailbox',
-				params: {
-					mailboxId: this.$route.params.mailboxId,
-				},
-			})
+		},
+		onMove() {
+			this.$emit('move')
 		},
 	},
 }


### PR DESCRIPTION
After a thread envelope has been moved the user is redirect. Currently this also happens when the user cancels the move (closes the move modal).