### PR TITLE
Allow complex expressions in message search queries and enhance the PI

### DIFF
--- a/lib/Service/Search/FilterStringParser.php
+++ b/lib/Service/Search/FilterStringParser.php
@@ -68,6 +68,55 @@ class FilterStringParser {
 					$query->addFlag($type === 'is' ? $flag : $flag->invert());
 					return true;
 				}
+				if ($param === 'pi-important') {
+					// We assume this is about 'is' and not 'not'
+					// imp && ~read
+					$query->addFlagExpression(
+						FlagExpression::and(
+							Flag::is(Flag::IMPORTANT),
+							Flag::not(Flag::SEEN)
+						)
+					);
+
+					return true;
+				}
+				if ($param === 'pi-starred') {
+					// We assume this is about 'is' and not 'not'
+					// fav /\ (~imp \/ (imp /\ read))
+					$query->addFlagExpression(
+						FlagExpression::and(
+							Flag::is(Flag::FLAGGED),
+							FlagExpression::or(
+								Flag::not(Flag::IMPORTANT),
+								FlagExpression::or(
+									Flag::is(Flag::IMPORTANT),
+									Flag::is(Flag::SEEN)
+								)
+							)
+						)
+					);
+
+					return true;
+				}
+				if ($param === 'pi-other') {
+					// We assume this is about 'is' and not 'not'
+					// ~fav && (~imp || (imp && read))
+					$query->addFlagExpression(
+						FlagExpression::and(
+							Flag::not(Flag::FLAGGED),
+							FlagExpression::or(
+								Flag::not(Flag::IMPORTANT),
+								FlagExpression::and(
+									Flag::is(Flag::IMPORTANT),
+									Flag::is(Flag::SEEN)
+								)
+							)
+						)
+					);
+
+					return true;
+				}
+
 				break;
 			case 'from':
 				$query->addFrom($param);

--- a/lib/Service/Search/FlagExpression.php
+++ b/lib/Service/Search/FlagExpression.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Service\Search;
+
+class FlagExpression {
+
+	/**
+	 * @var string
+	 * @psalm-var "and"|"or"
+	 */
+	private $operator;
+
+	/**
+	 * @var array
+	 * @psalm-var (Flag|FlagExpression)[]
+	 */
+	private $operands;
+
+	/**
+	 * @psalm-param "and"|"or" $operator
+	 * @param array $operands
+	 */
+	private function __construct(string $operator, array $operands) {
+		$this->operator = $operator;
+		$this->operands = $operands;
+	}
+
+	/**
+	 * @param Flag|FlagExpression ...$operands
+	 *
+	 * @return static
+	 */
+	public static function and(...$operands): self {
+		return new self("and", $operands);
+	}
+
+	/**
+	 * @param Flag|FlagExpression ...$operands
+	 *
+	 * @return static
+	 */
+	public static function or(...$operands): self {
+		return new self("or", $operands);
+	}
+
+	public function getOperator(): string {
+		return $this->operator;
+	}
+
+	/**
+	 * @return array
+	 * @psalm-return (Flag|FlagExpression)[]
+	 */
+	public function getOperands(): array {
+		return $this->operands;
+	}
+}

--- a/lib/Service/Search/SearchQuery.php
+++ b/lib/Service/Search/SearchQuery.php
@@ -33,6 +33,9 @@ class SearchQuery {
 	/** @var Flag[] */
 	private $flags = [];
 
+	/** @var FlagExpression[] */
+	private $flagExpressions = [];
+
 	/** @var string[] */
 	private $to = [];
 
@@ -53,6 +56,7 @@ class SearchQuery {
 
 	/**
 	 * @return int|null
+	 * @psalm-mutation-free
 	 */
 	public function getCursor(): ?int {
 		return $this->cursor;
@@ -67,6 +71,7 @@ class SearchQuery {
 
 	/**
 	 * @return Flag[]
+	 * @psalm-mutation-free
 	 */
 	public function getFlags(): array {
 		return $this->flags;
@@ -74,6 +79,17 @@ class SearchQuery {
 
 	public function addFlag(Flag $flag): void {
 		$this->flags[] = $flag;
+	}
+
+	/**
+	 * @return FlagExpression[]
+	 */
+	public function getFlagExpressions(): array {
+		return $this->flagExpressions;
+	}
+
+	public function addFlagExpression(FlagExpression $expression) {
+		$this->flagExpressions[] = $expression;
 	}
 
 	/**

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -18,7 +18,7 @@
 					:bus="bus" />
 				<template v-else>
 					<div class="app-content-list-item">
-						<SectionTitle class="important" :name="t('mail', 'Important')" />
+						<SectionTitle class="important" :name="t('mail', 'Important and unread')" />
 						<Popover trigger="hover focus">
 							<button slot="trigger" :aria-label="t('mail', 'Important info')" class="button icon-info" />
 							<p class="important-info">
@@ -30,7 +30,7 @@
 						class="nameimportant"
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
-						:search-query="appendToSearch('is:important')"
+						:search-query="appendToSearch('is:pi-important')"
 						:paginate="'manual'"
 						:is-priority-inbox="true"
 						:initial-page-size="5"
@@ -41,7 +41,7 @@
 						class="namestarred"
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
-						:search-query="appendToSearch('is:starred not:important')"
+						:search-query="appendToSearch('is:pi-starred')"
 						:paginate="'manual'"
 						:is-priority-inbox="true"
 						:initial-page-size="5"
@@ -52,7 +52,7 @@
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
 						:open-first="false"
-						:search-query="appendToSearch('not:starred not:important')"
+						:search-query="appendToSearch('is:pi-other')"
 						:is-priority-inbox="true"
 						:bus="bus" />
 				</template>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3299

As subtle as the description in that ticket sounds, putting this logic into combinatory logic in order to run this on a db level isn't too trivial. But it's doable. So when we now receive special search queries for priority inbox (pi) filters, we translate them into three flag expressions that take care of the logic. On the db mapper level we furthermore translate the abstract expression to a db where clause expression.

In the future we could move the expression to the client-side again and have a real parser on the back-end to construct the expression from a string, but right now that wouldn't give us any advantages.

When testing please pay attention to where each of the messages appears. Ideally compare the data between this branch and master to see if anything is actually missing. I think it's not but those expressions are easy to get wrong …

All in all I think this is a huge step forward for the usefulness of the priority inbox.

cc @lock @feutl @violoncelloCH 