### PR TITLE
Prevent account settings reuse when account changes

### DIFF
--- a/src/views/AccountSettings.vue
+++ b/src/views/AccountSettings.vue
@@ -12,11 +12,11 @@
 						href="#account-form"
 						:title="t('mail', 'Change name')" />
 				</p>
-				<AliasSettings v-if="!account.provisioned" :account="account" />
+				<AliasSettings v-if="!account.provisioned" :key="'alias-settings-' + account.id" :account="account" />
 			</div>
-			<SignatureSettings :account="account" />
-			<EditorSettings :account="account" />
-			<AccountDefaultsSettings :account="account" />
+			<SignatureSettings :key="'signature-settings-' + account.id" :account="account" />
+			<EditorSettings :key="'editor-settings-' + account.id" :account="account" />
+			<AccountDefaultsSettings :key="'defaults-settings-' + account.id" :account="account" />
 			<div v-if="!account.provisioned" class="section">
 				<h2>{{ t('mail', 'Mail server') }}</h2>
 				<div id="mail-settings">


### PR DESCRIPTION
Vue is clever and always tries to recycle a component when certain
criteria is met. Apparently it also does it for components with objects
as props, which led to the problem that when you navigated from one
account's settings to another account's setting, the mailbox default
didn't update and you actually saw mailboxes of the previous account.

By key-ing the components we can express that the rendering depends on
the account ID and every time this value changes, Vue has to throw away
the instance and render a new one.

Fixes https://github.com/nextcloud/mail/issues/3916

Ref https://michaelnthiessen.com/force-re-render/