### PR TITLE
Sort UIDs before the initial sync

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -46,6 +46,7 @@ use function iterator_to_array;
 use function max;
 use function min;
 use function reset;
+use function sort;
 use function sprintf;
 
 class MessageMapper {
@@ -178,6 +179,8 @@ class MessageMapper {
 				return $uid > $highestKnownUid;
 			}
 		);
+		// We don't know if the server already sorted the UIDs
+		sort($uidCandidates);
 		$uidsToFetch = array_slice(
 			$uidCandidates,
 			0,


### PR DESCRIPTION
The logic of chunked and incremental initial syncs relied on the IMAP
server sorting UIDs strictly ascending. If that is not given, we fetch
messages with a UID too high for the current chunk. The next chunk will
continue with only higher UIDs than previous, leaving out any UIDs that
were missing from the previous chunk(s). Eventually the initial sync
finishes, but the mailbox is incomplete.