### PR TITLE
Always show Mail search results first

### DIFF
--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -71,6 +71,11 @@ class Provider implements IProvider {
 	}
 
 	public function getOrder(string $route, array $routeParameters): int {
+		if (strpos($route, Application::APP_ID . '.') === 0) {
+			// Active app, prefer Mail results
+			return -1;
+		}
+
 		return 20;
 	}
 


### PR DESCRIPTION
If a search request origins from a Mail page, we should show Mail
results on top.

Inspect the result of ``/ocs/v2.php/search/providers?from=%2Fapps%2Fmail%2Fbox%2F3232%2Fthread%2F285830`` and you'll see that before we returned the default order number, now it will return `-1`  when you are on a Mail page.

Fixes https://github.com/nextcloud/mail/issues/4037