### PR TITLE
Fix unified account colors on paged results

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -123,7 +123,7 @@ export default {
 		})
 
 		await Promise.all(inboxes.map(async(mailbox) => {
-			const messages = await fetchEnvelopes(mailbox.databaseId, this.query, undefined, 10)
+			const messages = await fetchEnvelopes(mailbox.accountId, mailbox.databaseId, this.query, undefined, 10)
 			this.messages = this.messages !== null ? [...this.messages, ...messages] : messages
 			this.fetchedAccounts++
 		}))

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -27,7 +27,7 @@ export function fetchEnvelope(id) {
 		})
 }
 
-export function fetchEnvelopes(mailboxId, query, cursor, limit) {
+export function fetchEnvelopes(accountId, mailboxId, query, cursor, limit) {
 	const url = generateUrl('/apps/mail/api/messages')
 	const params = {
 		mailboxId,
@@ -48,6 +48,7 @@ export function fetchEnvelopes(mailboxId, query, cursor, limit) {
 			params,
 		})
 		.then((resp) => resp.data)
+		.then(envelopes => envelopes.map(amendEnvelopeWithIds(accountId)))
 		.catch((error) => {
 			throw convertAxiosError(error)
 		})

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -316,7 +316,7 @@ export default {
 					)
 				)
 			)
-		)(mailboxId, query, undefined, PAGE_SIZE)
+		)(mailbox.accountId, mailboxId, query, undefined, PAGE_SIZE)
 	},
 	async fetchNextEnvelopePage({ commit, getters, dispatch }, { mailboxId, query }) {
 		const envelopes = await dispatch('fetchNextEnvelopes', {
@@ -412,7 +412,7 @@ export default {
 			return Promise.reject(new Error('Cannot find last envelope. Required for the mailbox cursor'))
 		}
 
-		return fetchEnvelopes(mailboxId, query, lastEnvelope.dateInt, quantity).then((envelopes) => {
+		return fetchEnvelopes(mailbox.accountId, mailboxId, query, lastEnvelope.dateInt, quantity).then((envelopes) => {
 			logger.debug(`fetched ${envelopes.length} messages for mailbox ${mailboxId}`, {
 				envelopes,
 			})


### PR DESCRIPTION
The `accountId` of message pages was not added to the AJAX result, hence
we always calculated the color for an undefined account ID.

Fixes https://github.com/nextcloud/mail/issues/4799

How to test:
* Configure at least two accounts
* On the initial page envelopes will have the correct account color
* Load more pages, at some point everything is shown in some kind of pink on master, here it's again the correct account color