### PR TITLE
l10n: Fix to get string to TX.

### DIFF
--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -85,7 +85,7 @@
 					{{
 						t(
 							'mail',
-							"This setting only makes most sense if you use the same user back-end for your organization's Nextcloud and mail server."
+							'This setting only makes most sense if you use the same user back-end for your Nextcloud and mail server of your organization.'
 						)
 					}}
 				</p>


### PR DESCRIPTION
The string is not available at GitHub.
Changed wording to avoid use of apostrophe.

Signed-off-by: rakekniven <2069590+rakekniven@users.noreply.github.com>