### PR TITLE
Select multiple envelopes at once using shift

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -27,7 +27,10 @@
 					class="checkbox"
 					type="checkbox"
 					:checked="selected">
-				<label :for="`select-checkbox-${data.uid}`" @click.prevent="toggleSelected" />
+				<label
+					:for="`select-checkbox-${data.uid}`"
+					@click.exact.prevent="toggleSelected"
+					@click.shift.prevent="onSelectMultiple" />
 			</p>
 		</div>
 		<div class="app-content-list-item-line-one" :title="addresses">
@@ -222,6 +225,9 @@ export default {
 		},
 		toggleSelected() {
 			this.$emit('update:selected', !this.selected)
+		},
+		onSelectMultiple() {
+			this.$emit('select-multiple')
 		},
 		onToggleFlagged() {
 			this.$store.dispatch('toggleEnvelopeFlagged', this.data)


### PR DESCRIPTION
Select multiple envelopes at once using the shift + click shortcut.

![shift-select-multiple](https://user-images.githubusercontent.com/1479486/97976329-d17a8900-1dca-11eb-93c2-465e9ba0e023.gif)
