### PR TITLE
Rename $id to $uid to prevent ambiguity

### DIFF
--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -96,13 +96,13 @@ class Mailbox implements IMailBox {
 	}
 
 	/**
-	 * @param int $id
+	 * @param int $uid
 	 * @param bool $loadHtmlMessageBody
 	 *
 	 * @return IMAPMessage
 	 */
-	public function getMessage(int $id, bool $loadHtmlMessageBody = false) {
-		return new IMAPMessage($this->conn, $this->mailBox, $id, null, $loadHtmlMessageBody);
+	public function getMessage(int $uid, bool $loadHtmlMessageBody = false) {
+		return new IMAPMessage($this->conn, $this->mailBox, $uid, null, $loadHtmlMessageBody);
 	}
 
 	/**

--- a/lib/Service/IMailBox.php
+++ b/lib/Service/IMailBox.php
@@ -41,10 +41,11 @@ interface IMailBox {
 	public function getSpecialRole();
 
 	/**
-	 * @param int $id
+	 * @param int $uid
+	 *
 	 * @return IMessage
 	 */
-	public function getMessage(int $id, bool $loadHtmlMessageBody = false);
+	public function getMessage(int $uid, bool $loadHtmlMessageBody = false);
 
 	/**
 	 * @param int $messageUid


### PR DESCRIPTION
As seen in https://github.com/nextcloud/mail/pull/3879.

An *id* is typically the *database ID* and *UID* is the *uid* used on IMAP. Hence using `$id` for a *uid* leads to confusion :)