### PR TITLE
Add noreferrer to external links. Don't forward external links via proxy.

### DIFF
--- a/lib/Service/HtmlPurify/TransformHTMLLinks.php
+++ b/lib/Service/HtmlPurify/TransformHTMLLinks.php
@@ -26,7 +26,6 @@ namespace OCA\Mail\Service\HtmlPurify;
 use HTMLPurifier_AttrTransform;
 use HTMLPurifier_Config;
 use HTMLPurifier_Context;
-use HTMLPurifier_URIParser;
 use OCP\IURLGenerator;
 
 /**
@@ -34,17 +33,11 @@ use OCP\IURLGenerator;
  */
 class TransformHTMLLinks extends HTMLPurifier_AttrTransform {
 
-	/**
-	 * @type HTMLPurifier_URIParser
-	 */
-	private $parser;
-
 	/** @var IURLGenerator */
 	private $urlGenerator;
 
 	public function __construct(IURLGenerator $urlGenerator) {
 		$this->urlGenerator = $urlGenerator;
-		$this->parser = new HTMLPurifier_URIParser();
 	}
 
 	/**
@@ -59,7 +52,7 @@ class TransformHTMLLinks extends HTMLPurifier_AttrTransform {
 		}
 
 		$attr['target'] = '_blank';
-		$attr['rel'] = 'noopener';
+		$attr['rel'] = 'external noopener noreferrer';
 
 		// Open mailto: links in Mail
 		if (stripos($attr['href'], 'mailto:') === 0) {

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -123,23 +123,16 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 		// If element is of type "href" it is most likely a link that should get redirected
 		// otherwise it's an element that we send through our proxy
 		if ($element === 'href') {
-			$uri = new \HTMLPurifier_URI(
-				$this->request->getServerProtocol(),
-				null,
-				$this->request->getServerHost(),
-				null,
-				$this->urlGenerator->linkToRoute('mail.proxy.redirect'),
-				'src=' . $originalURL,
-				null
-			);
-			return $uri;
-		} else {
-			$uri = new \HTMLPurifier_URI(
-				$this->request->getServerProtocol(), null, $this->request->getServerHost(), null,
-				$this->urlGenerator->linkToRoute('mail.proxy.proxy'),
-				'src=' . $originalURL . '&requesttoken=' . \OC::$server->getSession()->get('requesttoken'),
-				null);
 			return $uri;
 		}
+
+		return new \HTMLPurifier_URI(
+			$this->request->getServerProtocol(),
+			null, $this->request->getServerHost(),
+			null,
+			$this->urlGenerator->linkToRoute('mail.proxy.proxy'),
+			'src=' . $originalURL . '&requesttoken=' . \OC::$server->getSession()->get('requesttoken'),
+			null
+		);
 	}
 }


### PR DESCRIPTION
Patch to make #5233 less worse / Don't sent external links via our proxy.

The proper fix for #5233 is to always forward / reply to the unmodified html body of a message.