### PR TITLE
Fix column for account name too narrow

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We don’t have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.12.0-alpha.1</version>
+	<version>1.12.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author>Greta Doçi</author>

--- a/lib/Migration/Version1115Date20211216144446.php
+++ b/lib/Migration/Version1115Date20211216144446.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Make the mail_accounts.name column wider
+ */
+class Version1115Date20211216144446 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		$accountsNameColumn = $accountsTable->getColumn('name');
+		$accountsNameColumn->setLength(255);
+
+		$aliasesTable = $schema->getTable('mail_aliases');
+		$aliasesNameColumn = $aliasesTable->getColumn('name');
+		$aliasesNameColumn->setLength(255);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
The old length was 64. There were instances where this was too little.
Now we use 255.

Fixes

```
An exception occurred while executing a query: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'name' at row 1
``` 