### PR TITLE
Unify action menu icons

### DIFF
--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -37,7 +37,7 @@
 					envelope.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
 				}}
 			</ActionButton>
-			<ActionButton icon="icon-starred"
+			<ActionButton :icon="iconFavorite"
 				:close-after-click="true"
 				@click.prevent="onToggleFlagged">
 				{{
@@ -232,6 +232,9 @@ export default {
 		},
 		threadingFileName() {
 			return `${this.envelope.databaseId}.json`
+		},
+		iconFavorite() {
+			return this.envelope.flags.flagged ? 'icon-favorite' : 'icon-starred'
 		},
 	},
 	methods: {

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -339,7 +339,6 @@ export default {
 		margin-top: -2px;
 		margin-left: 27px;
 		cursor: pointer;
-
 	}
 	.left:not(.seen) {
 		font-weight: bold;


### PR DESCRIPTION
@jancborchardt the version of icon-star-dark is lighter than other icons. I used the same as on talk. Should we keep it like this?
![favorite_star](https://user-images.githubusercontent.com/12728974/106176672-e5e6db80-6197-11eb-889c-16692f62b2aa.png)
![favoritegold](https://user-images.githubusercontent.com/12728974/106176677-e7180880-6197-11eb-9581-8b259d8d591b.png)
