### PR TITLE
Confirm before sending to many recipients in to/cc

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -35,6 +35,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ManyRecipientsException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Http\JsonResponse as MailJsonResponse;
 use OCA\Mail\Model\NewMessageData;
@@ -383,13 +384,19 @@ class AccountsController extends Controller {
 						 int $draftId = null,
 						 int $messageId = null,
 						 array $attachments = [],
-						 int $aliasId = null): JSONResponse {
+						 int $aliasId = null,
+						 bool $force = false): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $id);
 		$alias = $aliasId ? $this->aliasesService->find($aliasId, $this->currentUserId) : null;
 
 		$expandedTo = $this->groupsIntegration->expand($to);
 		$expandedCc = $this->groupsIntegration->expand($cc);
 		$expandedBcc = $this->groupsIntegration->expand($bcc);
+
+		$count = substr_count($expandedTo, ',') + substr_count($expandedCc, ',');
+		if (!$force && $count >= 10) {
+			throw new ManyRecipientsException();
+		}
 
 		$messageData = NewMessageData::fromRequest($account, $expandedTo, $expandedCc, $expandedBcc, $subject, $body, $attachments, $isHtml, $requestMdn);
 		$repliedMessageData = null;

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -393,7 +393,7 @@ class AccountsController extends Controller {
 		$expandedCc = $this->groupsIntegration->expand($cc);
 		$expandedBcc = $this->groupsIntegration->expand($bcc);
 
-		$count = substr_count($expandedTo, ',') + substr_count($expandedCc, ',');
+		$count = substr_count($expandedTo, ',') + substr_count($expandedCc, ',') + 1;
 		if (!$force && $count >= 10) {
 			throw new ManyRecipientsException();
 		}

--- a/lib/Exception/ManyRecipientsException.php
+++ b/lib/Exception/ManyRecipientsException.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 /*
- * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
  * @author 2021 Matthias Rella <mrella@pisys.eu>
  *
  * @license GNU AGPL version 3 or any later version

--- a/lib/Exception/ManyRecipientsException.php
+++ b/lib/Exception/ManyRecipientsException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Matthias Rella <mrella@pisys.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Exception;
+
+class ManyRecipientsException extends ClientException {
+	public function __construct() {
+		parent::__construct("Many recipients in TO and/or CC");
+	}
+}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -226,6 +226,18 @@
 			{{ t('mail', 'Retry') }}
 		</button>
 	</div>
+	<div v-else-if="state === STATES.WARNING" class="emptycontent" role="alert">
+		<h2>{{ t('mail', 'Warning sending your message') }}</h2>
+		<p v-if="errorText">
+			{{ errorText }}
+		</p>
+		<button class="button primary" @click="state = STATES.EDITING">
+			{{ t('mail', 'Go back') }}
+		</button>
+		<button class="button" @click="onForceSend">
+			{{ t('mail', 'Send anyway') }}
+		</button>
+	</div>
 	<div v-else class="emptycontent">
 		<h2>{{ t('mail', 'Message sent!') }}</h2>
 		<button v-if="!isReply" class="button primary" @click="reset">
@@ -265,6 +277,8 @@ import NoSentMailboxConfiguredError
 	from '../errors/NoSentMailboxConfiguredError'
 import NoDraftsMailboxConfiguredError
 	from '../errors/NoDraftsMailboxConfiguredError'
+import ManyRecipientsError
+	from '../errors/ManyRecipientsError'
 
 const debouncedSearch = debouncePromise(findRecipient, 500)
 
@@ -278,6 +292,7 @@ const STATES = Object.seal({
 	SENDING: 2,
 	ERROR: 3,
 	FINISHED: 4,
+	WARNING: 5,
 })
 
 export default {
@@ -701,7 +716,7 @@ export default {
 			this.newRecipients.push(res)
 			list.push(res)
 		},
-		async onSend() {
+		async onSend(_, force = false) {
 			if (this.encrypt) {
 				logger.debug('get encrypted message from mailvelope')
 				await this.$refs.mailvelopeEditor.pull()
@@ -713,22 +728,24 @@ export default {
 				.then(() => (this.state = STATES.SENDING))
 				.then(() => this.draftsPromise)
 				.then(this.getMessageData)
-				.then((data) => this.send(data))
+				.then((data) => this.send({ ...data, force }))
 				.then(() => logger.info('message sent'))
 				.then(() => (this.state = STATES.FINISHED))
 				.catch(async(error) => {
-					logger.error('could not send message', { error })
-					this.errorText = await matchError(error, {
+					logger.error('could not send message', { error });
+					[this.errorText, this.state] = await matchError(error, {
 						[NoSentMailboxConfiguredError.getName()]() {
-							return t('mail', 'No sent mailbox configured. Please pick one in the account settings.')
+							return [t('mail', 'No sent mailbox configured. Please pick one in the account settings.'), STATES.ERROR]
+						},
+						[ManyRecipientsError.getName()]() {
+							return [t('mail', 'You are trying to send to many recipients in To and/or Cc. Consider using Bcc to hide recipient addresses.'), STATES.WARNING]
 						},
 						default(error) {
 							if (error && error.toString) {
-								return error.toString()
+								return [error.toString(), STATES.ERROR]
 							}
 						},
 					})
-					this.state = STATES.ERROR
 				})
 
 			// Sync sent mailbox when it's currently open
@@ -742,6 +759,9 @@ export default {
 					})
 				}, 500)
 			}
+		},
+		async onForceSend() {
+			await this.onSend(null, true)
 		},
 		reset() {
 			this.draftsPromise = Promise.resolve() // "resets" draft uid as well

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -291,8 +291,8 @@ const STATES = Object.seal({
 	UPLOADING: 1,
 	SENDING: 2,
 	ERROR: 3,
-	FINISHED: 4,
-	WARNING: 5,
+	WARNING: 4,
+	FINISHED: 5,
 })
 
 export default {

--- a/src/errors/ManyRecipientsError.js
+++ b/src/errors/ManyRecipientsError.js
@@ -1,6 +1,4 @@
 /**
- * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
  * @author 2021 Matthias Rella <mrella@pisys.eu>
  *
  * @license GNU AGPL version 3 or any later version

--- a/src/errors/ManyRecipientsError.js
+++ b/src/errors/ManyRecipientsError.js
@@ -1,0 +1,34 @@
+/**
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Matthias Rella <mrella@pisys.eu>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default class ManyRecipientsError extends Error {
+
+	constructor(message) {
+		super(message)
+		this.name = ManyRecipientsError.getName()
+		this.message = message
+	}
+
+	static getName() {
+		return 'ManyRecipientsError'
+	}
+
+}

--- a/src/errors/convert.js
+++ b/src/errors/convert.js
@@ -26,6 +26,7 @@ import NoSentMailboxConfiguredError from './NoSentMailboxConfiguredError'
 import NoTrashMailboxConfiguredError from './NoTrashMailboxConfiguredError'
 import CouldNotConnectError from './CouldNotConnectError'
 import ManageSieveError from './ManageSieveError'
+import ManyRecipientsError from './ManyRecipientsError'
 
 const map = {
 	'OCA\\Mail\\Exception\\DraftsMailboxNotSetException': NoDraftsMailboxConfiguredError,
@@ -34,6 +35,7 @@ const map = {
 	'OCA\\Mail\\Exception\\SentMailboxNotSetException': NoSentMailboxConfiguredError,
 	'OCA\\Mail\\Exception\\TrashMailboxNotSetException': NoTrashMailboxConfiguredError,
 	'OCA\\Mail\\Exception\\CouldNotConnectException': CouldNotConnectError,
+	'OCA\\Mail\\Exception\\ManyRecipientsException': ManyRecipientsError,
 	'Horde\\ManageSieve\\Exception': ManageSieveError,
 }
 

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -441,21 +441,25 @@ class AccountsControllerTest extends TestCase {
 
 	public function testSendingManyRecipientsError() {
 		$this->expectException(ManyRecipientsException::class);
+
 		$recipients = [];
-		for ($i = 0; $i < 11; $i++) {
+		for ($i = 0; $i <= 10; $i++) {
 			$recipients[] = "$i@x.com";
 		}
 		$recipients = implode(',', $recipients);
+
 		$this->controller->send(13, 'sub', 'bod', $recipients, '', '');
 	}
 
 	public function testSendingManyRecipientsCcError() {
 		$this->expectException(ManyRecipientsException::class);
+
 		$recipients = [];
-		for ($i = 0; $i < 11; $i++) {
+		for ($i = 0; $i <= 10; $i++) {
 			$recipients[] = "$i@x.com";
 		}
 		$recipients = implode(',', $recipients);
+
 		$this->controller->send(13, 'sub', 'bod', '', $recipients, '');
 	}
 

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -34,6 +34,7 @@ use OCA\Mail\Controller\AccountsController;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ManyRecipientsException;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
 use OCA\Mail\Service\AccountService;
@@ -436,6 +437,26 @@ class AccountsControllerTest extends TestCase {
 		$this->expectException(Horde_Exception::class);
 
 		$this->controller->send(13, 'sub', 'bod', 'to@d.com', '', '');
+	}
+
+	public function testSendingManyRecipientsError() {
+		$this->expectException(ManyRecipientsException::class);
+		$recipients = [];
+		for ($i = 0; $i < 11; $i++) {
+			$recipients[] = "$i@x.com";
+		}
+		$recipients = implode(',', $recipients);
+		$this->controller->send(13, 'sub', 'bod', $recipients, '', '');
+	}
+
+	public function testSendingManyRecipientsCcError() {
+		$this->expectException(ManyRecipientsException::class);
+		$recipients = [];
+		for ($i = 0; $i < 11; $i++) {
+			$recipients[] = "$i@x.com";
+		}
+		$recipients = implode(',', $recipients);
+		$this->controller->send(13, 'sub', 'bod', '', $recipients, '');
 	}
 
 	public function testSendReply() {


### PR DESCRIPTION
Fixes #4505

I'm not sure about hard-coding the limit of to/cc recipients. Is there a better, configurable way?