### PR TITLE
Handle IMAP disconnects more explicitly

### DIFF
--- a/lib/Command/DiagnoseAccount.php
+++ b/lib/Command/DiagnoseAccount.php
@@ -84,7 +84,6 @@ class DiagnoseAccount extends Command {
 			$output->writeln('<error>No IMAP passwort set. The user might have to log into their account to set it.</error>');
 		}
 		$imapClient = $this->clientFactory->getClient($account);
-
 		try {
 			$this->printCapabilitiesStats($output, $imapClient);
 			$this->printMailboxesMessagesStats($output, $imapClient);
@@ -94,6 +93,8 @@ class DiagnoseAccount extends Command {
 			]);
 			$output->writeln("<error>Horde error occurred: " . $e->getMessage() . ". See nextcloud.log for more details.</error>");
 			return 2;
+		} finally {
+			$imapClient->logout();
 		}
 
 		return 0;

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -98,6 +98,8 @@ class MailboxSync {
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
 			$logger->debug('Getting namespaces for account ' . $account->getId() . ' failed: ' . $e->getMessage());
+		} finally {
+			$client->logout();
 		}
 
 		try {
@@ -137,7 +139,6 @@ class MailboxSync {
 	 */
 	public function syncStats(Account $account, Mailbox $mailbox): void {
 		$client = $this->imapClientFactory->getClient($account);
-
 		try {
 			$stats = $this->folderMapper->getFoldersStatusAsObject($client, $mailbox->getName());
 		} catch (Horde_Imap_Client_Exception $e) {
@@ -147,6 +148,8 @@ class MailboxSync {
 				(int)$e->getCode(),
 				$e
 			);
+		} finally {
+			$client->logout();
 		}
 
 		$mailbox->setMessages($stats->getTotal());

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -81,9 +81,10 @@ class PreviewEnhancer {
 			return $messages;
 		}
 
+		$client = $this->clientFactory->getClient($account);
 		try {
 			$data = $this->imapMapper->getBodyStructureData(
-				$this->clientFactory->getClient($account),
+				$client,
 				$mailbox->getName(),
 				$needAnalyze
 			);
@@ -94,6 +95,8 @@ class PreviewEnhancer {
 			]);
 
 			return $messages;
+		} finally {
+			$client->logout();
 		}
 
 		return $this->mapper->updatePreviewDataBulk(...array_map(function (Message $message) use ($data) {

--- a/lib/IMAP/Search/Provider.php
+++ b/lib/IMAP/Search/Provider.php
@@ -51,7 +51,6 @@ class Provider {
 								Mailbox $mailbox,
 								SearchQuery $searchQuery): array {
 		$client = $this->clientFactory->getClient($account);
-
 		try {
 			$fetchResult = $client->search(
 				$mailbox->getName(),
@@ -59,6 +58,8 @@ class Provider {
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException('Could not get message IDs: ' . $e->getMessage(), 0, $e);
+		} finally {
+			$client->logout();
 		}
 
 		return $fetchResult['match']->ids;

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -90,6 +90,8 @@ class DeleteDraftListener implements IEventListener {
 		} catch (DoesNotExistException $e) {
 			$this->logger->warning("Account has no draft mailbox set, can't delete the draft");
 			return;
+		} finally {
+			$client->logout();
 		}
 
 		try {

--- a/lib/Listener/FlagRepliedMessageListener.php
+++ b/lib/Listener/FlagRepliedMessageListener.php
@@ -78,8 +78,8 @@ class FlagRepliedMessageListener implements IEventListener {
 			return;
 		}
 
+		$client = $this->imapClientFactory->getClient($event->getAccount());
 		try {
-			$client = $this->imapClientFactory->getClient($event->getAccount());
 			$this->messageMapper->addFlag(
 				$client,
 				$mailbox,
@@ -90,6 +90,8 @@ class FlagRepliedMessageListener implements IEventListener {
 			$this->logger->warning('Could not flag replied message: ' . $e, [
 				'exception' => $e,
 			]);
+		} finally {
+			$client->logout();
 		}
 	}
 }

--- a/lib/Listener/SaveSentMessageListener.php
+++ b/lib/Listener/SaveSentMessageListener.php
@@ -83,14 +83,17 @@ class SaveSentMessageListener implements IEventListener {
 			return;
 		}
 
+		$client = $this->imapClientFactory->getClient($event->getAccount());
 		try {
 			$this->messageMapper->save(
-				$this->imapClientFactory->getClient($event->getAccount()),
+				$client,
 				$sentMailbox,
 				$event->getMail()
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException('Could not save sent message on IMAP', 0, $e);
+		} finally {
+			$client->logout();
 		}
 	}
 }

--- a/lib/Service/AutoConfig/ImapConnector.php
+++ b/lib/Service/AutoConfig/ImapConnector.php
@@ -85,8 +85,12 @@ class ImapConnector {
 
 		$a = new Account($account);
 		$client = $this->clientFactory->getClient($a);
-		$client->login();
-		$this->logger->info("Test-Account-Successful: $this->userId, $host, $port, $user, $encryptionProtocol");
-		return $account;
+		try {
+			$client->login();
+			$this->logger->info("Test-Account-Successful: $this->userId, $host, $port, $user, $encryptionProtocol");
+			return $account;
+		} finally {
+			$client->logout();
+		}
 	}
 }

--- a/lib/Service/SetupService.php
+++ b/lib/Service/SetupService.php
@@ -167,6 +167,8 @@ class SetupService {
 			$imapClient->login();
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new CouldNotConnectException($e, 'IMAP', $mailAccount->getInboundHost(), $mailAccount->getInboundPort());
+		} finally {
+			$imapClient->logout();
 		}
 
 		$transport = $this->smtpClientFactory->create($account);

--- a/tests/Integration/IMAP/AbstractTest.php
+++ b/tests/Integration/IMAP/AbstractTest.php
@@ -78,23 +78,6 @@ abstract class AbstractTest extends TestCase {
 	}
 
 	/**
-	 * @param string $name
-	 * @return Mailbox
-	 */
-	public function createMailBox($name) {
-		try {
-			$this->getTestAccount()->getMailbox($name);
-			$this->deleteMailbox($name);
-		} catch (Exception $e) {
-			// Ignore mailbox not found
-		}
-
-		$mailbox = $this->getTestAccount()->createMailbox($name);
-		self::$createdMailboxes[$name] = $mailbox;
-		return $mailbox;
-	}
-
-	/**
 	 * @return Account
 	 */
 	protected function getTestAccount() {


### PR DESCRIPTION
This changes the IMAP client usages to be used as a *resource* that is
freed after finished use. Previously we just memoized connections to the
same account to lower the number of connections, but that has still
shown to cause too many open connections during tests but possibly also
in production.

* [x] Move IMAP client usage into try-(catch-)finally patterns
* [x] Drop the IMAP client factory memoization
* [x] Open follow-up ticket to diagnose if we have potential reconnects because of this change. If we previously used the memoized connection in two sections of a code there is now a little overhead. It might not be worth the optimization but should be checked nevertheless. https://github.com/nextcloud/mail/issues/6175