### PR TITLE
Add bottom reply mode

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -138,6 +138,7 @@ class PageController extends Controller {
 				'app-version' => $this->config->getAppValue('mail', 'installed_version'),
 				'accounts' => base64_encode(json_encode($accountsJson)),
 				'external-avatars' => $this->preferences->getPreference('external-avatars', 'true'),
+				'reply-mode' => $this->preferences->getPreference('reply-mode', 'top'),
 				'collect-data' => $this->preferences->getPreference('collect-data', 'true'),
 				'account-settings' => base64_encode($accountSettings),
 			]);

--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -29,10 +29,11 @@ import { html } from './util/text'
  * @param {Text} original original
  * @param {object} from from
  * @param {Number} date date
+ * @param {boolean} replyOnTop put reply on top?
  * @returns {Text}
  */
-export const buildReplyBody = (original, from, date) => {
-	const start = '<p></p><p></p>'
+export const buildReplyBody = (original, from, date, replyOnTop = true) => {
+	const startEnd = '<p></p><p></p>'
 	const plainBody = '<br>&gt; ' + original.value.replace(/\n/g, '<br>&gt; ')
 	const htmlBody = `<blockquote>${original.value}</blockquote>`
 
@@ -40,16 +41,24 @@ export const buildReplyBody = (original, from, date) => {
 	case 'plain':
 		if (from) {
 			const dateString = moment.unix(date).format('LLL')
-			return html(`${start}"${from.label}" ${from.email} – ${dateString}` + plainBody)
+			return replyOnTop
+				? html(`${startEnd}"${from.label}" ${from.email} – ${dateString}` + plainBody)
+				: html(`"${from.label}" ${from.email} – ${dateString}` + plainBody + startEnd)
 		} else {
-			return html(`${start}${plainBody}`)
+			return replyOnTop
+				? html(`${startEnd}${plainBody}`)
+				: html(`${plainBody}${startEnd}`)
 		}
 	case 'html':
 		if (from) {
 			const dateString = moment.unix(date).format('LLL')
-			return html(`${start}"${from.label}" ${from.email} – ${dateString}<br>${htmlBody}`)
+			return replyOnTop
+				? html(`${startEnd}"${from.label}" ${from.email} – ${dateString}<br>${htmlBody}`)
+				: html(`"${from.label}" ${from.email} – ${dateString}<br>${htmlBody}${startEnd}`)
 		} else {
-			return html(`${start}${htmlBody}`)
+			return replyOnTop
+				? html(`${startEnd}${htmlBody}`)
+				: html(`${htmlBody}${startEnd}`)
 		}
 	}
 

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -6,7 +6,7 @@
 
 		<p v-if="loadingOptOutSettings" class="app-settings">
 			<span class="icon-loading-small" />
-			{{ text }}
+			{{ optOutSettingsText }}
 		</p>
 		<p v-else class="app-settings">
 			<input
@@ -15,7 +15,7 @@
 				type="checkbox"
 				:checked="useDataCollection"
 				@change="onToggleCollectData">
-			<label for="data-collection-toggle">{{ text }}</label>
+			<label for="data-collection-toggle">{{ optOutSettingsText }}</label>
 		</p>
 
 		<p v-if="loadingAvatarSettings" class="app-settings avatar-settings">
@@ -31,11 +31,27 @@
 				@change="onToggleExternalAvatars">
 			<label for="gravatar-enabled">{{ t('mail', 'Use Gravatar and favicon avatars') }}</label>
 		</p>
+
+		<p v-if="loadingAvatarSettings" class="app-settings reply-settings">
+			<span class="icon-loading-small" />
+			{{ replySettingsText }}
+		</p>
+		<p v-else class="app-settings">
+			<input
+				id="bottom-reply-enabled"
+				class="checkbox"
+				type="checkbox"
+				:checked="useBottomReplies"
+				@change="onToggleButtonReplies">
+			<label for="bottom-reply-enabled">{{ replySettingsText }}</label>
+		</p>
+
 		<p>
 			<button class="icon-mail app-settings-button" @click="registerProtocolHandler">
 				{{ t('mail', 'Register as application for mail links') }}
 			</button>
 		</p>
+
 		<button
 			class="icon-details app-settings-button"
 			@click.prevent.stop="showKeyboardShortcuts"
@@ -60,12 +76,18 @@ export default {
 		return {
 			loadingAvatarSettings: false,
 			// eslint-disable-next-line
-			text: t('mail', 'Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally.'),
+			optOutSettingsText: t('mail', 'Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally.'),
 			loadingOptOutSettings: false,
+			// eslint-disable-next-line
+			replySettingsText: t('mail', 'Put my text to the bottom of a reply instead of on top of it.'),
+			loadingReplySettings: false,
 			displayKeyboardShortcuts: false,
 		}
 	},
 	computed: {
+		useBottomReplies() {
+			return this.$store.getters.getPreference('reply-mode', 'top') === 'bottom'
+		},
 		useExternalAvatars() {
 			return this.$store.getters.getPreference('external-avatars', 'true') === 'true'
 		},
@@ -74,6 +96,19 @@ export default {
 		},
 	},
 	methods: {
+		onToggleButtonReplies(e) {
+			this.loadingReplySettings = true
+
+			this.$store
+				.dispatch('savePreference', {
+					key: 'reply-mode',
+					value: e.target.checked ? 'bottom' : 'top',
+				})
+				.catch((error) => Logger.error('could not save preferences', { error }))
+				.then(() => {
+					this.loadingReplySettings = false
+				})
+		},
 		onToggleExternalAvatars(e) {
 			this.loadingAvatarSettings = true
 

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -445,7 +445,9 @@ export default {
 		await this.onMailvelopeLoaded(await getMailvelope())
 	},
 	mounted() {
-		this.$refs.toLabel.$el.focus()
+		if (!this.isReply) {
+			this.$refs.toLabel.$el.focus()
+		}
 
 		// event is triggered when user clicks 'new message' in navigation
 		this.$root.$on('newMessage', () => {
@@ -530,7 +532,8 @@ export default {
 					buildReplyBody(
 						this.editorPlainText ? toPlain(this.body) : toHtml(this.body),
 						this.replyTo.from[0],
-						this.replyTo.dateInt
+						this.replyTo.dateInt,
+						this.$store.getters.getPreference('reply-mode', 'top') === 'top'
 					).value
 				).value
 			} else if (this.forwardFrom) {
@@ -539,7 +542,8 @@ export default {
 					buildReplyBody(
 						this.editorPlainText ? toPlain(this.body) : toHtml(this.body),
 						this.forwardFrom.from[0],
-						this.forwardFrom.dateInt
+						this.forwardFrom.dateInt,
+						this.$store.getters.getPreference('reply-mode', 'top') === 'top'
 					).value
 				).value
 			} else {

--- a/src/tests/unit/ReplyBuilder.spec.js
+++ b/src/tests/unit/ReplyBuilder.spec.js
@@ -20,24 +20,28 @@
  *
  */
 
-import { buildReplyBody, buildRecipients, buildReplySubject } from '../../ReplyBuilder'
-import { html, plain } from '../../util/text'
+import {
+	buildRecipients,
+	buildReplyBody,
+	buildReplySubject
+} from '../../ReplyBuilder'
+import {html, plain} from '../../util/text'
 
 describe('ReplyBuilder', () => {
 	it('creates a reply body without any sender', () => {
 		const body = plain('Newsletter\nhello\ncheers')
-		const expectedReply = html('<p></p><p></p><br>&gt; Newsletter<br>&gt; hello<br>&gt; cheers')
 
-		const replyBody = buildReplyBody(body)
+		const replyBodyTop = buildReplyBody(body)
+		const replyBodyBottom = buildReplyBody(body, undefined, undefined, false)
 
-		expect(replyBody).to.deep.equal(expectedReply)
+		expect(replyBodyTop).to.deep.equal(html('<p></p><p></p><br>&gt; Newsletter<br>&gt; hello<br>&gt; cheers'))
+		expect(replyBodyBottom).to.deep.equal(html('<br>&gt; Newsletter<br>&gt; hello<br>&gt; cheers<p></p><p></p>'))
 	})
 
 	it('creates a reply body', () => {
 		const body = plain('Newsletter\nhello')
-		const expectedReply = html('<p></p><p></p>"Test User" test@user.ru – November 5, 2018 ')
 
-		const replyBody = buildReplyBody(
+		const replyBodyTop = buildReplyBody(
 			body,
 			{
 				label: 'Test User',
@@ -45,8 +49,18 @@ describe('ReplyBuilder', () => {
 			},
 			1541426237
 		)
+		const replyBodyBottom = buildReplyBody(
+			body,
+			{
+				label: 'Test User',
+				email: 'test@user.ru',
+			},
+			1541426237,
+			false
+		)
 
-		expect(replyBody.value.startsWith(expectedReply.value)).to.be.true
+		expect(replyBodyTop.value.startsWith(html('<p></p><p></p>"Test User" test@user.ru – November 5, 2018 ').value)).to.be.true
+		expect(replyBodyBottom.value.endsWith(html('<p></p><p></p>').value)).to.be.true
 	})
 
 	let envelope

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -120,10 +120,11 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
-		$this->preferences->expects($this->exactly(3))
+		$this->preferences->expects($this->exactly(4))
 			->method('getPreference')
 			->willReturnMap([
 				['external-avatars', 'true', 'true'],
+				['reply-mode', 'top', 'bottom'],
 				['collect-data', 'true', 'true'],
 				['account-settings', json_encode([]), json_encode([])],
 			]);
@@ -229,6 +230,7 @@ class PageControllerTest extends TestCase {
 				'debug' => true,
 				'attachment-size-limit' => 123,
 				'external-avatars' => 'true',
+				'reply-mode' => 'bottom',
 				'app-version' => '1.2.3',
 				'accounts' => base64_encode(json_encode($accountsJson)),
 				'collect-data' => 'true',


### PR DESCRIPTION
Adds a simple switch to let the user add their reply text on the bottom
instead of on top of the quoted message.

Todo
* [x] New preference checkbox
* [x] Adjust reply text logic
* [x] Tests
* [ ] ~~Focus end of text if bottom reply~~ https://github.com/nextcloud/mail/issues/4563

Fixes https://github.com/nextcloud/mail/issues/3063