### PR TITLE
Fix updateEnvelope mutation

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -168,7 +168,7 @@ export default {
 			})
 	},
 	updateEnvelope(state, { envelope }) {
-		const existing = state.envelopes[envelope.uid]
+		const existing = state.envelopes[envelope.databaseId]
 		if (!existing) {
 			return
 		}


### PR DESCRIPTION
The `updateEnvelope` mutation is currently broken. No envelope will actually be updated because the existing one can never be found.