### PR TITLE
Fix outbox send now error handling and improve message action labels

### DIFF
--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -40,13 +40,13 @@
 				icon="icon-checkmark"
 				:close-after-click="true"
 				@click="sendMessage">
-				{{ t('mail', 'Send message now') }}
+				{{ t('mail', 'Send now') }}
 			</ActionButton>
 			<ActionButton
 				icon="icon-delete"
 				:close-after-click="true"
 				@click="deleteMessage">
-				{{ t('mail', 'Delete message') }}
+				{{ t('mail', 'Delete') }}
 			</ActionButton>
 		</template>
 	</ListItem>
@@ -109,8 +109,12 @@ export default {
 		},
 		async sendMessage(data) {
 			logger.debug('sending message', { data })
-			await this.$store.dispatch('outbox/sendMessage', { id: this.message.id })
-			showSuccess(t('mail', 'Message sent'))
+			try {
+				await this.$store.dispatch('outbox/sendMessage', { id: this.message.id })
+				showSuccess(t('mail', 'Message sent'))
+			} catch (error) {
+				showError(t('mail', 'Could not send message'))
+			}
 		},
 		async openModal() {
 			await this.$store.dispatch('showMessageComposer', {


### PR DESCRIPTION
## How to test

1. Send a message to an invalid recipient
2. Go to the outbox
3. Open the message's action menu and click *Send now*

On the target branch: *Message sent* (lie)
![Bildschirmfoto vom 2022-04-07 21-50-24](https://user-images.githubusercontent.com/1374172/162287290-4514e112-c26e-4f79-b6d8-43c33481a3dd.png)


Here: nice error message

![Bildschirmfoto vom 2022-04-07 22-05-02](https://user-images.githubusercontent.com/1374172/162287264-452d2c0e-5bc0-4a30-88c4-f71d8a568f5f.png)

This will work best in combination with https://github.com/nextcloud/mail/pull/6203 because without it errors are swallowed and do not bubble.
