### PR TITLE
Exit early if no message ids are to be fixed

### DIFF
--- a/lib/Migration/AddMissingMessageIds.php
+++ b/lib/Migration/AddMissingMessageIds.php
@@ -51,7 +51,7 @@ class AddMissingMessageIds implements IRepairStep {
 		return 'Add a generated message-id to all Mail messages that have none';
 	}
 
-	public function run(IOutput $output) {
+	public function run(IOutput $output): void {
 		$output->info('Looking up messages without a message-id');
 
 		/**
@@ -69,6 +69,9 @@ class AddMissingMessageIds implements IRepairStep {
 		}
 
 		$toFix = $this->mapper->findWithEmptyMessageId();
+		if (empty($toFix)) {
+			return;
+		}
 		$output->info(sprintf('%d messages need an update', count($toFix)));
 		$output->startProgress(count($toFix));
 		foreach ($toFix as $message) {


### PR DESCRIPTION
I ran into this:

![Bildschirmfoto von 2021-04-19 13-04-52](https://user-images.githubusercontent.com/1374172/115231074-6d981280-a115-11eb-9ec1-1cec69123a42.png)

I can't quite explain it, but somehow starting with a progress of max 0 wasn't so well received by Symfony.