### PR TITLE
Run dependabot-approve-merge only for dependabot branches.

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -1,5 +1,8 @@
 name: Dependabot
-on: pull_request_target
+on:
+  pull_request:
+    branches:
+      - 'dependabot/**'
 
 jobs:
   auto-merge:


### PR DESCRIPTION
![Screenshot from 2021-04-09 13-01-02](https://user-images.githubusercontent.com/3902676/114170892-dc19eb00-9933-11eb-9a0b-f7c120c33663.png)

Was looking for some CI results and noticed that the auto approve action run's for every branch. I think we can limit the workflow to branches starting with dependabot.

Ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags