### PR TITLE
Fix seen vs unseen mixup

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -236,7 +236,7 @@ export default {
 			this.$store.dispatch('toggleEnvelopeImportant', this.data)
 		},
 		onToggleSeen() {
-			this.$store.dispatch('toggleEnvelopeSeen', this.data)
+			this.$store.dispatch('toggleEnvelopeSeen', { envelope: this.data })
 		},
 		onToggleJunk() {
 			this.$store.dispatch('toggleEnvelopeJunk', this.data)

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -180,7 +180,7 @@ export default {
 		},
 		areAllSelectedRead() {
 			// returns false if at least one selected message has not been read yet
-			return this.selection.every((idx) => this.envelopes[idx].flags.unseen === false)
+			return this.selection.every((idx) => this.envelopes[idx].flags.seen === true)
 		},
 		areAllSelectedFavorite() {
 			// returns false if at least one selected message has not been favorited yet
@@ -199,11 +199,11 @@ export default {
 			return this.selection.includes(idx)
 		},
 		markSelectedSeenOrUnseen() {
-			const seenFlag = this.areAllSelectedRead
+			const seen = !this.areAllSelectedRead
 			this.selection.forEach((envelopeId) => {
-				this.$store.dispatch('markEnvelopeSeenOrUnseen', {
+				this.$store.dispatch('toggleEnvelopeSeen', {
 					envelope: this.envelopes[envelopeId],
-					seenFlag,
+					seen,
 				})
 			})
 			this.unselectAll()

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -360,7 +360,7 @@ export default {
 				break
 			case 'unseen':
 				logger.debug('marking message as seen/unseen via shortkey', { env })
-				this.$store.dispatch('toggleEnvelopeSeen', env).catch((error) =>
+				this.$store.dispatch('toggleEnvelopeSeen', { envelope: env }).catch((error) =>
 					logger.error('could not mark envelope as seen/unseen via shortkey', {
 						env,
 						error,

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -305,7 +305,7 @@ export default {
 				logger.debug(`message ${this.envelope.databaseId} fetched`, { message })
 
 				if (!this.envelope.flags.seen) {
-					this.$store.dispatch('toggleEnvelopeSeen', this.envelope)
+					this.$store.dispatch('toggleEnvelopeSeen', { envelope: this.envelope })
 				}
 
 				this.loading = false
@@ -327,7 +327,7 @@ export default {
 			})
 		},
 		onToggleSeen() {
-			this.$store.dispatch('toggleEnvelopeSeen', this.envelope)
+			this.$store.dispatch('toggleEnvelopeSeen', { envelope: this.envelope })
 		},
 		onToggleJunk() {
 			this.$store.dispatch('toggleEnvelopeJunk', this.envelope)

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -591,16 +591,17 @@ export default {
 			})
 		})
 	},
-	toggleEnvelopeSeen({ commit, getters }, envelope) {
+	toggleEnvelopeSeen({ commit, getters }, { envelope, seen }) {
 		// Change immediately and switch back on error
 		const oldState = envelope.flags.seen
+		const newState = seen === undefined ? !oldState : seen
 		commit('flagEnvelope', {
 			envelope,
 			flag: 'seen',
-			value: !oldState,
+			value: newState,
 		})
 
-		setEnvelopeFlag(envelope.databaseId, 'seen', !oldState).catch((e) => {
+		setEnvelopeFlag(envelope.databaseId, 'seen', newState).catch((e) => {
 			console.error('could not toggle message seen state', e)
 
 			// Revert change
@@ -647,26 +648,6 @@ export default {
 			commit('flagEnvelope', {
 				envelope,
 				flag: 'flagged',
-				value: oldState,
-			})
-		})
-	},
-	markEnvelopeSeenOrUnseen({ commit, getters }, { envelope, seenFlag }) {
-		// Change immediately and switch back on error
-		const oldState = envelope.flags.unseen
-		commit('flagEnvelope', {
-			envelope,
-			flag: 'unseen',
-			value: seenFlag,
-		})
-
-		setEnvelopeFlag(envelope.databaseId, 'unseen', seenFlag).catch((e) => {
-			console.error('could not mark message ' + envelope.uid + ' seen/unseen', e)
-
-			// Revert change
-			commit('flagEnvelope', {
-				envelope,
-				flag: 'unseen',
 				value: oldState,
 			})
 		})

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -412,7 +412,7 @@ class MessagesControllerTest extends TestCase {
 		$mailboxId = 987;
 		$id = 123;
 		$flags = [
-			'unseen' => false
+			'seen' => false
 		];
 		$message = new \OCA\Mail\Db\Message();
 		$message->setUid(444);
@@ -434,7 +434,7 @@ class MessagesControllerTest extends TestCase {
 			->will($this->returnValue($this->account));
 		$this->mailManager->expects($this->once())
 			->method('flagMessage')
-			->with($this->account, 'INBOX', 444, 'unseen', false);
+			->with($this->account, 'INBOX', 444, 'seen', false);
 
 		$expected = new JSONResponse();
 		$response = $this->controller->setFlags(


### PR DESCRIPTION
Is it me or did the 'read flag' got renamed from 'unseen' to 'seen'?

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>