### PR TITLE
Always set a account name for provisioned accounts

### DIFF
--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -119,10 +119,7 @@ class Manager {
 
 	private function updateAccount(IUser $user, MailAccount $account, Config $config): MailAccount {
 		$account->setEmail($config->buildEmail($user));
-		if ($user->getDisplayName() !== $user->getUID()) {
-			// Only set if it's something meaningful
-			$account->setName($user->getDisplayName());
-		}
+		$account->setName($user->getDisplayName());
 		$account->setInboundUser($config->buildImapUser($user));
 		$account->setInboundHost($config->getImapHost());
 		$account->setInboundPort($config->getImapPort());


### PR DESCRIPTION
If displayname = bob and uid = bob we never set a name for the account. I don't know if that happens in the wild :see_no_evil: 