### PR TITLE
Refactor: Global EventBus

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -121,7 +121,6 @@
 				class="message-body"
 				:placeholder="t('mail', 'Write message …')"
 				:focus="isReply"
-				:bus="bus"
 				@input="onInputChanged" />
 			<TextEditor
 				v-else-if="!encrypt && !editorPlainText"
@@ -132,7 +131,6 @@
 				class="message-body"
 				:placeholder="t('mail', 'Write message …')"
 				:focus="isReply"
-				:bus="bus"
 				@input="onInputChanged" />
 			<MailvelopeEditor
 				v-else
@@ -143,7 +141,7 @@
 				:is-reply-or-forward="isReply || isForward" />
 		</div>
 		<div class="composer-actions">
-			<ComposerAttachments v-model="attachments" :bus="bus" @upload="onAttachmentsUploading" />
+			<ComposerAttachments v-model="attachments" @upload="onAttachmentsUploading" />
 			<div class="composer-actions-right">
 				<p class="composer-actions-draft">
 					<span v-if="!canSaveDraft" id="draft-status">{{ t('mail', 'Can not save draft because this account does not have a drafts mailbox configured.') }}</span>
@@ -250,6 +248,7 @@ import NoSentMailboxConfiguredError
 	from '../errors/NoSentMailboxConfiguredError'
 import NoDraftsMailboxConfiguredError
 	from '../errors/NoDraftsMailboxConfiguredError'
+import EventBus from '../util/EventBus'
 
 const debouncedSearch = debouncePromise(findRecipient, 500)
 
@@ -341,7 +340,6 @@ export default {
 			selectTo: this.to,
 			selectCc: this.cc,
 			selectBcc: this.bcc,
-			bus: new Vue(),
 			encrypt: false,
 			mailvelope: {
 				available: false,
@@ -571,13 +569,13 @@ export default {
 			this.saveDraftDebounced(this.getMessageData)
 		},
 		onAddLocalAttachment() {
-			this.bus.$emit('onAddLocalAttachment')
+			EventBus.$emit('onAddLocalAttachment')
 		},
 		onAddCloudAttachment() {
-			this.bus.$emit('onAddCloudAttachment')
+			EventBus.$emit('onAddCloudAttachment')
 		},
 		onAddCloudAttachmentLink() {
-			this.bus.$emit('onAddCloudAttachmentLink')
+			EventBus.$emit('onAddCloudAttachmentLink')
 		},
 		onAutocomplete(term) {
 			if (term === undefined || term === '') {

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -54,16 +54,13 @@ import Vue from 'vue'
 import Logger from '../logger'
 import { uploadLocalAttachment } from '../service/AttachmentService'
 import { shareFile } from '../service/FileSharingService'
+import EventBus from '../util/EventBus'
 
 export default {
 	name: 'ComposerAttachments',
 	props: {
 		value: {
 			type: Array,
-			required: true,
-		},
-		bus: {
-			type: Object,
 			required: true,
 		},
 	},
@@ -85,9 +82,9 @@ export default {
 		},
 	},
 	created() {
-		this.bus.$on('onAddLocalAttachment', this.onAddLocalAttachment)
-		this.bus.$on('onAddCloudAttachment', this.onAddCloudAttachment)
-		this.bus.$on('onAddCloudAttachmentLink', this.onAddCloudAttachmentLink)
+		EventBus.$on('onAddLocalAttachment', this.onAddLocalAttachment)
+		EventBus.$on('onAddCloudAttachment', this.onAddCloudAttachment)
+		EventBus.$on('onAddCloudAttachmentLink', this.onAddCloudAttachmentLink)
 	},
 	methods: {
 		onAddLocalAttachment() {
@@ -160,7 +157,7 @@ export default {
 			)
 		},
 		appendToBodyAtCursor(toAppend) {
-			this.bus.$emit('appendToBodyAtCursor', toAppend)
+			EventBus.$emit('appendToBodyAtCursor', toAppend)
 		},
 	},
 }

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -57,6 +57,7 @@ import EmptyMailboxSection from './EmptyMailboxSection'
 import { showError } from '@nextcloud/dialogs'
 import NoTrashMailboxConfiguredError
 	from '../errors/NoTrashMailboxConfiguredError'
+import EventBus from '../util/EventBus'
 
 export default {
 	name: 'Mailbox',
@@ -74,10 +75,6 @@ export default {
 			required: true,
 		},
 		mailbox: {
-			type: Object,
-			required: true,
-		},
-		bus: {
 			type: Object,
 			required: true,
 		},
@@ -145,18 +142,18 @@ export default {
 		},
 	},
 	created() {
-		this.bus.$on('loadMore', this.onScroll)
-		this.bus.$on('delete', this.onDelete)
-		this.bus.$on('shortcut', this.handleShortcut)
+		EventBus.$on('loadMore', this.onScroll)
+		EventBus.$on('delete', this.onDelete)
+		EventBus.$on('shortcut', this.handleShortcut)
 		this.loadMailboxInterval = setInterval(this.loadMailbox, 60000)
 	},
 	async mounted() {
 		return await this.loadEnvelopes()
 	},
 	destroyed() {
-		this.bus.$off('loadMore', this.onScroll)
-		this.bus.$off('delete', this.onDelete)
-		this.bus.$off('shortcut', this.handleShortcut)
+		EventBus.$off('loadMore', this.onScroll)
+		EventBus.$off('delete', this.onDelete)
+		EventBus.$off('shortcut', this.handleShortcut)
 		this.stopInterval()
 	},
 	methods: {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -14,8 +14,7 @@
 					v-if="!mailbox.isPriorityInbox"
 					:account="account"
 					:mailbox="mailbox"
-					:search-query="query"
-					:bus="bus" />
+					:search-query="query" />
 				<template v-else>
 					<div class="app-content-list-item">
 						<SectionTitle class="important" :name="t('mail', 'Important')" />
@@ -34,8 +33,7 @@
 						:paginate="'manual'"
 						:is-priority-inbox="true"
 						:initial-page-size="5"
-						:collapsible="true"
-						:bus="bus" />
+						:collapsible="true" />
 					<SectionTitle class="app-content-list-item starred" :name="t('mail', 'Favorites')" />
 					<Mailbox
 						class="namestarred"
@@ -44,8 +42,7 @@
 						:search-query="appendToSearch('is:starred not:important')"
 						:paginate="'manual'"
 						:is-priority-inbox="true"
-						:initial-page-size="5"
-						:bus="bus" />
+						:initial-page-size="5" />
 					<SectionTitle class="app-content-list-item other" :name="t('mail', 'Other')" />
 					<Mailbox
 						class="nameother"
@@ -53,8 +50,7 @@
 						:mailbox="unifiedInbox"
 						:open-first="false"
 						:search-query="appendToSearch('not:starred not:important')"
-						:is-priority-inbox="true"
-						:bus="bus" />
+						:is-priority-inbox="true" />
 				</template>
 			</AppContentList>
 			<NewMessageDetail v-if="newMessage" />
@@ -71,7 +67,6 @@ import Popover from '@nextcloud/vue/dist/Components/Popover'
 import infiniteScroll from 'vue-infinite-scroll'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import SectionTitle from './SectionTitle'
-import Vue from 'vue'
 
 import AppDetailsToggle from './AppDetailsToggle'
 import logger from '../logger'
@@ -80,6 +75,7 @@ import NewMessageDetail from './NewMessageDetail'
 import NoMessageSelected from './NoMessageSelected'
 import Thread from './Thread'
 import { UNIFIED_ACCOUNT_ID, UNIFIED_INBOX_ID } from '../store/constants'
+import EventBus from '../util/EventBus'
 
 export default {
 	name: 'MailboxThread',
@@ -112,7 +108,6 @@ export default {
 		return {
 			// eslint-disable-next-line
 			importantInfo: t('mail', 'Messages will automatically be marked as important based on which messages you interacted with or marked as important. In the beginning you might have to manually change the importance to teach the system, but it will improve over time.'),
-			bus: new Vue(),
 			searchQuery: undefined,
 			shortkeys: {
 				del: ['del'],
@@ -166,15 +161,15 @@ export default {
 			})
 		},
 		deleteMessage(id) {
-			this.bus.$emit('delete', id)
+			EventBus.$emit('delete', id)
 		},
 		onScroll(event) {
 			logger.debug('scroll', { event })
 
-			this.bus.$emit('loadMore')
+			EventBus.$emit('loadMore')
 		},
 		onShortcut(e) {
-			this.bus.$emit('shortcut', e)
+			EventBus.$emit('shortcut', e)
 		},
 		appendToSearch(str) {
 			if (this.searchQuery === undefined) {

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -27,8 +27,7 @@
 		</p>
 		<TextEditor v-model="signature"
 			:html="true"
-			:placeholder="t('mail', 'Signature …')"
-			:bus="bus" />
+			:placeholder="t('mail', 'Signature …')" />
 		<button
 			class="primary"
 			:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
@@ -46,7 +45,6 @@
 import logger from '../logger'
 import TextEditor from './TextEditor'
 import { detect, toHtml } from '../util/text'
-import Vue from 'vue'
 
 export default {
 	name: 'SignatureSettings',
@@ -62,7 +60,6 @@ export default {
 	data() {
 		return {
 			loading: false,
-			bus: new Vue(),
 		}
 	},
 	computed: {

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -45,6 +45,7 @@ import { getLanguage } from '@nextcloud/l10n'
 import DOMPurify from 'dompurify'
 
 import logger from '../logger'
+import EventBus from '../util/EventBus'
 
 export default {
 	name: 'TextEditor',
@@ -67,10 +68,6 @@ export default {
 		focus: {
 			type: Boolean,
 			default: false,
-		},
-		bus: {
-			type: Object,
-			required: true,
 		},
 	},
 	data() {
@@ -187,7 +184,7 @@ export default {
 
 			logger.debug(`setting TextEditor contents to <${this.text}>`)
 
-			this.bus.$on('appendToBodyAtCursor', this.appendToBodyAtCursor)
+			EventBus.$on('appendToBodyAtCursor', this.appendToBodyAtCursor)
 		},
 		onInput() {
 			logger.debug(`TextEditor input changed to <${this.text}>`)

--- a/src/util/EventBus.js
+++ b/src/util/EventBus.js
@@ -1,0 +1,3 @@
+import Vue from 'vue'
+const EventBus = new Vue()
+export default EventBus


### PR DESCRIPTION
This PR has no functional changes. It implements a global event bus (extracted from #4048) which makes triggering and listening to events across different components easier. 

Currently, there are three seperate bus'es created in `Composer.vue`, `MailboxThread.vue` and `SignatureSettings.vue` which are then passed down to child components as a prop, sometimes multiple levels deep. 

Using a global event bus, it can be imported where ever needed, without having to prop-drill:
```javascript
import EventBus from '../util/EventBus'
```
and used just like before:
```javascript
// Component A:
- this.bus.$emit('onSomething')
+ EventBus.$emit('onSomething')

// Component B:
- this.bus.$on('onSomething', this.doSomething)
+ EventBus.$on('onSomething', this.doSomething)
```

Signed-off-by: Johannes Brückner <johannes@dotplex.com>