### PR TITLE
Fix the extra space on envelope hover

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -354,7 +354,6 @@ export default {
 		position: relative;
 		display: flex;
 		padding: 10px;
-		margin-bottom: 3px;
 		border-radius: var(--border-radius);
 
 		&:hover {


### PR DESCRIPTION
after
![afterextraspace](https://user-images.githubusercontent.com/12728974/132675433-5891b868-9336-439b-8db3-ce890fc8549e.png)
before
![extraspace](https://user-images.githubusercontent.com/12728974/132675434-ac4c162f-eb72-4edc-b387-9102ea25a0e0.png)
