### PR TITLE
Trimming IMAP and SMTP hosts on Setup.

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -208,7 +208,7 @@ class AccountsController extends Controller {
 			if ($autoDetect) {
 				$account = $this->setup->createNewAutoConfiguredAccount($accountName, $emailAddress, $password);
 			} else {
-				$account = $this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId, $id);
+				$account = $this->setup->createNewAccount($accountName, $emailAddress, trim($imapHost), $imapPort, $imapSslMode, $imapUser, $imapPassword, trim($smtpHost), $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId, $id);
 			}
 		} catch (Exception $ex) {
 			$errorMessage = $ex->getMessage();
@@ -345,7 +345,7 @@ class AccountsController extends Controller {
 			if ($autoDetect) {
 				$account = $this->setup->createNewAutoConfiguredAccount($accountName, $emailAddress, $password);
 			} else {
-				$account = $this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId);
+				$account = $this->setup->createNewAccount($accountName, $emailAddress, trim($imapHost), $imapPort, $imapSslMode, $imapUser, $imapPassword, trim($smtpHost), $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId);
 			}
 		} catch (Exception $ex) {
 			$errorMessage = $ex->getMessage();


### PR DESCRIPTION
Often when you try to add new mail accounts from manual setup, you copy the IMAP and SMTP hosts from your provider. However, more than often, copying like that may lead to additional unwanted whitespaces on the hosts fields.

This pull requests adds trimming both IMAP and SMTP hosts on setup in the Accounts controller.

It doesn't cost much but is a great quality of life feature because the mail app tries, unsuccessfully, to connect to hosts with whitespaces and doesn't give any meaningful message related to it.