### PR TITLE
Prevent Vue from making the CKEditor instance reactive

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -87,7 +87,6 @@ export default {
 			text: '',
 			ready: false,
 			editor: Editor,
-			editorInstance: {},
 			config: {
 				placeholder: this.placeholder,
 				plugins,


### PR DESCRIPTION
Anything declared in `data()` is reactive. This makes sense most of the
time. For the editor intance, however, we don't really need (nor want)
Vue to overwrite all properties with reactive setters because we just
need the object to call a method on it later to insert a link at the
cursor position.

In recent versions of Firefox this somehow lead to the problem that
CKEditor (the non-vue part of it) called `pop` on an array that Vue
observed because of the reactivity through `data()`. And then when the
observer was invoked, the object didn't have a special Vue property. I
can't explain why that is or if that could be fixable in CKEditor, but
it's also not really supposed to work like that.

So this patch changes the editor instance to be assigned to `this`
without any former declaration in `data()`, hence Vue won't do its magic
and the CKEditor instance will remain untouched.

Ref https://github.com/vuejs/vue/issues/2637#issuecomment-207076744

Fixes https://github.com/nextcloud/mail/issues/4104

On a side note if feels like the CKEditor is also faster now. Could be my optimistic perception now that the bug is fixed, but could also be the fewer Vue observers that are attached to the editor.