### PR TITLE
Fix text alignment on settings

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -147,6 +147,7 @@ p.app-settings {
 
 	padding-left: 34px;
 	background-position: 10px center;
+	text-align: left;
 }
 .app-settings-button.button.primary.new-button {
 	color: var(--color-main-background);


### PR DESCRIPTION
Looks like on Mac in all browsers, the settings buttons that have a long description it is shown like this
![settingsalign](https://user-images.githubusercontent.com/12728974/105520785-6c547680-5cdb-11eb-90e8-913939edbbe3.png)

or in all operation systems the same problem it is shown when the translation is long, but not with the current decs.  

`adding text-align: left` fixes it
![textalignfix](https://user-images.githubusercontent.com/12728974/105520902-8b530880-5cdb-11eb-807e-c86708440aff.png)

