### PR TITLE
Fix text detection with null or undefined string

### DIFF
--- a/src/util/text.js
+++ b/src/util/text.js
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import isString from 'lodash/fp/isString'
 import { curry } from 'ramda'
 import { fromString } from 'html-to-text'
 
@@ -70,6 +71,11 @@ export const plain = wrap('plain')
 export const html = wrap('html')
 
 export const detect = (str) => {
+	if (!isString(str)) {
+		// Fall back to a hopefully sane default
+		return plain('')
+	}
+
 	if (!str.includes('>')) {
 		return plain(str)
 	} else {


### PR DESCRIPTION
Eliminates some errors from https://github.com/nextcloud/mail/issues/5708

Since checking for string type is not as trivial as it seems I'm using lodash. Ref https://stackoverflow.com/questions/4059147/check-if-a-variable-is-a-string-in-javascript.