### PR TITLE
Fix/3829 Saving Signatures

### DIFF
--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -63,12 +63,11 @@ export default {
 		return {
 			loading: false,
 			bus: new Vue(),
+			signature: '',
 		}
 	},
-	computed: {
-		signature() {
-			return this.account.signature ? toHtml(detect(this.account.signature)).value : ''
-		},
+	created() {
+		this.signature = this.account.signature ? toHtml(detect(this.account.signature)).value : ''
 	},
 	methods: {
 		deleteSignature() {


### PR DESCRIPTION
Fixes #3829 

### Problem
Signature changes are not stored in the database

### Cause
The text editor's model binding to `this.signature`...
```javascript
<TextEditor v-model="signature" ...
```
... collides with using a computed property:
```javascript
signature() {
    return this.account.signature ? toHtml(detect(this.account.signature)).value : ''
},
```

### Solution
Initialize `this.signature` with and empty string in `data()` and assign the account's stored signature in `created()`. This will properly set the initial value and allows the model binding on `<TextEditor />` to update the value.

Signed-off-by: Johannes Brückner <johannes@dotplex.com>