### PR TITLE
Fix mark (un)important action on envelope list

### DIFF
--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -283,6 +283,7 @@ class Message extends Entity implements JsonSerializable {
 				'draft' => ($this->getFlagDraft() === true),
 				'forwarded' => ($this->getFlagForwarded() === true),
 				'hasAttachments' => ($this->getFlagAttachments() ?? false),
+				'important' => ($this->getFlagImportant() === true),
 				'junk' => ($this->getFlagJunk() === true),
 				'mdnsent' => ($this->getFlagMdnsent() === true),
 			],

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -60,7 +60,7 @@
 				:close-after-click="true"
 				@click.prevent="onToggleImportant">
 				{{
-					data.flags.important ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
+					isImportant ? t('mail', 'Mark unimportant') : t('mail', 'Mark important')
 				}}
 			</ActionButton>
 			<ActionButton icon="icon-starred"
@@ -296,7 +296,7 @@ export default {
 		isImportant() {
 			return this.$store.getters
 				.getEnvelopeTags(this.data.databaseId)
-				.find((tag) => tag.imapLabel === '$label1')
+				.some((tag) => tag.imapLabel === '$label1')
 		},
 		tags() {
 			return this.$store.getters.getEnvelopeTags(this.data.databaseId).filter((tag) => tag.imapLabel !== '$label1')

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -270,7 +270,7 @@ export default {
 		isImportant() {
 			return this.$store.getters
 				.getEnvelopeTags(this.envelope.databaseId)
-				.find((tag) => tag.imapLabel === '$label1')
+				.some((tag) => tag.imapLabel === '$label1')
 		},
 	},
 	methods: {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -603,21 +603,18 @@ export default {
 	},
 	async toggleEnvelopeImportant({ dispatch, getters }, envelope) {
 		const importantLabel = '$label1'
-		const tag = getters
+		const hasTag = getters
 			.getEnvelopeTags(envelope.databaseId)
-			.find((tag) => tag.imapLabel === importantLabel)
-		if (tag) {
+			.some((tag) => tag.imapLabel === importantLabel)
+		if (hasTag) {
 			await dispatch('removeEnvelopeTag', {
 				envelope,
-				tag,
-
+				imapLabel: importantLabel,
 			})
 		} else {
 			await dispatch('addEnvelopeTag', {
-
 				envelope,
 				imapLabel: importantLabel,
-
 			})
 		}
 	},


### PR DESCRIPTION
Reported by @st3iny while reviewing the threading pr. 

1) removeEnvelopeTag was called with tag but expects imapLabel
2) ~important is not a flag and not available as data.flags.important~ say hello again to data.flags.important
3) change find to some to return a boolean if $label1 is true for a given message