### PR TITLE
Replaced provisioned with new provisioningId

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -30,11 +30,11 @@
 			:title="t('mail', 'Account settings')">
 			<strong>{{ displayName }}</strong> &lt;{{ email }}&gt;
 			<a
-				v-if="!account.provisioned"
+				v-if="!account.provisioningId"
 				class="button icon-rename"
 				:title="t('mail', 'Change name')"
 				@click="handleClick" />
-			<AliasSettings v-if="!account.provisioned" :account="account" />
+			<AliasSettings v-if="!account.provisioningId" :account="account" />
 		</AppSettingsSection>
 		<AppSettingsSection :title="t('mail', 'Signature')">
 			<p class="settings-hint">
@@ -56,7 +56,7 @@
 			</p>
 			<AccountDefaultsSettings :account="account" />
 		</AppSettingsSection>
-		<AppSettingsSection v-if="account && !account.provisioned" :title="t('mail', 'Mail server')">
+		<AppSettingsSection v-if="account && !account.provisioningId" :title="t('mail', 'Mail server')">
 			<div id="mail-settings">
 				<AccountForm
 					:key="account.accountId"
@@ -67,7 +67,7 @@
 					:account="account" />
 			</div>
 		</AppSettingsSection>
-		<AppSettingsSection v-if="account && !account.provisioned" :title="t('mail', 'Sieve filter server')">
+		<AppSettingsSection v-if="account && !account.provisioningId" :title="t('mail', 'Sieve filter server')">
 			<div id="sieve-settings">
 				<SieveAccountForm
 					:key="account.accountId"


### PR DESCRIPTION
Fixes a small issue with the account settings where the old `provisioned` value was still used.