### PR TITLE
Mark database message as "\\answered"

### DIFF
--- a/lib/Listener/FlagRepliedMessageListener.php
+++ b/lib/Listener/FlagRepliedMessageListener.php
@@ -97,6 +97,9 @@ class FlagRepliedMessageListener implements IEventListener {
 						'exception' => $e,
 					]);
 				}
+
+				$message->setFlagAnswered(true);
+				$this->dbMessageMapper->update($message);
 			}
 		} finally {
 			$client->logout();


### PR DESCRIPTION
In addition to marking the IMAP message, also mark the database message entry.

Partial fix for #6189