### PR TITLE
Use consistent input vector size for the importance classifier

### DIFF
--- a/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
@@ -26,7 +26,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Classification\FeatureExtraction;
 
 use OCA\Mail\Account;
-use function array_filter;
 
 /**
  * Combines a set of DI'ed extractors so they can be used as one class
@@ -35,9 +34,6 @@ class CompositeExtractor {
 
 	/** @var IExtractor[] */
 	private $extractors;
-
-	/** @var IExtractor[] */
-	private $applicableExtractors;
 
 	public function __construct(ImportantMessagesExtractor $ex1,
 								ReadMessagesExtractor $ex2,
@@ -55,17 +51,14 @@ class CompositeExtractor {
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
 							array $messages): void {
-		$this->applicableExtractors = array_filter(
-			$this->extractors,
-			function (IExtractor $extractor) use ($account, $incomingMailboxes, $outgoingMailboxes, $messages) {
-				return $extractor->prepare($account, $incomingMailboxes, $outgoingMailboxes, $messages);
-			}
-		);
+		foreach ($this->extractors as $extractor) {
+			$extractor->prepare($account, $incomingMailboxes, $outgoingMailboxes, $messages);
+		}
 	}
 
 	public function extract(string $email): array {
 		return array_map(function (IExtractor $extractor) use ($email) {
 			return $extractor->extract($email);
-		}, $this->applicableExtractors);
+		}, $this->extractors);
 	}
 }

--- a/lib/Service/Classification/FeatureExtraction/IExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/IExtractor.php
@@ -39,13 +39,11 @@ interface IExtractor {
 	 * @param Mailbox[] $incomingMailboxes
 	 * @param Mailbox[] $outgoingMailboxes
 	 * @param Message[] $messages
-	 *
-	 * @return bool
 	 */
 	public function prepare(Account $account,
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
-							array $messages): bool;
+							array $messages): void;
 
 	/**
 	 * Return the feature value for the given sender address

--- a/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
@@ -49,7 +49,7 @@ class ImportantMessagesExtractor implements IExtractor {
 	public function prepare(Account $account,
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
-							array $messages): bool {
+							array $messages): void {
 		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
@@ -58,9 +58,6 @@ class ImportantMessagesExtractor implements IExtractor {
 		})));
 		$this->totalMessages = $this->statisticsDao->getNumberOfMessagesGrouped($incomingMailboxes, $senders);
 		$this->flaggedMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'important', $senders);
-
-		// This extractor is only applicable if there are incoming messages
-		return !empty($this->totalMessages);
 	}
 
 	public function extract(string $email): float {

--- a/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
@@ -49,7 +49,7 @@ class ReadMessagesExtractor implements IExtractor {
 	public function prepare(Account $account,
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
-							array $messages): bool {
+							array $messages): void {
 		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
@@ -59,8 +59,6 @@ class ReadMessagesExtractor implements IExtractor {
 
 		$this->totalMessages = $this->statisticsDao->getNumberOfMessagesGrouped($incomingMailboxes, $senders);
 		$this->readMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'seen', $senders);
-
-		return true;
 	}
 
 	public function extract(string $email): float {

--- a/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
@@ -49,7 +49,7 @@ class RepliedMessagesExtractor implements IExtractor {
 	public function prepare(Account $account,
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
-							array $messages): bool {
+							array $messages): void {
 		/** @var string[] $senders */
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
@@ -59,8 +59,6 @@ class RepliedMessagesExtractor implements IExtractor {
 
 		$this->totalMessages = $this->statisticsDao->getNumberOfMessagesGrouped($incomingMailboxes, $senders);
 		$this->repliedMessages = $this->statisticsDao->getNumberOfMessagesWithFlagGrouped($incomingMailboxes, 'answered', $senders);
-
-		return true;
 	}
 
 	public function extract(string $email): float {

--- a/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
@@ -49,7 +49,7 @@ class SentMessagesExtractor implements IExtractor {
 	public function prepare(Account $account,
 							array $incomingMailboxes,
 							array $outgoingMailboxes,
-							array $messages): bool {
+							array $messages): void {
 		$senders = array_unique(array_map(function (Message $message) {
 			return $message->getFrom()->first()->getEmail();
 		}, array_filter($messages, function (Message $message) {
@@ -58,9 +58,6 @@ class SentMessagesExtractor implements IExtractor {
 
 		$this->messagesSentTotal = $this->statisticsDao->getMessagesTotal(...$outgoingMailboxes);
 		$this->messagesSent = $this->statisticsDao->getMessagesSentToGrouped($outgoingMailboxes, $senders);
-
-		// This extractor is only applicable if there are sent messages
-		return $this->messagesSentTotal > 0;
 	}
 
 	public function extract(string $email): float {

--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -190,7 +190,7 @@ class ImportanceClassifier {
 		);
 		$validationSet = array_slice($dataSet, 0, $validationThreshold);
 		$trainingSet = array_slice($dataSet, $validationThreshold);
-		$logger->debug('data set split into ' . count($trainingSet) . ' training and ' . count($validationSet) . ' validation sets');
+		$logger->debug('data set split into ' . count($trainingSet) . ' training and ' . count($validationSet) . ' validation sets with ' . count($trainingSet[0]['features'] ?? []) . ' dimensions');
 		if (empty($validationSet) || empty($trainingSet)) {
 			$logger->info('not enough messages to train a classifier');
 			$perf->end();


### PR DESCRIPTION
When training the importance classifier we build a feature vector. We build the same vector when new messages are classified.

Before this patch, the size of the vector was dynamic. As in, two of the feature extractors conditionally were part of the vector or not. This works fine later when the trained model is deserialized and used for classification, but only as long as the vector size stays the same.

A more specific example is the ``\OCA\Mail\Service\Classification\FeatureExtraction\ImportantMessagesExtractor``. It was only active when the user account had important messages. If at least one message is marked as important then and the next sync is performed, where new messages come in, a classifier with one column too few is used.

Without the conditional feature extractor we just default to a sane value. This is `0` right now because the features are always percentages, e.g. *how many of my important messages are from this sender* and *how many of my sent emails are from this sender*. So the semantics of `0` seem appropriate.

### Original error

```json
{
  "reqId": "hGlfb1KNi5Cr3KJCxDd0",
  "level": 3,
  "time": "2020-12-03T12:19:26+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "mail",
  "method": "",
  "url": "--",
  "message": {
    "Exception": "InvalidArgumentException",
    "Message": "Dataset must contain samples with exactly 4 dimensions, 3 given.",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/html/apps/mail/vendor/rubix/ml/src/Classifiers/GaussianNB.php",
        "line": 298,
        "function": "check",
        "class": "Rubix\\ML\\Specifications\\DatasetHasDimensionality",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/Service/Classification/ImportanceClassifier.php",
        "line": 327,
        "function": "predict",
        "class": "Rubix\\ML\\Classifiers\\GaussianNB",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/Listener/NewMessageClassificationListener.php",
        "line": 74,
        "function": "classifyImportance",
        "class": "OCA\\Mail\\Service\\Classification\\ImportanceClassifier",
        "type": "->"
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 76,
        "function": "handle",
        "class": "OCA\\Mail\\Listener\\NewMessageClassificationListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 251,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 86,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/Service/Sync/ImapToDbSynchronizer.php",
        "line": 348,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/Service/Sync/ImapToDbSynchronizer.php",
        "line": 218,
        "function": "runPartialSync",
        "class": "OCA\\Mail\\Service\\Sync\\ImapToDbSynchronizer",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/Service/Sync/ImapToDbSynchronizer.php",
        "line": 128,
        "function": "sync",
        "class": "OCA\\Mail\\Service\\Sync\\ImapToDbSynchronizer",
        "type": "->"
      },
      {
        "file": "/var/www/html/apps/mail/lib/BackgroundJob/SyncJob.php",
        "line": 92,
        "function": "syncAccount",
        "class": "OCA\\Mail\\Service\\Sync\\ImapToDbSynchronizer",
        "type": "->"
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/Job.php",
        "line": 80,
        "function": "run",
        "class": "OCA\\Mail\\BackgroundJob\\SyncJob",
        "type": "->"
      },
      {
        "file": "/var/www/html/lib/public/BackgroundJob/TimedJob.php",
        "line": 61,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\Job",
        "type": "->"
      },
      {
        "file": "/var/www/html/cron.php",
        "line": 127,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\TimedJob",
        "type": "->"
      }
    ],
    "File": "/var/www/html/apps/mail/vendor/rubix/ml/src/Specifications/DatasetHasDimensionality.php",
    "Line": 60,
    "CustomMessage": "Could not classify incoming message importance: Dataset must contain samples with exactly 4 dimensions, 3 given."
  },
  "userAgent": "--",
  "version": "20.0.2.2",
  "id": "5fc8da44183ba"
}
```

### Testing

1) Set up a new account and access *only the inbox* via the web interface
2) Use `occ mail:account:train` on the CLI for that account

On master, you'll see

![Bildschirmfoto von 2020-12-04 18-38-29](https://user-images.githubusercontent.com/1374172/101195737-24608e00-3660-11eb-807d-30613d9688c3.png)

On this branch you will see

![Bildschirmfoto von 2020-12-04 18-38-20](https://user-images.githubusercontent.com/1374172/101195762-2d515f80-3660-11eb-8eda-b5e4b59f56d4.png)

-> 4 columns is correct. Because if you stay on master and then access the sent mailbox and another one after, the classification is likely to run into this case where the classifier was trained with 3 columns (no sent messages at that point) but is used with 4 (sent messages are known then)