### PR TITLE
Change folder into mailbox

### DIFF
--- a/src/components/EmptyMailbox.vue
+++ b/src/components/EmptyMailbox.vue
@@ -1,7 +1,7 @@
 <template>
 	<div id="emptycontent">
 		<div class="icon-mail" />
-		<h2>{{ t('mail', 'No messages in this folder') }}</h2>
+		<h2>{{ t('mail', 'No messages in this mailbox') }}</h2>
 	</div>
 </template>
 

--- a/src/components/MailboxPicker.vue
+++ b/src/components/MailboxPicker.vue
@@ -2,7 +2,7 @@
 	<Modal @close="onClose">
 		<div ref="content" class="modal-content">
 			<h2 class="oc-dialog-title">
-				{{ t('mail', 'Choose target folder') }}
+				{{ t('mail', 'Choose target mailbox') }}
 			</h2>
 			<span class="crumbs">
 				<div class="level icon-breadcrumb">
@@ -31,7 +31,7 @@
 				</ul>
 				<div v-else class="empty">
 					<div class="empty-icon icon-folder" />
-					<h2>{{ t('mail', 'No more subfolders in here') }}</h2>
+					<h2>{{ t('mail', 'No more submailboxes in here') }}</h2>
 				</div>
 			</div>
 			<div class="buttons">

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -45,10 +45,10 @@
 				:checked="account.showSubscribedOnly"
 				:disabled="savingShowOnlySubscribed"
 				@update:checked="changeShowSubscribedOnly">
-				{{ t('mail', 'Show only subscribed folders') }}
+				{{ t('mail', 'Show only subscribed mailboxes') }}
 			</ActionCheckbox>
 			<ActionButton v-if="!editing" icon="icon-folder" @click="openCreateMailbox">
-				{{ t('mail', 'Add folder') }}
+				{{ t('mail', 'Add mailbox') }}
 			</ActionButton>
 			<ActionInput v-if="editing" icon="icon-folder" @submit.prevent.stop="createMailbox" />
 			<ActionText v-if="showSaving" icon="icon-loading-small">

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -44,16 +44,16 @@ export default {
 		},
 		title() {
 			if (this.account.collapsed && this.account.showSubscribedOnly) {
-				return t('mail', 'Show all subscribed folders')
+				return t('mail', 'Show all subscribed mailbox')
 			} else if (this.account.collapsed && !this.account.showSubscribedOnly) {
-				return t('mail', 'Show all folders')
+				return t('mail', 'Show all mailboxes')
 			}
-			return t('mail', 'Collapse folders')
+			return t('mail', 'Collapse mailboxes')
 		},
 	},
 	methods: {
 		async toggleCollapse() {
-			logger.debug('toggling collapsed folders for account ' + this.account.id)
+			logger.debug('toggling collapsed mailboxes for account ' + this.account.id)
 			try {
 				await this.$store.commit('toggleAccountCollapsed', this.account.id)
 				await this.$store

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -59,7 +59,7 @@
 					v-if="!editing && top && !account.isUnified && mailbox.specialRole !== 'flagged'"
 					icon="icon-folder"
 					@click="openCreateMailbox">
-					{{ t('mail', 'Add subfolder') }}
+					{{ t('mail', 'Add submailbox') }}
 				</ActionButton>
 				<ActionInput v-if="editing" icon="icon-folder" @submit.prevent.stop="createMailbox" />
 				<ActionButton
@@ -109,7 +109,7 @@
 				</ActionCheckbox>
 
 				<ActionButton v-if="!account.isUnified && !mailbox.specialRole && !hasSubMailboxes" icon="icon-delete" @click="deleteMailbox">
-					{{ t('mail', 'Delete folder') }}
+					{{ t('mail', 'Delete mailbox') }}
 				</ActionButton>
 			</template>
 		</template>
@@ -434,11 +434,11 @@ export default {
 			const id = this.mailbox.databaseId
 			logger.info('delete mailbox', { mailbox: this.mailbox })
 			OC.dialogs.confirmDestructive(
-				t('mail', 'The folder and all messages in it will be deleted.'),
-				t('mail', 'Delete folder'),
+				t('mail', 'The mailbox and all messages in it will be deleted.'),
+				t('mail', 'Delete mailbox'),
 				{
 					type: OC.dialogs.YES_NO_BUTTONS,
-					confirm: t('mail', 'Delete folder {name}', { name: this.mailbox.displayName }),
+					confirm: t('mail', 'Delete mailbox {name}', { name: this.mailbox.displayName }),
 					confirmClasses: 'error',
 					cancel: t('mail', 'Cancel'),
 				},


### PR DESCRIPTION
Some time ago we renamed _folder_ into _mailbox_.  Some actions are still called folder. This PR fixes that.