### PR TITLE
Fix dark theme on small screen

### DIFF
--- a/css/mobile.scss
+++ b/css/mobile.scss
@@ -16,7 +16,7 @@
 	/* overlay message detail on top of message list */
 	#mail-message {
 		z-index: 100;
-		background: #fff;
+		background: var(--color-main-background);
 		width: 100%;
 		left: 0;
 		top: 0;


### PR DESCRIPTION
When resizing the screen while on dark theme, the dark color turns white in some screen sizes. This looks like fixes the problem. Please test it to see if i missed something.