### PR TITLE
Check if user exists before creating account

### DIFF
--- a/lib/Command/CreateAccount.php
+++ b/lib/Command/CreateAccount.php
@@ -25,6 +25,7 @@ namespace OCA\Mail\Command;
 
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Service\AccountService;
+use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -52,11 +53,17 @@ class CreateAccount extends Command {
 	/** @var \OCP\Security\ICrypto */
 	private $crypto;
 
-	public function __construct(AccountService $service, ICrypto $crypto) {
+	/** @var IUserManager */
+	private $userManager;
+
+	public function __construct(AccountService $service,
+								ICrypto $crypto,
+								IUserManager $userManager) {
 		parent::__construct();
 
 		$this->accountService = $service;
 		$this->crypto = $crypto;
+		$this->userManager = $userManager;
 	}
 
 	/**
@@ -98,6 +105,11 @@ class CreateAccount extends Command {
 		$smtpSslMode = $input->getArgument(self::ARGUMENT_SMTP_SSL_MODE);
 		$smtpUser = $input->getArgument(self::ARGUMENT_SMTP_USER);
 		$smtpPassword = $input->getArgument(self::ARGUMENT_SMTP_PASSWORD);
+
+		if (!$this->userManager->userExists($userId)) {
+			$output->writeln("<error>User $userId does not exist</error>");
+			return 1;
+		}
 
 		$account = new MailAccount();
 		$account->setUserId($userId);


### PR DESCRIPTION
Fixes #4595

Report an error and quit if the given user id is invalid.