### PR TITLE
Drag and Drop (revisited)

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1,5 +1,16 @@
 <template>
-	<router-link class="app-content-list-item" :class="{seen: data.flags.seen, draft, selected: selected}" :to="link">
+	<router-link
+		v-draggable-envelope="{
+			accountId: data.accountId ? data.accountId : mailbox.accountId,
+			mailboxId: data.mailboxId,
+			envelopeId: data.databaseId,
+			draggableLabel: `${data.subject} (${data.from[0].label})`,
+			selectedEnvelopes,
+		}"
+		class="app-content-list-item"
+		:class="{seen: data.flags.seen, draft, selected: selected}"
+		:to="link"
+		:data-envelope-id="data.databaseId">
 		<div
 			v-if="mailbox.isUnified"
 			class="mail-message-account-color"
@@ -133,6 +144,7 @@ import { matchError } from '../errors/match'
 import NoTrashMailboxConfiguredError
 	from '../errors/NoTrashMailboxConfiguredError'
 import logger from '../logger'
+import { DraggableEnvelopeDirective } from '../directives/drag-and-drop/draggable-envelope'
 
 export default {
 	name: 'Envelope',
@@ -143,6 +155,9 @@ export default {
 		Avatar,
 		Moment,
 		MoveModal,
+	},
+	directives: {
+		draggableEnvelope: DraggableEnvelopeDirective,
 	},
 	props: {
 		data: {
@@ -160,6 +175,11 @@ export default {
 		selected: {
 			type: Boolean,
 			default: false,
+		},
+		selectedEnvelopes: {
+			type: Array,
+			required: false,
+			default: () => [],
 		},
 	},
 	data() {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -98,6 +98,7 @@
 				:mailbox="mailbox"
 				:selected="selection.includes(env.databaseId)"
 				:select-mode="selectMode"
+				:selected-envelopes="selectedEnvelopes"
 				@delete="$emit('delete', env.databaseId)"
 				@update:selected="onEnvelopeSelectToggle(env, index, ...$event)"
 				@select-multiple="onEnvelopeSelectMultiple(env, index)" />
@@ -125,6 +126,7 @@ import { matchError } from '../errors/match'
 import NoTrashMailboxConfiguredError
 	from '../errors/NoTrashMailboxConfiguredError'
 import { differenceWith } from 'ramda'
+import dragEventBus from '../directives/drag-and-drop/util/dragEventBus'
 
 export default {
 	name: 'EnvelopeList',
@@ -202,7 +204,20 @@ export default {
 				})
 		},
 	},
+	mounted() {
+		dragEventBus.$on('envelopesDropped', this.unselectAll)
+	},
+	beforeDestroy() {
+		dragEventBus.$off('envelopesDropped', this.unselectAll)
+	},
 	methods: {
+		isEnvelopeSelected(idx) {
+			if (this.selection.length === 0) {
+				return false
+			}
+
+			return this.selection.includes(idx)
+		},
 		markSelectedSeenOrUnseen() {
 			const seen = !this.areAllSelectedRead
 			this.selectedEnvelopes.forEach((envelope) => {

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -63,7 +63,6 @@ export default {
 		return {
 			loading: false,
 			bus: new Vue(),
-			signature: '',
 		}
 	},
 	created() {

--- a/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
+++ b/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
@@ -1,0 +1,104 @@
+import dragEventBus from '../util/dragEventBus'
+import defer from 'lodash/defer'
+
+export class DraggableEnvelope {
+
+	constructor(el, componentInstance, options) {
+		this.el = el
+		this.options = options
+		this.registerListeners.bind(this)(el)
+		this.setInitialAttributes()
+	}
+
+	setInitialAttributes() {
+		this.el.setAttribute('draggable', 'true')
+		this.el.classList.add('draggable-envelope')
+	}
+
+	update(el, instance) {
+		this.options = instance.options
+	}
+
+	registerListeners(el) {
+		el.addEventListener('dragstart', this.onDragStart.bind(this))
+		el.addEventListener('dragend', this.onDragEnd.bind(this))
+	}
+
+	removeListeners(el) {
+		el.removeEventListener('dragstart', this.onDragStart)
+		el.removeEventListener('dragend', this.onDragEnd)
+	}
+
+	onDragStart(event) {
+		const { accountId, mailboxId, selectedEnvelopes } = this.options
+
+		event.dataTransfer.clearData()
+		event.dataTransfer.effectAllowed = 'move'
+
+		const envelopes = []
+		if (selectedEnvelopes.length) {
+			// handle dragged selection mode items
+			selectedEnvelopes.forEach((envelope, index) => {
+				envelopes.push({
+					accountId,
+					mailboxId,
+					envelopeId: envelope.databaseId,
+					draggableLabel: `${envelope.subject} (${envelope.from[0].label})`,
+				})
+			})
+		} else {
+			// handle single dragged item
+			const { envelopeId, draggableLabel } = this.options
+			envelopes.push({ accountId, mailboxId, envelopeId, draggableLabel })
+		}
+
+		event.dataTransfer.setData('text/plain', JSON.stringify(envelopes))
+		this.attachGhost({ event, envelopes })
+
+		dragEventBus.$emit('dragStart', {
+			accountId,
+			mailboxId,
+			itemCount: envelopes.length,
+		})
+	}
+
+	onDragEnd(event) {
+		dragEventBus.$emit('dragEnd', { accountId: this.options.accountId })
+	}
+
+	attachGhost({ event, envelopes }) {
+		const baseClass = 'draggable-envelope-ghost'
+		const dragNode = document.createElement('div')
+		dragNode.classList.add(baseClass)
+
+		const counterNode = document.createElement('span')
+		counterNode.classList.add(`${baseClass}--counter`)
+		const textCountNode = document.createTextNode(envelopes.length)
+		counterNode.appendChild(textCountNode)
+		dragNode.appendChild(counterNode)
+
+		const labelWrapperNode = document.createElement('div')
+		labelWrapperNode.classList.add(`${baseClass}--label-wrapper`)
+
+		envelopes.forEach(envelope => {
+			const labelNode = document.createElement('div')
+			labelNode.classList.add(`${baseClass}--label-wrapper--label`)
+			const textLabelNode = document.createTextNode(envelope.draggableLabel)
+			labelNode.appendChild(textLabelNode)
+			labelWrapperNode.appendChild(labelNode)
+		})
+
+		dragNode.appendChild(labelWrapperNode)
+		document.body.appendChild(dragNode)
+
+		event.dataTransfer.setDragImage(dragNode, 0, 15)
+
+		// the item can be removed immediately, because the
+		// browser will take a "screenshot" of the dragImage
+		// upon initialization to be used while dragging
+		defer(() => {
+			document.body.removeChild(dragNode)
+		})
+	}
+
+}

--- a/src/directives/drag-and-drop/draggable-envelope/index.js
+++ b/src/directives/drag-and-drop/draggable-envelope/index.js
@@ -1,0 +1,24 @@
+import { DraggableEnvelope } from './draggable-envelope'
+
+let instances = []
+
+export const DraggableEnvelopeDirective = {
+	bind(el, binding, vnode) {
+		const instance = new DraggableEnvelope(el, vnode.context, binding.value)
+		instances.push(instance)
+	},
+	componentUpdated(el, binding) {
+		const options = binding.value
+		setTimeout(() => {
+			instances.forEach(instance => {
+				instance.options.selectedEnvelopes = options.selectedEnvelopes
+				instance.update(el, instance)
+			})
+		})
+	},
+	unbind(el) {
+		instances = instances.filter((instance) => instance.el !== el)
+	},
+}
+
+export default DraggableEnvelope

--- a/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
@@ -1,0 +1,132 @@
+import store from '../../../store'
+import logger from '../../../logger'
+import dragEventBus from '../util/dragEventBus'
+
+export class DroppableMailbox {
+
+	constructor(el, componentInstance, options) {
+		this.el = el
+		this.options = options
+		this.registerListeners.bind(this)(el)
+		this.setInitialAttributes()
+	}
+
+	setInitialAttributes() {
+		this.draggableInfo = {}
+		this.setStatus('enabled')
+	}
+
+	update(el, instance) {
+		this.setInitialAttributes()
+		this.options = instance.options
+	}
+
+	registerListeners(el) {
+		dragEventBus.$on('dragStart', this.onDragStart.bind(this))
+		dragEventBus.$on('dragEnd', this.onDragEnd.bind(this))
+
+		// event listeners need to be attached to the first child element
+		// (a button or an anchor tag) instead of the root el, because there
+		// can be sub-mailboxes within the root element of the directive
+		el.firstChild.addEventListener('dragover', this.onDragOver.bind(this))
+		el.firstChild.addEventListener('dragleave', this.onDragLeave.bind(this))
+		el.firstChild.addEventListener('drop', this.onDrop.bind(this))
+	}
+
+	removeListeners(el) {
+		dragEventBus.$off('dragStart', this.onDragStart)
+		dragEventBus.$off('dragEnd', this.onDragEnd)
+
+		el.firstChild.removeEventListener('dragover', this.onDragOver)
+		el.firstChild.removeEventListener('dragleave', this.onDragLeave)
+		el.firstChild.removeEventListener('drop', this.onDrop)
+	}
+
+	setStatus(status) {
+		this.el.setAttribute('droppable-mailbox', status)
+	}
+
+	onDragStart(draggableInfo) {
+		this.draggableInfo = draggableInfo
+
+		if (!this.canBeDropped()) {
+			this.setStatus('disabled')
+		}
+	}
+
+	canBeDropped() {
+		return this.isSameAccount() && this.options.isValidDropTarget
+	}
+
+	isSameAccount() {
+		return this.draggableInfo.accountId === this.options.accountId
+	}
+
+	onDragEnd() {
+		this.setInitialAttributes()
+	}
+
+	onDragOver(event) {
+		event.preventDefault()
+
+		// Prevent dropping into current folder
+		if (this.draggableInfo.mailboxId === this.options.mailboxId) {
+			return
+		}
+
+		if (this.options.isValidDropTarget) {
+			this.setStatus('dragover')
+		}
+
+		event.dataTransfer.dropEffect = 'move'
+	}
+
+	onDragLeave(event) {
+		event.preventDefault()
+		this.setStatus('enabled')
+	}
+
+	async onDrop(event) {
+		event.preventDefault()
+
+		// Prevent dropping into current folder
+		if (this.draggableInfo.mailboxId === this.options.mailboxId) {
+			return
+		}
+
+		this.setInitialAttributes()
+		const envelopesBeingDragged = JSON.parse(event.dataTransfer.getData('text'))
+		dragEventBus.$emit('envelopesDropped', { envelopes: envelopesBeingDragged })
+
+		try {
+			const processedEnvelopes = envelopesBeingDragged.map(async envelope => {
+				const processed = await this.processDroppedItem(parseInt(envelope.envelopeId))
+				return processed
+			})
+			await Promise.all(processedEnvelopes)
+		} catch (error) {
+			logger.error('could not process dropped messages', error)
+		} finally {
+			dragEventBus.$emit('envelopesMoved', {
+				mailboxId: this.options.mailboxId,
+				movedEnvelopes: envelopesBeingDragged,
+			})
+		}
+	}
+
+	async processDroppedItem(envelopeId) {
+		const item = document.querySelector(`[data-envelope-id="${envelopeId}"]`)
+		item.setAttribute('draggable-envelope', 'pending')
+
+		try {
+			await store.dispatch('moveMessage', {
+				id: envelopeId,
+				destMailboxId: this.options.mailboxId,
+			})
+		} catch (error) {
+			item.removeAttribute('draggable-envelope')
+			logger.error('could not move messages', error)
+		}
+	}
+
+}

--- a/src/directives/drag-and-drop/droppable-mailbox/index.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/index.js
@@ -1,0 +1,15 @@
+import { DroppableMailbox } from './droppable-mailbox'
+
+let instance
+
+export const DroppableMailboxDirective = {
+	bind(el, binding, vnode) {
+		instance = new DroppableMailbox(el, vnode.context, binding.value)
+	},
+	componentUpdated(el, binding) {
+		instance.options = binding.value
+		instance.update(el, instance)
+	},
+}
+
+export default DroppableMailbox

--- a/src/directives/drag-and-drop/styles/drag-and-drop.scss
+++ b/src/directives/drag-and-drop/styles/drag-and-drop.scss
@@ -1,0 +1,2 @@
+@import 'draggable-envelope';
+@import 'droppable-mailbox';

--- a/src/directives/drag-and-drop/styles/draggable-envelope.scss
+++ b/src/directives/drag-and-drop/styles/draggable-envelope.scss
@@ -1,0 +1,49 @@
+[draggable-envelope="pending"] {
+	opacity: 0.6;
+	pointer-events: none;
+	cursor: default;
+}
+.draggable-envelope-ghost {
+	height: auto;
+	width: 300px;
+
+	&--counter {
+		position: absolute;
+		left: -40px;
+		background-color: var(--color-primary-element);
+		color: #fff;
+		font-weight: bold;
+		text-align: center;
+		display: inline-block;
+		margin-right: 10px;
+		border-top-left-radius: 20px;
+		border-bottom-left-radius: 20px;
+		width: 10px;
+		padding: 8px 15px;
+	}
+
+	&--label-wrapper {
+		&--label {
+			padding: 8px 15px;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+			overflow: hidden;
+			width: 100%;
+			text-align: left;
+			margin-bottom: 1px;
+			background-color: #fff;
+			border-left: 2px solid var(--color-primary-element);
+
+			&:first-child {
+				border-top-right-radius: 20px;
+			}
+			&:last-child {
+				border-bottom-right-radius: 20px;
+				border-bottom-left-radius: 20px;
+			}
+			&:only-child {
+				border-bottom-left-radius: 0;
+			}
+		}
+	}
+}

--- a/src/directives/drag-and-drop/styles/droppable-mailbox.scss
+++ b/src/directives/drag-and-drop/styles/droppable-mailbox.scss
@@ -1,0 +1,71 @@
+[droppable-mailbox] {
+	a.app-navigation-entry-link {
+		position: relative;
+
+		&:before,
+		&:after {
+			transition: .1s border-color ease-in-out;
+		}
+	}
+
+	> a {
+		&:before {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 2px;
+			bottom: 0;
+			right: 0;
+			transition: .1s opacity ease-in-out;
+			border: 2px solid transparent;
+			pointer-events: none;
+			border-radius: 20px;
+		}
+
+		&:after {
+			content: '';
+			position: absolute;
+			width: 0;
+			height: 0;
+			border-top: 5px solid transparent;
+			border-left: 5px solid transparent;
+			border-bottom: 5px solid transparent;
+			left: 4px;
+			top: 50%;
+			margin-top: -5px;
+		}
+	}
+}
+[droppable-mailbox="disabled"] {
+	pointer-events: none;
+	opacity: .3;
+}
+[droppable-mailbox="dragover"] {
+	> a {
+		&:before {
+			content: '';
+			position: absolute;
+			top: 0;
+			left: 2px;
+			bottom: 0;
+			right: 0;
+			transition: .1s opacity ease-in-out;
+			border: 2px solid var(--color-primary-element);
+			pointer-events: none;
+			border-radius: 20px;
+		}
+
+		&:after {
+			content: '';
+			position: absolute;
+			width: 0;
+			height: 0;
+			border-top: 5px solid transparent;
+			border-left: 5px solid var(--color-primary-element);
+			border-bottom: 5px solid transparent;
+			left: 4px;
+			top: 50%;
+			margin-top: -5px;
+		}
+	}
+}

--- a/src/directives/drag-and-drop/util/dragEventBus.js
+++ b/src/directives/drag-and-drop/util/dragEventBus.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+const dragEventBus = new Vue()
+export default dragEventBus

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import { getRequestToken } from '@nextcloud/auth'
 import { sync } from 'vuex-router-sync'
 import { generateFilePath } from '@nextcloud/router'
 import '@nextcloud/dialogs/styles/toast.scss'
+import './directives/drag-and-drop/styles/drag-and-drop.scss'
 import VueShortKey from 'vue-shortkey'
 import VTooltip from 'v-tooltip'
 


### PR DESCRIPTION
## Adds drag & drop support for moving emails to folders

First off, I know there has been a previous attempt (#2834) to implement this and it has been closed in favor of #3591. This PR doesn't aim to replace the newly implemented modal window to move mails, but rather to complement it. It in fact uses methods introduced in #3591 to actually move the mails.

This approach also makes use of the multi-selection feature, to enable dragging of single and multiple emails.

I have recorded a quick **video** to showcase the feature (too bad I cant attach it right here, Nextcloud to the rescue!): 
https://cloud.dotplex.com/s/RHNGPL8xCzspCkr

**Sneak peek:**

![Screenshot_10_11_20__12_18](https://user-images.githubusercontent.com/459512/98667587-def5bd00-234e-11eb-8680-7fc60807d932.png)

### Features
- dragging and dropping of single or multiple mails
- customized draggable-ghost to match the general style
  - with count of mails being dragged, their subject and sender
- visual feedback for invalid drop-targets (faded out)
- collapsed folders of the same account expand automatically when starting to drag
- support for subfolders
- dragging to trash/junk is possible
- source and target folders are synced right away once the mails have been dropped

### Code
This is dependency-free. I am **not** using any external libraries for this. I dug into the [HTML5 drag and drop API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API). I've studied #2834 and the [library that was used there](https://github.com/Vivify-Ideas/vue-draggable) and figured out that in order for this to work, event listeners would have to be attached in a more dynamic manner, since mails are loaded asynchronously. I was trying to make it work with vue-draggable, as well as some other libraries, but each of them would spawn a different set of challanges. So in the end I decided to do it "by hand", which has the huge benefit of being able to tailor the feature exactly to our needs.

### It's a draft!
In order to get this to work, I had to do some low-level attaching of eventListeners and dom manipulations (to create the draggable-ghost). It's basically exactly what vue-draggable does, just with less overhead. I would love to wrap that up in two [custom directives](https://vuejs.org/v2/guide/custom-directive.html) (one for the draggables, one for the drop-targets), but I've never done that before and ran into some issues. So, before pouring more time into this, I wanted to make sure that this feature would be accepted in the first place. 

### How does this work?
There are `dragstart` and `dragend` eventListeners attached to an envelope in `Envelope.vue`. On the other hand, there are `dragenter`, `dragover`, `dragleave` and `drop` eventListeners on each folder/mailbox in `NavigationMailbox.vue` that matches the criteria for a valid drop-target.

On `dragstart`, each envelope being dragged is added to the global $store and a drag-ghost is created. The HTML5 API to customize that is kinda wierd... you have to create an element to your liking and attach it to the DOM. The browser will then take a "screenshot" of that element, at which point you can remove the element from the DOM again. So in practice: you create the element, attach it to the dom, set it as a [DragImage](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage) and remove it right away. 🤷‍♂️

Once you drop the mail(s) on a valid drop target (mailbox), the mails to be moved are pulled from the $store and processed. It would be possible to make them disappear right away, but I went with a slight fade-out until they are actually moved. In theory, it would be possible to use the [HTML5 DataTransfer object](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer) instead of the $store, but that API is pretty wierd as well. Good luck passing objects... :/

### Improvements
- Code isolation – as stated before. Maybe using custom directives? Glad for any suggestion.
- Styles: I blatently stuck the styling for the draggable-ghost into `App.vue`, as it **needs to be** global. Of course, that's not the right place. How/where is [`mail.scss`](https://github.com/nextcloud/mail/blob/master/css/mail.scss) compiled? I'd like to add it there.

### Trojan Horse 🐴
[This commit](https://github.com/nextcloud/mail/commit/4f5e1d89664477214ac440db33f6ac48dc23af96) has nothing to do with the feature, but it neccessary for it to work. I need to pass an event from an envelope to a mailbox/folder. Apparently there is an event bus, but it is created in [`MailboxThread.vue`](https://github.com/nextcloud/mail/commit/4f5e1d89664477214ac440db33f6ac48dc23af96#diff-2ef5622c7090ce9f7e480022e8f1217a0c811b608ecf6335e71758ec3c43768eL115) and only passed down as a prop to its' subcomponents. Instead, I am proposing [this pattern](https://medium.com/@andrejsabrickis/https-medium-com-andrejsabrickis-create-simple-eventbus-to-communicate-between-vue-js-components-cdc11cd59860) to make it available whereever neccessary. I'd submit this as a separate PR once out of draft-phase.

## Conclusion
I strongly believe that this is a **must have** for an email client. Every user will try to drag an email. We are just used to it from any other client out there. However, I am not married to the specifics of this implementation and am glad for any help with this!