### PR TITLE
Fix redirect after moving thread envelope

### DIFF
--- a/src/components/MoveModal.vue
+++ b/src/components/MoveModal.vue
@@ -50,7 +50,6 @@ export default {
 					.map((envelope) => envelope.databaseId)
 
 				if (envelopeIds.length === 0) {
-					this.$emit('close')
 					return
 				}
 
@@ -64,6 +63,7 @@ export default {
 				}))
 
 				await this.$store.dispatch('syncEnvelopes', { mailboxId: this.destMailboxId })
+				this.$emit('move')
 			} catch (error) {
 				logger.error('could not move messages', {
 					error,

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -136,6 +136,7 @@
 					v-if="showMoveModal"
 					:account="account"
 					:envelopes="[envelope]"
+					@move="onMove"
 					@close="onCloseMoveModal" />
 			</div>
 		</div>
@@ -363,12 +364,9 @@ export default {
 		},
 		onCloseMoveModal() {
 			this.showMoveModal = false
-			this.$router.replace({
-				name: 'mailbox',
-				params: {
-					mailboxId: this.$route.params.mailboxId,
-				},
-			})
+		},
+		onMove() {
+			this.$emit('move')
 		},
 	},
 }


### PR DESCRIPTION
Continuation of #3895 

After a thread envelope has been moved the user is redirected. Currently this also happens when the user cancels the move (closes the move modal).

The responsiveness of moving envelopes inside a thread is much better now. When moving the parent envelope (currently selected in envelope list) the redirect is triggered. When another envelope from the thread is moved the view stays as is and only the thread gets refreshed.

The moved thread envelope will be collapsed but can then be extended again without any error (due to the source envelope being moved/deleted).

If the move is cancelled nothing happens.