### PR TITLE
Specify which account had a sync error

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -41,6 +41,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Folder;
 use OCP\AppFramework\Utility\ITimeFactory;
+use function sprintf;
 
 class MailboxSync {
 
@@ -104,7 +105,7 @@ class MailboxSync {
 			$this->folderMapper->getFoldersStatus($folders, $client);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
-				"IMAP error: " . $e->getMessage(),
+				sprintf("IMAP error synchronizing account %d: %s", $account->getId(), $e->getMessage()),
 				(int)$e->getCode(),
 				$e
 			);


### PR DESCRIPTION
Traces on production instances do not show the account IDs and it becomes really hard to track down which account is creating log entries. This will help with the live debugging.