### PR TITLE
Fix MessageMapper mailbox_id type to be int

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -110,7 +110,7 @@ class MessageMapper extends QBMapper {
 
 		$query->select($query->func()->max('uid'))
 			->from($this->getTableName())
-			->where($query->expr()->eq('mailbox_id', $query->createNamedParameter($mailbox->getId())));
+			->where($query->expr()->eq('mailbox_id', $query->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
 
 		$result = $query->execute();
 		$max = (int)$result->fetchColumn();


### PR DESCRIPTION
Values and comparisons are strings by default. This could lead to wrong quoting/casting.

Extracted from https://github.com/nextcloud/mail/pull/5721