### PR TITLE
Fix icon styling for reply button

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -62,7 +62,7 @@
 						primary: expanded,
 					}"
 					class="button">
-					{{ t('mail', 'Reply') }}
+					<span class="action-label"> {{ t('mail', 'Reply') }}</span>
 				</router-link>
 				<Actions class="app-content-list-item-menu" menu-align="right">
 					<ActionButton v-if="hasMultipleRecipients"


### PR DESCRIPTION
The reply button icon doesnt show properly on small screen, because the `class=action-label` was missing after we moved to thread.
fixes #4009 

before
![button_small screen](https://user-images.githubusercontent.com/12728974/98821106-60248100-242f-11eb-9cff-213648ab3a03.png)

after
![after_button_smallscreen](https://user-images.githubusercontent.com/12728974/98821108-60bd1780-242f-11eb-9497-fdf66a49b6c3.png)
