### PR TITLE
Fix too many concurrent requests when PI is loaded

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -36,22 +36,26 @@
 						:is-priority-inbox="true"
 						:initial-page-size="5"
 						:collapsible="true"
-						:bus="bus" />
+						:bus="bus"
+						@loaded="loadPriorityInboxSection.starred = true" />
 					<SectionTitle class="app-content-list-item starred" :name="t('mail', 'Favorites')" />
 					<Mailbox
 						class="namestarred"
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
+						:load="loadPriorityInboxSection.starred"
 						:search-query="appendToSearch('is:pi-starred')"
 						:paginate="'manual'"
 						:is-priority-inbox="true"
 						:initial-page-size="5"
-						:bus="bus" />
+						:bus="bus"
+						@loaded="loadPriorityInboxSection.other = true"/>
 					<SectionTitle class="app-content-list-item other" :name="t('mail', 'Other')" />
 					<Mailbox
 						class="nameother"
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
+						:load="loadPriorityInboxSection.other"
 						:open-first="false"
 						:search-query="appendToSearch('is:pi-other')"
 						:is-priority-inbox="true"
@@ -120,6 +124,10 @@ export default {
 				prev: ['arrowleft'],
 				refresh: ['r'],
 				unseen: ['u'],
+			},
+			loadPriorityInboxSection: {
+				starred: false,
+				other: false,
 			},
 		}
 	},


### PR DESCRIPTION
When loading the priority inbox we load the same inboxes for three sections. Each of the sections might need to run a sync request before they can fetch messages. In that case the sections are fighting for the locks, the fastest request wins and the others have to wait. This can cause load and concurrency problems on the server, e.g. when using sqlite.

This patch serializes the loading of the three sections.

I'm currently running into other sync issues related to tagging, so I can't actually test the change.