### PR TITLE
Catch when iconv returns false

### DIFF
--- a/lib/Address.php
+++ b/lib/Address.php
@@ -79,7 +79,11 @@ class Address implements JsonSerializable {
 			return null;
 		}
 		// Lets make sure the e-mail is valid UTF-8 at all times
-		return iconv("UTF-8","UTF-8//IGNORE", $email);
+		$utf8 = iconv("UTF-8", "UTF-8//IGNORE", $email);
+		if ($utf8 === false) {
+			throw new \Exception("Email address <$email> could not be converted via iconv");
+		}
+		return $utf8;
 	}
 
 	/**


### PR DESCRIPTION
This happens when iconv doesn't work as expected, e.g. on Alpine.
Instead of causing a type error on the return value we can show a more
useful exception.

Ref https://github.com/nextcloud/mail/issues/3999