### PR TITLE
Reintroduce unread counter in app navigation

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -24,12 +24,10 @@ declare(strict_types=1);
 namespace OCA\Mail\Contracts;
 
 use OCA\Mail\Db\Tag;
-use OCA\Mail\Folder;
 use OCA\Mail\Account;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Service\Quota;
-use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
@@ -65,14 +63,6 @@ interface IMailManager {
 	 * @throws ServiceException
 	 */
 	public function createMailbox(Account $account, string $name): Mailbox;
-
-	/**
-	 * @param Account $account
-	 * @param Mailbox $mailbox
-	 *
-	 * @return FolderStats
-	 */
-	public function getMailboxStats(Account $account, Mailbox $mailbox): FolderStats;
 
 	/**
 	 * @param Mailbox $mailbox

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -226,11 +226,7 @@ class MailboxesController extends Controller {
 	 */
 	public function stats(int $id): JSONResponse {
 		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
-		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
-
-		$stats = $this->mailManager->getMailboxStats($account, $mailbox);
-
-		return new JSONResponse($stats);
+		return new JSONResponse($mailbox->getStats());
 	}
 
 	/**

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Db;
 
 use JsonSerializable;
+use OCA\Mail\IMAP\MailboxStats;
 use OCP\AppFramework\Db\Entity;
 use function base64_encode;
 use function in_array;
@@ -138,6 +139,13 @@ class Mailbox extends Entity implements JsonSerializable {
 		return false;
 	}
 
+	/**
+	 * @return MailboxStats
+	 */
+	public function getStats(): MailboxStats {
+		return new MailboxStats($this->getMessages(), $this->getUnseen());
+	}
+
 	public function jsonSerialize() {
 		$specialUse = $this->getSpecialUseParsed();
 		return [
@@ -152,6 +160,7 @@ class Mailbox extends Entity implements JsonSerializable {
 			'specialRole' => $specialUse[0] ?? 0,
 			'mailboxes' => [],
 			'syncInBackground' => ($this->getSyncInBackground() === true),
+			'unread' => $this->unseen,
 		];
 	}
 }

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -79,6 +79,13 @@ class Folder {
 	}
 
 	/**
+	 * @return array
+	 */
+	public function getStatus(): array {
+		return $this->status;
+	}
+
+	/**
 	 * @param array $status
 	 *
 	 * @return void

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -139,13 +139,13 @@ class FolderMapper {
 	 *
 	 * @throws Horde_Imap_Client_Exception
 	 *
-	 * @return FolderStats
+	 * @return MailboxStats
 	 */
 	public function getFoldersStatusAsObject(Horde_Imap_Client_Socket $client,
-											 string $mailbox): FolderStats {
+											 string $mailbox): MailboxStats {
 		$status = $client->status($mailbox);
 
-		return new FolderStats(
+		return new MailboxStats(
 			$status['messages'],
 			$status['unseen']
 		);

--- a/lib/IMAP/MailboxStats.php
+++ b/lib/IMAP/MailboxStats.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2021 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -27,7 +28,7 @@ namespace OCA\Mail\IMAP;
 
 use JsonSerializable;
 
-class FolderStats implements JsonSerializable {
+class MailboxStats implements JsonSerializable {
 
 	/** @var int */
 	private $total;
@@ -38,6 +39,20 @@ class FolderStats implements JsonSerializable {
 	public function __construct(int $total, int $unread) {
 		$this->total = $total;
 		$this->unread = $unread;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getTotal(): int {
+		return $this->total;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getUnread(): int {
+		return $this->unread;
 	}
 
 	public function jsonSerialize() {

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -126,6 +126,33 @@ class MailboxSync {
 		);
 	}
 
+	/**
+	 * Sync unread and total message statistics.
+	 *
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 *
+	 * @throws ServiceException
+	 */
+	public function syncStats(Account $account, Mailbox $mailbox): void {
+		$client = $this->imapClientFactory->getClient($account);
+
+		try {
+			$stats = $this->folderMapper->getFoldersStatusAsObject($client, $mailbox->getName());
+		} catch (Horde_Imap_Client_Exception $e) {
+			$id = $mailbox->getId();
+			throw new ServiceException(
+				"Could not fetch stats of mailbox $id. IMAP error: " . $e->getMessage(),
+				(int)$e->getCode(),
+				$e
+			);
+		}
+
+		$mailbox->setMessages($stats->getTotal());
+		$mailbox->setUnseen($stats->getUnread());
+		$this->mailboxMapper->update($mailbox);
+	}
+
 	private function persist(Account $account, array $folders, array $existing): void {
 		foreach ($folders as $folder) {
 			if (isset($existing[$folder->getMailbox()])) {
@@ -164,8 +191,8 @@ class MailboxSync {
 		$mailbox->setDelimiter($folder->getDelimiter());
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages(0); // TODO
-		$mailbox->setUnseen(0); // TODO
+		$mailbox->setMessages($folder->getStatus()['messages']);
+		$mailbox->setUnseen($folder->getStatus()['unseen']);
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$this->mailboxMapper->update($mailbox);
@@ -177,8 +204,8 @@ class MailboxSync {
 		$mailbox->setAccountId($account->getId());
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages(0); // TODO
-		$mailbox->setUnseen(0); // TODO
+		$mailbox->setMessages($folder->getStatus()['messages']);
+		$mailbox->setUnseen($folder->getStatus()['unseen']);
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$this->mailboxMapper->insert($mailbox);

--- a/lib/IMAP/Sync/Response.php
+++ b/lib/IMAP/Sync/Response.php
@@ -25,6 +25,7 @@ namespace OCA\Mail\IMAP\Sync;
 
 use JsonSerializable;
 use OCA\Mail\Db\Message;
+use OCA\Mail\IMAP\MailboxStats;
 use OCA\Mail\Model\IMAPMessage;
 
 class Response implements JsonSerializable {
@@ -38,18 +39,23 @@ class Response implements JsonSerializable {
 	/** @var int[] */
 	private $vanishedMessageUids;
 
+	/** @var MailboxStats */
+	private $stats;
+
 	/**
-	 * @param string $syncToken
 	 * @param IMAPMessage[]|Message[] $newMessages
 	 * @param IMAPMessage[]|Message[] $changedMessages
 	 * @param int[] $vanishedMessageUids
+	 * @param MailboxStats|null $stats
 	 */
 	public function __construct(array $newMessages = [],
 								array $changedMessages = [],
-								array $vanishedMessageUids = []) {
+								array $vanishedMessageUids = [],
+								MailboxStats $stats = null) {
 		$this->newMessages = $newMessages;
 		$this->changedMessages = $changedMessages;
 		$this->vanishedMessageUids = $vanishedMessageUids;
+		$this->stats = $stats;
 	}
 
 	/**
@@ -73,11 +79,19 @@ class Response implements JsonSerializable {
 		return $this->vanishedMessageUids;
 	}
 
+	/**
+	 * @return MailboxStats
+	 */
+	public function getStats(): MailboxStats {
+		return $this->stats;
+	}
+
 	public function jsonSerialize(): array {
 		return [
 			'newMessages' => $this->newMessages,
 			'changedMessages' => $this->changedMessages,
 			'vanishedMessages' => $this->vanishedMessageUids,
+			'stats' => $this->stats,
 		];
 	}
 

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -35,7 +35,6 @@ use OCA\Mail\Db\TagMapper;
 use Psr\Log\LoggerInterface;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Db\MailboxMapper;
-use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\IMAP\FolderMapper;
 use OCA\Mail\Model\IMAPMessage;
@@ -165,19 +164,6 @@ class MailManager implements IMailManager {
 		$this->mailboxSync->sync($account, $this->logger,true);
 
 		return $this->mailboxMapper->find($account, $name);
-	}
-
-	/**
-	 * @param Account $account
-	 * @param Mailbox $mailbox
-	 *
-	 * @return FolderStats
-	 * @throws Horde_Imap_Client_Exception
-	 */
-	public function getMailboxStats(Account $account, Mailbox $mailbox): FolderStats {
-		$client = $this->imapClientFactory->getClient($account);
-
-		return $this->folderMapper->getFoldersStatusAsObject($client, $mailbox->getName());
 	}
 
 	public function getImapMessage(Account $account,

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -111,7 +111,7 @@
 				{{ t('mail', 'Delete mailbox') }}
 			</ActionButton>
 		</template>
-		<AppNavigationCounter v-if="mailbox.unread" slot="counter">
+		<AppNavigationCounter v-if="showUnreadCounter" slot="counter">
 			{{ mailbox.unread }}
 		</AppNavigationCounter>
 		<template slot="extra">
@@ -292,6 +292,9 @@ export default {
 				return true
 			}
 			return this.mailbox.specialUse.includes('inbox') && this.$store.getters.accounts.length > 2
+		},
+		showUnreadCounter() {
+			return this.mailbox.unread > 0 && this.filter !== 'starred'
 		},
 	},
 	mounted() {

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -81,6 +81,7 @@ export async function syncEnvelopes(accountId, id, ids, query, init = false) {
 			newMessages: response.data.newMessages.map(amend),
 			changedMessages: response.data.changedMessages.map(amend),
 			vanishedMessages: response.data.vanishedMessages,
+			stats: response.data.stats,
 		}
 	} catch (e) {
 		throw convertAxiosError(e)

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -499,6 +499,11 @@ export default {
 					// Already removed from unified inbox
 				})
 
+				commit('setMailboxUnreadCount', {
+					id: mailboxId,
+					unread: syncData.stats.unread,
+				})
+
 				return syncData.newMessages
 			})
 			.catch((error) => {

--- a/tests/Unit/Controller/MailboxesControllerTest.php
+++ b/tests/Unit/Controller/MailboxesControllerTest.php
@@ -31,7 +31,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Controller\MailboxesController;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Folder;
-use OCA\Mail\IMAP\FolderStats;
+use OCA\Mail\IMAP\MailboxStats;
 use OCA\Mail\Service\AccountService;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCP\AppFramework\Http\JSONResponse;
@@ -137,26 +137,17 @@ class MailboxesControllerTest extends TestCase {
 	}
 
 	public function testStats() {
-		$account = $this->createMock(Account::class);
-		$stats = $this->createMock(FolderStats::class);
-		$accountId = 28;
 		$mailbox = new Mailbox();
-		$mailbox->setAccountId($accountId);
+		$mailbox->setUnseen(10);
+		$mailbox->setMessages(42);
 		$this->mailManager->expects($this->once())
 			->method('getMailbox')
 			->with('john', 13)
 			->willReturn($mailbox);
-		$this->accountService->expects($this->once())
-			->method('find')
-			->with($this->equalTo($this->userId), $this->equalTo($accountId))
-			->willReturn($account);
-		$this->mailManager->expects($this->once())
-			->method('getMailboxStats')
-			->with($this->equalTo($account), $mailbox)
-			->willReturn($stats);
 
 		$response = $this->controller->stats(13);
 
+		$stats = new MailboxStats(42, 10);
 		$expected = new JSONResponse($stats);
 		$this->assertEquals($expected, $response);
 	}

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -29,7 +29,7 @@ use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
-use OCA\Mail\IMAP\FolderStats;
+use OCA\Mail\IMAP\MailboxStats;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 
 class FolderMapperTest extends TestCase {
@@ -207,7 +207,7 @@ class FolderMapperTest extends TestCase {
 
 		$stats = $this->mapper->getFoldersStatusAsObject($client, 'INBOX');
 
-		$expected = new FolderStats(123, 2);
+		$expected = new MailboxStats(123, 2);
 		$this->assertEquals($expected, $stats);
 	}
 

--- a/tests/Unit/IMAP/Sync/ResponseTest.php
+++ b/tests/Unit/IMAP/Sync/ResponseTest.php
@@ -34,6 +34,7 @@ class ResponseTest extends TestCase {
 			'newMessages' => [],
 			'changedMessages' => [],
 			'vanishedMessages' => [],
+			'stats' => null,
 		];
 
 		$json = $response->jsonSerialize();

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -37,7 +37,6 @@ use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
-use OCA\Mail\IMAP\FolderStats;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\IMAP\MessageMapper as ImapMessageMapper;
@@ -151,28 +150,6 @@ class MailManagerTest extends TestCase {
 		$created = $this->manager->createMailbox($account, 'new');
 
 		$this->assertEquals($mailbox, $created);
-	}
-
-	public function testGetFolderStats() {
-		$client = $this->createMock(Horde_Imap_Client_Socket::class);
-		$account = $this->createMock(Account::class);
-		$this->imapClientFactory->expects($this->once())
-			->method('getClient')
-			->willReturn($client);
-		$stats = $this->createMock(FolderStats::class);
-		$this->folderMapper->expects($this->once())
-			->method('getFoldersStatusAsObject')
-			->with($this->equalTo($client), $this->equalTo('INBOX'))
-			->willReturn($stats);
-		$mailbox = new Mailbox();
-		$mailbox->setName('INBOX');
-
-		$actual = $this->manager->getMailboxStats(
-			$account,
-			$mailbox
-		);
-
-		$this->assertEquals($stats, $actual);
 	}
 
 	public function testDeleteMessageSourceFolderNotFound(): void {

--- a/tests/Unit/Service/Sync/SyncServiceTest.php
+++ b/tests/Unit/Service/Sync/SyncServiceTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * @copyright 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\Sync;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Exception\MailboxNotCachedException;
+use OCA\Mail\IMAP\MailboxStats;
+use OCA\Mail\IMAP\MailboxSync;
+use OCA\Mail\IMAP\PreviewEnhancer;
+use OCA\Mail\IMAP\Sync\Response;
+use OCA\Mail\Service\Search\FilterStringParser;
+use OCA\Mail\Service\Sync\ImapToDbSynchronizer;
+use OCA\Mail\Service\Sync\SyncService;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class SyncServiceTest extends TestCase {
+
+	/** @var ImapToDbSynchronizer */
+	private $synchronizer;
+
+	/** @var FilterStringParser */
+	private $filterStringParser;
+
+	/** @var MailboxMapper */
+	private $mailboxMapper;
+
+	/** @var MessageMapper */
+	private $messageMapper;
+
+	/** @var PreviewEnhancer */
+	private $previewEnhancer;
+
+	/** @var LoggerInterface */
+	private $loggerInterface;
+
+	/** @var MailboxSync */
+	private $mailboxSync;
+
+	/** @var SyncService */
+	private $syncService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->synchronizer = $this->createMock(ImapToDbSynchronizer::class);
+		$this->filterStringParser = $this->createMock(FilterStringParser::class);
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->messageMapper = $this->createMock(MessageMapper::class);
+		$this->previewEnhancer = $this->createMock(PreviewEnhancer::class);
+		$this->loggerInterface = $this->createMock(LoggerInterface::class);
+		$this->mailboxSync = $this->createMock(MailboxSync::class);
+
+		$this->syncService = new SyncService(
+			$this->synchronizer,
+			$this->filterStringParser,
+			$this->mailboxMapper,
+			$this->messageMapper,
+			$this->previewEnhancer,
+			$this->loggerInterface,
+			$this->mailboxSync
+		);
+	}
+
+	public function testPartialSyncOnUncachedMailbox() {
+		$account = $this->createMock(Account::class);
+		$mailbox = $this->createMock(Mailbox::class);
+		$mailbox->expects($this->once())
+			->method('isCached')
+			->willReturn(false);
+
+		$this->expectException(MailboxNotCachedException::class);
+		$this->syncService->syncMailbox(
+			$account,
+			$mailbox,
+			42,
+			[],
+			true
+		);
+	}
+
+	public function testSyncMailboxReturnsFolderStats() {
+		$account = $this->createMock(Account::class);
+		$account->method('getUserId')->willReturn('user');
+		$mailbox = new Mailbox();
+		$mailbox->setMessages(42);
+		$mailbox->setUnseen(10);
+		$expectedResponse = new Response(
+			[],
+			[],
+			[],
+			new MailboxStats(42, 10)
+		);
+
+		$this->messageMapper
+			->method('findUidsForIds')
+			->with($mailbox, [])
+			->willReturn([]);
+		$this->synchronizer->expects($this->once())
+			->method('sync')
+			->with(
+				$account,
+				$mailbox,
+				$this->loggerInterface,
+				0,
+				[],
+				true
+			);
+		$this->mailboxSync->expects($this->once())
+			->method('syncStats')
+			->with($account, $mailbox);
+
+		$response = $this->syncService->syncMailbox(
+			$account,
+			$mailbox,
+			0,
+			[],
+			false
+		);
+
+		$this->assertEquals($expectedResponse, $response);
+	}
+}


### PR DESCRIPTION
Fixes #1400

Show unread count next to the name of each mailbox.

![unread-counter](https://user-images.githubusercontent.com/1479486/115409434-0b610f80-a1f2-11eb-8c6d-3dd8018b0f0b.png)

## Backend
The backend will fetch stats (unseen and total count) when a mailbox is synced and cache them in the existing database rows.

## Frontend
The frontend reuses the `mailboxes/{id}/stats` route to fetch current stats after every `syncEnvelopes` dispatch. Changes that do not force a sync right away (e.g. toggling unseen flag) will commit temporary changes to the vuex store. Those will be overwritten by the next unread stats sync dispatch. This way we should never get in a situation where the unread counter is asynchronous and if we do, it shouldn't last long (sync is run every time a mailbox is opened).

## Breaking changes
The stats api route (`mailboxes/{id}/stats`) now returns cached values instead of fetching data directly from the imap server.

## TODO
- [x] Fix tests