### PR TITLE
Lock the full mailbox when doing a (forced) initial sync

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -197,15 +197,15 @@ class ImapToDbSynchronizer {
 			return;
 		}
 
-		if ($criteria & Horde_Imap_Client::SYNC_NEWMSGSUIDS) {
+		if ($force || ($criteria & Horde_Imap_Client::SYNC_NEWMSGSUIDS)) {
 			$logger->debug("Locking mailbox " . $mailbox->getId() . " for new messages sync");
 			$this->mailboxMapper->lockForNewSync($mailbox);
 		}
-		if ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS) {
+		if ($force || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {
 			$logger->debug("Locking mailbox " . $mailbox->getId() . " for changed messages sync");
 			$this->mailboxMapper->lockForChangeSync($mailbox);
 		}
-		if ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS) {
+		if ($force || ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS)) {
 			$logger->debug("Locking mailbox " . $mailbox->getId() . " for vanished messages sync");
 			$this->mailboxMapper->lockForVanishedSync($mailbox);
 		}
@@ -241,15 +241,15 @@ class ImapToDbSynchronizer {
 		} catch (Throwable $e) {
 			throw new ServiceException('Sync failed for ' . $account->getId() . ':' . $mailbox->getName() . ': ' . $e->getMessage(), 0, $e);
 		} finally {
-			if ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS) {
+			if ($force || ($criteria & Horde_Imap_Client::SYNC_VANISHEDUIDS)) {
 				$logger->debug("Unlocking mailbox " . $mailbox->getId() . " from vanished messages sync");
 				$this->mailboxMapper->unlockFromVanishedSync($mailbox);
 			}
-			if ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS) {
+			if ($force || ($criteria & Horde_Imap_Client::SYNC_FLAGSUIDS)) {
 				$logger->debug("Unlocking mailbox " . $mailbox->getId() . " from changed messages sync");
 				$this->mailboxMapper->unlockFromChangedSync($mailbox);
 			}
-			if ($criteria & Horde_Imap_Client::SYNC_NEWMSGSUIDS) {
+			if ($force || ($criteria & Horde_Imap_Client::SYNC_NEWMSGSUIDS)) {
 				$logger->debug("Unlocking mailbox " . $mailbox->getId() . " from new messages sync");
 				$this->mailboxMapper->unlockFromNewSync($mailbox);
 			}


### PR DESCRIPTION
I honestly can't tell if this solves and of the existing sync/locking issues or creates new ones. But while reading the code and stepping it through with a debugger I noticed that a forced sync of one mailbox does not actually lock it.

Would anyone else mind taking a closer look?