### PR TITLE
Download attachments without opening a new tab

### DIFF
--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -163,8 +163,7 @@ export default {
 				.then(() => (this.savingToCloud = false))
 		},
 		download() {
-			window.open(this.url)
-			window.focus()
+			window.location = this.url
 		},
 		loadCalendars() {
 			this.loadingCalendars = true


### PR DESCRIPTION
Fixes #283 

Requires that an attachment has the header `Content-Disposition: attachment; filename="foo.bar";`, which we provide in attachment responses. Browsers will download the file instead of navigating in this case.

Inspired by https://stackoverflow.com/a/12365583.