### PR TITLE
Refactor flag strings for search into a class

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Db;
 
-use Horde_Imap_Client;
 use OCA\Mail\Account;
 use OCA\Mail\Address;
 use OCA\Mail\AddressList;
@@ -40,7 +39,6 @@ use OCP\IUser;
 use function array_combine;
 use function array_keys;
 use function array_map;
-use function in_array;
 use function ltrim;
 use function mb_substr;
 
@@ -543,26 +541,9 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->in('uid', $qb->createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY))
 			);
 		}
-
-		$flags = $query->getFlags();
-		$flagKeys = array_keys($flags);
-		foreach ([
-			Horde_Imap_Client::FLAG_ANSWERED,
-			Horde_Imap_Client::FLAG_DELETED,
-			Horde_Imap_Client::FLAG_DRAFT,
-			Horde_Imap_Client::FLAG_FLAGGED,
-			Horde_Imap_Client::FLAG_RECENT,
-			Horde_Imap_Client::FLAG_SEEN,
-			Horde_Imap_Client::FLAG_FORWARDED,
-			Horde_Imap_Client::FLAG_JUNK,
-			Horde_Imap_Client::FLAG_NOTJUNK,
-			'\\important',
-			Horde_Imap_Client::FLAG_MDNSENT,
-		] as $flag) {
-			if (in_array($flag, $flagKeys, true)) {
-				$key = ltrim($flag, '\\$');
-				$select->andWhere($qb->expr()->eq("flag_$key", $qb->createNamedParameter($flags[$flag], IQueryBuilder::PARAM_BOOL)));
-			}
+		foreach ($query->getFlags() as $flag) {
+			$key = ltrim($flag->getFlag(), '\\$');
+			$select->andWhere($qb->expr()->eq("flag_$key", $qb->createNamedParameter($flag->isSet(), IQueryBuilder::PARAM_BOOL)));
 		}
 
 		$select = $select
@@ -652,26 +633,9 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->in('uid', $qb->createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY))
 			);
 		}
-
-		$flags = $query->getFlags();
-		$flagKeys = array_keys($flags);
-		foreach ([
-			Horde_Imap_Client::FLAG_ANSWERED,
-			Horde_Imap_Client::FLAG_DELETED,
-			Horde_Imap_Client::FLAG_DRAFT,
-			Horde_Imap_Client::FLAG_FLAGGED,
-			Horde_Imap_Client::FLAG_RECENT,
-			Horde_Imap_Client::FLAG_SEEN,
-			Horde_Imap_Client::FLAG_FORWARDED,
-			Horde_Imap_Client::FLAG_JUNK,
-			Horde_Imap_Client::FLAG_NOTJUNK,
-			'\\important',
-			Horde_Imap_Client::FLAG_MDNSENT,
-		] as $flag) {
-			if (in_array($flag, $flagKeys, true)) {
-				$key = ltrim($flag, '\\$');
-				$select->andWhere($qb->expr()->eq("flag_$key", $qb->createNamedParameter($flags[$flag], IQueryBuilder::PARAM_BOOL)));
-			}
+		foreach ($query->getFlags() as $flag) {
+			$key = ltrim($flag->getFlag(), '\\$');
+			$select->andWhere($qb->expr()->eq("flag_$key", $qb->createNamedParameter($flag->isSet(), IQueryBuilder::PARAM_BOOL)));
 		}
 
 		$select = $select

--- a/lib/Service/Search/Flag.php
+++ b/lib/Service/Search/Flag.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Search;
+
+use Horde_Imap_Client;
+
+/**
+ * @psalm-immutable
+ */
+class Flag {
+	public const ANSWERED = Horde_Imap_Client::FLAG_ANSWERED;
+	public const SEEN = Horde_Imap_Client::FLAG_SEEN;
+	public const FLAGGED = Horde_Imap_Client::FLAG_FLAGGED;
+	public const IMPORTANT = '\\important';
+	public const DELETED = Horde_Imap_Client::FLAG_DELETED;
+
+	/** @var string */
+	private $flag;
+
+	/** @var bool */
+	private $isSet;
+
+	/**
+	 * @psalm-param Flag::* $flag
+	 */
+	private function __construct(string $flag, bool $isSet) {
+		$this->flag = $flag;
+		$this->isSet = $isSet;
+	}
+
+	/**
+	 * @psalm-param Flag::* $flag
+	 */
+	public static function is(string $flag): self {
+		return new self($flag, true);
+	}
+
+	/**
+	 * @psalm-param Flag::* $flag
+	 */
+	public static function not(string $flag): self {
+		return new self($flag, false);
+	}
+
+	public function invert(): self {
+		return new self($this->flag, !$this->isSet);
+	}
+
+	/**
+	 * @psalm-return Flag::*
+	 */
+	public function getFlag(): string {
+		return $this->flag;
+	}
+
+	public function isSet(): bool {
+		return $this->isSet;
+	}
+}

--- a/lib/Service/Search/MailSearch.php
+++ b/lib/Service/Search/MailSearch.php
@@ -114,11 +114,11 @@ class MailSearch implements IMailSearch {
 		}
 		// In flagged we don't want anything but flagged messages
 		if ($mailbox->isSpecialUse(Horde_Imap_Client::SPECIALUSE_FLAGGED)) {
-			$query->addFlag(Horde_Imap_Client::FLAG_FLAGGED);
+			$query->addFlag(Flag::is(Flag::FLAGGED));
 		}
 		// Don't show deleted messages except for trash folders
 		if (!$mailbox->isSpecialUse(Horde_Imap_Client::SPECIALUSE_TRASH)) {
-			$query->addFlag(Horde_Imap_Client::FLAG_DELETED, false);
+			$query->addFlag(Flag::not(Flag::DELETED));
 		}
 
 		return $this->previewEnhancer->process(

--- a/lib/Service/Search/SearchQuery.php
+++ b/lib/Service/Search/SearchQuery.php
@@ -30,7 +30,7 @@ class SearchQuery {
 	/** @var int|null */
 	private $cursor;
 
-	/** @var bool[] */
+	/** @var Flag[] */
 	private $flags = [];
 
 	/** @var string[] */
@@ -66,14 +66,14 @@ class SearchQuery {
 	}
 
 	/**
-	 * @return bool[]
+	 * @return Flag[]
 	 */
 	public function getFlags(): array {
 		return $this->flags;
 	}
 
-	public function addFlag(string $flag, bool $value = true): void {
-		$this->flags[$flag] = $value;
+	public function addFlag(Flag $flag): void {
+		$this->flags[] = $flag;
 	}
 
 	/**

--- a/tests/Unit/Service/Search/MailSearchTest.php
+++ b/tests/Unit/Service/Search/MailSearchTest.php
@@ -36,6 +36,7 @@ use OCA\Mail\Exception\MailboxNotCachedException;
 use OCA\Mail\IMAP\PreviewEnhancer;
 use OCA\Mail\IMAP\Search\Provider;
 use OCA\Mail\Service\Search\FilterStringParser;
+use OCA\Mail\Service\Search\Flag;
 use OCA\Mail\Service\Search\MailSearch;
 use OCA\Mail\Service\Search\SearchQuery;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -134,7 +135,7 @@ class MailSearchTest extends TestCase {
 		$mailbox->setSyncChangedToken('def');
 		$mailbox->setSyncVanishedToken('ghi');
 		$query = new SearchQuery();
-		$query->addFlag('seen');
+		$query->addFlag(Flag::is(Flag::SEEN));
 		$this->filterStringParser->expects($this->once())
 			->method('parse')
 			->with('my search')


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/3299#issuecomment-760737003 we'll need logic groups. Those are a bit of pain to do with raw strings, so I'm adding an abstract type that makes it easier to pass around complex logic combinations that we then convert to db queries.

As a matter of fact even the existing code got simplified by this. Yay.