### PR TITLE
Fix mailbox fetching after creating an account

### DIFF
--- a/src/service/AccountService.js
+++ b/src/service/AccountService.js
@@ -13,7 +13,7 @@ export const create = (data) => {
 
 	return axios
 		.post(url, data)
-		.then((resp) => resp.data)
+		.then((resp) => resp.data.data)
 		.then(fixAccountId)
 		.catch((e) => {
 			if (e.response && e.response.status === 400) {


### PR DESCRIPTION
The response structure changed and we have to access the account object
from a nested `data` property now.

Regression of https://github.com/nextcloud/mail/pull/6099.

Fixes https://github.com/nextcloud/mail/issues/6212