### PR TITLE
Add debug logs to the imap message mapper findByIds

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -209,9 +209,20 @@ class MessageMapper {
 			]
 		);
 
+		/** @var Horde_Imap_Client_Data_Fetch[] $fetchResults */
 		$fetchResults = iterator_to_array($client->fetch($mailbox, $query, [
 			'ids' => new Horde_Imap_Client_Ids($ids),
 		]), false);
+
+		if (empty($fetchResults)) {
+			$this->logger->debug("findByIds in $mailbox got " . count($ids) . " UIDs but found none");
+		} else {
+			$minRequested = $ids[0];
+			$maxRequested = $ids[count($ids) - 1];
+			$minFetched = $fetchResults[0]->getUid();
+			$maxFetched = $fetchResults[count($fetchResults) - 1]->getUid();
+			$this->logger->debug("findByIds in $mailbox got " . count($ids) . " UIDs ($minRequested:$maxRequested) and found " . count($fetchResults) . ". minFetched=$minFetched maxFetched=$maxFetched");
+		}
 
 		return array_map(function (Horde_Imap_Client_Data_Fetch $fetchResult) use ($client, $mailbox, $loadBody) {
 			if ($loadBody) {

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -54,7 +54,7 @@ class MessageMapperTest extends TestCase {
 		);
 	}
 
-	public function testGetByIds() {
+	public function testGetByIds(): void {
 		/** @var Horde_Imap_Client_Socket|MockObject $imapClient */
 		$imapClient = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
@@ -63,16 +63,14 @@ class MessageMapperTest extends TestCase {
 		$fetchResults = new Horde_Imap_Client_Fetch_Results();
 		$fetchResult1 = $this->createMock(Horde_Imap_Client_Data_Fetch::class);
 		$fetchResult2 = $this->createMock(Horde_Imap_Client_Data_Fetch::class);
-		$imapClient->expects($this->once())
+		$imapClient->expects(self::once())
 			->method('fetch')
 			->willReturn($fetchResults);
 		$fetchResults[0] = $fetchResult1;
 		$fetchResults[1] = $fetchResult2;
-		$fetchResult1->expects($this->once())
-			->method('getUid')
+		$fetchResult1->method('getUid')
 			->willReturn(1);
-		$fetchResult2->expects($this->once())
-			->method('getUid')
+		$fetchResult2->method('getUid')
 			->willReturn(3);
 		$message1 = new IMAPMessage($imapClient, $mailbox, 1, $fetchResult1);
 		$message2 = new IMAPMessage($imapClient, $mailbox, 3, $fetchResult2);


### PR DESCRIPTION
This can show if unexpected results are fetched. If min expected doesn't match the min fetched or max expected doesn't match max fetched then something is wrong.

Extracted from https://github.com/nextcloud/mail/pull/5721