### PR TITLE
Pointer cursor for quoted text clickability feedback

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -69,6 +69,10 @@ export default {
 <style lang="scss">
 .quoted-text {
 	color: var(--color-text-maxcontrast)
+
+	summary {
+		cursor: pointer
+	}
 }
 </style>
 <style lang="scss" scoped>
@@ -77,5 +81,9 @@ export default {
 }
 .mail-signature, .quoted {
 	color: var(--color-text-maxcontrast)
+
+	summary {
+		cursor: pointer
+	}
 }
 </style>


### PR DESCRIPTION
Now shows a pointer cursor for "Quoted text" segments in emails to give feedback that they can be clicked to expand/collapse.

Before | After
-|-
![Mail pointer feedback before](https://user-images.githubusercontent.com/925062/154134759-37ab6863-c51a-491c-acc2-552a80499781.gif)|![mail quote feedback after](https://user-images.githubusercontent.com/925062/154134761-502bd65c-aac0-4650-a92a-10bc51e58a5b.gif)

