### PR TITLE
Sanitize urls in css style sheets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
 		"pear-pear.horde.org/horde_util": "^2.5.8@stable",
 		"psr/log": "^1",
 		"rubix/ml": "0.4.1",
+		"sabberworm/php-css-parser": "^8.3",
 		"youthweb/urllinker": "^1.3"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37b96159064d686c39e6a4366d0e25e7",
+    "content-hash": "5b99ab29b81c72b9aa6578eaf9503c1a",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1943,6 +1943,51 @@
                 }
             ],
             "time": "2021-05-25T05:36:16+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "8.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabberworm/PHP-CSS-Parser.git",
+                "reference": "d217848e1396ef962fb1997cf3e2421acba7f796"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabberworm/PHP-CSS-Parser/zipball/d217848e1396ef962fb1997cf3e2421acba7f796",
+                "reference": "d217848e1396ef962fb1997cf3e2421acba7f796",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "codacy/coverage": "^1.4",
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Sabberworm\\CSS": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "http://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "time": "2020-06-01T09:10:00+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/lib/Service/HtmlPurify/TransformStyleURLs.php
+++ b/lib/Service/HtmlPurify/TransformStyleURLs.php
@@ -31,9 +31,9 @@ use HTMLPurifier_Context;
 use OCP\IURLGenerator;
 
 /**
- * Adds copies src to data-src on all img tags.
+ * Blocks urls in style attributes and backups original styles for restoring them later.
  */
-class TransformCSSBackground extends HTMLPurifier_AttrTransform {
+class TransformStyleURLs extends HTMLPurifier_AttrTransform {
 
 	/** @var IURLGenerator */
 	private $urlGenerator;
@@ -49,8 +49,7 @@ class TransformCSSBackground extends HTMLPurifier_AttrTransform {
 	 * @return array
 	 */
 	public function transform($attr, $config, $context) {
-		if (!isset($attr['style']) ||
-			strpos($attr['style'], 'background') === false) {
+		if (!isset($attr['style']) || strpos($attr['style'], 'url(') === false) {
 			return $attr;
 		}
 
@@ -64,10 +63,9 @@ class TransformCSSBackground extends HTMLPurifier_AttrTransform {
 			}
 
 			[$name, $value] = explode(':', $cssAttribute, 2);
-			if (strpos($name, 'background') !== false &&
-				strpos($value, 'url(') !== false) {
+			if (strpos($value, 'url(') !== false) {
 				// Replace image URL
-				$value = preg_replace('/url\("?http.*\)/i',
+				$value = preg_replace('/url\(("|\')?http.*\)/i',
 					'url(' . $this->urlGenerator->imagePath('mail', 'blocked-image.png') . ')',
 					$value);
 				return $name . ':' . $value;

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -92,6 +92,7 @@ export default {
 			this.hasBlockedContent
 				= iframeDoc.querySelectorAll('[data-original-src]').length > 0
 				|| iframeDoc.querySelectorAll('[data-original-style]').length > 0
+				|| iframeDoc.querySelectorAll('style[data-original-content]').length > 0
 
 			this.loading = false
 			if (this.isSenderTrusted) {
@@ -114,6 +115,11 @@ export default {
 			iframeDoc
 				.querySelectorAll('[data-original-style]')
 				.forEach((node) => node.setAttribute('style', node.getAttribute('data-original-style')))
+			iframeDoc
+				.querySelectorAll('style[data-original-content]')
+				.forEach((node) => {
+					node.innerHTML = node.getAttribute('data-original-content')
+				})
 			this.hasBlockedContent = false
 		},
 		async onShowBlockedContent() {


### PR DESCRIPTION
Currently, CSS style sheets are not sanitized and allow tracker scripts to bypass our trusted senders feature. Furthermore, our style attribute sanitizer was not strict enough so I improved it to replace all `url(...)` values (not just those of `background-*` rules).

I added a new PHP dependency for parsing CSS style sheets. Using regex is not sufficient to parse style sheets and could be exploited by a future attacker.

## Example
```css
ul { list-style-image: url(https://my.tracker.com/some-image.png); }
div { background-image: url(https://my.tracker.com/some-image.png); }
```