### PR TITLE
fixes an issue where attachment sent would not be the one selected

### DIFF
--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -103,15 +103,6 @@ export default {
 		onAddLocalAttachment() {
 			this.$refs.localAttachments.click()
 		},
-		fileNameToAttachment(name, size, id) {
-			return {
-				fileName: name,
-				displayName: trimStart('/')(name),
-				id,
-				size,
-				type: id !== undefined ? 'local' : 'cloud',
-			}
-		},
 		emitNewAttachments(attachments) {
 			this.$emit('input', this.value.concat(attachments))
 		},
@@ -157,8 +148,15 @@ export default {
 
 				return uploadLocalAttachment(file, progress(file.name)).then(({ file, id }) => {
 					logger.info('uploaded')
-					return this.emitNewAttachments([this.fileNameToAttachment(file.name, file.size, id)])
+					return this.emitNewAttachments([{
+						fileName: file.name,
+						displayName: trimStart('/')(name),
+						id,
+						size: file.size,
+						type: 'local',
+					}])
 				})
+
 			}, e.target.files)
 
 			const done = Promise.all(promises)
@@ -183,7 +181,13 @@ export default {
 					return
 				}
 
-				this.emitNewAttachments(paths.map(this.fileNameToAttachment))
+				this.emitNewAttachments(paths.map(function(name) {
+					return {
+						fileName: name,
+						displayName: trimStart('/')(name),
+						type: 'cloud',
+					}
+				}))
 			} catch (error) {
 				logger.error('could not choose a file as attachment', { error })
 			}


### PR DESCRIPTION
Could you please test this fix to #4403 ?

For some reason, the attachment popover won't open anymore on my development setup but it doesn't make much sense (some caching issue maybe?...)

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>