### PR TITLE
Mark background jobs as time sensitive/insensitive

### DIFF
--- a/lib/BackgroundJob/CleanupJob.php
+++ b/lib/BackgroundJob/CleanupJob.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\BackgroundJob;
 use OCA\Mail\Service\CleanupService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use function method_exists;
 
 class CleanupJob extends TimedJob {
 
@@ -40,6 +41,12 @@ class CleanupJob extends TimedJob {
 		$this->cleanupService = $cleanupService;
 
 		$this->setInterval(24 * 60 * 60);
+		/**
+		 * @todo remove check with 24+
+		 */
+		if (method_exists($this, 'setTimeSensitivity')) {
+			$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		}
 	}
 
 	protected function run($argument): void {

--- a/lib/BackgroundJob/MigrateImportantJob.php
+++ b/lib/BackgroundJob/MigrateImportantJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright 2021 Anna Larch <anna.larch@nextcloud.com>
  *

--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -36,6 +36,7 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function method_exists;
 use function sprintf;
 
 class SyncJob extends TimedJob {
@@ -75,6 +76,12 @@ class SyncJob extends TimedJob {
 		$this->jobList = $jobList;
 
 		$this->setInterval(3600);
+		/**
+		 * @todo remove check with 24+
+		 */
+		if (method_exists($this, 'setTimeSensitivity')) {
+			$this->setTimeSensitivity(self::TIME_SENSITIVE);
+		}
 	}
 
 	/**

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -33,6 +33,7 @@ use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function method_exists;
 
 class TrainImportanceClassifierJob extends TimedJob {
 
@@ -60,7 +61,13 @@ class TrainImportanceClassifierJob extends TimedJob {
 		$this->jobList = $jobList;
 		$this->logger = $logger;
 
-		$this->setInterval(3600);
+		$this->setInterval(24 * 60 * 60);
+		/**
+		 * @todo remove check with 24+
+		 */
+		if (method_exists($this, 'setTimeSensitivity')) {
+			$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This contributes the Mail part of https://github.com/nextcloud/groupware/issues/28.

Only the hourly sync job is time sensitive, the rest can be done at off times.

`method_exists` checks will allow us to ship this to older Nextcloud releases.

And only run the important mailbox train job once a day.