### PR TITLE
Consider passwordless signins when provisioning accounts

### DIFF
--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -70,9 +70,15 @@ class ProvisioningMiddleware extends Middleware {
 		}
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);
+			$password = $this->credentialStore->getLoginCredentials()->getPassword();
+			if ($password === null) {
+				// Nothing to update, might be passwordless signin
+				$this->logger->debug('No password set for ' . $user->getUID());
+				return;
+			}
 			$this->provisioningManager->updatePassword(
 				$user,
-				$this->credentialStore->getLoginCredentials()->getPassword()
+				$password
 			);
 		} catch (CredentialsUnavailableException | PasswordUnavailableException $e) {
 			// Nothing to update

--- a/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
@@ -140,6 +140,36 @@ class ProvisioningMiddlewareTest extends TestCase {
 		);
 	}
 
+	public function testBeforeControllerPasswordlessSignin() {
+		$user = $this->createConfiguredMock(IUser::class, [
+			'getEmailAddress' => 'bruce.wayne@batman.com'
+		]);
+		$this->userSession->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$configs = [new Provisioning()];
+		$this->provisioningManager->expects($this->once())
+			->method('getConfigs')
+			->willReturn($configs);
+		$this->provisioningManager->expects($this->once())
+			->method('provisionSingleUser')
+			->with($configs, $user);
+		$credentials = $this->createMock(ICredentials::class);
+		$this->credentialStore->expects($this->once())
+			->method('getLoginCredentials')
+			->willReturn($credentials);
+		$credentials->expects($this->once())
+			->method('getPassword')
+			->willReturn(null);
+		$this->provisioningManager->expects($this->never())
+			->method('updatePassword');
+
+		$this->middleware->beforeController(
+			$this->createMock(PageController::class),
+			'index'
+		);
+	}
+
 	public function testBeforeControllerNoConfigAvailable() {
 		$user = $this->createConfiguredMock(IUser::class, [
 			'getEmailAddress' => 'bruce.wayne@batman.com'


### PR DESCRIPTION
Add a null check on the password and skip updating the password for these accounts.

Fixes #5933