### PR TITLE
Fix initial sync stopping prematurely and endlessly

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -40,9 +40,13 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 use function array_filter;
 use function array_map;
+use function count;
 use function in_array;
 use function iterator_to_array;
+use function max;
+use function min;
 use function reset;
+use function sprintf;
 
 class MessageMapper {
 
@@ -107,11 +111,11 @@ class MessageMapper {
 			]
 		);
 		/** @var int $min */
-		$min = $metaResults['min'];
+		$min = (int) $metaResults['min'];
 		/** @var int $max */
-		$max = $metaResults['max'];
+		$max = (int) $metaResults['max'];
 		/** @var int $total */
-		$total = $metaResults['count'];
+		$total = (int) $metaResults['count'];
 
 		if ($total === 0) {
 			// Nothing to fetch for this mailbox
@@ -149,10 +153,10 @@ class MessageMapper {
 				'ids' => new Horde_Imap_Client_Ids($lower . ':' . $upper)
 			]
 		);
-		if (count($fetchResult) === 0 && $upper < $max) {
+		if (count($fetchResult) === 0) {
 			/*
-			 * There were no messages in this range, but we've not reached the
-			 * latest message. This means we should try again until there is a
+			 * There were no messages in this range.
+			 * This means we should try again until there is a
 			 * page that actually returns at least one message
 			 *
 			 * We take $upper as the lowest known UID as we just found out that
@@ -161,30 +165,38 @@ class MessageMapper {
 			$this->logger->debug("Range for findAll did not find any messages. Trying again with a succeeding range");
 			return $this->findAll($client, $mailbox, $maxResults, $upper);
 		}
-		$uidsToFetch = array_slice(
-			array_filter(
-				array_map(
-					function (Horde_Imap_Client_Data_Fetch $data) {
-						return $data->getUid();
-					},
-					iterator_to_array($fetchResult)
-				),
-
-				function (int $uid) use ($highestKnownUid) {
-					// Don't load the ones we already know
-					return $uid > $highestKnownUid;
-				}
+		$uidCandidates = array_filter(
+			array_map(
+				function (Horde_Imap_Client_Data_Fetch $data) {
+					return $data->getUid();
+				},
+				iterator_to_array($fetchResult)
 			),
+
+			function (int $uid) use ($highestKnownUid) {
+				// Don't load the ones we already know
+				return $uid > $highestKnownUid;
+			}
+		);
+		$uidsToFetch = array_slice(
+			$uidCandidates,
 			0,
 			$maxResults
 		);
+		$highestUidToFetch = $uidsToFetch[count($uidsToFetch) - 1];
+		$this->logger->debug(sprintf("Range for findAll min=$min max=$max found %d messages, %d left after filtering. Highest UID to fetch is %d", count($uidCandidates), count($uidsToFetch), $highestUidToFetch));
+		if ($highestUidToFetch === $max) {
+			$this->logger->debug("All messages of mailbox $mailbox have been fetched");
+		} else {
+			$this->logger->debug("Mailbox $mailbox has more messages to fetch");
+		}
 		return [
 			'messages' => $this->findByIds(
 				$client,
 				$mailbox,
 				$uidsToFetch
 			),
-			'all' => $upper === $max,
+			'all' => $highestUidToFetch === $max,
 			'total' => $total,
 		];
 	}


### PR DESCRIPTION
The initial sync is broken up into chunks. These chunks are estimated
because we only know the lowest and highest UID and there are likely
gaps in this range. One of the last chunks might query a range that has
more messages than the allowed chunk size. We slice it down. This means
the actually fetched max UID is lower than the theoretical max UID for this
chunk.

If the stop condition is to stop at the theoretical max UID then we
occasionally stop too early. Where we actually have to stop is the
actually fetched highest UID.

Extracted from https://github.com/nextcloud/mail/pull/5721 to be easier to review.