### PR TITLE
Correctly center envelop header content using flexbox

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -295,6 +295,7 @@ export default {
 		justify-content: flex-end;
 		margin-left: 10px;
 		height: 44px;
+		align-self: center;
 
 		.app-content-list-item-menu {
 			margin-left: 4px;
@@ -321,8 +322,7 @@ export default {
 		}
 	}
 	.avatardiv {
-		display: inline-block;
-		margin-bottom: -23px;
+		align-self: center
 	}
 	.subject {
 		margin-left: 8px;


### PR DESCRIPTION
This change was done using the webinspector and I didn't test it locally
    since I encountered ssl errors when setting the mail app up and I was
    expecting this patch to be a 5min job :)
    
Please test locally when reviewing

Before: 
![image](https://user-images.githubusercontent.com/23653902/140762574-b16e02b5-224e-4341-ba87-ca6ec52d83a4.png)

After:
![image](https://user-images.githubusercontent.com/23653902/140762501-ea234518-2a4a-4af1-b90f-075c1d88d69f.png)

Signed-off-by: Carl Schwan <carl@carlschwan.eu>