### PR TITLE
Do not re-enqueue outbox messages when they are sent

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -97,9 +97,9 @@ export default {
 					inReplyToMessageId: null,
 					sendAt: Math.floor(now / 1000), // JS timestamp is in milliseconds
 				}
-				// TODO: update the message instead of enqueing another time
-				const message = await this.$store.dispatch('outbox/enqueueMessage', {
+				const message = await this.$store.dispatch('outbox/updateMessage', {
 					message: dataForServer,
+					id: this.composerData.id,
 				})
 
 				await this.$store.dispatch('outbox/sendMessage', { id: message.id })

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -183,6 +183,10 @@ export default {
 			},
 		})
 	},
+	convertComposerMessageToOutbox(state, { message }) {
+		Vue.set(state.newMessage, 'type', 'outbox')
+		Vue.set(state.newMessage.data, 'id', message.id)
+	},
 	hideMessageComposer(state) {
 		Vue.delete(state, 'newMessage')
 	},

--- a/src/store/outbox/actions.js
+++ b/src/store/outbox/actions.js
@@ -48,6 +48,12 @@ export default {
 	async enqueueMessage({ commit }, { message }) {
 		message = await OutboxService.enqueueMessage(message)
 		commit('addMessage', { message })
+
+		// Future drafts/sends after an error should go through outbox logic
+		commit('convertComposerMessageToOutbox', { message }, {
+			root: true,
+		})
+
 		return message
 	},
 


### PR DESCRIPTION
When we send a new message, then it will be pushed to the outbox. So far, so good

If that message can't be sent, so that it gets stuck in the outbox and we send it again, it shouldn't be added to the outbox another time. Instead we just update it.

## How to test
1. Write a message to an invalid recipient
2. See that the message is stuck in the outbox
3. Go to the outbox, open the message another time
4. Send the message without modification

On the base branch: message is added to the outbox another time (duplicate).
Here: message is not added another time.