### PR TITLE
fix: handle invalid imap message id

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -696,13 +696,16 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$msg = new Message();
 
 		$messageId = $this->getMessageId();
-		if (empty(trim($messageId))) {
-			// Sometimes the message ID is missing. Then we create one.
+		$msg->setMessageId($messageId);
+
+		// Sometimes the message ID is missing or invalid and therefore not set.
+		// Then we create one and set it.
+		if (!$msg->getMessageId()) {
 			$messageId = self::generateMessageId();
+			$msg->setMessageId($messageId);
 		}
 
 		$msg->setUid($this->getUid());
-		$msg->setMessageId($messageId);
 		$msg->setRawReferences($this->getRawReferences());
 		$msg->setThreadRootId($messageId);
 		$msg->setInReplyTo($this->getRawInReplyTo());


### PR DESCRIPTION
When IMAPMessage.toDbMessage() encountered an invalid messageId it was
creating a DB Message without messageId. This leads for example to
TagMapper::tagMessage() to fail because it must not be called with a
null messageId.

This patch leverages the functionality to create a valid messageId in
case the messageId was missing completely. It now uses it as well for
invalid messageIds not accepted by Horde_Mail_Rfc822_Identification and
therefore not set by Message.setMessageId().

An example for an invalid messageId I encountered in my inbox is
Message-ID: <359f166ea1b402e793c0801834a9722a-support@aruba-studios.de
(The closing > bracket is missing).