### PR TITLE
Translate special mailbox labels in tooltips

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -38,7 +38,7 @@
 				<ActionText
 					v-if="!account.isUnified && mailbox.specialRole !== 'flagged'"
 					icon="icon-info"
-					:title="mailbox.name">
+					:title="mailbox.specialRole ? t('mail', mailbox.name) : mailbox.name">
 					{{ statsText }}
 				</ActionText>
 


### PR DESCRIPTION
Small improvement to translate the title/label of a mailbox tooltip:

![Pasted_Image_03_11_20__19_50](https://user-images.githubusercontent.com/459512/98028129-e9bfc780-1e0d-11eb-9e8d-e14e2c9f2003.png)

This change will pass `mailbox.name` through the translation interface, but only if the mailbox has a `specialRole`. That way, custom folder names remain untouched.

Currently, the following string translations are missing: `INBOX`, `Deleted Messages`, `Sent Messages`.

Signed-off-by: Johannes Brückner <johannes@dotplex.com>