### PR TITLE
Fix text quotes for every > sign

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -32,7 +32,7 @@ export default {
 	},
 	computed: {
 		enhancedBody() {
-			return this.body.replace(/(&gt;.*\n?)+/g, (match) => {
+			return this.body.replace(/(^&gt;.*\n)+/gm, (match) => {
 				return `<details class="quoted-text"><summary>${t('mail', 'Quoted text')}</summary>${match}</details>`
 			})
 		},


### PR DESCRIPTION
Only greater than signs at the beginning of a line indicate a quote. This only happens with plain text emails.

## Before

![Bildschirmfoto von 2021-10-21 19-52-35](https://user-images.githubusercontent.com/1374172/138331248-88f45c07-8319-415f-a9d4-2eb26d7eb150.png)

## After

![Bildschirmfoto von 2021-10-21 19-52-12](https://user-images.githubusercontent.com/1374172/138331272-d3441d79-d580-423a-bd1b-2fcfc37a63a2.png)
