### PR TITLE
Responsive mail iframe

### DIFF
--- a/css/html-response.css
+++ b/css/html-response.css
@@ -1,0 +1,7 @@
+* {
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+}
+
+body {
+	color: var(--color-main-text);
+}

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -336,12 +336,13 @@ class MessagesController extends Controller {
 	 * @TrapError
 	 *
 	 * @param int $id
+	 * @param bool $plain do not inject scripts if true (default=false)
 	 *
 	 * @return HtmlResponse|TemplateResponse
 	 *
 	 * @throws ClientException
 	 */
-	public function getHtmlBody(int $id): Response {
+	public function getHtmlBody(int $id, bool $plain=false): Response {
 		try {
 			try {
 				$message = $this->mailManager->getMessage($this->currentUserId, $id);
@@ -364,7 +365,8 @@ class MessagesController extends Controller {
 					true
 				)->getHtmlBody(
 					$id
-				)
+				),
+				$plain
 			);
 
 			// Harden the default security policy

--- a/package-lock.json
+++ b/package-lock.json
@@ -8024,6 +8024,11 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "iframe-resizer": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.2.11.tgz",
+      "integrity": "sha512-fj5vX5kkpRbMb5Qje6veIDzqoJpnCEqUDdSOwASOeQHYmb8hLYX6Ev2yXf3jjMs2MclwcYY3chyZ3diGKcr8DA=="
+    },
     "ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "dompurify": "^2.2.0",
     "html-to-text": "^5.1.1",
     "ical.js": "^1.4.0",
+    "iframe-resizer": "^4.2.11",
     "js-base64": "^3.5.2",
     "lodash": "^4.17.20",
     "md5": "^2.3.0",

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -24,7 +24,7 @@
 		<div v-if="message.itineraries.length > 0" class="message-itinerary">
 			<Itinerary :entries="message.itineraries" :message-id="message.messageId" />
 		</div>
-		<MessageHTMLBody v-if="message.hasHtmlBody" :url="htmlUrl" />
+		<MessageHTMLBody v-if="message.hasHtmlBody" :url="htmlUrl" :full-height="fullHeight" />
 		<MessageEncryptedBody v-else-if="isEncrypted" :body="message.body" :from="from" />
 		<MessagePlainTextBody v-else :body="message.body" :signature="message.signature" />
 		<Popover v-if="message.attachments[0]" class="attachment-popover">
@@ -73,6 +73,11 @@ export default {
 		message: {
 			required: true,
 			type: Object,
+		},
+		fullHeight: {
+			required: false,
+			type: Boolean,
+			default: false,
 		},
 	},
 	computed: {

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -253,7 +253,7 @@ export default {
 				if (message.hasHtmlBody) {
 					logger.debug('original message has HTML body')
 					const resp = await Axios.get(
-						generateUrl('/apps/mail/api/messages/{id}/html', {
+						generateUrl('/apps/mail/api/messages/{id}/html?plain=true', {
 							id,
 						})
 					)

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -20,6 +20,7 @@
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
 				:expanded="expandedThreads.includes(env.databaseId)"
+				:full-height="thread.length === 1"
 				@move="onMove(env.databaseId)"
 				@toggleExpand="toggleExpand(env.databaseId)" />
 		</template>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -155,7 +155,10 @@
 			</div>
 		</div>
 		<Loading v-if="loading" />
-		<Message v-else-if="message" :envelope="envelope" :message="message" />
+		<Message v-else-if="message"
+			:envelope="envelope"
+			:message="message"
+			:full-height="fullHeight" />
 		<Error v-else-if="error"
 			:error="error && error.message ? error.message : t('mail', 'Not found')"
 			:message="errorMessage"
@@ -214,6 +217,11 @@ export default {
 			default: undefined,
 		},
 		expanded: {
+			required: false,
+			type: Boolean,
+			default: false,
+		},
+		fullHeight: {
 			required: false,
 			type: Boolean,
 			default: false,

--- a/src/html-response.js
+++ b/src/html-response.js
@@ -1,0 +1,38 @@
+/**
+ * @copyright 2020 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author 2020 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// injected styles
+import '../css/html-response.css'
+
+// iframe-resizer client script
+import 'iframe-resizer/js/iframeResizer.contentWindow.js'
+window.iFrameResizer = {
+	onMessage: (message) => {
+		if (!message.cssVars) {
+			return
+		}
+
+		// inject received css vars
+		Object.entries(message.cssVars).forEach(([key, val]) => {
+			document.documentElement.style.setProperty(key, val)
+		})
+	},
+}

--- a/tests/Unit/Http/HtmlResponseTest.php
+++ b/tests/Unit/Http/HtmlResponseTest.php
@@ -24,6 +24,7 @@ namespace OCA\Mail\Tests\Unit\Http;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Http\HtmlResponse;
+use OCP\Util;
 
 class HtmlResponseTest extends TestCase {
 
@@ -34,9 +35,18 @@ class HtmlResponseTest extends TestCase {
 	 * @param $contentType
 	 */
 	public function testIt($content) {
-		$resp = new HtmlResponse($content);
-		$injectedStyles = "<style>* { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; }</style>";
-		$this->assertEquals($injectedStyles . $content, $resp->render());
+		$defaultResp = new HtmlResponse($content);
+		$plainResp = new HtmlResponse($content, true);
+		$richResp = new HtmlResponse($content, false);
+
+		$scriptSrcRegex = preg_quote(Util::linkToAbsolute('mail', 'js/htmlresponse.js'), '/');
+		$contentRegex = preg_quote($content, '/');
+		$responseRegex = '/<script nonce=".+" src="' . $scriptSrcRegex . '"><\/script>'
+			. $contentRegex . '/';
+
+		$this->assertMatchesRegularExpression($responseRegex, $defaultResp->render());
+		$this->assertEquals($content, $plainResp->render());
+		$this->assertMatchesRegularExpression($responseRegex, $richResp->render());
 	}
 
 	public function providesResponseData() {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -22,7 +22,8 @@ module.exports = {
 		autoredirect: path.join(__dirname, 'src/autoredirect.js'),
 		dashboard: path.join(__dirname, 'src/main-dashboard.js'),
 		mail: path.join(__dirname, 'src/main.js'),
-		settings: path.join(__dirname, 'src/main-settings')
+		settings: path.join(__dirname, 'src/main-settings'),
+		htmlresponse: path.join(__dirname, 'src/html-response.js'),
 	},
 	output: {
 		path: path.resolve(__dirname, 'js'),


### PR DESCRIPTION
This is highly experimental but works well. I discovered a js library ([iframe-resizer](https://github.com/davidjbradshaw/iframe-resizer)) which enables responsive iframes. The client script is injected into the message html response with a nonce attached so that it is executable.

As a nice side effect we can apply our custom scroll bars to the message container (via `max-height: 50vh`).

Feel free to try it out and provide feedback. Is this too big of a security risk?

![responsive-iframe](https://user-images.githubusercontent.com/1479486/97441046-8d9a0680-1928-11eb-9da7-0adfb5ddf8d1.png)