### PR TITLE
Make the sync response generic so it can hold two types of messages

### DIFF
--- a/lib/IMAP/Sync/Response.php
+++ b/lib/IMAP/Sync/Response.php
@@ -24,16 +24,17 @@ declare(strict_types=1);
 namespace OCA\Mail\IMAP\Sync;
 
 use JsonSerializable;
-use OCA\Mail\Db\Message;
 use OCA\Mail\IMAP\MailboxStats;
-use OCA\Mail\Model\IMAPMessage;
 
+/**
+ * @psalm-template T
+ */
 class Response implements JsonSerializable {
 
-	/** @var IMAPMessage[]|Message[] */
+	/** @var T[] */
 	private $newMessages;
 
-	/** @var IMAPMessage[]|Message[] */
+	/** @var T[] */
 	private $changedMessages;
 
 	/** @var int[] */
@@ -43,14 +44,14 @@ class Response implements JsonSerializable {
 	private $stats;
 
 	/**
-	 * @param IMAPMessage[]|Message[] $newMessages
-	 * @param IMAPMessage[]|Message[] $changedMessages
+	 * @param T[] $newMessages
+	 * @param T[] $changedMessages
 	 * @param int[] $vanishedMessageUids
 	 * @param MailboxStats|null $stats
 	 */
-	public function __construct(array $newMessages = [],
-								array $changedMessages = [],
-								array $vanishedMessageUids = [],
+	public function __construct(array $newMessages,
+								array $changedMessages,
+								array $vanishedMessageUids,
 								MailboxStats $stats = null) {
 		$this->newMessages = $newMessages;
 		$this->changedMessages = $changedMessages;
@@ -59,14 +60,14 @@ class Response implements JsonSerializable {
 	}
 
 	/**
-	 * @return IMAPMessage[]|Message[]
+	 * @return T[]
 	 */
 	public function getNewMessages(): array {
 		return $this->newMessages;
 	}
 
 	/**
-	 * @return IMAPMessage[]|Message[]
+	 * @return T[]
 	 */
 	public function getChangedMessages(): array {
 		return $this->changedMessages;
@@ -93,13 +94,5 @@ class Response implements JsonSerializable {
 			'vanishedMessages' => $this->vanishedMessageUids,
 			'stats' => $this->stats,
 		];
-	}
-
-	public function merge(Response $other): self {
-		return new self(
-			array_merge($this->getNewMessages(), $other->getNewMessages()),
-			array_merge($this->getChangedMessages(), $other->getChangedMessages()),
-			array_merge($this->getVanishedMessageUids(), $other->getVanishedMessageUids())
-		);
 	}
 }


### PR DESCRIPTION
We use the same container class for two purposes, once for the
IMAPMessage class, then for Message. Psalm rightfully complains that we
can't make assumptions of the returned polymorphic types, so it makes
sense to just type it as a generic class and let Psalm derive the
specialized type based on the constructor usage.

The `merge` method isn't used anywhere.

Extracted from https://github.com/nextcloud/mail/pull/5495.