### PR TITLE
Fix outbox API from/to/cc/bcc properties

### DIFF
--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Db;
 
 use JsonSerializable;
 use OCP\AppFramework\Db\Entity;
+use function array_filter;
 
 /**
  * @method int getType()
@@ -106,7 +107,18 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'html' => $this->isHtml(),
 			'inReplyToMessageId' => $this->getInReplyToMessageId(),
 			'attachments' => $this->getAttachments(),
-			'recipients' => $this->getRecipients()
+			'from' => array_filter($this->getRecipients(), function (Recipient $recipient) {
+				return $recipient->getType() === Recipient::TYPE_FROM;
+			}),
+			'to' => array_filter($this->getRecipients(), function (Recipient $recipient) {
+				return $recipient->getType() === Recipient::TYPE_TO;
+			}),
+			'cc' => array_filter($this->getRecipients(), function (Recipient $recipient) {
+				return $recipient->getType() === Recipient::TYPE_CC;
+			}),
+			'bcc' => array_filter($this->getRecipients(), function (Recipient $recipient) {
+				return $recipient->getType() === Recipient::TYPE_BCC;
+			}),
 		];
 	}
 


### PR DESCRIPTION
They are expected as four properties but were normalized into one array.

I missed this in https://github.com/nextcloud/mail/pull/6031.

On the target branch all outbox messages show a *?* for the avatar. With this patch it corresponds to the first recipient again.

Moreover if you continue editing an outbox message it previously lost all recipients.