### PR TITLE
Pin mariadb to 10.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
                   - 993:993
                   - 4190:4190
           mysql-service:
-              image: mariadb:10
+              image: mariadb:10.5
               env:
                   MYSQL_ROOT_PASSWORD: my-secret-pw
                   MYSQL_DATABASE: nextcloud


### PR DESCRIPTION
MariaDB 10.6 is now stable: https://hub.docker.com/_/mariadb.

As Nextcloud does not support MariaDB 10.6 (https://github.com/nextcloud/server/pull/25474) we need MariaDB 10.5 for now.