### PR TITLE
Fetch LDAP provider factory on demand

### DIFF
--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -34,12 +34,14 @@ use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Exception\ValidationException;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\IServerContainer;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\LDAP\ILDAPProvider;
 use OCP\LDAP\ILDAPProviderFactory;
 use OCP\Security\ICrypto;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 class Manager {
 
@@ -55,8 +57,8 @@ class Manager {
 	/** @var ICrypto */
 	private $crypto;
 
-	/** @var ILDAPProviderFactory */
-	private $ldapProviderFactory;
+	/** @var IServerContainer */
+	private $serverContainer;
 
 	/** @var AliasMapper */
 	private $aliasMapper;
@@ -71,7 +73,7 @@ class Manager {
 								ProvisioningMapper $provisioningMapper,
 								MailAccountMapper $mailAccountMapper,
 								ICrypto $crypto,
-								ILDAPProviderFactory $ldapProviderFactory,
+								IServerContainer $appContainer,
 								AliasMapper $aliasMapper,
 								LoggerInterface $logger,
 								TagMapper $tagMapper) {
@@ -79,7 +81,7 @@ class Manager {
 		$this->provisioningMapper = $provisioningMapper;
 		$this->mailAccountMapper = $mailAccountMapper;
 		$this->crypto = $crypto;
-		$this->ldapProviderFactory = $ldapProviderFactory;
+		$this->serverContainer = $appContainer;
 		$this->aliasMapper = $aliasMapper;
 		$this->logger = $logger;
 		$this->tagMapper = $tagMapper;
@@ -160,15 +162,21 @@ class Manager {
 			return $provisioning;
 		}
 
-		/** @psalm-suppress UndefinedInterfaceMethod */
-		if ($this->ldapProviderFactory->isAvailable() === false) {
-			$this->logger->debug('Request to provision mail aliases but LDAP not available');
-			return $provisioning;
+		try {
+			$ldapProviderFactory = $this->serverContainer->get(ILDAPProviderFactory::class);
+			/** @psalm-suppress UndefinedInterfaceMethod */
+			if ($ldapProviderFactory->isAvailable() === false) {
+				$this->logger->debug('Request to provision mail aliases but LDAP not available');
+				return $provisioning;
+			}
+			$ldapProvider = $ldapProviderFactory->getLDAPProvider();
+			/** @psalm-suppress UndefinedInterfaceMethod */
+			$provisioning->setAliases($ldapProvider->getMultiValueUserAttribute($user->getUID(), $provisioning->getLdapAliasesAttribute()));
+		} catch (Throwable $e) {
+			$this->logger->debug('Request to provision mail aliases but LDAP erros: ' . $e->getMessage(), [
+				'exception' => $e,
+			]);
 		}
-
-		$ldapProvider = $this->ldapProviderFactory->getLDAPProvider();
-		/** @psalm-suppress UndefinedInterfaceMethod */
-		$provisioning->setAliases($ldapProvider->getMultiValueUserAttribute($user->getUID(), $provisioning->getLdapAliasesAttribute()));
 
 		return $provisioning;
 	}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -311,6 +311,13 @@
       <code>SaveDraftEvent</code>
     </MissingDependency>
   </file>
+  <file src="lib/Service/Provisioning/Manager.php">
+    <MissingDependency occurrences="3">
+      <code>$this-&gt;serverContainer</code>
+      <code>IServerContainer</code>
+      <code>IServerContainer</code>
+    </MissingDependency>
+  </file>
   <file src="lib/Service/Sync/ImapToDbSynchronizer.php">
     <MissingDependency occurrences="4">
       <code>NewMessagesSynchronized</code>


### PR DESCRIPTION
The provider is not injectible on Nextcloud 20. Therefore it needs some
error handling to factor in the possible absence.

Fixes https://github.com/nextcloud/mail/issues/5741