### PR TITLE
Always show sender in avatar header, even on very small screens

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -93,6 +93,9 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.user-bubble__title {
+	max-width: 30vw;
+}
 .user-bubble-email {
 	margin: 10px;
 }

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -154,7 +154,13 @@ export default {
 
 			if (childrenWidth > maxWidth) {
 				// There's not enough space to show all thread participants
-				this.participantsToDisplay = fits - 1
+				if (fits > 1) {
+					this.participantsToDisplay = fits - 1
+				} else if (fits === 0) {
+					this.participantsToDisplay = 1
+				} else {
+					this.participantsToDisplay = fits
+				}
 			} else {
 				// There's enough space to show all thread participants
 				this.participantsToDisplay = this.threadParticipants.length


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8179031/102606100-88865600-4126-11eb-9ff7-2efcabb50b49.png)

On even smaller screens, the avatar-more (+5) component might get hidden though. But I think that's good enough for now 😃 

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>