### PR TITLE
Add forward as attachment

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -366,9 +366,9 @@ class MessageMapper {
 	 * @return string|null
 	 * @throws ServiceException
 	 */
-	public function getSource(Horde_Imap_Client_Socket $client,
-							  string $mailbox,
-							  int $uid): ?string {
+	public function getFullText(Horde_Imap_Client_Socket $client,
+								string $mailbox,
+								int $uid): ?string {
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
 		$query->fullText([

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -601,7 +601,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 *
 	 * @return void
 	 */
-	public function addForwardedAttachment(string $name, string $content): void {
+	public function addRawAttachment(string $name, string $content): void {
 		throw new Exception('IMAP message is immutable');
 	}
 

--- a/lib/Model/IMessage.php
+++ b/lib/Model/IMessage.php
@@ -129,7 +129,7 @@ interface IMessage {
 	 * @param string $name
 	 * @param string $content
 	 */
-	public function addForwardedAttachment(string $name, string $content): void;
+	public function addRawAttachment(string $name, string $content): void;
 
 	/**
 	 * @param File $fileName

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -217,7 +217,7 @@ class Message implements IMessage {
 	 * Adds a file that's coming from another email's attachment (typical
 	 * use case is forwarding a message)
 	 */
-	public function addForwardedAttachment(string $name, string $content): void {
+	public function addRawAttachment(string $name, string $content): void {
 		$mime = 'application/octet-stream';
 		if (extension_loaded('fileinfo')) {
 			$finfo = new finfo(FILEINFO_MIME_TYPE);

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -218,7 +218,7 @@ class MailManager implements IMailManager {
 		$client = $this->imapClientFactory->getClient($account);
 
 		try {
-			return $this->imapMessageMapper->getSource(
+			return $this->imapMessageMapper->getFullText(
 				$client,
 				$mailbox,
 				$uid

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -67,6 +67,18 @@
 							}
 						) }}
 					</ActionButton>
+					<ActionButton
+						icon="icon-forward"
+						:close-after-click="true"
+						@click.prevent="forwardSelectedAsAttachment">
+						{{ t(
+							'mail',
+							'Forward {number} as attachment',
+							{
+								number: selection.length,
+							}
+						) }}
+					</ActionButton>
 					<ActionButton icon="icon-delete"
 						:close-after-click="true"
 						@click.prevent="deleteAllSelected">
@@ -314,6 +326,20 @@ export default {
 		},
 		onOpenMoveModal() {
 			this.showMoveModal = true
+		},
+		async forwardSelectedAsAttachment() {
+			const selected = this.selection
+			this.$router.push({
+				name: 'message',
+				params: {
+					mailboxId: this.$route.params.mailboxId,
+					threadId: 'new',
+				},
+				query: {
+					forwardedMessages: selected,
+				},
+			})
+			this.unselectAll()
 		},
 		onCloseMoveModal() {
 			this.showMoveModal = false


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3060

This adds a "Forward X as attachment" action to the multiselect.

Note that our client can't show embedded messages. We can send them, but you'll need another client to verify that the attached embedded message is correct.