### PR TITLE
Fixes use mailbox.accountId as fallback when accountId isn't defined in Envelope.vue

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -249,7 +249,7 @@ export default {
 			return this.data.flags.draft
 		},
 		account() {
-			const accountId = this.data.accountId ?? this.data.accountId
+			const accountId = this.data.accountId
 			return this.$store.getters.getAccount(accountId)
 		},
 		link() {


### PR DESCRIPTION
reported in https://github.com/nextcloud/mail/pull/4288#issuecomment-972831255

Signed-off-by: Cyrille Bollu <cyr.debian@bollu.be>