### PR TITLE
Fix Psalm checks against server master with PHP7.3

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,7 +25,11 @@ jobs:
                 coverage: none
           - name: Install dependencies
             run: composer i
-          - name: Install dependencies
+          - name: Install OCP package
+            if: ${{ matrix.ocp-version != 'dev-master' }}
             run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
+          - name: Install OCP package
+            if: ${{ matrix.ocp-version == 'dev-master' }}
+            run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }} --ignore-platform-reqs
           - name: Run coding standards check
             run: composer run psalm

--- a/lib/BackgroundJob/CleanupJob.php
+++ b/lib/BackgroundJob/CleanupJob.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\BackgroundJob;
 use OCA\Mail\Service\CleanupService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use function defined;
 use function method_exists;
 
 class CleanupJob extends TimedJob {
@@ -42,9 +43,9 @@ class CleanupJob extends TimedJob {
 
 		$this->setInterval(24 * 60 * 60);
 		/**
-		 * @todo remove check with 24+
+		 * @todo remove checks with 24+
 		 */
-		if (method_exists($this, 'setTimeSensitivity')) {
+		if (defined('\OCP\BackgroundJob\IJob::TIME_INSENSITIVE') && method_exists($this, 'setTimeSensitivity')) {
 			$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 		}
 	}

--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -36,6 +36,7 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function defined;
 use function method_exists;
 use function sprintf;
 
@@ -77,9 +78,9 @@ class SyncJob extends TimedJob {
 
 		$this->setInterval(3600);
 		/**
-		 * @todo remove check with 24+
+		 * @todo remove checks with 24+
 		 */
-		if (method_exists($this, 'setTimeSensitivity')) {
+		if (defined('\OCP\BackgroundJob\IJob::TIME_SENSITIVE') && method_exists($this, 'setTimeSensitivity')) {
 			$this->setTimeSensitivity(self::TIME_SENSITIVE);
 		}
 	}

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -33,6 +33,7 @@ use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function defined;
 use function method_exists;
 
 class TrainImportanceClassifierJob extends TimedJob {
@@ -63,9 +64,9 @@ class TrainImportanceClassifierJob extends TimedJob {
 
 		$this->setInterval(24 * 60 * 60);
 		/**
-		 * @todo remove check with 24+
+		 * @todo remove checks with 24+
 		 */
-		if (method_exists($this, 'setTimeSensitivity')) {
+		if (defined('\OCP\BackgroundJob\IJob::TIME_INSENSITIVE') && method_exists($this, 'setTimeSensitivity')) {
 			$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 		}
 	}

--- a/vendor-bin/cs-fixer/composer.lock
+++ b/vendor-bin/cs-fixer/composer.lock
@@ -152,16 +152,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a"
+                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
-                "reference": "0c1a3925ec58a4ec98e992b9c7d171e9e184be0a",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/9e36aeed4616366d2b690bdce11f71e9178c579a",
+                "reference": "9e36aeed4616366d2b690bdce11f71e9178c579a",
                 "shasum": ""
             },
             "require": {
@@ -209,7 +209,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T17:06:45+00:00"
+            "time": "2022-02-24T20:20:32+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/vendor-bin/mozart/composer.json
+++ b/vendor-bin/mozart/composer.json
@@ -1,4 +1,10 @@
 {
+	"config": {
+		"platform": {
+			"php": "7.3"
+		},
+		"sort-packages": true
+	},
     "require": {
         "coenjacobs/mozart": "^0.7.1"
     }

--- a/vendor-bin/mozart/composer.lock
+++ b/vendor-bin/mozart/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "374a2f74f2ed6737d95fee931106a5c6",
+    "content-hash": "158cf2d7db6ee13775ddf4330bafbee2",
     "packages": [
         {
             "name": "coenjacobs/mozart",
@@ -204,20 +204,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -244,7 +244,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "symfony/console",
@@ -1112,5 +1112,8 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3"
+    },
     "plugin-api-version": "1.1.0"
 }

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,4 +1,10 @@
 {
+	"config": {
+		"platform": {
+			"php": "7.3"
+		},
+		"sort-packages": true
+	},
     "require-dev": {
         "christophwurst/nextcloud_testing": "^0.12.4"
     }

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b73c10d96a562539d21751bcd116d12",
+    "content-hash": "c233690f8f795e6bc659e8269c525c0e",
     "packages": [],
     "packages-dev": [
         {
@@ -596,16 +596,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.11",
+            "version": "9.2.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f"
+                "reference": "deac8540cb7bd40b2b8cfa679b76202834fd04e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/665a1ac0a763c51afc30d6d130dac0813092b17f",
-                "reference": "665a1ac0a763c51afc30d6d130dac0813092b17f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/deac8540cb7bd40b2b8cfa679b76202834fd04e8",
+                "reference": "deac8540cb7bd40b2b8cfa679b76202834fd04e8",
                 "shasum": ""
             },
             "require": {
@@ -665,7 +665,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-18T12:46:09+00:00"
+            "time": "2022-02-23T17:02:38+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -894,16 +894,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.14",
+            "version": "9.5.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1883687169c017d6ae37c58883ca3994cfc34189"
+                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1883687169c017d6ae37c58883ca3994cfc34189",
-                "reference": "1883687169c017d6ae37c58883ca3994cfc34189",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
+                "reference": "5ff8c545a50226c569310a35f4fa89d79f1ddfdc",
                 "shasum": ""
             },
             "require": {
@@ -919,7 +919,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -989,7 +989,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-18T12:54:07+00:00"
+            "time": "2022-02-23T17:10:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2297,5 +2297,8 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.3"
+    },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
The OCP package doesn't allow for PHP7.3 but our composer.json
overwrites it so that we do not update dependencies to versions with too
restrictive minimum PHP versions (looking at you Dependabot). Hence we
ignore the platform dependency here. Once PHP7.3 got dropped we will
update composer.json and the platform requirement can be enforced again.