### PR TITLE
Fix the page controller test after #5075

### DIFF
--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -116,17 +116,17 @@ class PageControllerTest extends TestCase {
 		);
 	}
 
-	public function testIndex() {
+	public function testIndex(): void {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
 		$this->preferences->expects($this->exactly(4))
 			->method('getPreference')
 			->willReturnMap([
+				['account-settings', '[]', json_encode([])],
 				['external-avatars', 'true', 'true'],
 				['reply-mode', 'top', 'bottom'],
 				['collect-data', 'true', 'true'],
-				['account-settings', null, json_encode([])],
 			]);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')


### PR DESCRIPTION
With that darn integration test failling I didn't notice there was a unit test regression in https://github.com/nextcloud/mail/pull/5075. This fixes it again.