### PR TITLE
Check for method existence before calling during upgrade

### DIFF
--- a/lib/Migration/AddMissingMessageIds.php
+++ b/lib/Migration/AddMissingMessageIds.php
@@ -30,6 +30,7 @@ use OCA\Mail\Model\IMAPMessage;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 use Psr\Log\LoggerInterface;
+use function method_exists;
 use function sprintf;
 
 class AddMissingMessageIds implements IRepairStep {
@@ -52,6 +53,21 @@ class AddMissingMessageIds implements IRepairStep {
 
 	public function run(IOutput $output) {
 		$output->info('Looking up messages without a message-id');
+
+		/**
+		 * During the upgrade to v1.9.2/v1.10.0 the old version of the
+		 * mapper is loaded before this new repair step is performed. Hence even after
+		 * the program code got replaced, the class doesn't have the new method. We
+		 *
+		 * Do the ugly method check here and hope that the repair is run soonish.
+		 *
+		 * @see https://github.com/nextcloud/mail/issues/4746
+		 */
+		if (!method_exists($this->mapper, 'findWithEmptyMessageId')) {
+			$output->warning('New Mail code hasn\'t been loaded yes, skipping message clean-up. Please run `occ maintenance:repair` after the upgrade.');
+			return;
+		}
+
 		$toFix = $this->mapper->findWithEmptyMessageId();
 		$output->info(sprintf('%d messages need an update', count($toFix)));
 		$output->startProgress(count($toFix));


### PR DESCRIPTION
The ``\OCA\Mail\Db\MessageMapper::findWithEmptyMessageId`` is new and
due to the nature of how Nextcloud upgrades work, the loaded code won't
have the new method when the post-migration repair step is run. Hence we
have to do a (arguably ugly) method exists check before the method is
called.

Fixes #4746