### PR TITLE
Rework fetchThread Query

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.17.1@8f211792d813e4dc89f04ed372785ce93b902fd1">
+<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
   <file src="lib/Attachment.php">
     <MissingDocblockType occurrences="1">
       <code>$fetch</code>
@@ -30,49 +30,9 @@
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/MessageMapper.php">
-    <ImplicitToStringCast occurrences="44">
+    <ImplicitToStringCast occurrences="23">
       <code>$messagesQuery-&gt;createFunction($mailboxesQuery-&gt;getSQL())</code>
       <code>$qb-&gt;createFunction($mailboxIdsQuery-&gt;getSQL())</code>
-      <code>$qb-&gt;createFunction($selectMailboxIds-&gt;getSQL())</code>
-      <code>$qb-&gt;createFunction($threadRootIdsQuery-&gt;getSQL())</code>
-      <code>$qb-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getBcc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getBcc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getCc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getCc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getFrom(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getFrom(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getTo(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($query-&gt;getTo(), IQueryBuilder::PARAM_STR_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb1-&gt;createParameter('flag_answered')</code>
-      <code>$qb1-&gt;createParameter('flag_deleted')</code>
-      <code>$qb1-&gt;createParameter('flag_draft')</code>
-      <code>$qb1-&gt;createParameter('flag_flagged')</code>
-      <code>$qb1-&gt;createParameter('flag_forwarded')</code>
-      <code>$qb1-&gt;createParameter('flag_important')</code>
-      <code>$qb1-&gt;createParameter('flag_junk')</code>
-      <code>$qb1-&gt;createParameter('flag_notjunk')</code>
-      <code>$qb1-&gt;createParameter('flag_seen')</code>
-      <code>$qb1-&gt;createParameter('in_reply_to')</code>
-      <code>$qb1-&gt;createParameter('mailbox_id')</code>
-      <code>$qb1-&gt;createParameter('message_id')</code>
-      <code>$qb1-&gt;createParameter('references')</code>
-      <code>$qb1-&gt;createParameter('sent_at')</code>
-      <code>$qb1-&gt;createParameter('subject')</code>
-      <code>$qb1-&gt;createParameter('thread_root_id')</code>
-      <code>$qb1-&gt;createParameter('uid')</code>
-      <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb2-&gt;createNamedParameter(array_keys($indexedMessages), IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb2-&gt;createParameter('email')</code>
-      <code>$qb2-&gt;createParameter('label')</code>
-      <code>$qb2-&gt;createParameter('message_id')</code>
-      <code>$qb2-&gt;createParameter('type')</code>
-      <code>$qb4-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$query-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$query-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
     </ImplicitToStringCast>
@@ -88,16 +48,6 @@
       <code>$qb-&gt;createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)</code>
     </ImplicitToStringCast>
   </file>
-  <file src="lib/Listener/AccountSynchronizedThreadUpdaterListener.php">
-    <MismatchingDocblockReturnType occurrences="1">
-      <code>DatabaseMessage[]|Generator</code>
-    </MismatchingDocblockReturnType>
-  </file>
-  <file src="lib/Model/IMAPMessage.php">
-    <LessSpecificImplementedReturnType occurrences="1">
-      <code>array</code>
-    </LessSpecificImplementedReturnType>
-  </file>
   <file src="lib/Service/Classification/ImportanceClassifier.php">
     <InvalidScalarArgument occurrences="1">
       <code>$predictedValidationLabel</code>
@@ -109,10 +59,5 @@
       <code>null</code>
       <code>null</code>
     </NullArgument>
-  </file>
-  <file src="vendor/cerdic/css-tidy/class.csstidy.php">
-    <InvalidDocblock occurrences="1">
-      <code>public function parse_string_list($value) {</code>
-    </InvalidDocblock>
   </file>
 </files>


### PR DESCRIPTION
Rework query to use a left join.

Still needs an index on `thread_root_id` but even without it, improves performance by about 50%.

see #4466