### PR TITLE
Users can clear their mailboxes

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -160,6 +160,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'mailboxes#clearMailbox',
+			'url' => '/api/mailboxes/{id}/clear',
+			'verb' => 'POST'
+		],
+		[
 			'name' => 'messages#downloadAttachment',
 			'url' => '/api/messages/{id}/attachment/{attachmentId}',
 			'verb' => 'GET'

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -205,6 +205,14 @@ interface IMailManager {
 	/**
 	 * @param Account $account
 	 * @param Mailbox $mailbox
+	 *
+	 * @throws ServiceException
+	 */
+	public function clearMailbox(Account $account, Mailbox $mailbox): void;
+
+	/**
+	 * @param Account $account
+	 * @param Mailbox $mailbox
 	 * @param bool $subscribed
 	 *
 	 * @return Mailbox

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -284,4 +284,22 @@ class MailboxesController extends Controller {
 		$this->mailManager->deleteMailbox($account, $mailbox);
 		return new JSONResponse();
 	}
+	
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 *
+	 * @return JSONResponse
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	public function clearMailbox(int $id): JSONResponse {
+		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
+		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
+
+		$this->mailManager->clearMailbox($account, $mailbox);
+		return new JSONResponse();
+	}
 }

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -586,6 +586,27 @@ class MailManager implements IMailManager {
 	}
 
 	/**
+	 * Clear messages in folder
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 *
+	 * @throws ServiceException
+	 */
+	public function clearMailbox(Account $account,
+								  Mailbox $mailbox): void {
+		$client = $this->imapClientFactory->getClient($account);
+		try {
+			$client->expunge($mailbox->getName(), [
+				'delete' => true
+			]);
+		} finally {
+			$client->logout();
+		}
+		//delete all messages in this mailbox folder
+		$this->dbMessageMapper->deleteAll($mailbox);
+	}
+
+	/**
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param Message $message

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -160,6 +160,16 @@
 				{{ t('mail', 'Sync in background') }}
 			</ActionCheckbox>
 
+			<ActionButton
+				v-if="mailbox.specialRole !== 'flagged' && !account.isUnified"
+				:close-after-click="true"
+				@click="clearMailbox">
+				<template #icon>
+					<EraserVariant :size="20" />
+				</template>
+				{{ t('mail', 'Clear mailbox') }}
+			</ActionButton>
+
 			<ActionButton v-if="!account.isUnified && !mailbox.specialRole && !hasSubMailboxes" @click="deleteMailbox">
 				<template #icon>
 					<IconDelete
@@ -218,6 +228,7 @@ import { translate as translateMailboxName } from '../i18n/MailboxTranslator'
 import { showInfo } from '@nextcloud/dialogs'
 import { DroppableMailboxDirective as droppableMailbox } from '../directives/drag-and-drop/droppable-mailbox'
 import dragEventBus from '../directives/drag-and-drop/util/dragEventBus'
+import EraserVariant from 'vue-material-design-icons/EraserVariant'
 
 export default {
 	name: 'NavigationMailbox',
@@ -243,6 +254,7 @@ export default {
 		IconInbox,
 		ImportantIcon,
 		MoveMailboxModal,
+		EraserVariant,
 	},
 	directives: {
 		droppableMailbox,
@@ -369,6 +381,9 @@ export default {
 		},
 		showUnreadCounter() {
 			return this.mailbox.unread > 0 && this.filter !== 'starred'
+		},
+		colorPrimaryElement() {
+			return getComputedStyle(document.body).getPropertyValue('--color-primary-element').trim()
 		},
 	},
 	mounted() {
@@ -525,6 +540,29 @@ export default {
 								logger.info(`mailbox ${id} deleted`)
 							})
 							.catch((error) => logger.error('could not delete mailbox', { error }))
+					}
+				}
+			)
+		},
+		clearMailbox() {
+			const id = this.mailbox.databaseId
+			OC.dialogs.confirmDestructive(
+				t('mail', 'All messages in folder will be deleted permanently.'),
+				t('mail', 'Clear mailbox {name}', { name: this.mailbox.displayName }),
+				{
+					type: OC.dialogs.YES_NO_BUTTONS,
+					confirm: t('mail', 'Clear mailbox'),
+					confirmClasses: 'error',
+					cancel: t('mail', 'Cancel'),
+				},
+				(result) => {
+					if (result) {
+						return this.$store
+							.dispatch('clearMailbox', { mailbox: this.mailbox })
+							.then(() => {
+								logger.info(`mailbox ${id} cleared`)
+							})
+							.catch((error) => logger.error('could not clear mailbox', { error }))
 					}
 				}
 			)

--- a/src/service/MailboxService.js
+++ b/src/service/MailboxService.js
@@ -54,3 +54,10 @@ export async function patchMailbox(id, data) {
 	const response = await axios.patch(url, data)
 	return response.data
 }
+export const clearMailbox = async(id) => {
+	const url = generateUrl('/apps/mail/api/mailboxes/{id}/clear', {
+		id,
+	})
+
+	await axios.post(url)
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -54,6 +54,7 @@ import {
 import {
 	create as createMailbox,
 	deleteMailbox,
+	clearMailbox,
 	fetchAll as fetchAllMailboxes,
 	markMailboxRead,
 	patchMailbox,
@@ -183,6 +184,11 @@ export default {
 	async deleteMailbox({ commit }, { mailbox }) {
 		await deleteMailbox(mailbox.databaseId)
 		commit('removeMailbox', { id: mailbox.databaseId })
+	},
+	async clearMailbox({ commit }, { mailbox }) {
+		await clearMailbox(mailbox.databaseId)
+		commit('removeEnvelopes', { id: mailbox.databaseId })
+		commit('setMailboxUnreadCount', { id: mailbox.databaseId })
 	},
 	async createMailbox({ commit }, { account, name }) {
 		const prefixed = (account.personalNamespace && !name.startsWith(account.personalNamespace))

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -344,6 +344,9 @@ export default {
 
 		Vue.delete(state.envelopes, id)
 	},
+	removeEnvelopes(state, { id }) {
+		Vue.set(state.mailboxes[id], 'envelopeLists', [])
+	},
 	addMessage(state, { message }) {
 		Vue.set(state.messages, message.databaseId, message)
 	},


### PR DESCRIPTION
**Goodnight!**
_Perhaps_ this refers to https://github.com/nextcloud/mail/issues/5858

![action-button-crear-mailbox](https://user-images.githubusercontent.com/3595562/164553958-f1a7502b-2e1b-47a6-b4fb-50f3487be000.png)
![action-button-crear-mailbox-confirm](https://user-images.githubusercontent.com/3595562/164553971-b06014f7-2bb5-4d90-840f-aae0c3b4958e.png)

The clear folder button is shown on each folder (inbox, drafts, trash)

I checked it several times. Everything seems to be cleared correctly. If you do not specify the ids parameter in the `$client->expunge` method, then all IDs are generated by default. Perhaps there is a more correct solution, but I ask you to familiarize yourself with my PR.

_You may have to wait a very long time to clear folders with a large number of emails (it seems so to me ...)._

Thanks!