### PR TITLE
Catch no account in envelope and console log spam

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -154,7 +154,7 @@ export default {
 			return this.$store.getters.getAccount(this.data.accountId)
 		},
 		accountColor() {
-			return calculateAccountColor(this.account.emailAddress)
+			return calculateAccountColor(this.account?.emailAddress ?? '')
 		},
 		draft() {
 			return this.data.flags.draft


### PR DESCRIPTION
For the past few weeks we've seen LOADS of `this.account is undefined` errors in the browser console. I really don't get why this happens. But I also want the error to go away. So here's my highly sophisticated *fix*.