### PR TITLE
Fix initializing the editor mode

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -253,6 +253,8 @@ import NoDraftsMailboxConfiguredError
 
 const debouncedSearch = debouncePromise(findRecipient, 500)
 
+const NO_ALIAS_SET = -1
+
 Vue.use(Autosize)
 
 const STATES = Object.seal({
@@ -323,7 +325,7 @@ export default {
 	data() {
 		return {
 			showCC: this.cc.length > 0,
-			selectedAlias: -1, // Fixed in `beforeMount`
+			selectedAlias: NO_ALIAS_SET, // Fixed in `beforeMount`
 			autocompleteRecipients: this.to.concat(this.cc).concat(this.bcc),
 			newRecipients: [],
 			subjectVal: this.subject,
@@ -452,7 +454,7 @@ export default {
 			} else {
 				this.selectedAlias = this.aliases[0]
 			}
-			if (previous === undefined) {
+			if (previous === NO_ALIAS_SET) {
 				this.editorMode = this.selectedAlias.editorMode
 			}
 		},


### PR DESCRIPTION
In the `data` of the Composer component we initialize the editor mode
with 'html' and update the mode as soon as the alias has been set (this
is done async). The uninitialized value is `-1` and not `undefined`,
hence before the patch the editor more always switch to `html` even when
the account was set to `plaintext`.

To test set your account to plain text editing and then either start a new message or start a reply. On master the editor uses formatting, on this branch it doesn't.

Regression of https://github.com/nextcloud/mail/pull/3208.