### PR TITLE
Fix moving multiple envelopes

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -24,7 +24,11 @@
 						@click.prevent="unselectAll">
 						{{ t('mail', 'Unselect ' + selection.length) }}
 					</ActionButton>
-					<ActionButton v-if="account.isUnified" icon="icon-external" @click.prevent="onOpenMoveModal">
+					<ActionButton
+						v-if="!account.isUnified"
+						icon="icon-external"
+						:close-after-click="true"
+						@click.prevent="onOpenMoveModal">
 						{{ t('mail', 'Move ' + selection.length) }}
 					</ActionButton>
 					<ActionButton icon="icon-delete"


### PR DESCRIPTION
The check implemented by 62e789061df96520bd8bdfc27a28b86a29924d1e is inverted. This commit readds the move action to the selection menu in non unified mailboxes (like the mentioned commit intended). 

This PR also fixes the selection context menu not being closed after clicking the move button.