### PR TITLE
Run integration tests on stable24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       strategy:
           matrix:
               php-versions: [7.4, 8.0]
-              nextcloud-versions: ['master']
+              nextcloud-versions: ['stable24']
               db: ['sqlite', 'mysql', 'pgsql']
       name: php${{ matrix.php-versions }}-${{ matrix.db }} integration tests
       services:


### PR DESCRIPTION
This is a quick fix until we branched of stable1.12. Otherwise, our integration tests will fail all the time and we can't merge PRs.

Revert this once stable1.12 was branched off.