### PR TITLE
Remove --hide-modules flag from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "agpl",
   "private": true,
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress --hide-modules --config webpack.prod.js",
+    "build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
     "dev": "NODE_ENV=development webpack --config webpack.dev.js",
     "watch": "NODE_ENV=development webpack --progress --watch --config webpack.dev.js",
     "lint": "eslint --ext .js,.vue --ignore-pattern tests src",


### PR DESCRIPTION
Make webpack-cli happy again. Apparently, this flag got removed in a recent version of webpack-cli.