### PR TITLE
Update info.xml authors with new maintainer and co-maintainers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,12 +14,8 @@
 	]]></description>
 	<version>1.12.0-alpha.2</version>
 	<licence>agpl</licence>
-	<author>Christoph Wurst</author>
 	<author>Greta Doçi</author>
-	<author>Julius Härtl</author>
-	<author>Cyrille Bollu</author>
-	<author>Holger Dehnhardt</author>
-	<author>Jan-Christoph Borchardt</author>
+	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
 	<namespace>Mail</namespace>
 	<documentation>
 		<user>https://github.com/nextcloud/mail/blob/main/doc/user.md</user>


### PR DESCRIPTION
Ref https://github.com/nextcloud/groupware/issues/6#issuecomment-975367771

Ideally `<author>` was named `<maintainer>`. Obviously we are all still authors. But there is now one main person to maintain the app, the rest of us are co-maintainers.