### PR TITLE
Sync the new draft messages per UID

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -466,7 +466,7 @@ class AccountsController extends Controller {
 			$this->syncService->syncMailbox(
 				$account,
 				$draftsMailbox,
-				Horde_Imap_Client::SYNC_NEWMSGS,
+				Horde_Imap_Client::SYNC_NEWMSGSUIDS,
 				[],
 				false
 			);


### PR DESCRIPTION
Our sync criteria is always a UID variant of the Horde bit flag, and not one for sequence numbers …