### PR TITLE
Only update direct dependencies for vendor-bin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,7 +52,6 @@ updates:
       - php
   allow:
       - dependency-type: direct
-      - dependency-type: indirect
 - package-ecosystem: composer
   directory: "/vendor-bin/cs-fixer/"
   schedule:
@@ -67,7 +66,6 @@ updates:
       - php
   allow:
       - dependency-type: direct
-      - dependency-type: indirect
 - package-ecosystem: composer
   directory: "/vendor-bin/phpunit/"
   schedule:
@@ -82,4 +80,3 @@ updates:
       - php
   allow:
       - dependency-type: direct
-      - dependency-type: indirect


### PR DESCRIPTION
![Screenshot from 2021-04-06 22-42-18](https://user-images.githubusercontent.com/3902676/113776016-bd480880-9729-11eb-9e57-c8cdc9a2c3ef.png)

As the dependencies in vendor-bin are mostly for development or ci it should be enough to only update the dependency itself with dependabot and ignore the sub dependencies.