### PR TITLE
move threads not messages in drag-and-drop

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -3,7 +3,7 @@
 		v-draggable-envelope="{
 			accountId: data.accountId ? data.accountId : mailbox.accountId,
 			mailboxId: data.mailboxId,
-			envelopeId: data.databaseId,
+			databaseId: data.databaseId,
 			draggableLabel,
 			selectedEnvelopes,
 			isDraggable,

--- a/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
+++ b/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
@@ -45,14 +45,14 @@ export class DraggableEnvelope {
 				envelopes.push({
 					accountId,
 					mailboxId,
-					envelopeId: envelope.databaseId,
+					databaseId: envelope.databaseId,
 					draggableLabel: `${envelope.subject} (${envelope.from[0].label})`,
 				})
 			})
 		} else {
 			// handle single dragged item
-			const { envelopeId, draggableLabel } = this.options
-			envelopes.push({ accountId, mailboxId, envelopeId, draggableLabel })
+			const { databaseId, draggableLabel } = this.options
+			envelopes.push({ accountId, mailboxId, databaseId, draggableLabel })
 		}
 
 		event.dataTransfer.setData('text/plain', JSON.stringify(envelopes))

--- a/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
@@ -100,7 +100,7 @@ export class DroppableMailbox {
 
 		try {
 			const processedEnvelopes = envelopesBeingDragged.map(async envelope => {
-				const processed = await this.processDroppedItem(parseInt(envelope.envelopeId))
+				const processed = await this.processDroppedItem(envelope)
 				return processed
 			})
 			await Promise.all(processedEnvelopes)
@@ -114,13 +114,13 @@ export class DroppableMailbox {
 		}
 	}
 
-	async processDroppedItem(envelopeId) {
-		const item = document.querySelector(`[data-envelope-id="${envelopeId}"]`)
+	async processDroppedItem(envelope) {
+		const item = document.querySelector(`[data-envelope-id="${envelope.databaseId}"]`)
 		item.setAttribute('draggable-envelope', 'pending')
 
 		try {
-			await store.dispatch('moveMessage', {
-				id: envelopeId,
+			await store.dispatch('moveThread', {
+				envelope,
 				destMailboxId: this.options.mailboxId,
 			})
 		} catch (error) {


### PR DESCRIPTION
Currently, the drag-and-drop function moves messages rather than threads. 

It results that when you move a thread, drag-and-drop actualy only moves the message corresponding to the selected envelope. This results in some visual glitch: first the envelope is removed from the envelope list resulting in the whole thread disappearing from the envelope list, then the envelope list is refreshed and displays back the thread by showing the envelope of another thread's message, one that hasn't been moved yet.

Moving threads rather than messages in the drag-and-drop function makes sense both from a logical perspective (ie: when the user moves a thread's envelope he actually wants to move the whole corresponding thread and not just the corresponding message) and a ux perspective (ie: avoiding this visual glitch).

This PR implements moving threads rather than messages in drag-and-drop.

<----------- EDIT START ------------>
It seems the limitations previously mentioned hereunder are not real:

1.Mail doesn't navigate after moving a thread => This is true but is already the case today, without this PR
2.After the thread is moved, the messages appear as individual messages, not as a single thread, in the destination mailbox => Cannot reproduce it. Was probably just caused by me forgeting to make dev-setup.

So, for me the PR is ready for merge
<----------- EDIT END ----------->

Some limitations of the PR currently are:
1. Mail doesn't navigate after moving a thread
2. After the thread is moved, the messages appear as individual messages, not as a single thread, in the destination mailbox => We probably need to re-compute thread information on the destination mailbox after the move.

Fixes https://github.com/nextcloud/mail/issues/8310