### PR TITLE
Force max-width for iframe content to fix some newsletters

### DIFF
--- a/src/html-response.js
+++ b/src/html-response.js
@@ -24,3 +24,12 @@ import '../css/html-response.css'
 
 // iframe-resizer client script
 import 'iframe-resizer/js/iframeResizer.contentWindow.js'
+
+// Fix width of some newsletter mails
+document.addEventListener('DOMContentLoaded', function() {
+	for (const el of document.querySelectorAll('*')) {
+		if (!el.style['max-width']) {
+			el.style['max-width'] = '100%'
+		}
+	}
+})


### PR DESCRIPTION
Newsletter that are composed from tables will sometimes overflow horizontally. This patch forces a max-width to all elements inside the iframe (which do not already have one) to mitigate this issue. This may not work on small resolutions.