### PR TITLE
Add show images temporarily

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -5,6 +5,10 @@
 			{{ t('mail', 'The images have been blocked to protect your privacy.') }}
 			<Actions default-icon="icon-toggle" :menu-title="t('mail', 'Show')">
 				<ActionButton icon="icon-toggle"
+					@click="displayIframe">
+					{{ t('mail', 'Show images temporarily') }}
+				</ActionButton>
+				<ActionButton icon="icon-toggle"
 					@click="onShowBlockedContent">
 					{{ t('mail', 'Always show images from {sender}', {sender: message.from[0].email}) }}
 				</ActionButton>


### PR DESCRIPTION
Quoting Christoph - " I want to show images of an email because it renders badly without. but that doesn't mean I want to always have their images loaded"