### PR TITLE
Fix message account sync error if uidCandidates list is empty

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -142,6 +142,15 @@ class MessageMapper {
 			$max,
 			$lower + $estimatedPageSize
 		);
+		if ($lower > $upper) {
+			$this->logger->debug("Range for findAll did not find any (not already known) messages and all messages of mailbox $mailbox have been fetched.");
+			return [
+				'messages' => [],
+				'all' => true,
+				'total' => 0,
+			];
+		}
+
 		$this->logger->debug("Built range for findAll: min=$min max=$max total=$total totalRange=$totalRange estimatedPageSize=$estimatedPageSize lower=$lower upper=$upper highestKnownUid=$highestKnownUid");
 
 		$query = new Horde_Imap_Client_Fetch_Query();

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -322,6 +322,44 @@ class MessageMapperTest extends TestCase {
 		self::assertFalse($result['all']);
 	}
 
+	public function testFindAllNoUidCandidates(): void {
+		/** @var Horde_Imap_Client_Socket|MockObject $client */
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$mailbox = 'inbox';
+		$client->expects(self::once())
+			->method('search')
+			->with(
+				$mailbox,
+				null,
+				[
+					'results' => [
+						Horde_Imap_Client::SEARCH_RESULTS_MIN,
+						Horde_Imap_Client::SEARCH_RESULTS_MAX,
+						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+					]
+				]
+			)
+			->willReturn([
+				'min' => 1,
+				'max' => 35791,
+				'count' => 32122,
+			]);
+		$query = new Horde_Imap_Client_Fetch_Query();
+		$query->uid();
+		$client->expects(self::never())
+			->method('fetch');
+
+		$result = $this->mapper->findAll(
+			$client,
+			$mailbox,
+			5000,
+			99999
+		);
+
+		self::assertTrue($result['all']);
+		self::assertEmpty($result['messages']);
+	}
+
 	public function testGetFlagged() {
 		/** @var Horde_Imap_Client_Socket|MockObject $imapClient */
 		$imapClient = $this->createMock(Horde_Imap_Client_Socket::class);


### PR DESCRIPTION
The mail app in my NC installation fails the initital account sync with the following error.
`"Message":"Undefined array key -1 at /var/www/html/custom_apps/mail/lib/IMAP/MessageMapper.php#186",`

The reason is that the `$uidCandidates` array is empty after the array_filter step, although the `$fetchResult` isn't.
To prevent an endless loop I added the shortcut and return an empty result.
