### PR TITLE
Fix defaults where mail stores drafts and sent

### DIFF
--- a/src/components/AccountDefaultsSettings.vue
+++ b/src/components/AccountDefaultsSettings.vue
@@ -20,39 +20,22 @@
   -->
 
 <template>
-	<div class="section">
-		<h2>{{ t('mail', 'Defaults') }}</h2>
-		<p class="settings-hint">
-			{{
-				t('mail', 'Here you can select where Nextcloud Mail stores your drafts as well as sent and deleted messages.')
-			}}
+	<div>
+		<p>
+			{{ t('mail', 'Drafts are saved in:') }}
 		</p>
-		<table>
-			<tr>
-				<td>
-					{{ t('mail', 'Draft messages are saved to:') }}
-				</td>
-				<td>
-					<MailboxInlinePicker v-model="draftsMailbox" :account="account" :disabled="saving" />
-				</td>
-			</tr>
-			<tr>
-				<td>
-					{{ t('mail', 'Sent messages are saved to:') }}
-				</td>
-				<td>
-					<MailboxInlinePicker v-model="sentMailbox" :account="account" :disabled="saving" />
-				</td>
-			</tr>
-			<tr>
-				<td>
-					{{ t('mail', 'Deleted messages are moved to:') }}
-				</td>
-				<td>
-					<MailboxInlinePicker v-model="trashMailbox" :account="account" :disabled="saving" />
-				</td>
-			</tr>
-		</table>
+		<MailboxInlinePicker v-model="draftsMailbox" :account="account" :disabled="saving" />
+
+		<p>
+			{{ t('mail', 'Sent messages are saved in:') }}
+		</p>
+
+		<MailboxInlinePicker v-model="sentMailbox" :account="account" :disabled="saving" />
+		<p>
+			{{ t('mail', 'Deleted messages are moved in:') }}
+		</p>
+
+		<MailboxInlinePicker v-model="trashMailbox" :account="account" :disabled="saving" />
 	</div>
 </template>
 

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -47,7 +47,14 @@
 			</p>
 			<EditorSettings :account="account" />
 		</AppSettingsSection>
-
+		<AppSettingsSection :title=" t('mail', 'Default folders')">
+			<p class="settings-hint">
+				{{
+					t('mail', 'The folders to use for drafts, sent messages and deleted messages.')
+				}}
+			</p>
+			<AccountDefaultsSettings :account="account" />
+		</AppSettingsSection>
 		<AppSettingsSection :title="t('mail', 'Mail server')">
 			<div v-if="!account.provisioned">
 				<div id="mail-settings">
@@ -67,6 +74,7 @@
 <script>
 import AccountForm from '../components/AccountForm'
 import EditorSettings from '../components/EditorSettings'
+import AccountDefaultsSettings from '../components/AccountDefaultsSettings'
 import Logger from '../logger'
 import SignatureSettings from '../components/SignatureSettings'
 import AliasSettings from '../components/AliasSettings'
@@ -81,6 +89,7 @@ export default {
 		SignatureSettings,
 		AppSettingsDialog,
 		AppSettingsSection,
+		AccountDefaultsSettings,
 	},
 	props: {
 		account: {

--- a/src/components/MailboxInlinePicker.vue
+++ b/src/components/MailboxInlinePicker.vue
@@ -71,7 +71,7 @@ export default {
 .vue-treeselect__control {
 	padding: 0;
 	border: 0;
-	width: 300px;
+	width: 250px;
 }
 .vue-treeselect__control-arrow-container {
 	display: none;
@@ -81,5 +81,6 @@ export default {
 }
 input.vue-treeselect__input {
 	margin: 0;
+	padding: 0;
 }
 </style>


### PR DESCRIPTION
We missed a setting on the way, while changing Account Settings into Modal.

![deafults](https://user-images.githubusercontent.com/12728974/102238727-627a6f00-3ef6-11eb-9ee9-ec5a339d901e.png)
