### PR TITLE
Add ckeditor plugin for signature element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ckeditor/ckeditor5-basic-styles": "~26.0.0",
         "@ckeditor/ckeditor5-block-quote": "~26.0.0",
         "@ckeditor/ckeditor5-build-balloon": "~26.0.0",
+        "@ckeditor/ckeditor5-core": "^26.0.0",
         "@ckeditor/ckeditor5-dev-utils": "24.4.1",
         "@ckeditor/ckeditor5-dev-webpack-plugin": "^24.4.1",
         "@ckeditor/ckeditor5-editor-balloon": "~26.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@ckeditor/ckeditor5-basic-styles": "~26.0.0",
     "@ckeditor/ckeditor5-block-quote": "~26.0.0",
     "@ckeditor/ckeditor5-build-balloon": "~26.0.0",
+    "@ckeditor/ckeditor5-core": "^26.0.0",
     "@ckeditor/ckeditor5-dev-utils": "24.4.1",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^24.4.1",
     "@ckeditor/ckeditor5-editor-balloon": "~26.0.0",

--- a/src/ckeditor/signature/InsertSignatureCommand.js
+++ b/src/ckeditor/signature/InsertSignatureCommand.js
@@ -1,0 +1,82 @@
+/**
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+import Command from '@ckeditor/ckeditor5-core/src/command'
+
+export default class InsertSignatureCommand extends Command {
+
+	removeSignatureElement(editor, writer) {
+		// Create a range spanning over the entire root content:
+		const range = editor.model.createRangeIn(
+			editor.model.document.getRoot()
+		)
+
+		// Iterate over all items in this range:
+		for (const value of range.getWalker({ shallow: true })) {
+			if (value.item.is('element') && value.item.name === 'signature') {
+				writer.remove(value.item)
+			}
+		}
+	}
+
+	insertSignatureElement(editor, writer, value) {
+		// Skip empty signature
+		if (value.length === 0) {
+			return
+		}
+
+		// Convert an HTML string to a view document fragment:
+		const viewFragment = editor.data.processor.toView(value)
+
+		// Convert the view document fragment to a model document fragment
+		// in the context of $root. This conversion takes the schema into
+		// account so if, for example, the view document fragment contained a bare text node,
+		// this text node cannot be a child of $root, so it will be automatically
+		// wrapped with a <paragraph>. You can define the context yourself (in the second parameter),
+		// and e.g. convert the content like it would happen in a <paragraph>.
+		// Note: The clipboard feature uses a custom context called $clipboardHolder
+		// which has a loosened schema.
+		const modelFragment = editor.data.toModel(viewFragment)
+
+		const signature = writer.createElement('signature')
+		writer.append(writer.createText('--'), signature)
+		writer.append(writer.createElement('paragraph'), signature)
+		writer.append(modelFragment, signature)
+
+		editor.model.insertContent(
+			signature,
+			writer.createPositionAt(editor.model.document.getRoot(), 'end')
+		)
+	}
+
+	/**
+	 * @param {string} value signature to append
+	 */
+	execute({ value }) {
+		this.editor.model.change(writer => {
+			this.removeSignatureElement(this.editor, writer)
+			this.insertSignatureElement(this.editor, writer, value)
+		})
+	}
+
+	refresh() {
+		this.isEnabled = true
+	}
+
+}

--- a/src/ckeditor/signature/SignaturePlugin.js
+++ b/src/ckeditor/signature/SignaturePlugin.js
@@ -1,0 +1,57 @@
+/**
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin'
+import InsertSignatureCommand from './InsertSignatureCommand'
+
+export default class Signature extends Plugin {
+
+	init() {
+		this._defineSchema()
+		this._defineConverters()
+
+		this.editor.commands.add(
+			'insertSignature',
+			new InsertSignatureCommand(this.editor)
+		)
+	}
+
+	_defineSchema() {
+		const schema = this.editor.model.schema
+
+		schema.register('signature', {
+			allowIn: '$root',
+			isLimit: true,
+			allowContentOf: '$block',
+		})
+	}
+
+	_defineConverters() {
+		const conversion = this.editor.conversion
+
+		conversion.elementToElement({
+			model: 'signature',
+			view: {
+				name: 'div',
+				classes: 'signature',
+			},
+		})
+	}
+
+}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -41,6 +41,7 @@ import ItalicPlugin from '@ckeditor/ckeditor5-basic-styles/src/italic'
 import LinkPlugin from '@ckeditor/ckeditor5-link/src/link'
 import ListStyle from '@ckeditor/ckeditor5-list/src/liststyle'
 import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph'
+import SignaturePlugin from '../ckeditor/signature/SignaturePlugin'
 
 import { getLanguage } from '@nextcloud/l10n'
 import DOMPurify from 'dompurify'
@@ -75,7 +76,7 @@ export default {
 		},
 	},
 	data() {
-		const plugins = [EssentialsPlugin, ParagraphPlugin]
+		const plugins = [EssentialsPlugin, ParagraphPlugin, SignaturePlugin]
 		const toolbar = ['undo', 'redo']
 
 		if (this.html) {
@@ -189,6 +190,7 @@ export default {
 			logger.debug(`setting TextEditor contents to <${this.text}>`)
 
 			this.bus.$on('appendToBodyAtCursor', this.appendToBodyAtCursor)
+			this.bus.$on('insertSignature', this.onInsertSignature)
 		},
 		onInput() {
 			logger.debug(`TextEditor input changed to <${this.text}>`)
@@ -199,6 +201,9 @@ export default {
 			const viewFragment = this.editorInstance.data.processor.toView(toAppend)
 			const modelFragment = this.editorInstance.data.toModel(viewFragment)
 			this.editorInstance.model.insertContent(modelFragment)
+		},
+		onInsertSignature(signature) {
+			this.editorInstance.execute('insertSignature', { value: signature })
 		},
 	},
 }


### PR DESCRIPTION
**Questions**

- [x] Append `--` as divider by default (user has no choice, rainloop or roundcube does not enforce a divider)
- [x] To much events / event structure
- [x] Where to store the ckeditor plugin
- [x] On account switch a new draft is created (we may delete it, might be complicate)
- [x] We do not update the route on account switch (internal state and active state for menu, we may remove the possibility to switch account in compose view for now)
- [x] SetAlias only set's the editor mode if the previous alias is -1 (out of scope for this issue)

**Todo**

- [x] alias is undefined on first account switch
- [x] something weird is happening the first time an account is switched (v-model = `:value` + `@input`, turn's out that `@select` is executed before the value is updated. now the value is updated by the event listener).
- [x] remove ckeditor inspector
- [x] don't append empty signature (null)
- [x] quoting of text in reply does not work anymore because ready event triggers before two way binding.

Fixes https://github.com/nextcloud/mail/issues/1660