### PR TITLE
Move KItinerary warning message to info

### DIFF
--- a/lib/Integration/KItinerary/ItineraryExtractor.php
+++ b/lib/Integration/KItinerary/ItineraryExtractor.php
@@ -81,7 +81,7 @@ class ItineraryExtractor {
 			$this->adapter = $this->findAvailableAdapter() ?? false;
 		}
 		if ($this->adapter === false) {
-			$this->logger->warning('KItinerary binary adapter is not available, can\'t extract information');
+			$this->logger->info('KItinerary binary adapter is not available, can\'t extract information');
 
 			return new Itinerary();
 		}


### PR DESCRIPTION
This PR is moving the error message `KItinerary binary adapter is not available, can't extract information` from being a Warning to an info.

This will reduce the logging for this on platform where KItinerary embedded cannot run (such as alpine).