### PR TITLE
LDAP alias provisioning

### DIFF
--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -72,8 +72,8 @@ class AliasesController extends Controller {
 	 * @NoAdminRequired
 	 * @TrapError
 	 */
-	public function update() {
-		throw new NotImplemented();
+	public function update(int $id, string $alias, string $aliasName): JSONResponse {
+		return new JSONResponse($this->aliasService->update($this->currentUserId, $id, $alias, $aliasName));
 	}
 
 	/**
@@ -84,7 +84,7 @@ class AliasesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function destroy(int $id): JSONResponse {
-		return new JSONResponse($this->aliasService->delete($id, $this->currentUserId));
+		return new JSONResponse($this->aliasService->delete($this->currentUserId, $id));
 	}
 
 	/**
@@ -116,7 +116,6 @@ class AliasesController extends Controller {
 	 * @throws DoesNotExistException
 	 */
 	public function updateSignature(int $id, string $signature = null): JSONResponse {
-		$this->aliasService->updateSignature($this->currentUserId, $id, $signature);
-		return new JSONResponse();
+		return new JSONResponse($this->aliasService->updateSignature($this->currentUserId, $id, $signature));
 	}
 }

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -60,6 +60,8 @@ class SettingsController extends Controller {
 			$this->provisioningManager->newProvisioning($data);
 		} catch (ValidationException $e) {
 			return HttpJsonResponse::fail([$e->getFields()]);
+		} catch (\Exception $e) {
+			return HttpJsonResponse::fail([$e->getMessage()]);
 		}
 
 		return new JSONResponse([]);
@@ -67,12 +69,11 @@ class SettingsController extends Controller {
 
 	public function updateProvisioning(int $id, array $data): JSONResponse {
 		try {
-			$this->provisioningManager->updateProvisioning(array_merge(
-				$data,
-				['id' => $id]
-			));
+			$this->provisioningManager->updateProvisioning(array_merge($data, ['id' => $id]));
 		} catch (ValidationException $e) {
 			return HttpJsonResponse::fail([$e->getFields()]);
+		} catch (\Exception $e) {
+			return HttpJsonResponse::fail([$e->getMessage()]);
 		}
 
 		return new JSONResponse([]);

--- a/lib/Db/Alias.php
+++ b/lib/Db/Alias.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Db;
 
 use JsonSerializable;
-
 use OCP\AppFramework\Db\Entity;
 
 /**
@@ -36,6 +35,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getAlias()
  * @method void setSignature(string|null $signature)
  * @method string|null getSignature()
+ * @method void setProvisioningId(int $provisioningId)
+ * @method int|null getProvisioningId()
  */
 class Alias extends Entity implements JsonSerializable {
 
@@ -51,10 +52,18 @@ class Alias extends Entity implements JsonSerializable {
 	/** @var string|null */
 	protected $signature;
 
+	/** @var int|null */
+	protected $provisioningId;
+
 	public function __construct() {
 		$this->addType('accountId', 'int');
 		$this->addType('name', 'string');
 		$this->addType('alias', 'string');
+		$this->addType('provisioningId', 'int');
+	}
+
+	public function isProvisioned(): bool {
+		return $this->getProvisioningId() !== null;
 	}
 
 	public function jsonSerialize(): array {
@@ -63,6 +72,7 @@ class Alias extends Entity implements JsonSerializable {
 			'name' => $this->getName(),
 			'alias' => $this->getAlias(),
 			'signature' => $this->getSignature(),
+			'provisioned' => $this->isProvisioned(),
 		];
 	}
 }

--- a/lib/Db/Provisioning.php
+++ b/lib/Db/Provisioning.php
@@ -60,6 +60,12 @@ use OCP\IUser;
  * @method void setSieveSslMode(?string $sieveSslMode)
  * @method string|null getSieveUser()
  * @method void setSieveUser(?string $sieveUser)
+ * @method array getAliases()
+ * @method void setAliases(array $aliases)
+ * @method bool getLdapAliasesProvisioning()
+ * @method void setLdapAliasesProvisioning(bool $ldapAliasesProvisioning)
+ * @method string|null getLdapAliasesAttribute()
+ * @method void setLdapAliasesAttribute(?string $ldapAliasesAttribute)
  */
 class Provisioning extends Entity implements JsonSerializable {
 	public const WILDCARD = '*';
@@ -79,13 +85,18 @@ class Provisioning extends Entity implements JsonSerializable {
 	protected $sieveHost;
 	protected $sievePort;
 	protected $sieveSslMode;
+	protected $aliases = [];
+	protected $ldapAliasesProvisioning;
+	protected $ldapAliasesAttribute;
 
 	public function __construct() {
 		$this->addType('imapPort', 'integer');
 		$this->addType('smtpPort', 'integer');
 		$this->addType('sieveEnabled', 'boolean');
 		$this->addType('sievePort', 'integer');
+		$this->addType('ldapAliasesProvisioning', 'boolean');
 	}
+
 	/**
 	 * @return array
 	 */
@@ -107,6 +118,9 @@ class Provisioning extends Entity implements JsonSerializable {
 			'sieveHost' => $this->getSieveHost(),
 			'sievePort' => $this->getSievePort(),
 			'sieveSslMode' => $this->getSieveSslMode(),
+			'aliases' => $this->getAliases(),
+			'ldapAliasesProvisioning' => $this->getLdapAliasesProvisioning(),
+			'ldapAliasesAttribute' => $this->getLdapAliasesAttribute(),
 		];
 	}
 

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -51,11 +51,11 @@ class ProvisioningMapper extends QBMapper {
 	 *
 	 * @return Provisioning[]
 	 */
-	public function getAll() : array {
+	public function getAll(): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb = $qb->select('*')
-				->from($this->getTableName())
-				->orderBy('provisioning_domain', 'desc');
+			->from($this->getTableName())
+			->orderBy('provisioning_domain', 'desc');
 		try {
 			return $this->findEntities($qb);
 		} catch (DoesNotExistException $e) {
@@ -69,7 +69,7 @@ class ProvisioningMapper extends QBMapper {
 	 * @return Provisioning
 	 * @throws ValidationException
 	 */
-	public function validate(array $data) : Provisioning {
+	public function validate(array $data): Provisioning {
 		$exception = new ValidationException();
 
 		if (!isset($data['provisioningDomain']) || $data['provisioningDomain'] === '') {
@@ -103,10 +103,16 @@ class ProvisioningMapper extends QBMapper {
 			$exception->setField('smtpSslMode', false);
 		}
 
+		$ldapAliasesProvisioning = (bool)($data['ldapAliasesProvisioning'] ?? false);
+		$ldapAliasesAttribute = $data['ldapAliasesAttribute'] ?? '';
+
+		if ($ldapAliasesProvisioning && empty($ldapAliasesAttribute)) {
+			$exception->setField('ldapAliasesAttribute', false);
+		}
+
 		if (!empty($exception->getFields())) {
 			throw $exception;
 		}
-
 
 		$provisioning = new Provisioning();
 		$provisioning->setId($data['id'] ?? null);
@@ -127,14 +133,17 @@ class ProvisioningMapper extends QBMapper {
 		$provisioning->setSievePort($data['sievePort'] ?? null);
 		$provisioning->setSieveSslMode($data['sieveSslMode'] ?? '');
 
+		$provisioning->setLdapAliasesProvisioning($ldapAliasesProvisioning);
+		$provisioning->setLdapAliasesAttribute($ldapAliasesAttribute);
+
 		return $provisioning;
 	}
 
 	public function get(int $id): ?Provisioning {
 		$qb = $this->db->getQueryBuilder();
 		$qb = $qb->select('*')
-				->from($this->getTableName())
-				->where($qb->expr()->eq('id', $qb->createNamedParameter($id), IQueryBuilder::PARAM_INT));
+			->from($this->getTableName())
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($id), IQueryBuilder::PARAM_INT));
 		try {
 			return $this->findEntity($qb);
 		} catch (DoesNotExistException $e) {

--- a/lib/Migration/Version1101Date20210616141806.php
+++ b/lib/Migration/Version1101Date20210616141806.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1101Date20210616141806 extends SimpleMigrationStep {
+	/**
+	 * @throws SchemaException
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$provisioningTable = $schema->getTable('mail_provisionings');
+		$provisioningTable->addColumn('ldap_aliases_provisioning', 'boolean', [
+			'notnull' => false,
+			'default' => false
+		]);
+		$provisioningTable->addColumn('ldap_aliases_attribute', 'string', [
+			'notnull' => false,
+			'length' => 255,
+			'default' => '',
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -29,6 +29,7 @@ use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IInitialStateService;
+use OCP\LDAP\ILDAPProvider;
 use OCP\Settings\ISettings;
 
 class AdminSettings implements ISettings {
@@ -50,6 +51,14 @@ class AdminSettings implements ISettings {
 			Application::APP_ID,
 			'provisioning_settings',
 			$this->provisioningManager->getConfigs()
+		);
+
+		$this->initialStateService->provideLazyInitialState(
+			Application::APP_ID,
+			'ldap_aliases_integration',
+			function () {
+				return method_exists(ILDAPProvider::class, 'getMultiValueUserAttribute');
+			}
 		);
 
 		return new TemplateResponse(Application::APP_ID, 'settings-admin');

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -28,13 +28,15 @@
 		:show-navigation="true">
 		<AppSettingsSection
 			:title="t('mail', 'Account settings')">
-			<strong>{{ displayName }}</strong> &lt;{{ email }}&gt;
-			<a
-				v-if="!account.provisioningId"
-				class="button icon-rename"
-				:title="t('mail', 'Change name')"
-				@click="handleClick" />
-			<AliasSettings v-if="!account.provisioningId" :account="account" />
+			<div class="alias-item">
+				<p><strong>{{ displayName }}</strong> &lt;{{ email }}&gt;</p>
+				<a
+					v-if="!account.provisioningId"
+					class="button icon-rename"
+					:title="t('mail', 'Change name')"
+					@click="handleClick" />
+			</div>
+			<AliasSettings :account="account" />
 		</AppSettingsSection>
 		<AppSettingsSection :title="t('mail', 'Signature')">
 			<p class="settings-hint">
@@ -178,6 +180,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.alias-item {
+	display: flex;
+	justify-content: space-between;
+}
+
 ::v-deep .modal-container {
 	display: block;
 	overflow: scroll;

--- a/src/components/AliasForm.vue
+++ b/src/components/AliasForm.vue
@@ -1,0 +1,158 @@
+<!--
+  - @copyright 2021 Daniel Kesselberg <mail@danielkesselberg.de>
+  -
+  - @author 2021 Daniel Kesselberg <mail@danielkesselberg.de>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<div>
+		<form v-if="showForm" class="alias-form" @submit.prevent="updateAlias">
+			<div>
+				<input v-model="changeName"
+					type="text"
+					required>
+				<input v-model="changeAlias"
+					type="email"
+					:disabled="alias.provisioned"
+					required>
+			</div>
+			<div class="button-group">
+				<button
+					class="icon"
+					type="submit"
+					:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark'"
+					:title="t('mail', 'Update alias')" />
+			</div>
+		</form>
+		<div v-else class="alias-item">
+			<p><strong>{{ alias.name }}</strong> &lt;{{ alias.alias }}&gt;</p>
+			<div class="button-group">
+				<button
+					class="icon icon-rename"
+					:title="t('mail', 'Show update alias form')"
+					@click="showForm = true" />
+				<button v-if="!alias.provisioned"
+					class="icon"
+					:title="t('mail', 'Delete alias')"
+					:class="loading ? 'icon-loading-small-dark' : 'icon-delete'"
+					@click="deleteAlias" />
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import logger from '../logger'
+
+export default {
+	name: 'AliasForm',
+	props: {
+		account: {
+			type: Object,
+			required: true,
+		},
+		alias: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			changeAlias: this.alias.alias,
+			changeName: this.alias.name,
+			showForm: false,
+			loading: false,
+		}
+	},
+	methods: {
+		async updateAlias(e) {
+			this.loading = true
+
+			await this.$store.dispatch('updateAlias', {
+				account: this.account,
+				aliasId: this.alias.id,
+				alias: this.changeAlias,
+				name: this.changeName,
+			})
+
+			logger.debug('updated alias', {
+				accountId: this.account.id,
+				aliasId: this.alias.id,
+				alias: this.changeAlias,
+				name: this.changeName,
+			})
+
+			this.showForm = false
+			this.loading = false
+		},
+		async deleteAlias() {
+			this.loading = true
+
+			await this.$store.dispatch('deleteAlias', {
+				account: this.account,
+				aliasId: this.alias.id,
+			})
+
+			logger.debug('deleted alias', {
+				accountId: this.account.id,
+				aliasId: this.alias.id,
+				alias: this.alias.alias,
+				name: this.alias.name,
+			})
+
+			this.showForm = false
+			this.loading = false
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.alias-form, .alias-item {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.button-group {
+	display: flex;
+	align-items: center;
+}
+
+.icon {
+	background-color: var(--color-main-background);
+	border: none;
+	opacity: 0.7;
+
+	&:hover, &:focus {
+		opacity: 1;
+	}
+}
+
+.icon-checkmark {
+	background-image: var(--icon-checkmark-000);
+}
+
+.icon-delete {
+	background-image: var(--icon-delete-000);
+}
+
+.icon-rename {
+	background-image: var(--icon-rename-000);
+}
+</style>

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -281,6 +281,36 @@
 						</div>
 					</div>
 				</div>
+				<div v-if="ldapAliasesIntegration" class="settings-group">
+					<div class="group-title">
+						{{ t('mail', 'LDAP aliases integration') }}
+					</div>
+					<div class="group-inputs">
+						<div>
+							<input
+								:id="'mail-provision-ldap-aliases-provisioning' + setting.id"
+								v-model="ldapAliasesProvisioning"
+								type="checkbox"
+								class="checkbox">
+							<label :for="'mail-provision-ldap-aliases-provisioning' + setting.id">
+								{{ t('mail', 'Enable ldap aliases integration') }}
+							</label>
+							<p>{{ t('mail', 'The ldap aliases integration reads a attribute from the configured ldap directory to provision email aliases.') }}</p>
+						</div>
+						<div>
+							<label :for="'mail-provision-ldap-aliases-attribute' + setting.id">
+								{{ t('mail', 'LDAP attribute for aliases') }}*
+								<br>
+								<input :id="'mail-provision-ldap-aliases-attribute' + setting.id"
+									v-model="ldapAliasesAttribute"
+									:disabled="loading"
+									:required="ldapAliasesProvisioning"
+									type="text">
+							</label>
+							<p>{{ t('mail', 'A multi value attribute to provision email aliases. For each value an alias is created. Alias existing in Nextcloud but not in the ldap directory are deleted.') }}</p>
+						</div>
+					</div>
+				</div>
 				<div class="settings-group">
 					<div class="group-title" />
 					<div class="group-inputs">
@@ -321,6 +351,9 @@
 <script>
 import logger from '../../logger'
 import ProvisionPreview from './ProvisionPreview'
+import { loadState } from '@nextcloud/initial-state'
+
+const ldapAliasesIntegration = loadState('mail', 'ldap_aliases_integration', false)
 
 export default {
 	name: 'ProvisioningSettings',
@@ -373,6 +406,9 @@ export default {
 				uid: 'user321',
 				email: 'user@domain.com',
 			},
+			ldapAliasesIntegration,
+			ldapAliasesProvisioning: this.setting.ldapAliasesProvisioning || false,
+			ldapAliasesAttribute: this.setting.ldapAliasesAttribute || '',
 			loading: false,
 		}
 	},
@@ -394,6 +430,8 @@ export default {
 				sieveHost: this.sieveHost,
 				sievePort: this.sievePort,
 				sieveSslMode: this.sieveSslMode,
+				ldapAliasesProvisioning: this.ldapAliasesProvisioning,
+				ldapAliasesAttribute: this.ldapAliasesAttribute,
 			}
 		},
 	},
@@ -423,6 +461,8 @@ export default {
 					sieveHost: this.sieveHost,
 					sievePort: this.sievePort,
 					sieveSslMode: this.sieveSslMode,
+					ldapAliasesProvisioning: this.ldapAliasesProvisioning,
+					ldapAliasesAttribute: this.ldapAliasesAttribute,
 				})
 
 				logger.info('provisioning setting updated')
@@ -462,6 +502,7 @@ export default {
 
 	.group-title {
 		min-width: 100px;
+		max-width: 100px;
 		text-align: right;
 		margin: 10px;
 		font-weight: bold;

--- a/src/service/AliasService.js
+++ b/src/service/AliasService.js
@@ -1,29 +1,66 @@
 import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 
-export const createAlias = async(account, data) => {
+/**
+ * @typedef {Object} Alias
+ * @property {number} id
+ * @property {string} alias
+ * @property {string} name
+ * @property {string} signature
+ * @property {boolean} provisioned
+ */
+
+/**
+ * @param {number} accountId id of account
+ * @param {string} alias new alias
+ * @param {string} aliasName new alias name
+ * @returns {Promise<Alias>}
+ */
+export const createAlias = async(accountId, alias, aliasName) => {
 	const url = generateUrl('/apps/mail/api/accounts/{id}/aliases', {
-		id: account.accountId,
+		id: accountId,
 	})
 
-	return axios.post(url, data).then((resp) => resp.data).catch((e) => {
-		if (e.response && e.response.status === 400) {
-			throw e.response.data
-		}
-
-		throw e
-	})
+	return axios.post(url, { alias, aliasName }).then(resp => resp.data)
 }
 
-export const deleteAlias = async(account, alias) => {
+/**
+ * @param {number} accountId id of account
+ * @param {number} aliasId if of alias
+ * @returns {Promise<Alias>}
+ */
+export const deleteAlias = async(accountId, aliasId) => {
 	const url = generateUrl('/apps/mail/api/accounts/{id}/aliases/{aliasId}', {
-		id: account.accountId,
-		aliasId: alias.id,
+		id: accountId,
+		aliasId,
 	})
 
 	return axios.delete(url).then((resp) => resp.data)
 }
 
+/**
+ * @param {number} accountId id of account
+ * @param {number} aliasId if of alias
+ * @param {string} alias new alias
+ * @param {string} aliasName new alias name
+ * @returns {Promise<Alias>}
+ */
+export const updateAlias = async(accountId, aliasId, alias, aliasName) => {
+	const url = generateUrl(
+		'/apps/mail/api/accounts/{id}/aliases/{aliasId}', {
+			id: accountId,
+			aliasId,
+		})
+
+	return axios.put(url, { alias, aliasName }).then(resp => resp.data)
+}
+
+/**
+ * @param {number} accountId id of account
+ * @param {number} aliasId id of alias
+ * @param {string} signature new signature
+ * @returns {Promise<Alias>}
+ */
 export const updateSignature = async(accountId, aliasId, signature) => {
 	const url = generateUrl(
 		'/apps/mail/api/accounts/{id}/aliases/{aliasId}/signature', {
@@ -31,5 +68,5 @@ export const updateSignature = async(accountId, aliasId, signature) => {
 			aliasId,
 		})
 
-	return axios.put(url, { signature })
+	return axios.put(url, { signature }).then(resp => resp.data)
 }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -739,17 +739,36 @@ export default {
 			throw err
 		}
 	},
-	async createAlias({ commit }, { account, aliasToAdd }) {
-		const alias = await AliasService.createAlias(account, aliasToAdd)
-		commit('createAlias', { account, alias })
+	async createAlias({ commit }, { account, alias, name }) {
+		const entity = await AliasService.createAlias(account.id, alias, name)
+		commit('createAlias', {
+			account,
+			alias: entity,
+		})
 	},
-	async deleteAlias({ commit }, { account, aliasToDelete }) {
-		await AliasService.deleteAlias(account, aliasToDelete)
-		commit('deleteAlias', { account, alias: aliasToDelete })
+	async deleteAlias({ commit }, { account, aliasId }) {
+		const entity = await AliasService.deleteAlias(account.id, aliasId)
+		commit('deleteAlias', {
+			account,
+			aliasId: entity.id,
+		})
+	},
+	async updateAlias({ commit }, { account, aliasId, alias, name }) {
+		const entity = await AliasService.updateAlias(account.id, aliasId, alias, name)
+		commit('patchAlias', {
+			account,
+			aliasId: entity.id,
+			data: { alias: entity.alias, name: entity.name },
+		})
+		commit('editAccount', account)
 	},
 	async updateAliasSignature({ commit }, { account, aliasId, signature }) {
-		await AliasService.updateSignature(account.id, aliasId, signature)
-		commit('patchAlias', { account, aliasId, data: { signature } })
+		const entity = await AliasService.updateSignature(account.id, aliasId, signature)
+		commit('patchAlias', {
+			account,
+			aliasId: entity.id,
+			data: { signature: entity.signature },
+		})
 		commit('editAccount', account)
 	},
 	async renameMailbox({ commit }, { account, mailbox, newName }) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -307,12 +307,17 @@ export default {
 	createAlias(state, { account, alias }) {
 		account.aliases.push(alias)
 	},
-	deleteAlias(state, { account, alias }) {
-		account.aliases.splice(account.aliases.indexOf(alias), 1)
+	deleteAlias(state, { account, aliasId }) {
+		const index = account.aliases.findIndex(temp => aliasId === temp.id)
+		if (index !== -1) {
+			account.aliases.splice(index, 1)
+		}
 	},
 	patchAlias(state, { account, aliasId, data }) {
-		const index = account.aliases.findIndex((temp) => aliasId === temp.id)
-		account.aliases[index] = Object.assign({}, account.aliases[index], data)
+		const index = account.aliases.findIndex(temp => aliasId === temp.id)
+		if (index !== -1) {
+			account.aliases[index] = Object.assign({}, account.aliases[index], data)
+		}
 	},
 	setMailboxUnreadCount(state, { id, unread }) {
 		Vue.set(state.mailboxes[id], 'unread', unread ?? 0)


### PR DESCRIPTION
Fix #5173

- [x] Requires: https://github.com/nextcloud/server/pull/27515. 

**Todo**

- [x] Add option to enable/disable alias provisioning
- [x] Add option to customize the ldap attribute
- [ ] ~Add option to filter aliases by regex~
- [x] Alias section is currently hidden for provisioned accounts. Show the section but disable add alias / delete alias
- [x] It should be possible to change the name but not the email/alias
- [x] Test that editing the signature for alias works
- [x] Add a database field (or virtual field) to alias if provisioned or not
- [ ] ~Add unique constraint to mail_aliases account_id and alias.~
- [x] UI to enable/disable, ldap attribute, set filter.


