### PR TITLE
Disable TidyImpl for html emails

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -128,6 +128,7 @@ class Html {
 		$config->set('URI.Host', Util::getServerHostName());
 
 		$config->set('Filter.ExtractStyleBlocks', true);
+		$config->set('Filter.ExtractStyleBlocks.TidyImpl', false);
 		$config->set('CSS.AllowTricky', true);
 		$config->set('CSS.Proprietary', true);
 


### PR DESCRIPTION
Fix #5279 

A css rule like `* img[tabindex="0"] + div { text-align:center }` is rewritten to `* + div { text-align:center }`. 

That looks like a bug in htmlpurifier: https://github.com/ezyang/htmlpurifier/issues/299. To workaround the bug we have to disable the `TidyImpl` option. 

> However, for trusted user input, you can set this to false to disable cleaning. In addition, you can supply your own concrete implementation of Tidy's interface to use, although I don't know why you'd want to do that. 

Please note http://htmlpurifier.org/live/configdoc/plain.html#Filter.ExtractStyleBlocks.TidyImpl

