### PR TITLE
Show message sending errors as such

### DIFF
--- a/src/store/outbox/actions.js
+++ b/src/store/outbox/actions.js
@@ -69,7 +69,7 @@ export default {
 			logger.debug(`Outbox message ${id} sent`)
 		} catch (error) {
 			logger.error(`Failed to send message ${id} from outbox`, { error })
-			return
+			throw error
 		}
 
 		commit('deleteMessage', { id })


### PR DESCRIPTION
They were ignored before and the user got a nice confirmation screen
instead.

## How to test
1. Write a new message but to an invalid recipient, e.g. "abc" (no email domain!)
2. Send the message

On the base branch: *:heavy_check_mark: Message sent*
Here: "nice" error screen. But at least I know something went wrong.