### PR TITLE
Bring back more php7.2 compatibility for some Nextcloud 20 instances

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: [7.3, 7.4]
+        php-versions: [7.2, 7.3, 7.4]
     name: php${{ matrix.php-versions }} lint
     steps:
     - name: Checkout

--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -69,7 +69,7 @@ class HtmlResponse extends Response {
 			$content,
 			false,
 			$nonce,
-			$scriptUrl,
+			$scriptUrl
 		);
 	}
 

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -153,7 +153,7 @@ class MessagesControllerTest extends TestCase {
 			$this->l10n,
 			$this->mimeTypeDetector,
 			$this->urlGenerator,
-			$this->nonceManager,
+			$this->nonceManager
 		);
 
 		$this->account = $this->createMock(Account::class);


### PR DESCRIPTION
We dropped php7.2 for the 1.6 release because it's reached EOL as per https://www.php.net/supported-versions.php.

However, it turned out that Nextcloud server doesn't currently check for platform dependency compatibility and so Nextcloud 20 installations that run on php7.2 will update to 1.6 even though their php isn't up to date. This leads to errors like #4063. Since we updated some dependency libs for 7.3+ already, the downgrade to 7.2 isn't easily possible and would certainly be a step back.

So I'm proposing that we fix the php7.2 issues specifically. For this purpose I'm reactivating the lint job. I'll update the PR with any fixes that are necessary to make this pass.

https://github.com/nextcloud/server/pull/24416 is fixing server to do the dependency check and only install apps that are compatible with the current php version. But right now the deployed Nextclouds still pull Mail 1.6+ on ph7.2, so we have to be very careful with composer dependency updates.

Fixes #4063 