### PR TITLE
Store collapsed-folder settings

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -128,6 +128,8 @@ class PageController extends Controller {
 			$accountsJson[] = $json;
 		}
 
+		$accountSettings = $this->preferences->getPreference('account-settings', json_encode([]));
+
 		$user = $this->userSession->getUser();
 		$response = new TemplateResponse($this->appName, 'index',
 			[
@@ -136,6 +138,7 @@ class PageController extends Controller {
 				'accounts' => base64_encode(json_encode($accountsJson)),
 				'external-avatars' => $this->preferences->getPreference('external-avatars', 'true'),
 				'collect-data' => $this->preferences->getPreference('collect-data', 'true'),
+				'account-settings' => base64_encode($accountSettings),
 			]);
 		$this->initialStateService->provideInitialState(
 			Application::APP_ID,

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -25,6 +25,7 @@
 
 <script>
 import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
+import logger from '../logger'
 
 export default {
 	name: 'NavigationAccountExpandCollapse',
@@ -51,8 +52,21 @@ export default {
 		},
 	},
 	methods: {
-		toggleCollapse() {
-			this.$store.commit('toggleAccountCollapsed', this.account.id)
+		async toggleCollapse() {
+			logger.debug('toggling collapsed folders for account ' + this.account.id)
+			try {
+				await this.$store.commit('toggleAccountCollapsed', this.account.id)
+				await this.$store
+					.dispatch('setAccountSetting', {
+						accountId: this.account.id,
+						key: 'collapsed',
+						value: this.account.collapsed,
+					})
+			} catch (error) {
+				logger.error('could not update account settings', {
+					error,
+				})
+			}
 		},
 	},
 }

--- a/src/main.js
+++ b/src/main.js
@@ -72,9 +72,21 @@ store.commit('savePreference', {
 	value: getPreferenceFromPage('collect-data'),
 })
 
+const accountSettings = JSON.parse(Base64.decode(getPreferenceFromPage('account-settings')))
 const accounts = JSON.parse(Base64.decode(getPreferenceFromPage('serialized-accounts')))
 accounts.map(fixAccountId).forEach((account) => {
-	store.commit('addAccount', account)
+	const settings = accountSettings.find(settings => settings.accountId === account.id)
+	if (settings) {
+		delete settings.accountId
+		Object.entries(settings).forEach(([key, value]) => {
+			store.commit('setAccountSetting', {
+				accountId: account.id,
+				key,
+				value,
+			})
+		})
+	}
+	store.commit('addAccount', { ...account, ...settings })
 })
 
 export default new Vue({

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -148,6 +148,10 @@ export default {
 			return account
 		})
 	},
+	setAccountSetting({ commit, getters }, { accountId, key, value }) {
+		commit('setAccountSetting', { accountId, key, value })
+		return savePreference('account-settings', JSON.stringify(getters.getAllAccountSettings))
+	},
 	deleteAccount({ commit }, account) {
 		return deleteAccount(account.id).catch((err) => {
 			console.error('could not delete account', err)
@@ -166,6 +170,7 @@ export default {
 		console.debug(`mailbox ${prefixed} created for account ${account.id}`, { mailbox })
 		commit('addMailbox', { account, mailbox })
 		commit('expandAccount', account.id)
+		commit('setAccountSetting', { accountId: account.id, key: 'collapsed', value: false })
 		return mailbox
 	},
 	moveAccount({ commit, getters }, { account, up }) {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -31,6 +31,9 @@ export const getters = {
 	getAccount: (state) => (id) => {
 		return state.accounts[id]
 	},
+	getAllAccountSettings: (state) => {
+		return state.allAccountSettings
+	},
 	accounts: (state) => {
 		return state.accountList.map((id) => state.accounts[id])
 	},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -50,6 +50,7 @@ export default new Vuex.Store({
 			},
 		},
 		accountList: [UNIFIED_ACCOUNT_ID],
+		allAccountSettings: [],
 		mailboxes: {
 			[UNIFIED_INBOX_ID]: {
 				id: UNIFIED_INBOX_ID,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -77,7 +77,7 @@ export default {
 		Vue.set(state.preferences, key, value)
 	},
 	addAccount(state, account) {
-		account.collapsed = true
+		account.collapsed = account.collapsed ?? true
 		Vue.set(state.accounts, account.id, account)
 		Vue.set(
 			state,
@@ -109,6 +109,16 @@ export default {
 	},
 	expandAccount(state, accountId) {
 		state.accounts[accountId].collapsed = false
+	},
+	setAccountSetting(state, { accountId, key, value }) {
+		const accountSettings = state.allAccountSettings.find(settings => settings.accountId === accountId)
+		if (accountSettings) {
+			accountSettings[key] = value
+		} else {
+			const newAccountSettings = { accountId }
+			newAccountSettings[key] = value
+			state.allAccountSettings.push(newAccountSettings)
+		}
 	},
 	addMailbox(state, { account, mailbox }) {
 		addMailboxToState(state, account, mailbox)

--- a/templates/index.php
+++ b/templates/index.php
@@ -33,3 +33,4 @@ script('mail', 'mail');
 <input type="hidden" id="serialized-accounts" value="<?php p($_['accounts']); ?>">
 <input type="hidden" id="external-avatars" value="<?php p($_['external-avatars']); ?>">
 <input type="hidden" id="collect-data" value="<?php p($_['collect-data']); ?>">
+<input type="hidden" id="account-settings" value="<?php p($_['account-settings']); ?>">

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -120,11 +120,12 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
-		$this->preferences->expects($this->exactly(2))
+		$this->preferences->expects($this->exactly(3))
 			->method('getPreference')
 			->willReturnMap([
 				['external-avatars', 'true', 'true'],
 				['collect-data', 'true', 'true'],
+				['account-settings', json_encode([]), json_encode([])],
 			]);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
@@ -227,7 +228,8 @@ class PageControllerTest extends TestCase {
 				'external-avatars' => 'true',
 				'app-version' => '1.2.3',
 				'accounts' => base64_encode(json_encode($accountsJson)),
-				'collect-data' => 'true'
+				'collect-data' => 'true',
+				'account-settings' => base64_encode(json_encode([])),
 			]);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');


### PR DESCRIPTION
_Hi! This is my first Open Source PR and I am excited! If you have any suggestions, they are warmly welcomed!_

---

## Problem
The UI doesn't store the last (un-)collapsed state of the folders for an account. If the user is making heavy use of email folders, they'll most likely want to have them uncollapsed at all times. At the moment they have to click on "Show all folders" on every reload/revisit.

## Suggested Solution
Store the last chosen state in the database.

## Approach
First I was thinking about a simple flag in `oc_mail_accounts` and while that would certainly work, it would "pollute" the table with UI settings, which gets worse the more settings are added down the line. Instead I stored the settings in `oc_preferences`, which is already used by the mail app to store the `collect-data` flag for example.

I though it might be useful to be able to store more than just the state of collapsible folders down the line, so tried to make it extendable by storing a JSON object like that:

| userid   | appid | configkey                   | configvalue |
|----------|-------|------------------------|--------------------------|
| username | mail  | account-settings | `{"1":{"accountId":1,"collapsed":false,"some-other-setting":true},"2":{"accountId":2,"collapsed":true}}`|

And that's basically it. The `account-settings` are now stored when using the toggle button. Upon reload, the [`PageController.php`](https://github.com/nextcloud/mail/compare/master...dotplex:enhancement/store-collapsed-folder-settings?expand=1#diff-70e5309fcd3311d771b3db9c93490ea270fd5894769093765ec37edb68e5dd9b) loads the settings and attaches them to [`templates/index.php`](https://github.com/nextcloud/mail/compare/master...dotplex:enhancement/store-collapsed-folder-settings?expand=1#diff-5258161aaab90de3916c094462a8b5035d08c02eff481989342aeca0a45c4be5) just like `collect-data` etc. The settings are then picked up in [`main.js`](https://github.com/nextcloud/mail/compare/master...dotplex:enhancement/store-collapsed-folder-settings?expand=1#diff-27653c212e1cfe533e4eb2f7d0d3f89604c9de48a09583b4cbbbcbd08a07da79) where they're merged with the actual account object. 

---

### Additional notes

- I wanted to pass an empty array as a default fallback to `getPreference()` in [`PageController.php`](https://github.com/nextcloud/mail/compare/master...dotplex:enhancement/store-collapsed-folder-settings?expand=1#diff-70e5309fcd3311d771b3db9c93490ea270fd5894769093765ec37edb68e5dd9b) like this: `$this->preferences->getPreference('account-settings', []);` – however... the return value would be `null` instead of the empty array. Is that intentional? Seems like a bug to me.
- I wasn't sure about the use of ternary operators here and there in terms of coding standards for this project. Please let me know if you want me to refactor these. 
- I wasn't able to set up the integration tests properly yet, so I can't tell if they would pass or not. Any help is much appreciated!

Fixes https://github.com/nextcloud/mail/issues/1025