### PR TITLE
Show unread messages bold on dashboard

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -2,6 +2,7 @@
   - @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
   -
   - @author Julius Härtl <jus@bitgrid.net>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -27,7 +28,10 @@
 		@hide="() => {}"
 		@markDone="() => {}">
 		<template v-slot:default="{ item }">
-			<DashboardWidgetItem :target-url="itemTargetUrl(item)" :main-text="itemMainText(item)" :sub-text="itemSubText(item)">
+			<DashboardWidgetItem :class="{unread: itemUnread(item)}"
+				:target-url="itemTargetUrl(item)"
+				:main-text="itemMainText(item)"
+				:sub-text="itemSubText(item)">
 				<template v-slot:avatar>
 					<Avatar v-if="item.from"
 						:email="item.from[0].email"
@@ -136,11 +140,14 @@ export default {
 		itemTargetUrl(item) {
 			return generateUrl(`/apps/mail/box/priority/thread/${item.databaseId}`)
 		},
+		itemUnread(item) {
+			return !item.flags.seen
+		},
 	},
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 #mail--empty-content {
 	text-align: center;
 	margin-top: 5vh;
@@ -148,5 +155,8 @@ export default {
 .no-account {
 	margin-top: 5vh;
 	margin-right: 5px;
+}
+.unread ::v-deep .item__details {
+	font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Resolves #4126 

Improve visual consistency by showing unread messages in bold in the dashboard widgets.

## Example with 1 read and 1 unread message:
![unread-messages-bold](https://user-images.githubusercontent.com/1479486/103465667-5ab42a80-4d3e-11eb-8728-b972302c87d5.png)
