### PR TITLE
Remove obsolete workflow lint/app-code-check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,31 +50,6 @@ jobs:
     - name: Run coding standards check
       run: composer run cs:check
 
-  app-code-check:
-    runs-on: ubuntu-latest
-    strategy:
-        matrix:
-            nextcloud-versions: ['master']
-    name: Nextcloud ${{ matrix.nextcloud-versions }} app code check
-    steps:
-        - name: Set up php7.4
-          uses: shivammathur/setup-php@master
-          with:
-              php-version: 7.4
-              tools: composer:v1
-              extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip
-              coverage: xdebug
-        - name: Checkout Nextcloud
-          run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
-        - name: Run tests
-          run: php -f nextcloud/occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-        - name: Checkout
-          uses: actions/checkout@master
-          with:
-              path: nextcloud/apps/mail
-        - name: Run tests
-          run: php -f nextcloud/occ app:check-code mail
-
   node-linters:
     runs-on: ubuntu-latest
     name: ESLint


### PR DESCRIPTION
Example output from this check:
```
Run php -f nextcloud/occ app:check-code mail
The app code checker doesn\t check anything and this command will be removed in Nextcloud 23
```

The check is required and has to be removed from the repository settings as well. I can't do that so it's stuck on `Waiting for status to be reported`.