### PR TITLE
Fix css being shown as text in reply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6046,6 +6046,11 @@
         "domelementtype": "1"
       }
     },
+    "dompurify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.0.tgz",
+      "integrity": "sha512-bqFOQ7XRmmozp0VsKdIEe8UwZYxj0yttz7l80GBtBqdVRY48cOpXH2J/CVO7AEkV51qY0EBVXfilec18mdmQ/w=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "core-js": "^3.6.5",
     "davclient.js": "git+https://github.com/owncloud/davclient.js.git#0.2.1",
     "debounce-promise": "^3.1.2",
+    "dompurify": "^2.2.0",
     "html-to-text": "^5.1.1",
     "ical.js": "^1.4.0",
     "js-base64": "^3.5.2",

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -42,6 +42,7 @@ import LinkPlugin from '@ckeditor/ckeditor5-link/src/link'
 import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph'
 
 import { getLanguage } from '@nextcloud/l10n'
+import DOMPurify from 'dompurify'
 
 import logger from '../logger'
 
@@ -96,8 +97,15 @@ export default {
 			},
 		}
 	},
+	computed: {
+		sanitizedValue() {
+			return DOMPurify.sanitize(this.value, {
+				FORBID_TAGS: ['style'],
+			})
+		},
+	},
 	watch: {
-		value(newVal) {
+		sanitizedValue(newVal) {
 			// needed for reset in composer
 			this.text = newVal
 		},
@@ -175,7 +183,7 @@ export default {
 
 			// Set value as late as possible, so the custom schema listener is used
 			// for the initial editor model
-			this.text = this.value
+			this.text = this.sanitizedValue
 
 			logger.debug(`setting TextEditor contents to <${this.text}>`)
 


### PR DESCRIPTION
Fixes #3863 

Ckeditor is converting stylesheets to plain text elements. Strip all stylesheets from the message html prior to passing them to ckeditor.