### PR TITLE
Set schema for url when empty. 

### DIFF
--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -71,6 +71,11 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	public function filter(&$uri, $config, $context) {
 		/** @var \HTMLPurifier_Context $context */
 		/** @var \HTMLPurifier_Config $config */
+
+		if ($uri->scheme === null) {
+			$uri->scheme = 'https';
+		}
+
 		// Only HTTPS and HTTP urls should get rewritten
 		if ($uri->scheme === 'https' || $uri->scheme === 'http' || $uri->scheme === 'ftp') {
 			$uri = $this->filterHttpFtp($uri, $context);


### PR DESCRIPTION
Schema is usually empty for relative urls (without a protocol).