### PR TITLE
New database table for reset

### DIFF
--- a/doc/developer.md
+++ b/doc/developer.md
@@ -16,6 +16,7 @@ DROP TABLE oc_mail_classifiers;
 DROP TABLE oc_mail_trusted_senders;
 DROP TABLE oc_mail_tags;
 DROP TABLE oc_mail_message_tags;
+DROP TABLE oc_mail_provisionings;
 ```
 
 ## Enable CKEditor Inspector


### PR DESCRIPTION
As version 1.11.0 introduces a new table, we need to include that table in the cleanup procedure as well in the docs.