### PR TITLE
Add unread mail dashboard widget

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -32,7 +32,8 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Contracts\IUserPreferences;
-use OCA\Mail\Dashboard\MailWidget;
+use OCA\Mail\Dashboard\ImportantMailWidget;
+use OCA\Mail\Dashboard\UnreadMailWidget;
 use OCA\Mail\Events\DraftSavedEvent;
 use OCA\Mail\Events\MailboxesSynchronizedEvent;
 use OCA\Mail\Events\SynchronizationEvent;
@@ -113,7 +114,8 @@ class Application extends App implements IBootstrap {
 		$context->registerMiddleWare(ErrorMiddleware::class);
 		$context->registerMiddleWare(ProvisioningMiddleware::class);
 
-		$context->registerDashboardWidget(MailWidget::class);
+		$context->registerDashboardWidget(ImportantMailWidget::class);
+		$context->registerDashboardWidget(UnreadMailWidget::class);
 		$context->registerSearchProvider(Provider::class);
 
 		// bypass Horde Translation system

--- a/lib/Dashboard/ImportantMailWidget.php
+++ b/lib/Dashboard/ImportantMailWidget.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ * @copyright Copyright (c) 2020 Richard Steinmetz <richard@steinmetz.cloud>
  *
- * @author Julius Härtl <jus@bitgrid.net>
  * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
@@ -25,27 +24,21 @@ declare(strict_types=1);
  *
  */
 
+namespace OCA\Mail\Dashboard;
 
-
-namespace OCA\Mail\Listener;
-
-use OCA\Mail\Dashboard\ImportantMailWidget;
-use OCA\Mail\Dashboard\UnreadMailWidget;
-use OCP\Dashboard\RegisterWidgetEvent;
-use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\IEventListener;
-
-class DashboardPanelListener implements IEventListener {
+class ImportantMailWidget extends MailWidget {
 
 	/**
 	 * @inheritDoc
 	 */
-	public function handle(Event $event): void {
-		if (!($event instanceof RegisterWidgetEvent)) {
-			return;
-		}
+	public function getId(): string {
+		return 'mail';
+	}
 
-		$event->registerWidget(ImportantMailWidget::class);
-		$event->registerWidget(UnreadMailWidget::class);
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('Important mail');
 	}
 }

--- a/lib/Dashboard/MailWidget.php
+++ b/lib/Dashboard/MailWidget.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
  *
  * @author Julius Härtl <jus@bitgrid.net>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -34,10 +35,10 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Util;
 
-class MailWidget implements IWidget {
+abstract class MailWidget implements IWidget {
 
 	/** @var IL10N */
-	private $l10n;
+	protected $l10n;
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
@@ -61,20 +62,6 @@ class MailWidget implements IWidget {
 		$this->accountService = $accountService;
 		$this->initialState = $initialState;
 		$this->userId = $userId;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getId(): string {
-		return Application::APP_ID;
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function getTitle(): string {
-		return $this->l10n->t('Important mail');
 	}
 
 	/**

--- a/lib/Dashboard/UnreadMailWidget.php
+++ b/lib/Dashboard/UnreadMailWidget.php
@@ -3,9 +3,8 @@
 declare(strict_types=1);
 
 /**
- * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ * @copyright Copyright (c) 2020 Richard Steinmetz <richard@steinmetz.cloud>
  *
- * @author Julius Härtl <jus@bitgrid.net>
  * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
@@ -25,27 +24,21 @@ declare(strict_types=1);
  *
  */
 
+namespace OCA\Mail\Dashboard;
 
-
-namespace OCA\Mail\Listener;
-
-use OCA\Mail\Dashboard\ImportantMailWidget;
-use OCA\Mail\Dashboard\UnreadMailWidget;
-use OCP\Dashboard\RegisterWidgetEvent;
-use OCP\EventDispatcher\Event;
-use OCP\EventDispatcher\IEventListener;
-
-class DashboardPanelListener implements IEventListener {
+class UnreadMailWidget extends MailWidget {
 
 	/**
 	 * @inheritDoc
 	 */
-	public function handle(Event $event): void {
-		if (!($event instanceof RegisterWidgetEvent)) {
-			return;
-		}
+	public function getId(): string {
+		return 'mail-unread';
+	}
 
-		$event->registerWidget(ImportantMailWidget::class);
-		$event->registerWidget(UnreadMailWidget::class);
+	/**
+	 * @inheritDoc
+	 */
+	public function getTitle(): string {
+		return $this->l10n->t('Unread mail');
 	}
 }

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -74,6 +74,12 @@ export default {
 		DashboardWidgetItem,
 		EmptyContent,
 	},
+	props: {
+		query: {
+			type: String,
+			required: true,
+		},
+	},
 	data() {
 		return {
 			messages: [],
@@ -113,7 +119,7 @@ export default {
 		})
 
 		await Promise.all(inboxes.map(async(mailbox) => {
-			const messages = await fetchEnvelopes(mailbox.databaseId, 'is:important', undefined, 10)
+			const messages = await fetchEnvelopes(mailbox.databaseId, this.query, undefined, 10)
 			this.messages = this.messages !== null ? [...this.messages, ...messages] : messages
 			this.fetchedAccounts++
 		}))

--- a/src/main-dashboard.js
+++ b/src/main-dashboard.js
@@ -2,6 +2,7 @@
  * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
  *
  * @author Julius Härtl <jus@bitgrid.net>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -25,7 +26,8 @@ import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 
 import Nextcloud from './mixins/Nextcloud'
-import Dashboard from './views/Dashboard'
+import DashboardImportant from './views/DashboardImportant'
+import DashboardUnread from './views/DashboardUnread'
 
 // eslint-disable-next-line camelcase
 __webpack_nonce__ = btoa(getRequestToken())
@@ -38,7 +40,12 @@ document.addEventListener('DOMContentLoaded', function() {
 	const register = OCA?.Dashboard?.register || (() => {})
 
 	register('mail', (el) => {
-		const View = Vue.extend(Dashboard)
+		const View = Vue.extend(DashboardImportant)
+		new View().$mount(el)
+	})
+
+	register('mail-unread', (el) => {
+		const View = Vue.extend(DashboardUnread)
 		new View().$mount(el)
 	})
 })

--- a/src/views/DashboardImportant.vue
+++ b/src/views/DashboardImportant.vue
@@ -1,0 +1,36 @@
+<!--
+  - @copyright Copyright (c) 2020 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<Dashboard query="is:important" />
+</template>
+
+<script>
+import Dashboard from '../components/Dashboard'
+
+export default {
+	name: 'DashboardImportant',
+	components: {
+		Dashboard,
+	},
+}
+</script>

--- a/src/views/DashboardUnread.vue
+++ b/src/views/DashboardUnread.vue
@@ -1,0 +1,36 @@
+<!--
+  - @copyright Copyright (c) 2020 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<Dashboard query="is:unread" />
+</template>
+
+<script>
+import Dashboard from '../components/Dashboard'
+
+export default {
+	name: 'DashboardUnread',
+	components: {
+		Dashboard,
+	},
+}
+</script>


### PR DESCRIPTION
Ref #3742

Adds a second widget for showing unread mails from all inboxes. Extensively reuses the the code from Julius.

Here is a screenshot (mails are blurred for privacy reasons):
![unread-mail-widget](https://user-images.githubusercontent.com/1479486/100113640-d209bb00-2e70-11eb-8908-4d4144a25f8e.png)
