### PR TITLE
Fix envelope timestamp overlap

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -22,7 +22,7 @@
 import { curry } from 'ramda'
 import escapeRegExp from 'lodash/fp/escapeRegExp'
 import orderBy from 'lodash/fp/orderBy'
-import sortedUniqBy from 'lodash/fp/sortedUniqBy'
+import uniq from 'lodash/fp/uniq'
 import Vue from 'vue'
 
 import { sortMailboxes } from '../imap/MailboxSorter'
@@ -141,9 +141,8 @@ export default {
 		const listId = normalizedEnvelopeListId(query)
 		const existing = mailbox.envelopeLists[listId] || []
 		const idToDateInt = (id) => state.envelopes[id].dateInt
-		const sortedUniqByDateInt = sortedUniqBy(idToDateInt)
 		const orderByDateInt = orderBy(idToDateInt, 'desc')
-		Vue.set(mailbox.envelopeLists, listId, sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.databaseId]))))
+		Vue.set(mailbox.envelopeLists, listId, uniq(orderByDateInt(existing.concat([envelope.databaseId]))))
 
 		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
 		unifiedAccount.mailboxes
@@ -154,7 +153,7 @@ export default {
 				Vue.set(
 					mailbox.envelopeLists,
 					listId,
-					sortedUniqByDateInt(orderByDateInt(existing.concat([envelope.databaseId])))
+					uniq(orderByDateInt(existing.concat([envelope.databaseId])))
 				)
 			})
 	},

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -643,7 +643,6 @@ describe('Vuex store mutations', () => {
 			},
 			envelopes: {
 				12345: {
-					accountId: 13,
 					mailboxId: 27,
 					databaseId: 12345,
 					uid: 321,
@@ -657,6 +656,82 @@ describe('Vuex store mutations', () => {
 					accountId: 13,
 					envelopeLists: {
 						'': [12345],
+					},
+				},
+			},
+		})
+	})
+
+	it('adds envelopes with overlapping timestamps', () => {
+		const state = {
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					mailboxes: [],
+				},
+			},
+			envelopes: {},
+			mailboxes: {
+				27: {
+					name: 'INBOX',
+					accountId: 13,
+					envelopeLists: {},
+				},
+			},
+		}
+
+		mutations.addEnvelope(state, {
+			query: undefined,
+			envelope: {
+				mailboxId: 27,
+				databaseId: 12345,
+				id: 123,
+				subject: 'henlo',
+				uid: 321,
+			},
+		})
+		mutations.addEnvelope(state, {
+			query: undefined,
+			envelope: {
+				mailboxId: 27,
+				databaseId: 12346,
+				id: 124,
+				subject: 'henlo 2',
+				uid: 322,
+			},
+		})
+
+		expect(state).to.deep.equal({
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					mailboxes: [],
+				},
+			},
+			envelopes: {
+				12345: {
+					mailboxId: 27,
+					databaseId: 12345,
+					uid: 321,
+					id: 123,
+					subject: 'henlo',
+				},
+				12346: {
+					mailboxId: 27,
+					databaseId: 12346,
+					id: 124,
+					subject: 'henlo 2',
+					uid: 322,
+				},
+			},
+			mailboxes: {
+				27: {
+					name: 'INBOX',
+					accountId: 13,
+					envelopeLists: {
+						'': [12345, 12346],
 					},
 				},
 			},
@@ -710,7 +785,6 @@ describe('Vuex store mutations', () => {
 				12345: {
 					databaseId: 12345,
 					mailboxId: 27,
-					accountId: 2,
 					uid: 321,
 					subject: 'henlo',
 				},


### PR DESCRIPTION
The code assume that timestamps would be unique. Of course that is not
always the case.

Fixes https://github.com/nextcloud/mail/issues/4000

cc @stavros-k