### PR TITLE
Fix thread scrolling

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<div>
+	<div class="envelope">
 		<div class="envelope--header">
 			<Avatar v-if="envelope.from && envelope.from[0]"
 				:email="envelope.from[0].email"
@@ -458,6 +458,12 @@ export default {
 		margin-left: 8px;
 		cursor: default;
 	}
+
+	.envelope {
+		display: flex;
+		flex-direction: column;
+	}
+
 	.envelope--header {
 		display: flex;
 		padding: 10px;


### PR DESCRIPTION
Fixes #4038 

This also restores `margin-bottom: 60px` of the message body which was not applied correctly before.

**Cause of this bug:**
The message body div has `flex: 1` but the parent div did not have `display: flex`.