### PR TITLE
Changed Horde link to https

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 - **🚀 Integration with other Nextcloud apps!** Currently Contacts, Calendar & Files – more to come.
 - **📥 Multiple mail accounts!** Personal and company account? No problem, and a nice unified inbox. Connect any IMAP account.
 - **🔒 Send & receive encrypted mails!** Using the great [Mailvelope](https://mailvelope.com) browser extension.
-- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](http://horde.org) libraries.
+- **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
 	<version>1.10.0-alpha.3</version>


### PR DESCRIPTION
it's a stupidly small change, but noticed that (for some reason) the link to Horde here didn't use https even though their website seems to work just fine with https