### PR TITLE
Switch to vue2 package of the CKEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,10 +1969,10 @@
         "lodash-es": "^4.17.15"
       }
     },
-    "@ckeditor/ckeditor5-vue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue/-/ckeditor5-vue-1.0.3.tgz",
-      "integrity": "sha512-8pYcWkOSUTZ4KD6nT2JbD4rQycvhCaoOAJeOiaSrjWb3X/xRWoDEOOJzXC6VRk9AeNE1UYY9wKBAsq3VoR5V9w=="
+    "@ckeditor/ckeditor5-vue2": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue2/-/ckeditor5-vue2-1.0.5.tgz",
+      "integrity": "sha512-snsNB/2oWfKw0drGJAmMGpTatmt//L1rQsOwkBw+1uKUuOJPKN3xwyUZVWT906VguIMXm4E9OHzquZ3bdkijiA=="
     },
     "@ckeditor/ckeditor5-widget": {
       "version": "23.1.0",
@@ -5511,7 +5511,7 @@
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
       "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@ckeditor/ckeditor5-list": "~23.1.0",
     "@ckeditor/ckeditor5-paragraph": "~23.1.0",
     "@ckeditor/ckeditor5-theme-lark": "~23.1.0",
-    "@ckeditor/ckeditor5-vue": "^1.0.3",
+    "@ckeditor/ckeditor5-vue2": "^1.0.5",
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.5.0",
     "@nextcloud/dialogs": "^3.1.1",

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import CKEditor from '@ckeditor/ckeditor5-vue'
+import CKEditor from '@ckeditor/ckeditor5-vue2'
 import AlignmentPlugin from '@ckeditor/ckeditor5-alignment/src/alignment'
 import Editor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor'
 import EssentialsPlugin from '@ckeditor/ckeditor5-essentials/src/essentials'


### PR DESCRIPTION
The main package targets Vue 3, so let's use the Vue 2 version for now until we update the full app.