### PR TITLE
Only use one AppDetailsToggle button and properly hide it if the navigation is open

### DIFF
--- a/src/components/AppDetailsToggle.vue
+++ b/src/components/AppDetailsToggle.vue
@@ -47,15 +47,17 @@ export default {
 	line-height: 17px;
 	transform: rotate(180deg);
 	background-color: var(--color-main-background);
-	z-index: 2000;
-&:active,
-&:hover,
-&:focus {
-	 opacity: 1;
- }
-// Hide app-navigation toggle if shown
-	&::v-deep + .app-navigation .app-navigation-toggle {
-	   display: none;
-   }
+	z-index: 1100; // needs to be above the main content(1000) and below the navigation(1800)
+
+	&:active,
+	&:hover,
+	&:focus {
+		opacity: 1;
+	}
+
+	// Hide app navigation toggle in case we are on mobile and have the back arrow visible
+	&::v-deep + .app-navigation--close .app-navigation-toggle {
+		display: none;
+	}
 }
 </style>

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -1,6 +1,5 @@
 <template>
 	<AppContent>
-		<AppDetailsToggle v-if="showThread" @close="hideMessage" />
 		<div id="app-content-wrapper">
 			<AppContentList
 				v-infinite-scroll="onScroll"
@@ -75,7 +74,6 @@ import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import SectionTitle from './SectionTitle'
 import Vue from 'vue'
 
-import AppDetailsToggle from './AppDetailsToggle'
 import logger from '../logger'
 import Mailbox from './Mailbox'
 import NewMessageDetail from './NewMessageDetail'
@@ -91,7 +89,6 @@ export default {
 	components: {
 		AppContent,
 		AppContentList,
-		AppDetailsToggle,
 		Mailbox,
 		NewMessageDetail,
 		NoMessageSelected,
@@ -158,15 +155,6 @@ export default {
 		},
 	},
 	methods: {
-		hideMessage() {
-			this.$router.replace({
-				name: 'mailbox',
-				params: {
-					mailboxId: this.mailbox.databaseId,
-					filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-				},
-			})
-		},
 		deleteMessage(id) {
 			this.bus.$emit('delete', id)
 		},


### PR DESCRIPTION
Should fix #4209 

There was something strange going on with the two instances of the component. This simplifies the code to only use one instance and properly hide the button under the navigation. If the sidebar is closed and the AppDetailsToggle (back arrow) is visible we properly hide the navigation toggle now.