### PR TITLE
Add `$notjunk` flag to messages marked not junk and add `$junk` to messages marked junk

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -668,18 +668,38 @@ export default {
 		const oldState = envelope.flags.junk
 		commit('flagEnvelope', {
 			envelope,
-			flag: 'junk',
+			flag: '$junk',
 			value: !oldState,
 		})
+		commit('flagEnvelope', {
+			envelope,
+			flag: '$notjunk',
+			value: oldState,
+		})
 
-		setEnvelopeFlag(envelope.databaseId, 'junk', !oldState).catch((e) => {
+		setEnvelopeFlag(envelope.databaseId, '$junk', !oldState).catch((e) => {
 			console.error('could not toggle message junk state', e)
 
 			// Revert change
 			commit('flagEnvelope', {
 				envelope,
-				flag: 'junk',
+				flag: '$junk',
 				value: oldState,
+			})
+			commit('flagEnvelope', {
+				envelope,
+				flag: '$notjunk',
+				value: !oldState,
+			})
+		})
+		setEnvelopeFlag(envelope.databaseId, '$notjunk', oldState).catch((e) => {
+			console.error('could not toggle message junk state', e)
+
+			// Revert change
+			commit('flagEnvelope', {
+				envelope,
+				flag: '$notjunk',
+				value: !oldState,
 			})
 		})
 	},


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/5331 and also fixes a bug that created a tag for messages flagged `junk` instead of `$junk`.