### PR TITLE
Set BCC for email recipients query

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -992,8 +992,8 @@ class MessageMapper extends QBMapper {
 					);
 					break;
 				case Address::TYPE_BCC:
-					$message->setFrom(
-						$message->getFrom()->merge(AddressList::fromRow($recipient))
+					$message->setBcc(
+						$message->getBcc()->merge(AddressList::fromRow($recipient))
 					);
 					break;
 			}


### PR DESCRIPTION
Previously, BCC was not set at all, and reset `from` again.