### PR TITLE
forwarding a message from a threadEnvelope's forward menu action doesn't forward the correct message

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -346,7 +346,7 @@ export default {
 					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
 				},
 				query: {
-					messageId: this.$route.params.threadId,
+					messageId: this.envelope.databaseId,
 				},
 			})
 		},


### PR DESCRIPTION
https://github.com/nextcloud/mail/pull/4170 was incomplete: forwarding a message from a threadEnvelope's forward menu action has the same problem

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>