### PR TITLE
Add missing fields to the outbox REST API

### DIFF
--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -94,6 +94,7 @@ class OutboxController extends Controller {
 	 * @param int|null $draftId
 	 * @param int|null $aliasId
 	 * @param string|null $inReplyToMessageId
+	 * @param int|null $sendAt
 	 * @return JsonResponse
 	 */
 	public function create(
@@ -107,8 +108,8 @@ class OutboxController extends Controller {
 		array   $attachments = [],
 		?int    $draftId = null,
 		?int    $aliasId = null,
-		?string $inReplyToMessageId = null
-	): JsonResponse {
+		?string $inReplyToMessageId = null,
+		?int $sendAt = null): JsonResponse {
 		$account = $this->accountService->find($this->userId, $accountId);
 
 		if ($draftId !== null) {
@@ -123,6 +124,7 @@ class OutboxController extends Controller {
 		$message->setBody($body);
 		$message->setHtml($isHtml);
 		$message->setInReplyToMessageId($inReplyToMessageId);
+		$message->setSendAt($sendAt);
 
 		$this->service->saveMessage($account, $message, $to, $cc, $bcc, $attachments);
 
@@ -144,6 +146,7 @@ class OutboxController extends Controller {
 	 * @param array $attachments
 	 * @param int|null $aliasId
 	 * @param string|null $inReplyToMessageId
+	 * @param int|null $sendAt
 	 * @return JsonResponse
 	 */
 	public function update(int     $id,
@@ -156,16 +159,18 @@ class OutboxController extends Controller {
 						   array   $bcc = [],
 						   array   $attachments = [],
 						   ?int    $aliasId = null,
-						   ?string $inReplyToMessageId = null): JsonResponse {
+						   ?string $inReplyToMessageId = null,
+						   ?int $sendAt = null): JsonResponse {
 		$message = $this->service->getMessage($id, $this->userId);
 		$account = $this->accountService->find($this->userId, $accountId);
 
 		$message->setAccountId($accountId);
+		$message->setAliasId($aliasId);
 		$message->setSubject($subject);
 		$message->setBody($body);
 		$message->setHtml($isHtml);
-		$message->setAliasId($aliasId);
 		$message->setInReplyToMessageId($inReplyToMessageId);
+		$message->setSendAt($sendAt);
 
 		$message = $this->service->updateMessage($account, $message, $to, $cc, $bcc, $attachments);
 

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -86,16 +86,16 @@ export default {
 				const now = new Date().getTime()
 				const dataForServer = {
 					accountId: data.account,
-					sendAt: Math.floor(now / 1000), // JS timestamp is in milliseconds
 					subject: data.subject,
 					body: data.isHtml ? data.body.value : toPlain(data.body).value,
 					isHtml: data.isHtml,
-					isMdn: false,
-					inReplyToMessageId: '',
 					to: data.to,
 					cc: data.cc,
 					bcc: data.bcc,
 					attachments: data.attachments,
+					aliasId: null,
+					inReplyToMessageId: null,
+					sendAt: Math.floor(now / 1000), // JS timestamp is in milliseconds
 				}
 				// TODO: update the message instead of enqueing another time
 				const message = await this.$store.dispatch('outbox/enqueueMessage', {
@@ -107,16 +107,16 @@ export default {
 				const now = new Date().getTime()
 				const dataForServer = {
 					accountId: data.account,
-					sendAt: Math.floor(now / 1000), // JS timestamp is in milliseconds
 					subject: data.subject,
 					body: data.isHtml ? data.body.value : toPlain(data.body).value,
 					isHtml: data.isHtml,
-					isMdn: false,
-					inReplyToMessageId: '',
 					to: data.to,
 					cc: data.cc,
 					bcc: data.bcc,
 					attachments: data.attachments,
+					aliasId: null,
+					inReplyToMessageId: null,
+					sendAt: Math.floor(now / 1000), // JS timestamp is in milliseconds
 				}
 				const message = await this.$store.dispatch('outbox/enqueueMessage', {
 					message: dataForServer,


### PR DESCRIPTION
- [x] `sendAt` timestamp to OutboxController
- [x] `aliasId` to frontend serverData
- [x] removed `isMdn` param as it's unused (outbox doesn't support MDN messages)
- [x] corrected default value for `inReplyToMessageId`