### PR TITLE
Show recipient avatars only in thread header

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -22,6 +22,7 @@
 <template>
 	<UserBubble :display-name="label"
 		:avatar-image="avatarUrlAbsolute"
+		:avatar-only="true"
 		@click="onClick">
 		<span class="user-bubble-email">{{ email }}</span>
 	</UserBubble>


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/pull/4315#issuecomment-786748992

Requires https://github.com/nextcloud/nextcloud-vue/pull/1745

A more compact thread participant header.

![compact-thread-header](https://user-images.githubusercontent.com/1479486/110338907-da54c300-8027-11eb-9b22-6ad21ff29609.png)
