### PR TITLE
Do not delete IMAP messages after sending an outbox message

### DIFF
--- a/src/components/OutboxComposer.vue
+++ b/src/components/OutboxComposer.vue
@@ -113,10 +113,6 @@ export default {
 			})
 
 			await this.$store.dispatch('outbox/sendMessage', { id: message.id })
-
-			// Remove old draft envelope
-			this.$store.commit('removeEnvelope', { id: data.draftId })
-			this.$store.commit('removeMessage', { id: data.draftId })
 		},
 		async fetchOriginalMessage() {
 			if (this.templateMessageId === undefined) {


### PR DESCRIPTION
Only IMAP messages has an IMAP draft. An outbox message doesn't have
one. Thus we must not delete any message with the same (coincidental)
ID.