### PR TITLE
Check mail for missing attachment

### DIFF
--- a/src/errors/AttachmentMissingError.js
+++ b/src/errors/AttachmentMissingError.js
@@ -1,0 +1,32 @@
+/**
+ * @author 2023 Maximilian Martin <maximilian_martin@gmx.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export default class AttachmentMissingError extends Error {
+
+	constructor(message) {
+		super(message)
+		this.name = AttachmentMissingError.getName()
+		this.message = message
+	}
+
+	static getName() {
+		return 'AttachmentMissingError'
+	}
+
+}


### PR DESCRIPTION
This PR sketches a solution to awkward problems that I sometimes encounter before my first coffee: I misspell the name of the email recipient in the salutation (Dear XXX) or I mention an attachment, but forget to attach something.

Before sending an email, the app now searches for these accidents and warns the user.

If there is interest, I can refactor and give the code presentable quality. Otherwise, feel free to close this.

![grafik](https://user-images.githubusercontent.com/56191773/161131349-075249d4-ed80-4326-bd0a-7b8bcf29376f.png)

![grafik](https://user-images.githubusercontent.com/56191773/161131387-8a08dc99-4a70-4275-8877-d458519040f8.png)
