### PR TITLE
Ignore first draft if message has already been sent

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -54,6 +54,11 @@ export default {
 	},
 	methods: {
 		async saveDraft(data) {
+			if (!this.composerMessage) {
+				logger.info('Ignoring draft because there is no message anymore', { data })
+				return
+			}
+
 			if (this.composerMessage.type === 'outbox') {
 				const dataForServer = {
 					...data,


### PR DESCRIPTION
Sending a message waits for the draft. But if we send before the first ever draft is saved, there is a race condition.

## How to reproduce
* Click *New message*
* Very quickly write a message (that is the challenge)
* Submit before any draft is saved
* Close the modal

On the main branch: message is sent successfully, then there is an error on the console because `composerData` is undefined already.
On this branch: a warning is logged but no more error.