### PR TITLE
Fix envelope list selection

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -4,8 +4,8 @@
 			<div v-if="selectMode" key="multiselect-header" class="multiselect-header">
 				<div class="button primary" @click.prevent="markSelectedSeenOrUnseen">
 					<span id="action-label">{{
-						areAllSelectedRead (
-							n(
+						areAllSelectedRead
+							? n(
 								'mail',
 								'Mark {number} unread',
 								'Mark {number} unread',
@@ -13,8 +13,8 @@
 								{
 									number: selection.length,
 								}
-							),
-							n(
+							)
+							: n(
 								'mail',
 								'Mark {number} read',
 								'Mark {number} read',
@@ -23,7 +23,6 @@
 									number: selection.length,
 								}
 							)
-						)
 					}}</span>
 				</div>
 				<Actions class="app-content-list-item-menu" menu-align="right">
@@ -32,24 +31,23 @@
 						@click.prevent="favoriteOrUnfavoriteAll">
 						{{
 							areAllSelectedFavorite
-								( n(
-										'mail',
-										'Unfavorite {number}',
-										'Unfavorite {number}',
-										selection.length,
-										{
-											number: selection.length,
-										}
-									),
-									n(
-										'mail',
-										'Favorite {number}',
-										'Favorite {number}',
-										selection.length,
-										{
-											number: selection.length,
-										}
-									)
+								? n(
+									'mail',
+									'Unfavorite {number}',
+									'Unfavorite {number}',
+									selection.length,
+									{
+										number: selection.length,
+									}
+								)
+								: n(
+									'mail',
+									'Favorite {number}',
+									'Favorite {number}',
+									selection.length,
+									{
+										number: selection.length,
+									}
 								)
 						}}
 					</ActionButton>


### PR DESCRIPTION
Fixes not being able to select envelopes from the list. This is a regression introduced by #4345.

Both `areAllSelectedRead` and `areAllSelectedFavorite` are computed properties so they can't be called.

Error message:
```
[Vue warn]: Error in render: "TypeError: _vm.areAllSelectedRead is not a function"

found in

---> <EnvelopeList> at src/components/EnvelopeList.vue
       <Mailbox> at src/components/Mailbox.vue
         <AppContentList>
           <AppContent>
             <MailboxThread> at src/components/MailboxThread.vue
               <Content>
                 <Home> at src/views/Home.vue
                   <App> at src/App.vue
                     <Root>
```