### PR TITLE
Revert partial update of CKEditor to v23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2541,54 +2541,15 @@
       }
     },
     "@ckeditor/ckeditor5-editor-balloon": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-23.1.0.tgz",
-      "integrity": "sha512-8pRTAZ//Rq3zSKPcps24Cc5Yk9npRtUKRoo6UGGhiN6nomfBHT2Nc9aWmWoXQZdl6xVrZ5c60w8GQqiDmX2o0A==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-23.0.0.tgz",
+      "integrity": "sha512-WavdJjWlzLyy5HTh0c4Y28SeyL9jFgt5t/+IrZzODYcNC0J5qQKaPW9QFtvuckF6kIz6BSR89Q8YotuHYSpKQA==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^23.1.0",
-        "@ckeditor/ckeditor5-engine": "^23.1.0",
-        "@ckeditor/ckeditor5-ui": "^23.1.0",
-        "@ckeditor/ckeditor5-utils": "^23.1.0",
+        "@ckeditor/ckeditor5-core": "^23.0.0",
+        "@ckeditor/ckeditor5-engine": "^23.0.0",
+        "@ckeditor/ckeditor5-ui": "^23.0.0",
+        "@ckeditor/ckeditor5-utils": "^23.0.0",
         "lodash-es": "^4.17.15"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-23.1.0.tgz",
-          "integrity": "sha512-Y+ttPMKbsfdN+V5/lV5vG3cI6Y0pNs8+TygOojw8ZMQqJY5WrVsFQcoz2DzdTKKOn5VJqjE+mHcGjCyk37FeOw==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-23.1.0.tgz",
-          "integrity": "sha512-HOIkiatjq/ByqHVvkaISA0l6Vab8w6gzD1QnjMv3ldgiLMD0jUAHhUZldfpYQ0s2bG+d1l/6w7C76gT8fY4/Jw==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-23.1.0.tgz",
-          "integrity": "sha512-Rw1mnp4D5SwuCHTnDhTnKzXgQbUzZHpXlce6Zf72Iw6ZfwDn2SlanIp8OKM8hYUAkoHHKLDx2QfXgHEiShC7CA==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-23.1.0.tgz",
-          "integrity": "sha512-hbAIQQrUFZZGGsEG07Em2iH216Y7NWIhY60HqOT94wwnn/F5ZE3zRWU+KsAR1Cn2U0uOEBkYP9qIFlGRzPo7Vg==",
-          "requires": {
-            "lodash-es": "^4.17.15"
-          }
-        }
       }
     },
     "@ckeditor/ckeditor5-engine": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2501,52 +2501,13 @@
       }
     },
     "@ckeditor/ckeditor5-block-quote": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-23.1.0.tgz",
-      "integrity": "sha512-KEs+dJKjs/nV/6L8Mrr82v2rfmJ/h7FD3jiFFuxp2QnS/tss1aFxAu/hou4OvKFL59O0WI4DA/Z5HDmieKXmUw==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-23.0.0.tgz",
+      "integrity": "sha512-q2kACi3JGoCyY3eoJw0qZtsu6g4YQPXFSpKDjdXIAeX3Z9vOcXv6352HyvjkRuLzVvjJ9QauTTl04bwqw1XLvw==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^23.1.0",
-        "@ckeditor/ckeditor5-ui": "^23.1.0",
-        "@ckeditor/ckeditor5-utils": "^23.1.0"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-23.1.0.tgz",
-          "integrity": "sha512-Y+ttPMKbsfdN+V5/lV5vG3cI6Y0pNs8+TygOojw8ZMQqJY5WrVsFQcoz2DzdTKKOn5VJqjE+mHcGjCyk37FeOw==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-23.1.0.tgz",
-          "integrity": "sha512-HOIkiatjq/ByqHVvkaISA0l6Vab8w6gzD1QnjMv3ldgiLMD0jUAHhUZldfpYQ0s2bG+d1l/6w7C76gT8fY4/Jw==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-23.1.0.tgz",
-          "integrity": "sha512-Rw1mnp4D5SwuCHTnDhTnKzXgQbUzZHpXlce6Zf72Iw6ZfwDn2SlanIp8OKM8hYUAkoHHKLDx2QfXgHEiShC7CA==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-23.1.0.tgz",
-          "integrity": "sha512-hbAIQQrUFZZGGsEG07Em2iH216Y7NWIhY60HqOT94wwnn/F5ZE3zRWU+KsAR1Cn2U0uOEBkYP9qIFlGRzPo7Vg==",
-          "requires": {
-            "lodash-es": "^4.17.15"
-          }
-        }
+        "@ckeditor/ckeditor5-core": "^23.0.0",
+        "@ckeditor/ckeditor5-ui": "^23.0.0",
+        "@ckeditor/ckeditor5-utils": "^23.0.0"
       }
     },
     "@ckeditor/ckeditor5-build-balloon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,63 +2702,14 @@
       }
     },
     "@ckeditor/ckeditor5-heading": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-23.1.0.tgz",
-      "integrity": "sha512-u5iV/0zTv8auvvZq6t1iZFOHUxw4yHImCtSGBN5mIK5qPygwtD5yyXqntA3UDTDuCfqA3uLydS4MVm1W43LL/g==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-23.0.0.tgz",
+      "integrity": "sha512-pW1jY8ZakrrVAbmM3lTdxaY1ZbJD+7UMzAkLM/K+sIzxImaoIQaLjERLof4WfbCAEM2v9PFax1RGKELFLLnJAg==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^23.1.0",
-        "@ckeditor/ckeditor5-paragraph": "^23.1.0",
-        "@ckeditor/ckeditor5-ui": "^23.1.0",
-        "@ckeditor/ckeditor5-utils": "^23.1.0"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-23.1.0.tgz",
-          "integrity": "sha512-Y+ttPMKbsfdN+V5/lV5vG3cI6Y0pNs8+TygOojw8ZMQqJY5WrVsFQcoz2DzdTKKOn5VJqjE+mHcGjCyk37FeOw==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-23.1.0.tgz",
-          "integrity": "sha512-HOIkiatjq/ByqHVvkaISA0l6Vab8w6gzD1QnjMv3ldgiLMD0jUAHhUZldfpYQ0s2bG+d1l/6w7C76gT8fY4/Jw==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-paragraph": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-23.1.0.tgz",
-          "integrity": "sha512-Nd70I64xUPYZFNWNpIqKpCBV/R2rza4sDy14N9TlIUWqlfnoXQ27eAq7pUqR0i0yeO+sOjxYolqj+TRtKJwHPg==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^23.1.0",
-            "@ckeditor/ckeditor5-ui": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-23.1.0.tgz",
-          "integrity": "sha512-Rw1mnp4D5SwuCHTnDhTnKzXgQbUzZHpXlce6Zf72Iw6ZfwDn2SlanIp8OKM8hYUAkoHHKLDx2QfXgHEiShC7CA==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-23.1.0.tgz",
-          "integrity": "sha512-hbAIQQrUFZZGGsEG07Em2iH216Y7NWIhY60HqOT94wwnn/F5ZE3zRWU+KsAR1Cn2U0uOEBkYP9qIFlGRzPo7Vg==",
-          "requires": {
-            "lodash-es": "^4.17.15"
-          }
-        }
+        "@ckeditor/ckeditor5-core": "^23.0.0",
+        "@ckeditor/ckeditor5-paragraph": "^23.0.0",
+        "@ckeditor/ckeditor5-ui": "^23.0.0",
+        "@ckeditor/ckeditor5-utils": "^23.0.0"
       }
     },
     "@ckeditor/ckeditor5-image": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2443,51 +2443,12 @@
       }
     },
     "@ckeditor/ckeditor5-alignment": {
-      "version": "23.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-23.1.0.tgz",
-      "integrity": "sha512-Dfi50iwrGKwzEZ5wOsik47foAeYLk5yszWJLDC0cRLVvUt0CamZQs8jRNN173rnkJ0mcJyQwTmBHGi2AKU/T/g==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-23.0.0.tgz",
+      "integrity": "sha512-UV1yYC9/u8Sc8+Y1mpHpPuXpBBmmOlk6NI3xZ6nvY73X3bIAbWZhLMO/IIrhrUGCvD1JbBPbkVhrBHdVdgxeaQ==",
       "requires": {
-        "@ckeditor/ckeditor5-core": "^23.1.0",
-        "@ckeditor/ckeditor5-ui": "^23.1.0"
-      },
-      "dependencies": {
-        "@ckeditor/ckeditor5-core": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-23.1.0.tgz",
-          "integrity": "sha512-Y+ttPMKbsfdN+V5/lV5vG3cI6Y0pNs8+TygOojw8ZMQqJY5WrVsFQcoz2DzdTKKOn5VJqjE+mHcGjCyk37FeOw==",
-          "requires": {
-            "@ckeditor/ckeditor5-engine": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-engine": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-23.1.0.tgz",
-          "integrity": "sha512-HOIkiatjq/ByqHVvkaISA0l6Vab8w6gzD1QnjMv3ldgiLMD0jUAHhUZldfpYQ0s2bG+d1l/6w7C76gT8fY4/Jw==",
-          "requires": {
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-ui": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-23.1.0.tgz",
-          "integrity": "sha512-Rw1mnp4D5SwuCHTnDhTnKzXgQbUzZHpXlce6Zf72Iw6ZfwDn2SlanIp8OKM8hYUAkoHHKLDx2QfXgHEiShC7CA==",
-          "requires": {
-            "@ckeditor/ckeditor5-core": "^23.1.0",
-            "@ckeditor/ckeditor5-utils": "^23.1.0",
-            "lodash-es": "^4.17.15"
-          }
-        },
-        "@ckeditor/ckeditor5-utils": {
-          "version": "23.1.0",
-          "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-23.1.0.tgz",
-          "integrity": "sha512-hbAIQQrUFZZGGsEG07Em2iH216Y7NWIhY60HqOT94wwnn/F5ZE3zRWU+KsAR1Cn2U0uOEBkYP9qIFlGRzPo7Vg==",
-          "requires": {
-            "lodash-es": "^4.17.15"
-          }
-        }
+        "@ckeditor/ckeditor5-core": "^23.0.0",
+        "@ckeditor/ckeditor5-ui": "^23.0.0"
       }
     },
     "@ckeditor/ckeditor5-basic-styles": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@ckeditor/ckeditor5-build-balloon": "^23.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^23.6.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^23.6.0",
-    "@ckeditor/ckeditor5-editor-balloon": "^23.1.0",
+    "@ckeditor/ckeditor5-editor-balloon": "^23.0.0",
     "@ckeditor/ckeditor5-essentials": "^23.0.0",
     "@ckeditor/ckeditor5-heading": "^23.0.0",
     "@ckeditor/ckeditor5-link": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@bundle-analyzer/webpack-plugin": "^0.5.1",
-    "@ckeditor/ckeditor5-alignment": "^23.1.0",
+    "@ckeditor/ckeditor5-alignment": "^23.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^23.0.0",
     "@ckeditor/ckeditor5-block-quote": "^23.0.0",
     "@ckeditor/ckeditor5-build-balloon": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@bundle-analyzer/webpack-plugin": "^0.5.1",
     "@ckeditor/ckeditor5-alignment": "^23.1.0",
     "@ckeditor/ckeditor5-basic-styles": "^23.0.0",
-    "@ckeditor/ckeditor5-block-quote": "^23.1.0",
+    "@ckeditor/ckeditor5-block-quote": "^23.0.0",
     "@ckeditor/ckeditor5-build-balloon": "^23.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^23.6.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^23.6.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^23.6.0",
     "@ckeditor/ckeditor5-editor-balloon": "^23.1.0",
     "@ckeditor/ckeditor5-essentials": "^23.0.0",
-    "@ckeditor/ckeditor5-heading": "^23.1.0",
+    "@ckeditor/ckeditor5-heading": "^23.0.0",
     "@ckeditor/ckeditor5-link": "^23.0.0",
     "@ckeditor/ckeditor5-paragraph": "^23.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^23.0.0",


### PR DESCRIPTION
Dependabot was motivated this weekend and bumped some packages of CKEditor from 23.0 to 23.1. But only *some*. Hence on master you get a duplicate module error and the page won't render.

This reverts the bumps. I'll have to do a manual round of updates later.