### PR TITLE
Fix thread view not being reactive

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -221,6 +221,16 @@ export default {
 					list.splice(idx, 1)
 				}
 			})
+
+		// Delete references from other threads
+		for (const [key, env] of Object.entries(state.envelopes)) {
+			if (!env.thread) {
+				continue
+			}
+
+			const thread = env.thread.filter(threadId => threadId !== id)
+			Vue.set(state.envelopes[key], 'thread', thread)
+		}
 	},
 	addMessage(state, { message }) {
 		Vue.set(state.messages, message.databaseId, message)

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -824,6 +824,12 @@ describe('Vuex store mutations', () => {
 					id: 123,
 					uid: 12345,
 				},
+				12346: {
+					mailboxId: 27,
+					id: 123,
+					uid: 12345,
+					thread: [12345, 12346],
+				},
 			},
 			mailboxes: {
 				27: {
@@ -869,6 +875,12 @@ describe('Vuex store mutations', () => {
 					mailboxId: 27,
 					id: 123,
 					uid: 12345,
+				},
+				12346: {
+					mailboxId: 27,
+					id: 123,
+					uid: 12345,
+					thread: [12346],
 				},
 			},
 			mailboxes: {


### PR DESCRIPTION
Fixes #4657 

Thread view is now reactive and will update when one of its envelopes is deleted.