### PR TITLE
Makes links highlighted in the ckeditor

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -204,6 +204,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+::v-deep a {
+	color: var(--ck-color-link-default);
+}
 ::v-deep p {
 	cursor: text;
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8179031/102023686-8bcbbb80-3d8d-11eb-8993-7de4cac58ed3.png)

Without this change, the link (the first "cyrille") would be black as a regular text

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>