### PR TITLE
Ignore subfolders when guessing special role of mailbox

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -224,8 +224,7 @@ class FolderMapper {
 			'junk' => ['junk', 'spam', 'bulk mail'],
 		];
 
-		$lowercaseExplode = explode($folder->getDelimiter(), $folder->getMailbox(), 2);
-		$lowercaseId = strtolower(array_pop($lowercaseExplode));
+		$lowercaseId = strtolower($folder->getMailbox());
 		foreach ($specialFoldersDict as $specialRole => $specialNames) {
 			if (in_array($lowercaseId, $specialNames)) {
 				$folder->addSpecialUse($specialRole);

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -241,9 +241,6 @@ class FolderMapperTest extends TestCase {
 			->method('getSpecialUse')
 			->willReturn([]);
 		$folders[0]->expects($this->once())
-			->method('getDelimiter')
-			->willReturn('.');
-		$folders[0]->expects($this->once())
 			->method('getMailbox')
 			->willReturn('Sent');
 		$folders[0]->expects($this->once())


### PR DESCRIPTION
fixes #4404

The issue is caused by using only the last segment of the mailbox path to detect special use (e.g. inbox, sent, junk) and that creates false positive cases for nested folders with certain names.

This PR removes this which fixes it for me. But I'm not sure why this is being done. The code is very old (oldest occurrence from 2017 I found is here: https://github.com/nextcloud/mail/blob/55ff9146da707ef702521df23eb63764c4c9d21d/lib/Mailbox.php#L394). There might be cases where this approach is useful to some extend. Somewhere else in a comment it is mentioned that there are cases like "INBOX.Archive.2020". I don't know. If you look at the code you will see that it is also only working to the second level (`explode` is getting a "2" as the third argument) so someone might have written this for some special use-case.

**Note:** As noted in the issue, this code is not run on page load, but when adding a new account and then persisted to settings and read from an encoded string from the HTML on load. Mind this when testing.