### PR TITLE
Fix box-shadow for dark theme

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -332,7 +332,7 @@ export default {
 	.envelope {
 		display: flex;
 		flex-direction: column;
-		box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 0 10px var(--color-box-shadow);
 		border-radius: 16px;
 		margin-left: 10px;
 		margin-right: 10px;


### PR DESCRIPTION
before
![boxbefore](https://user-images.githubusercontent.com/12728974/142604649-cd44a575-f4c1-48d6-996a-1d0261258f23.png)
after
![boxafterwhite](https://user-images.githubusercontent.com/12728974/142604644-352de331-7975-48ef-ab15-706cbb2ee61b.png)
before
![beforedarkbox](https://user-images.githubusercontent.com/12728974/142604717-b0fcb933-60ce-43c8-9a15-00e19aa24c10.png)
after
![afterdar](https://user-images.githubusercontent.com/12728974/142605089-c362ac15-6329-494d-bc7d-91bbf156c0f9.png)
