### PR TITLE
Generate an IMAP message ID when it's missing

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -38,6 +38,7 @@
 	</dependencies>
 	<repair-steps>
 		<post-migration>
+			<step>OCA\Mail\Migration\AddMissingMessageIds</step>
 			<step>OCA\Mail\Migration\FixCollectedAddresses</step>
 			<step>OCA\Mail\Migration\FixBackgroundJobs</step>
 			<step>OCA\Mail\Migration\MakeItineraryExtractorExecutable</step>

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -926,4 +926,19 @@ class MessageMapper extends QBMapper {
 		}
 		return (int) $rows[0]['id'];
 	}
+
+	/**
+	 * @return Message[]
+	 */
+	public function findWithEmptyMessageId(): array {
+		$qb = $this->db->getQueryBuilder();
+
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->isNull('message_id')
+			);
+
+		return $this->findEntities($select);
+	}
 }

--- a/lib/Migration/AddMissingMessageIds.php
+++ b/lib/Migration/AddMissingMessageIds.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Migration;
+
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Model\IMAPMessage;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+use function sprintf;
+
+class AddMissingMessageIds implements IRepairStep {
+
+	/** @var MessageMapper */
+	private $mapper;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(MessageMapper $mapper,
+								LoggerInterface $logger) {
+		$this->mapper = $mapper;
+		$this->logger = $logger;
+	}
+
+	public function getName() {
+		return 'Add a generated message-id to all Mail messages that have none';
+	}
+
+	public function run(IOutput $output) {
+		$output->info('Looking up messages without a message-id');
+		$toFix = $this->mapper->findWithEmptyMessageId();
+		$output->info(sprintf('%d messages need an update', count($toFix)));
+		$output->startProgress(count($toFix));
+		foreach ($toFix as $message) {
+			$id = IMAPMessage::generateMessageId();
+			$message->setMessageId($id);
+
+			// The thread root is is null if the message wasn't matched to a thread
+			// based on its subject. In that case we set default for the thread root
+			// as well.
+			if ($message->getThreadRootId() === null) {
+				$message->setThreadRootId($id);
+			}
+
+			$this->mapper->update($message);
+			$output->advance();
+		}
+	}
+}


### PR DESCRIPTION
There should be one in theory https://stackoverflow.com/a/8513707/2239067

But as we've seen in the wild there are cases where we don't get one. Other IMAP clients like Evolution also generate their own ID if it's missing from IMAP.

I chose to have a distinct prefix that expresses that the ID was generated by us. This could be helpful for debugging in the future.

There is also a repair step that fixes messages during upgrade or whenever `occ maintenance:repair` is run by admins.

![Bildschirmfoto von 2021-03-10 10-00-15](https://user-images.githubusercontent.com/1374172/110603852-bc9e6f80-8187-11eb-888b-04b07c1679e6.png)

(my dev instance had LOTS of machine-generated emails without a message-id. production instances do not show such high numbers according to my tests)