### PR TITLE
Chunk huge arrays to surpress Oracle IN() warning

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -176,10 +176,18 @@ class MessageMapper extends QBMapper {
 			->from($this->getTableName())
 			->where(
 				$query->expr()->eq('mailbox_id', $query->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
-				$query->expr()->in('id', $query->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
+				$query->expr()->in('id', $query->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY)
 			);
 
-		return $this->findUids($query);
+		$chunks = array_chunk($ids, 1000);
+
+		$results = [];
+		foreach ($chunks as $chunk) {
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+			$results[] = $this->findUids($query);
+		}
+
+		return array_merge(...$results);
 	}
 
 	/**

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -124,7 +124,6 @@
       <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb2-&gt;createNamedParameter(array_keys($indexedMessages), IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb4-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$query-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$query-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
     </ImplicitToStringCast>
   </file>


### PR DESCRIPTION
⚠️ Theory fix, I did not execute the code

```json
{
  "Exception": "Doctrine\\DBAL\\Query\\QueryException",
  "Message": "More than 1000 expressions in a list are not allowed on Oracle.",
  "Code": 0,
  "Trace": [
    {
      "file": "/var/www/html/apps/mail/lib/Db/MessageMapper.php",
      "line": 69,
      "function": "execute",
      "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
      "type": "->"
    },
    {
      "file": "/var/www/html/apps/mail/lib/Db/MessageMapper.php",
      "line": 169,
      "function": "findUids",
      "class": "OCA\\Mail\\Db\\MessageMapper",
      "type": "->"
    },
    {
      "file": "/var/www/html/apps/mail/lib/Service/Sync/SyncService.php",
      "line": 155,
      "function": "findUidsForIds",
      "class": "OCA\\Mail\\Db\\MessageMapper",
      "type": "->"
    }
```