### PR TITLE
Add html structure

### DIFF
--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -83,6 +83,6 @@ class HtmlResponse extends Response {
 			return $this->content;
 		}
 
-		return '<script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script>' . $this->content;
+		return '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script></head><body>' . $this->content . '</body></html>';
 	}
 }


### PR DESCRIPTION
The html body purified by html purifier is only the body. Some emails look weird / broken if only the html body is returned. This patch adds the html skeleton around the body.

We still loose any inline style defined on the body element (e.g. https://github.com/nextcloud/server/blob/1366b35081f1d92429787696f4175c19a602858a/lib/private/Mail/EMailTemplate.php#L90).