### PR TITLE
Add route for drafts

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -50,6 +50,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'page#draft',
+			'url' => '/box/{mailboxId}/thread/new/{draftId}',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'page#index',
 			'url' => '/',
 			'verb' => 'GET'

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -202,6 +202,16 @@ class PageController extends Controller {
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 *
+	 * @return TemplateResponse
+	 */
+	public function draft(int $mailboxId, int $draftId): TemplateResponse {
+		return $this->index();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
 	 * @param string $uri
 	 *
 	 * @return RedirectResponse


### PR DESCRIPTION
When hard reloading the page or manually visiting a draft, the user will be redirected to the default app.

This PR fixes it by adding a route to `routes.php`.

## Example:
* Visit `http://nextcloud.test/index.php/apps/mail/box/3/thread/new/566`
* Get redirected to `http://nextcloud.test/index.php/apps/dashboard`