### PR TITLE
Do not untag all envelopes in mailbox

### DIFF
--- a/lib/Db/TagMapper.php
+++ b/lib/Db/TagMapper.php
@@ -153,7 +153,7 @@ class TagMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete('mail_message_tags')
 			->where($qb->expr()->eq('imap_message_id', $qb->createNamedParameter($messageId)))
-			->where($qb->expr()->eq('tag_id', $qb->createNamedParameter($tag->getId())));
+			->andWhere($qb->expr()->eq('tag_id', $qb->createNamedParameter($tag->getId())));
 		$qb->execute();
 	}
 


### PR DESCRIPTION
Removing a tag from an envelope will remove the tag from all envelopes in its mailbox.

# How to reproduce?

1. Mark multiple envelopes as important in one mailbox.
2. Remove the important tag from one envelope.
3. Reload the page or look at the database (`message_tags`).

**=>** The important tag is removed from all envelopes in the mailbox.