### PR TITLE
Sort phpunit tests by defect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,10 +65,10 @@
 			"\"vendor/bin/mozart\" compose",
 			"composer dump-autoload"
 		],
-		"test:integration": "phpunit -c tests/phpunit.integration.xml tests/Integration --fail-on-warning",
-		"test:integration:dev": "phpunit -c tests/phpunit.integration.xml tests/Integration --no-coverage --fail-on-warning --stop-on-error --stop-on-failure",
-		"test:unit": "phpunit -c tests/phpunit.unit.xml tests/Unit --fail-on-warning",
-		"test:unit:dev": "phpunit -c tests/phpunit.unit.xml tests/Unit --no-coverage --fail-on-warning --stop-on-error --stop-on-failure"
+		"test:integration": "phpunit -c tests/phpunit.integration.xml --fail-on-warning",
+		"test:integration:dev": "phpunit -c tests/phpunit.integration.xml --no-coverage --order-by=defects --stop-on-defect --fail-on-warning --stop-on-error --stop-on-failure",
+		"test:unit": "phpunit -c tests/phpunit.unit.xml --fail-on-warning",
+		"test:unit:dev": "phpunit -c tests/phpunit.unit.xml --no-coverage --order-by=defects --stop-on-defect --fail-on-warning --stop-on-error --stop-on-failure"
 	},
 	"extra": {
 		"mozart": {

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -25,6 +25,7 @@
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
+		 cacheResult="true"
 		>
 	<testsuite name='Mail app tests'>
 		<directory suffix='test.php'>Integration</directory>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -4,6 +4,7 @@
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
+		 cacheResult="true"
 		>
 	<testsuite name='Mail app tests'>
 		<directory suffix='test.php'>Unit</directory>


### PR DESCRIPTION
Then the failing ones will show right away when re-running the tests
locally.

As seen at https://laravel-news.com/tips-to-speed-up-phpunit-tests.