### PR TITLE
Only show each thread once per message list

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -293,6 +293,16 @@ return [
 			'name' => 'sieve#updateActiveScript',
 			'url' => '/api/sieve/active/{id}',
 			'verb' => 'PUT'
+		],
+		[
+			'name' => 'thread#delete',
+			'url' => '/api/thread/{id}',
+			'verb' => 'DELETE'
+		],
+		[
+			'name' => 'thread#move',
+			'url' => '/api/thread/{id}',
+			'verb' => 'POST'
 		]
 	],
 	'resources' => [

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -110,11 +110,11 @@ interface IMailManager {
 
 	/**
 	 * @param Account $account
-	 * @param int $messageId database message ID
+	 * @param string $threadRootId thread root id
 	 *
 	 * @return Message[]
 	 */
-	public function getThread(Account $account, int $messageId): array;
+	public function getThread(Account $account, string $threadRootId): array;
 
 	/**
 	 * @param Account $sourceAccount
@@ -263,4 +263,25 @@ interface IMailManager {
 	 * @throws ClientException if the given tag does not exist
 	 */
 	public function updateTag(int $id, string $displayName, string $color, string $userId): Tag;
+
+	/**
+	 * @param Account $srcAccount
+	 * @param Mailbox $srcMailbox
+	 * @param Account $dstAccount
+	 * @param Mailbox $dstMailbox
+	 * @param string $threadRootId
+	 * @return void
+	 * @throws ServiceException
+	 */
+	public function moveThread(Account $srcAccount, Mailbox $srcMailbox, Account $dstAccount, Mailbox $dstMailbox, string $threadRootId): void;
+
+	/**
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 * @param string $threadRootId
+	 * @return void
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function deleteThread(Account $account, Mailbox $mailbox, string $threadRootId): void;
 }

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -307,7 +307,7 @@ class MessagesController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		return new JSONResponse($this->mailManager->getThread($account, $id));
+		return new JSONResponse($this->mailManager->getThread($account, $message->getThreadRootId()));
 	}
 
 	/**

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Controller;
+
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class ThreadController extends Controller {
+
+	/** @var string */
+	private $currentUserId;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var AccountService */
+	private $accountService;
+
+	/** @var IMailManager */
+	private $mailManager;
+
+	public function __construct(string $appName,
+								IRequest $request,
+								string $UserId,
+								AccountService $accountService,
+								IMailManager $mailManager) {
+		parent::__construct($appName, $request);
+
+		$this->currentUserId = $UserId;
+		$this->accountService = $accountService;
+		$this->mailManager = $mailManager;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 * @param int $destMailboxId
+	 *
+	 * @return JSONResponse
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function move(int $id, int $destMailboxId): JSONResponse {
+		try {
+			$message = $this->mailManager->getMessage($this->currentUserId, $id);
+			$srcMailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
+			$srcAccount = $this->accountService->find($this->currentUserId, $srcMailbox->getAccountId());
+			$dstMailbox = $this->mailManager->getMailbox($this->currentUserId, $destMailboxId);
+			$dstAccount = $this->accountService->find($this->currentUserId, $dstMailbox->getAccountId());
+		} catch (DoesNotExistException $e) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		$this->mailManager->moveThread(
+			$srcAccount,
+			$srcMailbox,
+			$dstAccount,
+			$dstMailbox,
+			$message->getThreadRootId()
+		);
+
+		return new JSONResponse();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 *
+	 * @return JSONResponse
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function delete(int $id): JSONResponse {
+		try {
+			$message = $this->mailManager->getMessage($this->currentUserId, $id);
+			$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
+			$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
+		} catch (DoesNotExistException $e) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		$this->mailManager->deleteThread(
+			$account,
+			$mailbox,
+			$message->getThreadRootId()
+		);
+
+		return new JSONResponse();
+	}
+}

--- a/lib/Db/ThreadMapper.php
+++ b/lib/Db/ThreadMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2021 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author 2021 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<Message>
+ */
+class ThreadMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'mail_messages');
+	}
+
+	/**
+	 * @return array<array-key, array{mailboxName: string, messageUid: int}>
+	 */
+	public function findMessageUidsAndMailboxNamesByAccountAndThreadRoot(MailAccount $mailAccount, string $threadRootId, bool $trash): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('messages.uid', 'mailboxes.name')
+			->from($this->tableName, 'messages')
+			->join('messages', 'mail_mailboxes', 'mailboxes', 'messages.mailbox_id = mailboxes.id')
+			->where(
+				$qb->expr()->eq('messages.thread_root_id', $qb->createNamedParameter($threadRootId, IQueryBuilder::PARAM_STR)),
+				$qb->expr()->eq('mailboxes.account_id', $qb->createNamedParameter($mailAccount->getId(), IQueryBuilder::PARAM_INT))
+			);
+
+		$trashMailboxId = $mailAccount->getTrashMailboxId();
+		if ($trashMailboxId !== null) {
+			if ($trash) {
+				$qb->andWhere($qb->expr()->eq('mailboxes.id', $qb->createNamedParameter($trashMailboxId, IQueryBuilder::PARAM_INT)));
+			} else {
+				$qb->andWhere($qb->expr()->neq('mailboxes.id', $qb->createNamedParameter($trashMailboxId, IQueryBuilder::PARAM_INT)));
+			}
+		}
+
+		$result = $qb->execute();
+		$rows = array_map(static function (array $row) {
+			return [
+				'messageUid' => (int)$row[0],
+				'mailboxName' => (string)$row[1]
+			];
+		}, $result->fetchAll(\PDO::FETCH_NUM));
+		$result->closeCursor();
+
+		return $rows;
+	}
+}

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -35,6 +35,7 @@ use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMessageMapper;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
+use OCA\Mail\Db\ThreadMapper;
 use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Events\MessageDeletedEvent;
 use OCA\Mail\Events\MessageFlaggedEvent;
@@ -87,16 +88,17 @@ class MailManager implements IMailManager {
 	/** @var DbMessageMapper */
 	private $dbMessageMapper;
 
-	/** @var TagMapper */
-	private $tagMapper;
-
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
-	/**
-	 * @var LoggerInterface
-	 */
+	/** @var LoggerInterface */
 	private $logger;
+
+	/** @var TagMapper */
+	private $tagMapper;
+
+	/** @var ThreadMapper */
+	private $threadMapper;
 
 	public function __construct(IMAPClientFactory $imapClientFactory,
 								MailboxMapper $mailboxMapper,
@@ -106,7 +108,8 @@ class MailManager implements IMailManager {
 								DbMessageMapper $dbMessageMapper,
 								IEventDispatcher $eventDispatcher,
 								LoggerInterface $logger,
-								TagMapper $tagMapper) {
+								TagMapper $tagMapper,
+								ThreadMapper $threadMapper) {
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->mailboxSync = $mailboxSync;
@@ -116,6 +119,7 @@ class MailManager implements IMailManager {
 		$this->eventDispatcher = $eventDispatcher;
 		$this->logger = $logger;
 		$this->tagMapper = $tagMapper;
+		$this->threadMapper = $threadMapper;
 	}
 
 	public function getMailbox(string $uid, int $id): Mailbox {
@@ -155,13 +159,13 @@ class MailManager implements IMailManager {
 			throw new ServiceException(
 				"Could not get mailbox status: " .
 				$e->getMessage(),
-				(int) $e->getCode(),
+				(int)$e->getCode(),
 				$e
 			);
 		}
 		$this->folderMapper->detectFolderSpecialUse([$folder]);
 
-		$this->mailboxSync->sync($account, $this->logger,true);
+		$this->mailboxSync->sync($account, $this->logger, true);
 
 		return $this->mailboxMapper->find($account, $name);
 	}
@@ -182,14 +186,14 @@ class MailManager implements IMailManager {
 		} catch (Horde_Imap_Client_Exception | DoesNotExistException $e) {
 			throw new ServiceException(
 				"Could not load message",
-				(int) $e->getCode(),
+				(int)$e->getCode(),
 				$e
 			);
 		}
 	}
 
-	public function getThread(Account $account, int $messageId): array {
-		return $this->dbMessageMapper->findThread($account, $messageId);
+	public function getThread(Account $account, string $threadRootId): array {
+		return $this->dbMessageMapper->findThread($account, $threadRootId);
 	}
 
 	public function getMessageIdForUid(Mailbox $mailbox, $uid): ?int {
@@ -349,7 +353,7 @@ class MailManager implements IMailManager {
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				"Could not set subscription status for mailbox " . $mailbox->getId() . " on IMAP: " . $e->getMessage(),
-				(int) $e->getCode(),
+				(int)$e->getCode(),
 				$e
 			);
 		}
@@ -357,7 +361,7 @@ class MailManager implements IMailManager {
 		/**
 		 * 2. Pull changes into the mailbox database cache
 		 */
-		$this->mailboxSync->sync($account, $this->logger,true);
+		$this->mailboxSync->sync($account, $this->logger, true);
 
 		/**
 		 * 3. Return the updated object
@@ -396,7 +400,7 @@ class MailManager implements IMailManager {
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				"Could not set message flag on IMAP: " . $e->getMessage(),
-				(int) $e->getCode(),
+				(int)$e->getCode(),
 				$e
 			);
 		}
@@ -445,7 +449,7 @@ class MailManager implements IMailManager {
 			} catch (Horde_Imap_Client_Exception $e) {
 				throw new ServiceException(
 					"Could not set message keyword on IMAP: " . $e->getMessage(),
-					(int) $e->getCode(),
+					(int)$e->getCode(),
 					$e
 				);
 			}
@@ -520,7 +524,7 @@ class MailManager implements IMailManager {
 		/**
 		 * 2. Get the IMAP changes into our database cache
 		 */
-		$this->mailboxSync->sync($account, $this->logger,true);
+		$this->mailboxSync->sync($account, $this->logger, true);
 
 		/**
 		 * 3. Return the cached object with the new ID
@@ -605,7 +609,7 @@ class MailManager implements IMailManager {
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				"Could not get message flag options from IMAP: " . $e->getMessage(),
-				(int) $e->getCode(),
+				(int)$e->getCode(),
 				$e
 			);
 		}
@@ -648,5 +652,60 @@ class MailManager implements IMailManager {
 		$tag->setColor($color);
 
 		return $this->tagMapper->update($tag);
+	}
+
+	public function moveThread(Account $srcAccount, Mailbox $srcMailbox, Account $dstAccount, Mailbox $dstMailbox, string $threadRootId): void {
+		$mailAccount = $srcAccount->getMailAccount();
+		$messageInTrash = $srcMailbox->getId() === $mailAccount->getTrashMailboxId();
+
+		$messages = $this->threadMapper->findMessageUidsAndMailboxNamesByAccountAndThreadRoot(
+			$mailAccount,
+			$threadRootId,
+			$messageInTrash
+		);
+
+		foreach ($messages as $message) {
+			$this->logger->debug('move message', [
+				'messageId' => $message['messageUid'],
+				'srcMailboxId' => $srcMailbox->getId(),
+				'dstMailboxId' => $dstMailbox->getId()
+			]);
+
+			$this->moveMessage(
+				$srcAccount,
+				$message['mailboxName'],
+				$message['messageUid'],
+				$dstAccount,
+				$dstMailbox->getName()
+			);
+		}
+	}
+
+	/**
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function deleteThread(Account $account, Mailbox $mailbox, string $threadRootId): void {
+		$mailAccount = $account->getMailAccount();
+		$messageInTrash = $mailbox->getId() === $mailAccount->getTrashMailboxId();
+
+		$messages = $this->threadMapper->findMessageUidsAndMailboxNamesByAccountAndThreadRoot(
+			$mailAccount,
+			$threadRootId,
+			$messageInTrash
+		);
+
+		foreach ($messages as $message) {
+			$this->logger->debug('deleting message', [
+				'messageId' => $message['messageUid'],
+				'mailboxId' => $mailbox->getId(),
+			]);
+
+			$this->deleteMessage(
+				$account,
+				$message['mailboxName'],
+				$message['messageUid']
+			);
+		}
 	}
 }

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -100,7 +100,7 @@
 			<ActionButton icon="icon-external"
 				:close-after-click="true"
 				@click.prevent="onOpenMoveModal">
-				{{ t('mail', 'Move') }}
+				{{ t('mail', 'Move thread') }}
 			</ActionButton>
 			<ActionRouter icon="icon-add"
 				:to="{
@@ -119,7 +119,7 @@
 			<ActionButton icon="icon-delete"
 				:close-after-click="true"
 				@click.prevent="onDelete">
-				{{ t('mail', 'Delete') }}
+				{{ t('mail', 'Delete thread') }}
 			</ActionButton>
 		</template>
 		<template #extra>
@@ -138,6 +138,7 @@
 			<MoveModal v-if="showMoveModal"
 				:account="account"
 				:envelopes="[data]"
+				:move-thread="true"
 				@move="onMove"
 				@close="onCloseMoveModal" />
 			<TagModal
@@ -338,10 +339,11 @@ export default {
 			// Remove from selection first
 			this.setSelected(false)
 			// Delete
-			this.$emit('delete')
+			this.$emit('delete', this.data.databaseId)
+
 			try {
-				await this.$store.dispatch('deleteMessage', {
-					id: this.data.databaseId,
+				await this.$store.dispatch('deleteThread', {
+					envelope: this.data,
 				})
 			} catch (error) {
 				showError(await matchError(error, {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -71,8 +71,8 @@
 						@click.prevent="onOpenMoveModal">
 						{{ n(
 							'mail',
-							'Move {number}',
-							'Move {number}',
+							'Move {number} thread',
+							'Move {number} threads',
 							selection.length,
 							{
 								number: selection.length,
@@ -98,8 +98,8 @@
 						@click.prevent="deleteAllSelected">
 						{{ n(
 							'mail',
-							'Delete {number}',
-							'Delete {number}',
+							'Delete {number} thread',
+							'Delete {number} threads',
 							selection.length,
 							{
 								number: selection.length,
@@ -111,6 +111,7 @@
 					v-if="showMoveModal"
 					:account="account"
 					:envelopes="selectedEnvelopes"
+					:move-thread="true"
 					@close="onCloseMoveModal" />
 			</div>
 		</transition>
@@ -266,8 +267,8 @@ export default {
 			})
 			this.unselectAll()
 		},
-		deleteAllSelected() {
-			this.selectedEnvelopes.forEach(async(envelope) => {
+		async deleteAllSelected() {
+			for (const envelope of this.selectedEnvelopes) {
 				// Navigate if the message being deleted is the one currently viewed
 				// Shouldn't we simply use $emit here?
 				// Would be better to navigate after all messages have been deleted
@@ -290,10 +291,10 @@ export default {
 						})
 					}
 				}
-				logger.info(`deleting message ${envelope.databaseId}`)
+				logger.info(`deleting thread ${envelope.threadRootId}`)
 				try {
-					await this.$store.dispatch('deleteMessage', {
-						id: envelope.databaseId,
+					await this.$store.dispatch('deleteThread', {
+						envelope,
 					})
 				} catch (error) {
 					showError(await matchError(error, {
@@ -306,7 +307,7 @@ export default {
 						},
 					}))
 				}
-			})
+			}
 
 			// Get new messages
 			this.$store.dispatch('fetchNextEnvelopes', {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -357,8 +357,8 @@ export default {
 				logger.debug('deleting', { env })
 				this.onDelete(env.databaseId)
 				try {
-					await this.$store.dispatch('deleteMessage', {
-						id: env.databaseId,
+					await this.$store.dispatch('deleteThread', {
+						envelope: env,
 					})
 				} catch (error) {
 					logger.error('could not delete envelope', {

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -81,7 +81,7 @@
 			<ActionButton icon="icon-external"
 				:close-after-click="true"
 				@click.prevent="onOpenMoveModal">
-				{{ t('mail', 'Move') }}
+				{{ t('mail', 'Move message') }}
 			</ActionButton>
 			<ActionButton v-if="withShowSource"
 				:icon="sourceLoading ? 'icon-loading-small' : 'icon-details'"
@@ -100,7 +100,7 @@
 			<ActionButton icon="icon-delete"
 				:close-after-click="true"
 				@click.prevent="onDelete">
-				{{ t('mail', 'Delete') }}
+				{{ t('mail', 'Delete message') }}
 			</ActionButton>
 		</Actions>
 		<Modal v-if="showSourceModal" class="source-modal" @close="onCloseSourceModal">
@@ -297,6 +297,9 @@ export default {
 
 			// Delete
 			this.$emit('delete', this.envelope.databaseId)
+
+			logger.info(`deleting message ${this.envelope.databaseId}`)
+
 			try {
 				await this.$store.dispatch('deleteMessage', {
 					id: this.envelope.databaseId,

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -90,7 +90,25 @@ export default {
 			return parseInt(this.$route.params.threadId, 10)
 		},
 		thread() {
-			return this.$store.getters.getEnvelopeThread(this.threadId)
+			const envelopes = this.$store.getters.getEnvelopeThread(this.threadId)
+			const envelope = envelopes.find(envelope => envelope.databaseId === this.threadId)
+
+			if (envelope === undefined) {
+				return []
+			}
+
+			const currentMailbox = this.$store.getters.getMailbox(envelope.mailboxId)
+			const trashMailbox = this.$store.getters.getMailboxes(currentMailbox.accountId).find(mailbox => mailbox.specialRole === 'trash')
+
+			if (trashMailbox === undefined) {
+				return envelopes
+			}
+
+			if (currentMailbox.databaseId === trashMailbox.databaseId) {
+				return envelopes.filter(envelope => envelope.mailboxId === trashMailbox.databaseId)
+			} else {
+				return envelopes.filter(envelope => envelope.mailboxId !== trashMailbox.databaseId)
+			}
 		},
 		threadParticipants() {
 			const recipients = this.thread.flatMap(envelope => {

--- a/src/service/ThreadService.js
+++ b/src/service/ThreadService.js
@@ -1,0 +1,27 @@
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+import { convertAxiosError } from '../errors/convert'
+
+export async function deleteThread(id) {
+	const url = generateUrl('/apps/mail/api/thread/{id}', {
+		id,
+	})
+
+	try {
+		return await axios.delete(url)
+	} catch (e) {
+		throw convertAxiosError(e)
+	}
+}
+
+export async function moveThread(id, destMailboxId) {
+	const url = generateUrl('/apps/mail/api/thread/{id}', {
+		id,
+	})
+
+	try {
+		return await axios.post(url, { destMailboxId })
+	} catch (e) {
+		throw convertAxiosError(e)
+	}
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -79,7 +79,8 @@ import SyncIncompleteError from '../errors/SyncIncompleteError'
 import MailboxLockedError from '../errors/MailboxLockedError'
 import { wait } from '../util/wait'
 import { updateAccount as updateSieveAccount } from '../service/SieveService'
-import { UNIFIED_INBOX_ID, PAGE_SIZE } from './constants'
+import { PAGE_SIZE, UNIFIED_INBOX_ID } from './constants'
+import * as ThreadService from '../service/ThreadService'
 
 const sliceToPage = slice(0, PAGE_SIZE)
 
@@ -798,5 +799,29 @@ export default {
 			envelope,
 			tagId: tag.id,
 		})
+	},
+	async deleteThread({ getters, commit }, { envelope }) {
+		commit('removeEnvelope', { id: envelope.databaseId })
+
+		try {
+			await ThreadService.deleteThread(envelope.databaseId)
+			console.debug('thread removed')
+		} catch (e) {
+			commit('addEnvelope', envelope)
+			console.error('could not delete thread', e)
+			throw e
+		}
+	},
+	async moveThread({ getters, commit }, { envelope, destMailboxId }) {
+		commit('removeEnvelope', { id: envelope.databaseId })
+
+		try {
+			await ThreadService.moveThread(envelope.databaseId, destMailboxId)
+			console.debug('thread removed')
+		} catch (e) {
+			commit('addEnvelope', envelope)
+			console.error('could not move thread', e)
+			throw e
+		}
 	},
 }

--- a/tests/Unit/Controller/ThreadControllerTest.php
+++ b/tests/Unit/Controller/ThreadControllerTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Controller;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Controller\ThreadController;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ThreadControllerTest extends TestCase {
+
+	/** @var string */
+	private $appName;
+
+	/** @var IRequest|MockObject */
+	private $request;
+
+	/** @var string */
+	private $userId;
+
+	/** @var AccountService|MockObject */
+	private $accountService;
+
+	/** @var IMailManager|MockObject */
+	private $mailManager;
+
+	/** @var ThreadController */
+	private $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appName = 'mail';
+		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
+		$this->userId = 'john';
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->mailManager = $this->createMock(IMailManager::class);
+
+		$this->controller = new ThreadController(
+			$this->appName,
+			$this->request,
+			$this->userId,
+			$this->accountService,
+			$this->mailManager
+		);
+	}
+
+	public function testMoveForbidden() {
+		$this->mailManager
+			->method('getMessage')
+			->willThrowException(new DoesNotExistException('for some reason there is no such record'));
+
+		$response = $this->controller->move(100, 20);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+
+	public function testMoveInbox(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setTrashMailboxId(80);
+		$this->accountService
+			->method('find')
+			->willReturn(new Account($mailAccount));
+		$srcMailbox = new Mailbox();
+		$srcMailbox->setId(20);
+		$srcMailbox->setName('INBOX');
+		$srcMailbox->setAccountId($mailAccount->getId());
+		$dstMailbox = new Mailbox();
+		$dstMailbox->setId(40);
+		$dstMailbox->setName('Archive');
+		$dstMailbox->setAccountId($mailAccount->getId());
+		$this->mailManager
+			->method('getMailbox')
+			->willReturnMap([
+				[$this->userId, $srcMailbox->getId(), $srcMailbox],
+				[$this->userId, $dstMailbox->getId(), $dstMailbox],
+			]);
+		$message = new Message();
+		$message->setId(300);
+		$message->setMailboxId($srcMailbox->getId());
+		$message->setThreadRootId('some-thread-root-id-1');
+		$this->mailManager
+			->method('getMessage')
+			->willReturn($message);
+		$this->mailManager
+			->expects(self::once())
+			->method('moveThread');
+
+		$response = $this->controller->move($message->getId(), $dstMailbox->getId());
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testMoveTrash(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setTrashMailboxId(80);
+		$this->accountService
+			->method('find')
+			->willReturn(new Account($mailAccount));
+		$srcMailbox = new Mailbox();
+		$srcMailbox->setId(80);
+		$srcMailbox->setName('Trash');
+		$srcMailbox->setAccountId($mailAccount->getId());
+		$dstMailbox = new Mailbox();
+		$dstMailbox->setId(20);
+		$dstMailbox->setName('Archive');
+		$dstMailbox->setAccountId($mailAccount->getId());
+		$this->mailManager
+			->method('getMailbox')
+			->willReturnMap([
+				[$this->userId, $srcMailbox->getId(), $srcMailbox],
+				[$this->userId, $dstMailbox->getId(), $dstMailbox],
+			]);
+		$message = new Message();
+		$message->setId(300);
+		$message->setMailboxId($srcMailbox->getId());
+		$message->setThreadRootId('some-thread-root-id-1');
+		$this->mailManager
+			->method('getMessage')
+			->willReturn($message);
+		$this->mailManager
+			->expects(self::once())
+			->method('moveThread');
+
+		$response = $this->controller->move($message->getId(), $dstMailbox->getId());
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testDeleteForbidden(): void {
+		$this->mailManager
+			->method('getMessage')
+			->willThrowException(new DoesNotExistException('for some reason there is no such record'));
+
+		$response = $this->controller->delete(100);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+
+	public function testDeleteInbox(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setTrashMailboxId(80);
+		$this->accountService
+			->method('find')
+			->willReturn(new Account($mailAccount));
+		$mailbox = new Mailbox();
+		$mailbox->setId(20);
+		$mailbox->setAccountId($mailAccount->getId());
+		$this->mailManager
+			->method('getMailbox')
+			->willReturn($mailbox);
+		$message = new Message();
+		$message->setId(300);
+		$message->setMailboxId($mailbox->getId());
+		$message->setThreadRootId('some-thread-root-id-1');
+		$this->mailManager
+			->method('getMessage')
+			->willReturn($message);
+		$this->mailManager
+			->expects(self::once())
+			->method('deleteThread');
+
+		$response = $this->controller->delete(300);
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testDeleteTrash(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setTrashMailboxId(80);
+		$this->accountService
+			->method('find')
+			->willReturn(new Account($mailAccount));
+		$mailbox = new Mailbox();
+		$mailbox->setId(80);
+		$mailbox->setAccountId($mailAccount->getId());
+		$this->mailManager
+			->method('getMailbox')
+			->willReturn($mailbox);
+		$message = new Message();
+		$message->setId(300);
+		$message->setMailboxId($mailbox->getId());
+		$message->setThreadRootId('some-thread-root-id-1');
+		$this->mailManager
+			->method('getMessage')
+			->willReturn($message);
+		$this->mailManager
+			->expects(self::once())
+			->method('deleteThread');
+
+		$response = $this->controller->delete($message->getId());
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -94,14 +94,12 @@
     </ImplicitToStringCast>
   </file>
   <file src="lib/Db/MessageMapper.php">
-    <ImplicitToStringCast occurrences="26">
+    <ImplicitToStringCast occurrences="25">
       <code>$deleteMessagesQuery-&gt;createParameter('messageIds')</code>
       <code>$deleteRecipientsQuery-&gt;createParameter('ids')</code>
       <code>$deleteRecipientsQuery-&gt;createParameter('messageIds')</code>
       <code>$messageIdQuery-&gt;createParameter('uids')</code>
       <code>$messagesQuery-&gt;createFunction($mailboxesQuery-&gt;getSQL())</code>
-      <code>$qb-&gt;createFunction($mailboxIdsQuery-&gt;getSQL())</code>
-      <code>$qb-&gt;createFunction($mailboxIdsQuery-&gt;getSQL())</code>
       <code>$qb-&gt;createFunction($selectMailboxIds-&gt;getSQL())</code>
       <code>$qb-&gt;createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)</code>
       <code>$qb-&gt;createNamedParameter($query-&gt;getBcc(), IQueryBuilder::PARAM_STR_ARRAY)</code>


### PR DESCRIPTION
Fixes #3652 

**Todo**

- [x] Endpoint to delete / move a thread
- [x] Delete in envelope list should delete all messages (excl. trash)
- [x] Move in envelope list should move all messages (excl. trash)
- [x] Delete the latest message in thread view should add the second latest message to the envelope list<sup>1</sup>
- [x] Move the latest message in thread view should add the second latest message to the envelope list<sup>1</sup>
- [x] Select multiple threads/messages in envelope to delete/move must still work
- [x] Keyboard shortcuts
- [x] Rename delete to delete thread in envelope list
- [x] Rename move to move thread in envelope list

<sup>1</sup> Is done by the existing sync backend request 

_Technical details and design decisions: https://github.com/nextcloud/mail/pull/4970._