### PR TITLE
Calculate height for iframe by taggedElement

### DIFF
--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -83,6 +83,6 @@ class HtmlResponse extends Response {
 			return $this->content;
 		}
 
-		return '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script></head><body>' . $this->content . '</body></html>';
+		return '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script></head><body>' . $this->content . '<div data-iframe-height></div></body></html>';
 	}
 }

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -75,7 +75,7 @@ export default {
 		scout.on('afterprint', this.onAfterPrint)
 	},
 	mounted() {
-		iframeResizer({}, this.$refs.iframe)
+		iframeResizer({ log: false, heightCalculationMethod: 'taggedElement' }, this.$refs.iframe)
 	},
 	beforeDestroy() {
 		scout.off('beforeprint', this.onBeforePrint)


### PR DESCRIPTION
Fix #5527  

We disabled CSSTidy on purpose because some CSS rules were rewritten in a weird way: https://github.com/nextcloud/mail/pull/5424

For some reason the iframe height calculation does not work anymore. document.body.offsetHeight is 150.

taggedElement as heightCalculationMethod finds the bottom of the lowest element with a data-iframe-height attribute.

As reference the documentation for heightcalculationmethod: https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md#heightcalculationmethod

bodyScroll for example also works but the recommendation is to use lowestElement or taggedElement when the default does not work. Please let me know if one of you know a better dummy element for the data-iframe-height attribute.