### PR TITLE
Sometimes the MoveModal window wouldn't show up

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1,7 +1,7 @@
 <template>
 	<router-link
 		v-draggable-envelope="{
-			accountId: data.accountId ? data.accountId : mailbox.accountId,
+			accountId: data.accountId ?? mailbox.accountId,
 			mailboxId: data.mailboxId,
 			envelopeId: data.databaseId,
 			draggableLabel: `${data.subject} (${data.from[0].label})`,


### PR DESCRIPTION
Sometimes the MoveModal window wouldn't show up and an error about account being undefined shows in the browser console.

This fixes this issue.

This is the same fix as what's done on line 4 of the file changed.

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>