### PR TITLE
Update throws annotations in ProvisioningManager

### DIFF
--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -110,12 +110,7 @@ class Manager {
 	 * A alias is orphaned if not listed in newAliases anymore
 	 * (=> the provisioning configuration does contain it anymore)
 	 *
-	 * Exception for Nextcloud 20: \Doctrine\DBAL\DBALException
-	 * Exception for Nextcloud 21 and newer: \OCP\DB\Exception
-	 *
-	 * @TODO: Change throws to \OCP\DB\Exception once Mail requires Nextcloud 21 or above
-	 *
-	 * @throws \Exception
+	 * @throws \OCP\DB\Exception
 	 */
 	private function deleteOrphanedAliases(string $userId, int $accountId, array $newAliases): void {
 		$existingAliases = $this->aliasMapper->findAll($accountId, $userId);
@@ -129,12 +124,7 @@ class Manager {
 	/**
 	 * Create new aliases for the given account.
 	 *
-	 * Exception for Nextcloud 20: \Doctrine\DBAL\DBALException
-	 * Exception for Nextcloud 21 and newer: \OCP\DB\Exception
-	 *
-	 * @TODO: Change throws to \OCP\DB\Exception once Mail requires Nextcloud 21 or above
-	 *
-	 * @throws \Exception
+	 * @throws \OCP\DB\Exception
 	 */
 	private function createNewAliases(string $userId, int $accountId, array $newAliases, string $displayName): void {
 		foreach ($newAliases as $newAlias) {
@@ -237,7 +227,7 @@ class Manager {
 
 	/**
 	 * @throws ValidationException
-	 * @throws \Exception
+	 * @throws \OCP\DB\Exception
 	 */
 	public function newProvisioning(array $data): void {
 		$provisioning = $this->provisioningMapper->validate($data);
@@ -246,7 +236,7 @@ class Manager {
 
 	/**
 	 * @throws ValidationException
-	 * @throws \Exception
+	 * @throws \OCP\DB\Exception
 	 */
 	public function updateProvisioning(array $data): void {
 		$provisioning = $this->provisioningMapper->validate($data);


### PR DESCRIPTION
Replace `\Exception` with `\OCP\DB\Exception`.