### PR TITLE
Removes a duplicate definition of 'page#index' route

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -60,11 +60,6 @@ return [
 			'verb' => 'GET'
 		],
 		[
-			'name' => 'page#index',
-			'url' => '/',
-			'verb' => 'GET'
-		],
-		[
 			'name' => 'page#compose',
 			'url' => '/compose',
 			'verb' => 'GET'


### PR DESCRIPTION
Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>