### PR TITLE
Show inline attachments for plain text emails.

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -477,14 +477,14 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		if ($this->hasHtmlMessage) {
 			$data['hasHtmlBody'] = true;
 			$data['body'] = $this->getHtmlBody($id);
+			$data['attachments'] = $this->attachments;
 		} else {
 			$mailBody = $this->htmlService->convertLinks($mailBody);
 			[$mailBody, $signature] = $this->htmlService->parseMailBody($mailBody);
 			$data['body'] = $mailBody;
 			$data['signature'] = $signature;
+			$data['attachments'] = array_merge($this->attachments, $this->inlineAttachments);
 		}
-
-		$data['attachments'] = $this->attachments;
 
 		return $data;
 	}


### PR DESCRIPTION
Fix #5282 

We distinguish between attachments (content-disposition: attachment) and inlineAttachments (content-disposition: inline).

For html messages we have a filter to replace a reference inside the message with an url to embed the attachment into the message.

For plain text messages it's not possible to embed / inline an attachment. In this case we merge inline attachments into attachments.

https://github.com/nextcloud/mail/blob/a3a8a6a37babf76536fae696166e8bab4bac264a/lib/Model/IMAPMessage.php#L517-L529

As reference: Is the step to inline / embed an attachment for a html message. A counterpart for plain text messages were missing. 

**Test plan**

Sent a plain text message and attach a file with content-disposition: inline. It seems the not working message was generated by OTRS (a trouble ticket system). I stored a message with a normal attachment as eml file. Modified the file a text editor and replace content-disposition: attachment with content-disposition: inline and imported the eml file back. 
