### PR TITLE
Fix reading missing mailbox stats

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -191,8 +191,8 @@ class MailboxSync {
 		$mailbox->setDelimiter($folder->getDelimiter());
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages($folder->getStatus()['messages']);
-		$mailbox->setUnseen($folder->getStatus()['unseen']);
+		$mailbox->setMessages($folder->getStatus()['messages'] ?? 0);
+		$mailbox->setUnseen($folder->getStatus()['unseen'] ?? 0);
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$this->mailboxMapper->update($mailbox);
@@ -204,8 +204,8 @@ class MailboxSync {
 		$mailbox->setAccountId($account->getId());
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages($folder->getStatus()['messages']);
-		$mailbox->setUnseen($folder->getStatus()['unseen']);
+		$mailbox->setMessages($folder->getStatus()['messages'] ?? 0);
+		$mailbox->setUnseen($folder->getStatus()['unseen'] ?? 0);
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$this->mailboxMapper->insert($mailbox);


### PR DESCRIPTION
Apparently there are occasions where we can't read the number of
messages of a mailbox. In that case the account setup fails with
``General error: 1364 Field 'messages' doesn't have a default value"``
on MySQL. This adds sane fallback values for the two mailbox stats.

Fixes https://github.com/nextcloud/mail/issues/4788