### PR TITLE
Lower the chunk size for IMAP syncs

### DIFF
--- a/lib/IMAP/Sync/Synchronizer.php
+++ b/lib/IMAP/Sync/Synchronizer.php
@@ -36,7 +36,15 @@ use function array_chunk;
 use function array_merge;
 
 class Synchronizer {
-	private const UID_CHUNK_SIZE = 15000;
+
+	/**
+	 * This determines how many UIDs we send to IMAP for a check of changed or
+	 * vanished messages. The number needs a balance between good performance
+	 * (few chunks) and staying below the IMAP command size limits. 15k has
+	 * shown to cause IMAP errors for some accounts where the UID list can't be
+	 * compressed much by Horde.
+	 */
+	private const UID_CHUNK_SIZE = 10000;
 
 	/** @var MessageMapper */
 	private $messageMapper;

--- a/tests/Unit/IMAP/Sync/SynchronizerTest.php
+++ b/tests/Unit/IMAP/Sync/SynchronizerTest.php
@@ -52,7 +52,7 @@ class SynchronizerTest extends TestCase {
 		$this->synchronizer = new Synchronizer($this->mapper);
 	}
 
-	public function testSync() {
+	public function testSync(): void {
 		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
 		$request = $this->createMock(Request::class);
 		$request->expects($this->any())
@@ -87,7 +87,7 @@ class SynchronizerTest extends TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function testSyncChunked() {
+	public function testSyncChunked(): void {
 		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
 		$request = $this->createMock(Request::class);
 		$request->method('getMailbox')
@@ -97,7 +97,7 @@ class SynchronizerTest extends TestCase {
 		$request->method('getUids')
 			->willReturn(range(1, 30000, 1));
 		$hordeSync = $this->createMock(Horde_Imap_Client_Data_Sync::class);
-		$imapClient->expects($this->exactly(2))
+		$imapClient->expects($this->exactly(3))
 			->method('sync')
 			->with($this->equalTo(new Horde_Imap_Client_Mailbox('inbox')), $this->equalTo('123456'))
 			->willReturn($hordeSync);


### PR DESCRIPTION
In #3110 I lowered the chances of too long IMAP commands by splitting
the sync process.

As we've seen in production it's still possible that certain accounts
run into the issue that their chunked UID list is producing an IMAP
command that is too long. So I'm once again lower the chances by
lowering the chunk size.

This could have a tiny effect on sync performance as it now takes more
chunks to check for the changed/vanished messages of one account.

Signed-off-by: Christoph Wurst <christoph@winzerhof-wurst.at>