### PR TITLE
Add app navigation to account settings

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -24,7 +24,8 @@
 
 <template>
 	<AppSettingsDialog
-		:open.sync="showSettings">
+		:open.sync="showSettings"
+		:show-navigation="true">
 		<AppSettingsSection
 			:title="t('mail', 'Account settings')">
 			<strong>{{ displayName }}</strong> &lt;{{ email }}&gt;


### PR DESCRIPTION
SInce now we have more than 3 sections, we need the navigation to make it easier to navigate.
the width is fixed on nc/vue
Before
![beforee](https://user-images.githubusercontent.com/12728974/108745710-b5e2ec00-753b-11eb-8620-5fc368a194ec.png)
After

![afteree](https://user-images.githubusercontent.com/12728974/108745717-b7141900-753b-11eb-9053-b3b6c691a140.png)

