### PR TITLE
Fix infinite scroll loading, by removing resizable column support

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -1,64 +1,62 @@
 <template>
 	<AppContent pane-config-key="mail" :show-details="isThreadShown" @update:showDetails="hideMessage">
-		<template slot="list">
-			<AppContentList
-				v-infinite-scroll="onScroll"
-				v-shortkey.once="shortkeys"
-				infinite-scroll-immediate-check="false"
-				:show-details="showThread"
-				:infinite-scroll-disabled="false"
-				:infinite-scroll-distance="10"
-				role="heading"
-				:aria-level="2"
-				@shortkey.native="onShortcut">
+		<AppContentList
+			v-infinite-scroll="onScroll"
+			v-shortkey.once="shortkeys"
+			infinite-scroll-immediate-check="false"
+			:show-details="showThread"
+			:infinite-scroll-disabled="false"
+			:infinite-scroll-distance="10"
+			role="heading"
+			:aria-level="2"
+			@shortkey.native="onShortcut">
+			<Mailbox
+				v-if="!mailbox.isPriorityInbox"
+				:account="account"
+				:mailbox="mailbox"
+				:search-query="query"
+				:bus="bus" />
+			<template v-else>
+				<div class="app-content-list-item">
+					<SectionTitle class="important" :name="t('mail', 'Important and unread')" />
+					<Popover trigger="hover focus">
+						<button slot="trigger" :aria-label="t('mail', 'Important info')" class="button icon-info" />
+						<p class="important-info">
+							{{ importantInfo }}
+						</p>
+					</Popover>
+				</div>
 				<Mailbox
-					v-if="!mailbox.isPriorityInbox"
-					:account="account"
-					:mailbox="mailbox"
-					:search-query="query"
+					class="nameimportant"
+					:account="unifiedAccount"
+					:mailbox="unifiedInbox"
+					:search-query="appendToSearch('is:pi-important')"
+					:paginate="'manual'"
+					:is-priority-inbox="true"
+					:initial-page-size="5"
+					:collapsible="true"
 					:bus="bus" />
-				<template v-else>
-					<div class="app-content-list-item">
-						<SectionTitle class="important" :name="t('mail', 'Important and unread')" />
-						<Popover trigger="hover focus">
-							<button slot="trigger" :aria-label="t('mail', 'Important info')" class="button icon-info" />
-							<p class="important-info">
-								{{ importantInfo }}
-							</p>
-						</Popover>
-					</div>
-					<Mailbox
-						class="nameimportant"
-						:account="unifiedAccount"
-						:mailbox="unifiedInbox"
-						:search-query="appendToSearch('is:pi-important')"
-						:paginate="'manual'"
-						:is-priority-inbox="true"
-						:initial-page-size="5"
-						:collapsible="true"
-						:bus="bus" />
-					<SectionTitle class="app-content-list-item starred" :name="t('mail', 'Favorites')" />
-					<Mailbox
-						class="namestarred"
-						:account="unifiedAccount"
-						:mailbox="unifiedInbox"
-						:search-query="appendToSearch('is:pi-starred')"
-						:paginate="'manual'"
-						:is-priority-inbox="true"
-						:initial-page-size="5"
-						:bus="bus" />
-					<SectionTitle class="app-content-list-item other" :name="t('mail', 'Other')" />
-					<Mailbox
-						class="nameother"
-						:account="unifiedAccount"
-						:mailbox="unifiedInbox"
-						:open-first="false"
-						:search-query="appendToSearch('is:pi-other')"
-						:is-priority-inbox="true"
-						:bus="bus" />
-				</template>
-			</AppContentList>
-		</template>
+				<SectionTitle class="app-content-list-item starred" :name="t('mail', 'Favorites')" />
+				<Mailbox
+					class="namestarred"
+					:account="unifiedAccount"
+					:mailbox="unifiedInbox"
+					:search-query="appendToSearch('is:pi-starred')"
+					:paginate="'manual'"
+					:is-priority-inbox="true"
+					:initial-page-size="5"
+					:bus="bus" />
+				<SectionTitle class="app-content-list-item other" :name="t('mail', 'Other')" />
+				<Mailbox
+					class="nameother"
+					:account="unifiedAccount"
+					:mailbox="unifiedInbox"
+					:open-first="false"
+					:search-query="appendToSearch('is:pi-other')"
+					:is-priority-inbox="true"
+					:bus="bus" />
+			</template>
+		</AppContentList>
 		<NewMessageDetail v-if="newMessage" />
 		<Thread v-else-if="showThread" @delete="deleteMessage" />
 		<NoMessageSelected v-else-if="hasEnvelopes && !isMobile" />


### PR DESCRIPTION
The infinite scroll loading was broken with https://github.com/nextcloud/mail/pull/5201. This is because the vue-infinite-scroll lib doesn't work when the component of the directive is within a slot, v-if or similar. The reason that `hook:mounted` doesn't fire and therefore no scroll event is ever bound.

I'm intentionally removing resizable columns again to unbreak the scroll feature, as that's way more important and a critical regression. For v1.11.0 we can look into resizable columns again. Either vue-infinite-scoll has to be fixed or we swap out the lib.

This is best reviewed as https://github.com/nextcloud/mail/pull/5258/files?w=1.

Ref https://github.com/ElemeFE/vue-infinite-scroll/issues/77
Ref https://github.com/ElemeFE/vue-infinite-scroll/blob/775b7d386ff4e609eb3360a4ccecee7d9a015c63/src/directive.js#L189

Fixes https://github.com/nextcloud/mail/issues/5234