### PR TITLE
Fix previous drafts not being deleted from the cache

### DIFF
--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -32,11 +32,13 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Events\DraftSavedEvent;
+use OCA\Mail\Events\MessageDeletedEvent;
 use OCA\Mail\Events\MessageSentEvent;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
 
@@ -54,14 +56,19 @@ class DeleteDraftListener implements IEventListener {
 	/** @var LoggerInterface */
 	private $logger;
 
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
+
 	public function __construct(IMAPClientFactory $imapClientFactory,
 								MailboxMapper $mailboxMapper,
 								MessageMapper $messageMapper,
-								LoggerInterface $logger) {
+								LoggerInterface $logger,
+								IEventDispatcher $eventDispatcher) {
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->logger = $logger;
+		$this->eventDispatcher = $eventDispatcher;
 	}
 
 	public function handle(Event $event): void {
@@ -105,6 +112,10 @@ class DeleteDraftListener implements IEventListener {
 				'exception' => $e,
 			]);
 		}
+
+		$this->eventDispatcher->dispatchTyped(
+			new MessageDeletedEvent($account, $draftsMailbox, $draft->getUid())
+		);
 	}
 
 	/**

--- a/src/components/NewMessageDetail.vue
+++ b/src/components/NewMessageDetail.vue
@@ -53,6 +53,7 @@ export default {
 			originalBody: undefined,
 			errorMessage: '',
 			error: undefined,
+			newDraftId: undefined,
 		}
 	},
 	computed: {
@@ -156,7 +157,12 @@ export default {
 			// `saveDraft` replaced the current URL with the updated draft UID
 			// in that case we don't really start a new draft but just keep the
 			// URL consistent, hence not loading anything
-			if (to.name === 'message' && this.draft && to.params.draftId === parseInt(this.draft.databaseId, 10)) {
+			if (to.name === 'message' && this.draft
+				&& (
+					to.params.draftId === parseInt(this.draft.databaseId, 10)
+					|| to.params.draftId === this.newDraftId
+				)
+			) {
 				logger.debug('detected navigation to current (new) draft UID, not reloading')
 				return
 			}
@@ -282,15 +288,41 @@ export default {
 				body: data.isHtml ? data.body.value : toPlain(data.body).value,
 			}
 			const { id } = await saveDraft(data.account, dataForServer)
+
+			// Remove old draft envelope
+			this.$store.commit('removeEnvelope', { id: data.draftId })
+			this.$store.commit('removeMessage', { id: data.draftId })
+
+			// Fetch new draft envelope
+			await this.$store.dispatch('fetchEnvelope', id)
+
+			// Update route to new draft (actual redirect will be skipped)
+			const account = this.$store.getters.getAccount(data.account)
+			if (parseInt(this.$route.params.mailboxId, 10) === account.draftsMailboxId) {
+				this.newDraftId = id
+				this.$router.replace({
+					to: 'message',
+					params: {
+						mailboxId: this.$route.params.mailboxId,
+						threadId: this.$route.params.threadId,
+						draftId: id,
+					},
+				})
+			}
+
 			return id
 		},
-		sendMessage(data) {
+		async sendMessage(data) {
 			logger.debug('sending message', { data })
 			const dataForServer = {
 				...data,
 				body: data.isHtml ? data.body.value : toPlain(data.body).value,
 			}
-			return sendMessage(data.account, dataForServer)
+			await sendMessage(data.account, dataForServer)
+
+			// Remove old draft envelope
+			this.$store.commit('removeEnvelope', { id: data.draftId })
+			this.$store.commit('removeMessage', { id: data.draftId })
 		},
 	},
 }


### PR DESCRIPTION
Fixes #3984 

The message was expunged from the imap server but not deleted from the db cache. To fix this, a `MessageDeletedEvent` is now emitted after successfully expunging the previous draft.

~~I also refactored the expunge code to use the `IMAP/MessageMapper.expunge()` method instead of manually flagging the message and expunging the whole drafts mailbox.~~

**EDIT:** The refactor of the expunge code is too big of a change. If you are still interested I can send another PR.