### PR TITLE
Set proper type for provisioning_id

### DIFF
--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -135,7 +135,7 @@ class MailAccountMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 
 		$delete = $qb->delete($this->getTableName())
-			->where($qb->expr()->eq('provisioning_id', $qb->createNamedParameter($provisioningId, IQueryBuilder::PARAM_BOOL)));
+			->where($qb->expr()->eq('provisioning_id', $qb->createNamedParameter($provisioningId, IQueryBuilder::PARAM_INT)));
 
 		$delete->execute();
 	}

--- a/lib/Migration/Version1105Date20210922104324.php
+++ b/lib/Migration/Version1105Date20210922104324.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+class Version1105Date20210922104324 extends SimpleMigrationStep {
+	private $connection;
+	private $logger;
+
+	public function __construct(IDBConnection $connection, LoggerInterface $logger) {
+		$this->connection = $connection;
+		$this->logger = $logger;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->select('accounts.id')
+			->from('mail_accounts', 'accounts')
+			->leftJoin('accounts', 'mail_provisionings', 'provisionings', $qb->expr()->eq('accounts.provisioning_id', 'provisionings.id'))
+			->where($qb->expr()->isNotNull('accounts.provisioning_id'))
+			->andWhere($qb->expr()->isNull('provisionings.id'));
+
+		try {
+			$result = $qb->execute();
+		} catch (Exception $e) {
+			$this->logger->info('Migration to cleanup mail accounts without valid provisioning configuration failed', [
+				'exception' => $e
+			]);
+			return;
+		}
+
+		$accountIds = array_map(static function ($row) {
+			return (int)$row['id'];
+		}, $result->fetchAll());
+		$result->closeCursor();
+
+		if (count($accountIds) === 0) {
+			return;
+		}
+
+		$qb = $this->connection->getQueryBuilder();
+		$qb->delete('mail_accounts')
+			->where($qb->expr()->in('id', $qb->createNamedParameter($accountIds, IQueryBuilder::PARAM_INT_ARRAY)));
+
+		try {
+			$qb->execute();
+		} catch (Exception $e) {
+			$this->logger->info('Migration to cleanup mail accounts without valid provisioning configuration failed', [
+				'exception' => $e
+			]);
+			return;
+		}
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -283,6 +283,11 @@
       <code>UserDeletedListener</code>
     </MissingDependency>
   </file>
+  <file src="lib/Migration/Version1105Date20210922104324.php">
+    <ImplicitToStringCast occurrences="1">
+      <code>$qb-&gt;createNamedParameter($accountIds, IQueryBuilder::PARAM_INT_ARRAY)</code>
+    </ImplicitToStringCast>
+  </file>
   <file src="lib/Service/Classification/ImportanceClassifier.php">
     <InvalidScalarArgument occurrences="1">
       <code>$predictedValidationLabel</code>


### PR DESCRIPTION
Fix #5549 

Deleting a provisioning configuration worked when the provisioning_id was 1 but a provisioning_id > 1 not.

`select * from oc_mail_accounts where provisioning_id = true` return all rows with provisioning_id = 1 on maria.