### PR TITLE
Add store for threads

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -121,6 +121,7 @@ export default {
 	},
 	computed: {
 		envelopes() {
+			return this.$store.getters.getThreads(this.mailbox.databaseId, this.searchQuery)
 			return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery)
 		},
 		envelopesToShow() {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -122,7 +122,7 @@ export default {
 	computed: {
 		envelopes() {
 			return this.$store.getters.getThreads(this.mailbox.databaseId, this.searchQuery)
-			return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery)
+			// return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery)
 		},
 		envelopesToShow() {
 			if (this.paginate === 'manual' && !this.expanded) {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -131,7 +131,8 @@ export default {
 			return this.$store.getters.getMailbox(UNIFIED_INBOX_ID)
 		},
 		hasEnvelopes() {
-			return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery).length > 0
+			return this.$store.getters.getThreads(this.mailbox.databaseId, this.searchQuery).length > 0
+			// return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery).length > 0
 		},
 		showThread() {
 			return (this.mailbox.isPriorityInbox === true || this.hasEnvelopes) && this.$route.name === 'message'

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -479,6 +479,11 @@ export default {
 				const unifiedMailbox = getters.getUnifiedMailbox(mailbox.specialRole)
 
 				syncData.newMessages.forEach((envelope) => {
+					commit('addThread', {
+						mailboxId,
+						envelope,
+						query,
+					})
 					commit('addEnvelope', {
 						envelope,
 						query,
@@ -495,6 +500,9 @@ export default {
 					})
 				})
 				syncData.vanishedMessages.forEach((id) => {
+					commit('removeThread', {
+						mailboxId, id,
+					})
 					commit('removeEnvelope', {
 						id,
 					})

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -262,6 +262,10 @@ export default {
 		const envelope = await fetchEnvelope(id)
 		// Only commit if not undefined (not found)
 		if (envelope) {
+			commit('addThread', {
+				mailboxId: envelope.mailboxId,
+				envelope,
+			})
 			commit('addEnvelope', {
 				envelope,
 			})
@@ -291,12 +295,17 @@ export default {
 				andThen(sliceToPage),
 				andThen(
 					tap(
-						map((envelope) =>
+						map((envelope) => {
+							commit('addThread', {
+								mailboxId,
+								envelope,
+								query,
+							})
 							commit('addEnvelope', {
 								envelope,
 								query,
 							})
-						)
+						})
 					)
 				)
 			)
@@ -308,12 +317,17 @@ export default {
 			fetchEnvelopes,
 			andThen(
 				tap(
-					map((envelope) =>
+					map((envelope) => {
+						commit('addThread', {
+							mailboxId,
+							envelope,
+							query,
+						})
 						commit('addEnvelope', {
 							query,
 							envelope,
 						})
-					)
+					})
 				)
 			)
 		)(mailboxId, query, undefined, PAGE_SIZE)
@@ -388,12 +402,17 @@ export default {
 			}
 
 			const envelopes = nextLocalUnifiedEnvelopes(getters.accounts)
-			envelopes.map((envelope) =>
+			envelopes.forEach((envelope) => {
+				commit('addThread', {
+					mailboxId,
+					envelope,
+					query,
+				})
 				commit('addEnvelope', {
 					query,
 					envelope,
 				})
-			)
+			})
 			return envelopes
 		}
 
@@ -416,12 +435,17 @@ export default {
 			logger.debug(`fetched ${envelopes.length} messages for mailbox ${mailboxId}`, {
 				envelopes,
 			})
-			envelopes.forEach((envelope) =>
+			envelopes.forEach((envelope) => {
+				commit('addThread', {
+					mailboxId,
+					envelope,
+					query,
+				})
 				commit('addEnvelope', {
 					query,
 					envelope,
 				})
-			)
+			})
 			return envelopes
 		})
 	},
@@ -503,9 +527,15 @@ export default {
 					commit('removeThread', {
 						mailboxId, id,
 					})
-					commit('removeEnvelope', {
-						id,
-					})
+					// if (!getters.isMessageMounted(mailboxId, id)) {
+					//
+					// }
+					// const envelope = getters.getEnvelope(id)
+					// if (envelope && getters.isThreadMounted(mailbox, envelope.threadRootId)) {
+					// 	commit('removeEnvelope', {
+					// 		id,
+					// 	})
+					// }
 					// Already removed from unified inbox
 				})
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -494,7 +494,8 @@ export default {
 			)
 		}
 
-		const ids = getters.getEnvelopes(mailboxId, query).map((env) => env.databaseId)
+		// const ids = getters.getEnvelopes(mailboxId, query).map((env) => env.databaseId)
+		const ids = getters.getThreads(mailboxId, query).map((env) => env.databaseId)
 		logger.debug(`mailbox sync of ${mailboxId} (${query}) has ${ids.length} known IDs`)
 		return syncEnvelopes(mailbox.accountId, mailboxId, ids, query, init)
 			.then((syncData) => {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -30,66 +30,13 @@ import {
 import actions from './actions'
 import { getters } from './getters'
 import mutations from './mutations'
-import { normalizedEnvelopeListId } from './normalization'
-import orderBy from 'lodash/fp/orderBy'
+import threadsStore from './threads'
+
 Vue.use(Vuex)
-
-const moduleThreads = {
-	state: {
-		lists: {
-			[UNIFIED_INBOX_ID]: {},
-			[PRIORITY_INBOX_ID]: {},
-		},
-	},
-	mutations: {
-		addAccount(state, account) {
-			const mailboxes = account.mailboxes || []
-			mailboxes.map(mailboxId => Vue.set(state.lists, mailboxId, {}))
-		},
-		addMailbox(state, { mailbox }) {
-			Vue.set(state.lists, mailbox.databaseId, {})
-		},
-		addThread(state, { mailboxId, query, envelope }) {
-			const listId = normalizedEnvelopeListId(query)
-			const list = state.lists[mailboxId][listId] || []
-
-			const index = list.findIndex((item) => item.threadRootId === envelope.threadRootId)
-			const item = { threadRootId: envelope.threadRootId, messageId: envelope.databaseId, dateInt: envelope.dateInt }
-
-			if (index === -1) {
-				list.push(item)
-			} else {
-				list[index] = item
-			}
-
-			orderBy(list, 'dateInt', 'desc')
-			Vue.set(state.lists[mailboxId], listId, list)
-		},
-		removeThread(state, { mailboxId, envelopeId }) {
-			const lists = state.lists[mailboxId]
-			const removeEnvelopeById = (item) => item.messageId !== envelopeId
-
-			for (let list in lists) {
-				list = list.filter(removeEnvelopeById)
-			}
-
-			Vue.set(state.lists, mailboxId, lists)
-		},
-	},
-	actions: {},
-	getters: {
-		getThreads: (state, getters, rootState) => (mailboxId, query) => {
-			const listId = normalizedEnvelopeListId(query)
-			const list = state.lists[mailboxId][listId] || []
-
-			return list.map((item) => rootState.envelopes[item.messageId])
-		},
-	},
-}
 
 export default new Vuex.Store({
 	modules: {
-		threads: moduleThreads,
+		threadsStore,
 	},
 	strict: process.env.NODE_ENV !== 'production',
 	state: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -49,8 +49,7 @@ const moduleThreads = {
 		addMailbox(state, { mailbox }) {
 			Vue.set(state.lists, mailbox.databaseId, {})
 		},
-		addEnvelope(state, { query, envelope }) {
-			const mailboxId = envelope.mailboxId
+		addThread(state, { mailboxId, query, envelope }) {
 			const listId = normalizedEnvelopeListId(query)
 			const list = state.lists[mailboxId][listId] || []
 
@@ -65,6 +64,16 @@ const moduleThreads = {
 
 			orderBy(list, 'dateInt', 'desc')
 			Vue.set(state.lists[mailboxId], listId, list)
+		},
+		removeThread(state, { mailboxId, envelopeId }) {
+			const lists = state.lists[mailboxId]
+			const removeEnvelopeById = (item) => item.messageId !== envelopeId
+
+			for (let list in lists) {
+				list = list.filter(removeEnvelopeById)
+			}
+
+			Vue.set(state.lists, mailboxId, lists)
 		},
 	},
 	actions: {},

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -175,24 +175,24 @@ export default {
 		const mailbox = state.mailboxes[envelope.mailboxId]
 		Vue.set(state.envelopes, envelope.databaseId, Object.assign({}, state.envelopes[envelope.databaseId] || {}, envelope))
 		Vue.set(envelope, 'accountId', mailbox.accountId)
-		const listId = normalizedEnvelopeListId(query)
-		const existing = mailbox.envelopeLists[listId] || []
-		const idToDateInt = (id) => state.envelopes[id].dateInt
-		const orderByDateInt = orderBy(idToDateInt, 'desc')
-		Vue.set(mailbox.envelopeLists, listId, uniq(orderByDateInt(existing.concat([envelope.databaseId]))))
+		// const listId = normalizedEnvelopeListId(query)
+		// const existing = mailbox.envelopeLists[listId] || []
+		// const idToDateInt = (id) => state.envelopes[id].dateInt
+		// const orderByDateInt = orderBy(idToDateInt, 'desc')
+		// Vue.set(mailbox.envelopeLists, listId, uniq(orderByDateInt(existing.concat([envelope.databaseId]))))
 
-		const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
-		unifiedAccount.mailboxes
-			.map((mbId) => state.mailboxes[mbId])
-			.filter((mb) => mb.specialRole && mb.specialRole === mailbox.specialRole)
-			.forEach((mailbox) => {
-				const existing = mailbox.envelopeLists[listId] || []
-				Vue.set(
-					mailbox.envelopeLists,
-					listId,
-					uniq(orderByDateInt(existing.concat([envelope.databaseId])))
-				)
-			})
+		// const unifiedAccount = state.accounts[UNIFIED_ACCOUNT_ID]
+		// unifiedAccount.mailboxes
+		// 	.map((mbId) => state.mailboxes[mbId])
+		// 	.filter((mb) => mb.specialRole && mb.specialRole === mailbox.specialRole)
+		// 	.forEach((mailbox) => {
+		// 		const existing = mailbox.envelopeLists[listId] || []
+		// 		Vue.set(
+		// 			mailbox.envelopeLists,
+		// 			listId,
+		// 			uniq(orderByDateInt(existing.concat([envelope.databaseId])))
+		// 		)
+		// 	})
 	},
 	updateEnvelope(state, { envelope }) {
 		const existing = state.envelopes[envelope.databaseId]
@@ -232,47 +232,47 @@ export default {
 			return
 		}
 		const mailbox = state.mailboxes[envelope.mailboxId]
-		for (const listId in mailbox.envelopeLists) {
-			if (!Object.hasOwnProperty.call(mailbox.envelopeLists, listId)) {
-				continue
-			}
-			const list = mailbox.envelopeLists[listId]
-			const idx = list.indexOf(id)
-			if (idx < 0) {
-				continue
-			}
-			console.debug('envelope ' + id + ' removed from mailbox list ' + listId)
-			list.splice(idx, 1)
-		}
+		// for (const listId in mailbox.envelopeLists) {
+		// 	if (!Object.hasOwnProperty.call(mailbox.envelopeLists, listId)) {
+		// 		continue
+		// 	}
+		// 	const list = mailbox.envelopeLists[listId]
+		// 	const idx = list.indexOf(id)
+		// 	if (idx < 0) {
+		// 		continue
+		// 	}
+		// 	console.debug('envelope ' + id + ' removed from mailbox list ' + listId)
+		// 	list.splice(idx, 1)
+		// }
 
 		if (!envelope.seen && mailbox.unread) {
 			Vue.set(mailbox, 'unread', mailbox.unread - 1)
 		}
 
-		state.accounts[UNIFIED_ACCOUNT_ID].mailboxes
-			.map((mailboxId) => state.mailboxes[mailboxId])
-			.filter((mb) => mb.specialRole && mb.specialRole === mailbox.specialRole)
-			.forEach((mailbox) => {
-				for (const listId in mailbox.envelopeLists) {
-					if (!Object.hasOwnProperty.call(mailbox.envelopeLists, listId)) {
-						continue
-					}
-					const list = mailbox.envelopeLists[listId]
-					const idx = list.indexOf(id)
-					if (idx < 0) {
-						console.warn(
-							'envelope does not exist in unified mailbox',
-							mailbox.databaseId,
-							id,
-							listId,
-							list
-						)
-						continue
-					}
-					console.debug('envelope removed from unified mailbox', mailbox.databaseId, id)
-					list.splice(idx, 1)
-				}
-			})
+		// state.accounts[UNIFIED_ACCOUNT_ID].mailboxes
+		// 	.map((mailboxId) => state.mailboxes[mailboxId])
+		// 	.filter((mb) => mb.specialRole && mb.specialRole === mailbox.specialRole)
+		// 	.forEach((mailbox) => {
+		// 		for (const listId in mailbox.envelopeLists) {
+		// 			if (!Object.hasOwnProperty.call(mailbox.envelopeLists, listId)) {
+		// 				continue
+		// 			}
+		// 			const list = mailbox.envelopeLists[listId]
+		// 			const idx = list.indexOf(id)
+		// 			if (idx < 0) {
+		// 				console.warn(
+		// 					'envelope does not exist in unified mailbox',
+		// 					mailbox.databaseId,
+		// 					id,
+		// 					listId,
+		// 					list
+		// 				)
+		// 				continue
+		// 			}
+		// 			console.debug('envelope removed from unified mailbox', mailbox.databaseId, id)
+		// 			list.splice(idx, 1)
+		// 		}
+		// 	})
 
 		// Delete references from other threads
 		for (const [key, env] of Object.entries(state.envelopes)) {

--- a/src/store/threads.js
+++ b/src/store/threads.js
@@ -22,8 +22,7 @@ const mutations = {
 		const listId = normalizedEnvelopeListId(query)
 		const list = state.lists[mailboxId][listId] || []
 
-		const index = list.findIndex(
-			(item) => item.threadRootId === envelope.threadRootId)
+		const index = list.findIndex((item) => item.threadRootId === envelope.threadRootId)
 		const item = {
 			threadRootId: envelope.threadRootId,
 			messageId: envelope.databaseId,
@@ -34,9 +33,12 @@ const mutations = {
 			list.push(item)
 		} else if (list[index].messageId < item.messageId) {
 			list[index] = item
+		} else {
+			return
 		}
 
-		list.sort(orderBy('dateInt', 'desc'))
+		list.sort((a, b) => b.dateInt - a.dateInt)
+		// list.sort(orderBy('dateInt', 'desc'))
 		Vue.set(state.lists[mailboxId], listId, list)
 	},
 	removeThread(state, { mailboxId, envelopeId }) {

--- a/src/store/threads.js
+++ b/src/store/threads.js
@@ -1,0 +1,65 @@
+import { PRIORITY_INBOX_ID, UNIFIED_INBOX_ID } from './constants'
+import Vue from 'vue'
+import { normalizedEnvelopeListId } from './normalization'
+import orderBy from 'lodash/fp/orderBy'
+
+const state = {
+	lists: {
+		[UNIFIED_INBOX_ID]: {},
+		[PRIORITY_INBOX_ID]: {},
+	},
+}
+
+const mutations = {
+	addAccount(state, account) {
+		const mailboxes = account.mailboxes || []
+		mailboxes.map(mailboxId => Vue.set(state.lists, mailboxId, {}))
+	},
+	addMailbox(state, { mailbox }) {
+		Vue.set(state.lists, mailbox.databaseId, {})
+	},
+	addThread(state, { mailboxId, query, envelope }) {
+		const listId = normalizedEnvelopeListId(query)
+		const list = state.lists[mailboxId][listId] || []
+
+		const index = list.findIndex(
+			(item) => item.threadRootId === envelope.threadRootId)
+		const item = {
+			threadRootId: envelope.threadRootId,
+			messageId: envelope.databaseId,
+			dateInt: envelope.dateInt,
+		}
+
+		if (index === -1) {
+			list.push(item)
+		} else {
+			list[index] = item
+		}
+
+		orderBy(list, 'dateInt', 'desc')
+		Vue.set(state.lists[mailboxId], listId, list)
+	},
+	removeThread(state, { mailboxId, envelopeId }) {
+		const lists = state.lists[mailboxId]
+		const removeEnvelopeById = (item) => item.messageId !== envelopeId
+
+		for (let list in lists) {
+			list = list.filter(removeEnvelopeById)
+		}
+
+		Vue.set(state.lists, mailboxId, lists)
+	},
+}
+
+const actions = {}
+
+const getters = {
+	getThreads: (state, getters, rootState) => (mailboxId, query) => {
+		const listId = normalizedEnvelopeListId(query)
+		const list = state.lists[mailboxId][listId] || []
+
+		return list.map((item) => rootState.envelopes[item.messageId])
+	},
+}
+
+export default { state, mutations, actions, getters }

--- a/src/store/threads.js
+++ b/src/store/threads.js
@@ -20,7 +20,7 @@ const mutations = {
 	},
 	addThread(state, { mailboxId, query, envelope }) {
 		const listId = normalizedEnvelopeListId(query)
-		let list = state.lists[mailboxId][listId] || []
+		const list = state.lists[mailboxId][listId] || []
 
 		const index = list.findIndex(
 			(item) => item.threadRootId === envelope.threadRootId)
@@ -32,11 +32,11 @@ const mutations = {
 
 		if (index === -1) {
 			list.push(item)
-		} else if (list[index].databaseId < item.databaseId) {
+		} else if (list[index].messageId < item.messageId) {
 			list[index] = item
 		}
 
-		list = orderBy(list, ['dateInt'], ['desc'])
+		list.sort(orderBy('dateInt', 'desc'))
 		Vue.set(state.lists[mailboxId], listId, list)
 	},
 	removeThread(state, { mailboxId, envelopeId }) {


### PR DESCRIPTION
**Story** 

Update front end to handle message threads better. After https://github.com/nextcloud/mail/pull/5106 the back end provide messages in a threaded way for the message list. For each thread the back end sent one message. Yet there are some (known) edge cases:

- #5322 when a new message is available for an existing/already shown thread
- Delete the latest message in thread view should add the second latest message to the envelope list
- Move the latest message in thread view should add the second latest message to the envelope list

**Todo**
- [x] A new message for the same thread replace the old message in the envelope list 
- [ ] Update envelope / thread view (right now it blanks after a while due a removeEnvelope action)

Fixes https://github.com/nextcloud/mail/issues/5322