### PR TITLE
Improve html message rendering

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -120,6 +120,8 @@ class Html {
 		$config->set('URI.Host', Util::getServerHostName());
 
 		$config->set('Filter.ExtractStyleBlocks', true);
+		$config->set('CSS.AllowTricky', true);
+		$config->set('CSS.Proprietary', true);
 
 		// Disable the cache since ownCloud has no really appcache
 		// TODO: Fix this - requires https://github.com/owncloud/core/issues/10767 to be fixed


### PR DESCRIPTION
Fixes #3076 

1. Allow more CSS properties in html messages: see [doSetupTricky()](https://github.com/ezyang/htmlpurifier/blob/2512f595e0f4c5235e99ef97603a8db902b3cc5f/library/HTMLPurifier/CSSDefinition.php#L437) and [doSetupProprietary()](https://github.com/ezyang/htmlpurifier/blob/2512f595e0f4c5235e99ef97603a8db902b3cc5f/library/HTMLPurifier/CSSDefinition.php#L389) for details.
2. ~~Proxy Content-Type header (fallback to `application/octet-stream`). Some browsers (e.g. chromium based) refuse to display svgs in img elements unless they are served with the correct Content-Type header.~~ 

**EDIT**: 2. is not secure