### PR TITLE
Chunking `in` statements for Oracle Compliance

### DIFF
--- a/lib/Db/AliasMapper.php
+++ b/lib/Db/AliasMapper.php
@@ -102,9 +102,11 @@ class AliasMapper extends QBMapper {
 		$result->closeCursor();
 
 		$qb2 = $this->db->getQueryBuilder();
-		$query = $qb2
-			->delete($this->getTableName())
-			->where($qb2->expr()->in('id', $qb2->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
-		$query->execute();
+		foreach (array_chunk($ids, 1000) as $chunk) {
+			$query = $qb2
+				->delete($this->getTableName())
+				->where($qb2->expr()->in('id', $qb2->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
+			$query->execute();
+		}
 	}
 }

--- a/lib/Db/CollectedAddressMapper.php
+++ b/lib/Db/CollectedAddressMapper.php
@@ -121,7 +121,10 @@ class CollectedAddressMapper extends QBMapper {
 		$qb2 = $this->db->getQueryBuilder();
 		$query = $qb2
 			->delete($this->getTableName())
-			->where($qb2->expr()->in('id', $qb2->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
-		$query->execute();
+			->where($qb2->expr()->in('id', $qb2->createParameter('ids')));
+		foreach (array_chunk($ids, 1000) as $chunk) {
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
+			$query->execute();
+		}
 	}
 }

--- a/lib/Db/MailboxMapper.php
+++ b/lib/Db/MailboxMapper.php
@@ -241,9 +241,11 @@ class MailboxMapper extends QBMapper {
 		$result->closeCursor();
 
 		$qb2 = $this->db->getQueryBuilder();
-		$query = $qb2
-			->delete($this->getTableName())
-			->where($qb2->expr()->in('id', $qb2->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
-		$query->execute();
+		foreach (array_chunk($ids, 1000) as $chunk) {
+			$query = $qb2
+				->delete($this->getTableName())
+				->where($qb2->expr()->in('id', $qb2->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
+			$query->execute();
+		}
 	}
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -80,30 +80,29 @@
   </file>
   <file src="lib/Db/AliasMapper.php">
     <ImplicitToStringCast occurrences="1">
-      <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$qb2-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/CollectedAddressMapper.php">
     <ImplicitToStringCast occurrences="1">
-      <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$qb2-&gt;createParameter('ids')</code>
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/MailboxMapper.php">
     <ImplicitToStringCast occurrences="1">
-      <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$qb2-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/MessageMapper.php">
     <ImplicitToStringCast occurrences="26">
-      <code>$deleteRecipientsQuery-&gt;createFunction($messageIdQuery-&gt;getSQL())</code>
-      <code>$deleteRecipientsQuery-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$messageIdQuery-&gt;createFunction($messageIdQuery-&gt;getSQL())</code>
+      <code>$deleteMessagesQuery-&gt;createParameter('messageIds')</code>
+      <code>$deleteRecipientsQuery-&gt;createParameter('ids')</code>
+      <code>$deleteRecipientsQuery-&gt;createParameter('messageIds')</code>
+      <code>$messageIdQuery-&gt;createParameter('uids')</code>
       <code>$messagesQuery-&gt;createFunction($mailboxesQuery-&gt;getSQL())</code>
       <code>$qb-&gt;createFunction($mailboxIdsQuery-&gt;getSQL())</code>
       <code>$qb-&gt;createFunction($mailboxIdsQuery-&gt;getSQL())</code>
       <code>$qb-&gt;createFunction($selectMailboxIds-&gt;getSQL())</code>
-      <code>$qb-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($query-&gt;getBcc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($query-&gt;getBcc(), IQueryBuilder::PARAM_STR_ARRAY)</code>
@@ -114,12 +113,14 @@
       <code>$qb-&gt;createNamedParameter($query-&gt;getTo(), IQueryBuilder::PARAM_STR_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($query-&gt;getTo(), IQueryBuilder::PARAM_STR_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb2-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$qb-&gt;createParameter('ids')</code>
+      <code>$qb-&gt;createParameter('ids')</code>
+      <code>$qb-&gt;createParameter('uids')</code>
+      <code>$qb-&gt;createParameter('uids')</code>
+      <code>$qb2-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb2-&gt;createNamedParameter(array_keys($indexedMessages), IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb4-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$query-&gt;createNamedParameter($uids, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$qb4-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
+      <code>$query-&gt;createParameter('ids')</code>
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/StatisticsDao.php">
@@ -137,7 +138,7 @@
     <ImplicitToStringCast occurrences="3">
       <code>$deleteQB-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$deleteQB-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>
-      <code>$qb-&gt;createNamedParameter($ids, IQueryBuilder::PARAM_STR_ARRAY)</code>
+      <code>$qb-&gt;createParameter('ids')</code>
     </ImplicitToStringCast>
     <InvalidArgument occurrences="1"/>
   </file>
@@ -267,11 +268,6 @@
     <UndefinedDocblockClass occurrences="1">
       <code>$this-&gt;contactsManager-&gt;getUserAddressBooks()</code>
     </UndefinedDocblockClass>
-  </file>
-  <file src="lib/Service/Html.php">
-    <UndefinedClass occurrences="1">
-      <code>UrlLinker</code>
-    </UndefinedClass>
   </file>
   <file src="lib/Service/HtmlPurify/TransformURLScheme.php">
     <NullArgument occurrences="3">


### PR DESCRIPTION
Oracle can't deal with more than 1000 values in an expression list for `in` queries.

Chunk all `in` queries so they'll use a max of 1000 values.

Fixes #4941
