### PR TITLE
Allow selection of the current hour in the custom schedule time picker

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1007,8 +1007,14 @@ export default {
 		 */
 		disabledDatetimepickerTime(date) {
 			const now = new Date()
-			const minimumDate = new Date(now.getTime())
-			return date.getTime() <= minimumDate
+
+			// Only compare minutes and seconds to allow the current hour to be selected
+			now.setSeconds(0)
+			now.setMilliseconds(0)
+			date.setSeconds(0)
+			date.setMilliseconds(0)
+
+			return date < now
 		},
 	},
 }


### PR DESCRIPTION
Fix #6282 

This does not work in some cases. I suspect that there is a low level bug in the date picker library. Julia said that it works on her machine where nc-vue is linked to master which supports my suspicion.