### PR TITLE
Fix envelopes not vanishing

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -405,7 +405,13 @@ class ImapToDbSynchronizer {
 			}
 			$perf->step('persist new messages');
 
-			$mailbox->setSyncVanishedToken($client->getSyncToken($mailbox->getName()));
+			// If a list of UIDs was *provided* (as opposed to loaded from the DB,
+			// we can not assume that all changes were detected, hence this is kinda
+			// a silent sync and we don't update the vanish token until the next full
+			// mailbox sync
+			if ($knownUids === null) {
+				$mailbox->setSyncVanishedToken($client->getSyncToken($mailbox->getName()));
+			}
 		}
 		$this->mailboxMapper->update($mailbox);
 		$perf->end();


### PR DESCRIPTION
# Bug
When syncing vanished envelopes, our backend has to send a list of known uids to the imap server. By default all uids from the db cache are sent. However, our frontend is allowed to do a partial sync by overwriting this list with a custom list of known uids (all uids currently in the vuex store). 

**Problem:** The sync vanished token is always updated even if the mailbox is partially synced. Thus, vanished envelopes are not picked up anymore in syncs when they weren't present in the vuex store at the time of a prior sync.

# Solution
Do not update sync vanished token on partial syncs.