### PR TITLE
Add threading to frontend

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -91,10 +91,13 @@ export default {
 			return parseInt(this.$route.params.threadId, 10)
 		},
 		thread() {
-			const envelopes = this.$store.getters.getEnvelopeThread(this.threadId)
-			const envelope = envelopes.find(envelope => envelope.databaseId === this.threadId)
-
+			const envelope = this.$store.getters.getEnvelope(this.threadId)
 			if (envelope === undefined) {
+				return []
+			}
+
+			const envelopes = this.$store.getters.getEnvelopesByThreadRootId(envelope.accountId, envelope.threadRootId)
+			if (envelopes.length === 0) {
 				return []
 			}
 

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { defaultTo, head, sortBy, prop } from 'ramda'
+import { defaultTo, head, prop, sortBy } from 'ramda'
 
 import { UNIFIED_ACCOUNT_ID } from './constants'
 import { normalizedEnvelopeListId } from './normalization'
@@ -69,6 +69,12 @@ export const getters = {
 	getEnvelopes: (state, getters) => (mailboxId, query) => {
 		const list = getters.getMailbox(mailboxId).envelopeLists[normalizedEnvelopeListId(query)] || []
 		return list.map((msgId) => state.envelopes[msgId])
+	},
+	getEnvelopesByThreadRootId: (state) => (accountId, threadRootId) => {
+		return sortBy(
+			prop('dateInt'),
+			Object.values(state.envelopes).filter(envelope => envelope.accountId === accountId && envelope.threadRootId === threadRootId)
+		)
 	},
 	getMessage: (state) => (id) => {
 		return state.messages[id]

--- a/src/tests/unit/store/getters.spec.js
+++ b/src/tests/unit/store/getters.spec.js
@@ -91,7 +91,7 @@ describe('Vuex store getters', () => {
 				1,
 				2,
 				3,
-			]
+			],
 		}
 		state.envelopes[2] = {
 			databaseId: 1,
@@ -117,7 +117,7 @@ describe('Vuex store getters', () => {
 					1,
 					2,
 					3,
-				]
+				],
 			},
 			{
 				databaseId: 1,
@@ -130,5 +130,66 @@ describe('Vuex store getters', () => {
 				mailboxId: 13,
 			},
 		])
+	})
+
+	it('return envelopes by thread root id', () => {
+		state.envelopes[0] = {
+			accountId: 1,
+			databaseId: 1,
+			uid: 101,
+			mailboxId: 13,
+			threadRootId: '123-456-789',
+		}
+		state.envelopes[1] = {
+			accountId: 1,
+			databaseId: 2,
+			uid: 102,
+			mailboxId: 13,
+			threadRootId: '123-456-789',
+		}
+		state.envelopes[2] = {
+			accountId: 1,
+			databaseId: 3,
+			uid: 103,
+			mailboxId: 13,
+			threadRootId: '234-567-890',
+		}
+		state.envelopes[3] = {
+			accountId: 1,
+			databaseId: 4,
+			uid: 104,
+			mailboxId: 13,
+			threadRootId: '234-567-890',
+		}
+		state.envelopes[4] = {
+			accountId: 2,
+			databaseId: 5,
+			uid: 105,
+			mailboxId: 23,
+			threadRootId: '123-456-789',
+		}
+		const getters = bindGetters()
+
+		const envelopesA = getters.getEnvelopesByThreadRootId(1, '123-456-789')
+		expect(envelopesA).to.be.length(2)
+		expect(envelopesA).to.deep.equal([
+			{
+				accountId: 1,
+				databaseId: 1,
+				uid: 101,
+				mailboxId: 13,
+				threadRootId: '123-456-789',
+			},
+			{
+				accountId: 1,
+				databaseId: 2,
+				uid: 102,
+				mailboxId: 13,
+				threadRootId: '123-456-789',
+			},
+		])
+
+		const envelopesB = getters.getEnvelopesByThreadRootId('345-678-901')
+		expect(envelopesB).to.be.empty
 	})
 })

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -189,7 +189,7 @@ describe('Vuex store mutations', () => {
 					envelopeLists: {},
 					path: 'INBOX.',
 					mailboxes: [],
-				}
+				},
 			},
 			tagList: [],
 			tags: {},
@@ -402,7 +402,7 @@ describe('Vuex store mutations', () => {
 					specialUse: ['archive'],
 					specialRole: 'archive',
 					mailboxes: [],
-				}
+				},
 			},
 			tagList: [],
 			tags: {},
@@ -418,7 +418,7 @@ describe('Vuex store mutations', () => {
 					delimiter: '.',
 					specialUse: ['archive'],
 					specialRole: 'archive',
-				}
+				},
 			})
 
 		expect(state).to.deep.equal({
@@ -493,7 +493,7 @@ describe('Vuex store mutations', () => {
 					specialUse: ['archive'],
 					specialRole: 'archive',
 					mailboxes: [],
-				}
+				},
 			},
 			tagList: [],
 			tags: {},
@@ -509,7 +509,7 @@ describe('Vuex store mutations', () => {
 					delimiter: '.',
 					specialUse: ['archive'],
 					specialRole: 'archive',
-				}
+				},
 			})
 
 		expect(state).to.deep.equal({
@@ -742,6 +742,7 @@ describe('Vuex store mutations', () => {
 				id: 123,
 				subject: 'henlo',
 				uid: 321,
+				threadRootId: '123-456-789',
 			},
 		})
 		mutations.addEnvelope(state, {
@@ -752,6 +753,7 @@ describe('Vuex store mutations', () => {
 				id: 124,
 				subject: 'henlo 2',
 				uid: 322,
+				threadRootId: '234-567-890',
 			},
 		})
 
@@ -771,6 +773,7 @@ describe('Vuex store mutations', () => {
 					id: 123,
 					subject: 'henlo',
 					tags: [],
+					threadRootId: '123-456-789',
 				},
 				12346: {
 					mailboxId: 27,
@@ -779,6 +782,7 @@ describe('Vuex store mutations', () => {
 					subject: 'henlo 2',
 					uid: 322,
 					tags: [],
+					threadRootId: '234-567-890',
 				},
 			},
 			mailboxes: {
@@ -1009,7 +1013,7 @@ describe('Vuex store mutations', () => {
 					databaseId: 124,
 					mailboxId: 27,
 					uid: 12346,
-				}
+				},
 			],
 		})
 
@@ -1431,5 +1435,55 @@ describe('Vuex store mutations', () => {
 				},
 			},
 		})
+	})
+
+	it('replace envelope for existing thread root id', () => {
+		const state = {
+			accounts: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					mailboxes: [],
+				},
+			},
+			envelopes: {},
+			mailboxes: {
+				27: {
+					name: 'INBOX',
+					accountId: 13,
+					envelopeLists: {},
+				},
+			},
+			tagList: [],
+			tags: {},
+		}
+
+		mutations.addEnvelope(state, {
+			query: undefined,
+			envelope: {
+				mailboxId: 27,
+				databaseId: 12345,
+				id: 123,
+				subject: 'henlo',
+				uid: 321,
+				threadRootId: '123-456-789',
+			},
+		})
+
+		expect(state.mailboxes[27].envelopeLists['']).to.be.length(1)
+
+		mutations.addEnvelope(state, {
+			query: undefined,
+			envelope: {
+				mailboxId: 27,
+				databaseId: 12347,
+				id: 234,
+				subject: 'henlo',
+				uid: 432,
+				threadRootId: '123-456-789',
+			},
+		})
+
+		expect(state.mailboxes[27].envelopeLists['']).to.be.length(1)
 	})
 })


### PR DESCRIPTION
Fix #5322 

23c0156a0214cbde6a67827f7d11933bd82eecd0 Add a getter to fetch envelopes from store by using a thread root id. 
a4e94c8777c77b7d8236c452dc908dbee993a793 Add helper to append or replace a existing envelope.


| | Before | After |
| --- | --- | --- |
| A reply for a thread already<br/> shown in envelope list | - New thread shown in envelope list<br/>- (When thread selected) message is not shown in message list | - Existing thread in evelope list is updated<br/>- (When thread selected) new reply is shown in message list |

**Open items / To decide**

- [ ] Update route `mail/box/10/thread/$latestMessageId`
- [ ] Rework `Mailbox.onDelete` /  `fetchNextEnvelopes` to not load new messages when a message but not the whole thread is deleted.

**How to test**
- Take email from https://github.com/nextcloud/mail/issues/5322
- Import to mail account (e.g. via thunderbird)
- Open mail and view mailbox
- Import the same message again to mail account
- Wait a few seconds orpress refresh mailbox button (but don't reload the page)
