### PR TITLE
Delete envelopes from vuex state

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -231,6 +231,8 @@ export default {
 			const thread = env.thread.filter(threadId => threadId !== id)
 			Vue.set(state.envelopes[key], 'thread', thread)
 		}
+
+		Vue.delete(state.envelopes, id)
 	},
 	addMessage(state, { message }) {
 		Vue.set(state.messages, message.databaseId, message)

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -871,11 +871,6 @@ describe('Vuex store mutations', () => {
 				},
 			},
 			envelopes: {
-				12345: {
-					mailboxId: 27,
-					id: 123,
-					uid: 12345,
-				},
 				12346: {
 					mailboxId: 27,
 					id: 123,


### PR DESCRIPTION
Discovered this while developing #4666. 

When deleting an envelope it is removed from mailboxes and threads but not the vuex state itself. If there is a reason for it to stay there after being deleted, feel free to close the PR. 