### PR TITLE
Add filtered routes for draft and thread

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -45,8 +45,18 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'page#filteredThread',
+			'url' => '/box/{filter}/{mailboxId}/thread/{id}',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'page#draft',
 			'url' => '/box/{mailboxId}/thread/new/{draftId}',
+			'verb' => 'GET'
+		],
+		[
+			'name' => 'page#filteredDraft',
+			'url' => '/box/{filter}/{mailboxId}/thread/new/{draftId}',
 			'verb' => 'GET'
 		],
 		[

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -196,7 +196,27 @@ class PageController extends Controller {
 	 *
 	 * @return TemplateResponse
 	 */
+	public function filteredThread(string $filter, int $mailboxId, int $id): TemplateResponse {
+		return $this->index();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return TemplateResponse
+	 */
 	public function draft(int $mailboxId, int $draftId): TemplateResponse {
+		return $this->index();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return TemplateResponse
+	 */
+	public function filteredDraft(string $filter, int $mailboxId, int $draftId): TemplateResponse {
 		return $this->index();
 	}
 


### PR DESCRIPTION
# Bug
Reloading the page when a filter is applied will send you back to the dashboard.

# Solution
I added 2 new routes to `routes.php` to account for the following routes from the frontend:
```js
path: '/box/:filter?/:mailboxId/thread/:threadId/:draftId?'
path: '/box/:filter?/:mailboxId'
```
