### PR TITLE
Use npm@7 in package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 14.x
+      - name: Set up npm
+        run: npm install -g npm@7
       - name: Set up php$
         uses: shivammathur/setup-php@master
         with:


### PR DESCRIPTION
According to our package.json file we require npm to be >= 7.0.0 but the default setup-node action installs an older version. This breaks the package workflow at #6219 and may break again in the future.