### PR TITLE
Log account ID for errors in the cron sync job

### DIFF
--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -112,7 +112,8 @@ class SyncJob extends TimedJob {
 				'exception' => $e,
 			]);
 		} catch (Throwable $e) {
-			$this->logger->error('Cron mail sync failed: ' . $e->getMessage(), [
+			$this->logger->error('Cron mail sync failed for account {accountId}', [
+				'accountId' => $account,
 				'exception' => $e,
 			]);
 		}


### PR DESCRIPTION
This helps debug background sync issues.