### PR TITLE
Save drafts every 10s, not every 700ms

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -351,7 +351,7 @@ export default {
 			attachmentsPromise: Promise.resolve(),
 			canSaveDraft: true,
 			savingDraft: undefined,
-			saveDraftDebounced: debounce(700, this.saveDraft),
+			saveDraftDebounced: debounce(10 * 1000, this.saveDraft),
 			state: STATES.EDITING,
 			errorText: undefined,
 			STATES,


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/4768

The shorter interval is problematic on slower servers, it will create a long backlog of draft requests (because we process them in order).