### PR TITLE
Truncate email addresses that are more than 244 characters long

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -341,7 +341,7 @@ class MessageMapper extends QBMapper {
 						$qb2->setParameter('message_id', $messageId, IQueryBuilder::PARAM_INT);
 						$qb2->setParameter('type', $type, IQueryBuilder::PARAM_INT);
 						$qb2->setParameter('label', mb_strcut($recipient->getLabel(), 0, 255), IQueryBuilder::PARAM_STR);
-						$qb2->setParameter('email', $recipient->getEmail(), IQueryBuilder::PARAM_STR);
+						$qb2->setParameter('email', mb_strcut($recipient->getEmail(), 0, 255), IQueryBuilder::PARAM_STR);
 
 						$qb2->executeStatement();
 					}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3608

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>