### PR TITLE
Cleanup internal alias api

### DIFF
--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Controller;
 
-use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Service\AliasesService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
@@ -96,7 +96,7 @@ class AliasesController extends Controller {
 	 * @param string $aliasName
 	 *
 	 * @return JSONResponse
-	 * @throws ClientException
+	 * @throws DoesNotExistException
 	 */
 	public function create(int $accountId, string $alias, string $aliasName): JSONResponse {
 		return new JSONResponse(

--- a/lib/Service/AliasesService.php
+++ b/lib/Service/AliasesService.php
@@ -26,7 +26,6 @@ namespace OCA\Mail\Service;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\MailAccountMapper;
-use OCA\Mail\Exception\ClientException;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 class AliasesService {
@@ -61,20 +60,16 @@ class AliasesService {
 	}
 
 	/**
-	 * @param string $currentUserId
+	 * @param string $userId
 	 * @param int $accountId
 	 * @param string $alias
 	 * @param string $aliasName
 	 *
 	 * @return Alias
-	 * @throws ClientException
+	 * @throws DoesNotExistException
 	 */
-	public function create(string $currentUserId, int $accountId, string $alias, string $aliasName): Alias {
-		try {
-			$this->mailAccountMapper->find($currentUserId, $accountId);
-		} catch (DoesNotExistException $e) {
-			throw new ClientException("Account $accountId does not exist or no permission to access it");
-		}
+	public function create(string $userId, int $accountId, string $alias, string $aliasName): Alias {
+		$this->mailAccountMapper->find($userId, $accountId);
 
 		$aliasEntity = new Alias();
 		$aliasEntity->setAccountId($accountId);

--- a/tests/Unit/Controller/AliasesControllerTest.php
+++ b/tests/Unit/Controller/AliasesControllerTest.php
@@ -26,7 +26,6 @@ use OCA\Mail\Controller\AliasesController;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\MailAccountMapper;
-use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Service\AliasesService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -143,7 +142,7 @@ class AliasesControllerTest extends TestCase {
 	}
 
 	public function testCreateForbiddenAccountId(): void {
-		$this->expectException(ClientException::class);
+		$this->expectException(DoesNotExistException::class);
 
 		$entity = new Alias();
 		$entity->setAccountId(200);

--- a/tests/Unit/Service/AliasesServiceTest.php
+++ b/tests/Unit/Service/AliasesServiceTest.php
@@ -25,7 +25,6 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\MailAccountMapper;
-use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\AliasesService;
 use OCP\AppFramework\Db\DoesNotExistException;
 
@@ -117,7 +116,7 @@ class AliasesServiceTest extends TestCase {
 	}
 
 	public function testCreateForbiddenAccountId(): void {
-		$this->expectException(ClientException::class);
+		$this->expectException(DoesNotExistException::class);
 
 		$entity = new Alias();
 		$entity->setAccountId(200);


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/mail/pull/4864

A small cleanup as I messed up our internal api a bit :see_no_evil: 

The AliasService should not return an client exception because they are "bound" to http requests but forward the original exception to the caller. As the ErrorMiddleware already knows DoesNotExistException no need to catch the exception in AliasController :broom: 

Internal changes => No backport required