### PR TITLE
Fix filter expression

### DIFF
--- a/lib/Service/Search/FilterStringParser.php
+++ b/lib/Service/Search/FilterStringParser.php
@@ -88,7 +88,7 @@ class FilterStringParser {
 							Flag::is(Flag::FLAGGED),
 							FlagExpression::or(
 								Flag::not(Flag::IMPORTANT),
-								FlagExpression::or(
+								FlagExpression::and(
 									Flag::is(Flag::IMPORTANT),
 									Flag::is(Flag::SEEN)
 								)


### PR DESCRIPTION
!a OR (a OR b) is always true ;)
Now it is also actually doing what the comments say it does.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>