### PR TITLE
Fix syncing mailboxes that don't support persistent mod-sequences

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1035,8 +1035,9 @@ class MessageMapper extends QBMapper {
 			$notInExpression[] = $subSelect->expr()->notIn('m.id', $select->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY));
 		}
 
+		// MIN returns NULL if there are no rows selected
 		$subSelect
-			->select($subSelect->func()->min('sent_at'))
+			->select($subSelect->createFunction('IFNULL(MIN(`sent_at`), 0)'))
 			->from($this->getTableName())
 			->where(
 				$subSelect->expr()->eq('mailbox_id', $select->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1037,7 +1037,7 @@ class MessageMapper extends QBMapper {
 
 		// MIN returns NULL if there are no rows selected
 		$subSelect
-			->select($subSelect->createFunction('IFNULL(MIN(`sent_at`), 0)'))
+			->select($subSelect->createFunction('IFNULL(MIN(' . $subSelect->getColumnName('sent_at') . '), 0)'))
 			->from($this->getTableName())
 			->where(
 				$subSelect->expr()->eq('mailbox_id', $select->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1037,7 +1037,7 @@ class MessageMapper extends QBMapper {
 
 		// MIN returns NULL if there are no rows selected
 		$subSelect
-			->select($subSelect->createFunction('IFNULL(MIN(' . $subSelect->getColumnName('sent_at') . '), 0)'))
+			->select($subSelect->createFunction('COALESCE(MIN(' . $subSelect->getColumnName('sent_at') . '), 0)'))
 			->from($this->getTableName())
 			->where(
 				$subSelect->expr()->eq('mailbox_id', $select->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -234,14 +234,11 @@ class ImapToDbSynchronizer {
 					$logger->debug("Running initial sync for " . $mailbox->getId() . " after cache reset");
 					$this->runInitialSync($account, $mailbox, $logger);
 				} catch (MailboxDoesNotSupportModSequencesException $e) {
-					$logger->warning('Mailbox does not support mod-sequences error occurred for mailbox ' . $mailbox->getId(), [
+					$logger->warning('Mailbox does not support mod-sequences error occured. Wiping cache and performing full sync for ' . $mailbox->getId(), [
 						'exception' => $e,
 					]);
-					if ($knownUids !== null) {
-						$this->messageMapper->deleteByUid($mailbox, ...$knownUids);
-					} else {
-						$this->resetCache($account, $mailbox);
-					}
+					$this->resetCache($account, $mailbox);
+					$logger->debug("Running initial sync for " . $mailbox->getId() . " after cache reset - no mod-sequences error");
 					$this->runInitialSync($account, $mailbox, $logger);
 				}
 			}

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -234,11 +234,14 @@ class ImapToDbSynchronizer {
 					$logger->debug("Running initial sync for " . $mailbox->getId() . " after cache reset");
 					$this->runInitialSync($account, $mailbox, $logger);
 				} catch (MailboxDoesNotSupportModSequencesException $e) {
-					$logger->warning('Mailbox does not support mod-sequences error occured. Wiping cache and performing full sync for ' . $mailbox->getId(), [
+					$logger->warning('Mailbox does not support mod-sequences error occurred for mailbox ' . $mailbox->getId(), [
 						'exception' => $e,
 					]);
-					$this->resetCache($account, $mailbox);
-					$logger->debug("Running initial sync for " . $mailbox->getId() . " after cache reset - no mod-sequences error");
+					if ($knownUids !== null) {
+						$this->messageMapper->deleteByUid($mailbox, ...$knownUids);
+					} else {
+						$this->resetCache($account, $mailbox);
+					}
 					$this->runInitialSync($account, $mailbox, $logger);
 				}
 			}


### PR DESCRIPTION
Ref #4479

I investigated this problem using an IMAP test account on manitu.de. 

The problem lies within `\OCA\Mail\Db\MessageMapper::findNewIds()`. We build a subquery to find the min `sent_at` value for all messages of that mailbox. However, if there is no message found the `min()` function of SQL will just return NULL. Later, the result of this query is used in a greater than comparison and breaks because comparing to NULL is weird. As a result this methods never actually returns any new ids. 

Usually, there are always some messages in the sub query but for this special case it's always empty. A mailbox which does not support persistent mod-sequences always triggers a full sync due to implementation details.

The performance of this is obviously very bad because every message of the mailbox is recreated every time a sync is triggered. I added a small performance fix to mitigate this by just deleting the known uids (if provided) instead of clearing the whole mailbox cache.

## TODO
* [ ] Fix tests