### PR TITLE
Allow images with data sources

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -116,7 +116,7 @@ class Html {
 		$config->set('HTML.TargetBlank', true);
 
 		// allow cid, http and ftp
-		$config->set('URI.AllowedSchemes', ['cid' => true, 'http' => true, 'https' => true, 'ftp' => true, 'mailto' => true]);
+		$config->set('URI.AllowedSchemes', ['data' => true, 'src'=>true, 'cid' => true, 'http' => true, 'https' => true, 'ftp' => true, 'mailto' => true]);
 		$config->set('URI.Host', Util::getServerHostName());
 
 		$config->set('Filter.ExtractStyleBlocks', true);


### PR DESCRIPTION
If you send a message to yourself using https://github.com/nextcloud/mail/pull/3858, the image won't show. In other clients it does. With this little patch also this client can render the image.