### PR TITLE
Use the same IMAP query for the HTML body part as for attachments

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -433,21 +433,7 @@ class MessageMapper {
 			// No HTML part
 			return null;
 		}
-		$partsQuery = new Horde_Imap_Client_Fetch_Query();
-		$partsQuery->fullText();
-		foreach ($structure->partIterator() as $structurePart) {
-			/** @var Horde_Mime_Part $structurePart */
-			$partsQuery->bodyPart($structurePart->getMimeId(), [
-				'decode' => true,
-				'peek' => true,
-			]);
-			$partsQuery->bodyPartSize($structurePart->getMimeId());
-			if ($structurePart->getMimeId() === $htmlPartId) {
-				$partsQuery->mimeHeader($structurePart->getMimeId(), [
-					'peek' => true
-				]);
-			}
-		}
+		$partsQuery = $this->buildAttachmentsPartsQuery($structure, [$htmlPartId]);
 
 		$parts = $client->fetch($mailbox, $partsQuery, [
 			'ids' => new Horde_Imap_Client_Ids([$uid]),


### PR DESCRIPTION
This not only removes some code but also makes this actually work, fixing
itinerary extraction from HTML bodies.