### PR TITLE
Do now allow messages to be their own parents in threading

### DIFF
--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -114,7 +114,7 @@ class ThreadBuilder {
 			// Step 1.C
 			//$parentId = $message->getReferences()[count($message->getReferences()) - 1] ?? null;
 			//$container->setParent($idTable[$parentId] ?? null);
-			if ($parent === null || !$parent->hasAncestor($container)) {
+			if (($parent === null || !$parent->hasAncestor($container)) && $container !== $parent) {
 				$container->setParent($parent);
 			}
 		}

--- a/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
+++ b/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
@@ -256,6 +256,33 @@ class ThreadBuilderTest extends TestCase {
 		);
 	}
 
+	public function testBuildTwoWithLoop(): void {
+		// 1 (but also points to itself)
+		// |
+		// 2
+		$messages = [
+			new Message('s1', 'id1', ['id1']),
+			new Message('s2', 'id2', ['id1']),
+		];
+
+		$result = $this->builder->build($messages, $this->logger);
+
+		$this->assertEquals(
+			[
+				[
+					'id' => 'id1',
+					'children' => [
+						[
+							'id' => 'id2',
+							'children' => [],
+						],
+					],
+				],
+			],
+			$this->abstract($result)
+		);
+	}
+
 	public function testBuildTree(): void {
 		//        1
 		//      /   \


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3869

### How to test
* Store the json from https://github.com/nextcloud/mail/issues/3869#issuecomment-788171500 into a file
* Run `occ mail:thread path/to/file.json`

On master: :boom: 
Here: smooth sailing :boat: 