### PR TITLE
Fix error reporting during mail setup

### DIFF
--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -58,8 +58,8 @@ export default {
 				.catch((error) => {
 					logger.error('Could not create account', { error })
 
-					if (error.message) {
-						this.error = error.message
+					if (error?.data?.message) {
+						this.error = error.data.message
 					} else {
 						this.error = t('mail', 'Unexpected error during account creation')
 					}


### PR DESCRIPTION
Previously only the generic (and not useful) error message was
displayed when a more useful message was available and could have
been displayed instead.

The error message is located in error.data.message and not error.message

![image](https://user-images.githubusercontent.com/23653902/125265197-e36edd00-e304-11eb-8d89-e51d35a5bbbf.png)
