### PR TITLE
Unify Icon usage for sending

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -284,14 +284,16 @@
 						</ActionInput>
 					</template>
 				</Actions>
-				<div>
-					<input
-						class="submit-message send primary icon-confirm-white"
-						type="submit"
-						:value="submitButtonTitle"
-						:disabled="!canSend"
-						@click="onSend">
-				</div>
+
+				<button :disabled="!canSend"
+					class="button primary send-button"
+					type="submit"
+					@click="onSend">
+					<Send
+						:title="submitButtonTitle"
+						:size="20" />
+					{{ submitButtonTitle }}
+				</button>
 			</div>
 		</div>
 	</div>
@@ -370,6 +372,7 @@ import NoDraftsMailboxConfiguredError
 	from '../errors/NoDraftsMailboxConfiguredError'
 import ManyRecipientsError
 	from '../errors/ManyRecipientsError'
+import Send from 'vue-material-design-icons/Send'
 import SendClock from 'vue-material-design-icons/SendClock'
 import moment from '@nextcloud/moment'
 
@@ -406,6 +409,7 @@ export default {
 		Multiselect,
 		TextEditor,
 		EmptyContent,
+		Send,
 		SendClock,
 	},
 	props: {
@@ -1136,17 +1140,10 @@ export default {
 	min-height: 100px;
 }
 
-.send {
-	padding: 12px 18px 13px 36px;
-	background-position: 12px center;
-	margin-left: 4px;
-}
 ::v-deep .multiselect .multiselect__tags {
 	border: none !important;
 }
-.submit-message.send.primary.icon-confirm-white {
-	color: var(--color-main-background);
-}
+
 .sending-hint {
 	height: 50px;
 	margin-top: 50px;
@@ -1161,5 +1158,14 @@ export default {
 }
 .send-action-radio {
 	padding: 5px 0 5px 0;
+}
+.send-button {
+	display: flex;
+	align-items: center;
+	padding: 10px 15px;
+	margin-left: 5px;
+}
+.send-button .send-icon {
+	padding-right: 5px;
 }
 </style>

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -42,6 +42,11 @@
 				:close-after-click="true"
 				@click="sendMessage">
 				{{ t('mail', 'Send now') }}
+				<template #icon>
+					<Send
+						:title="t('mail', 'Send now')"
+						:size="20" />
+				</template>
 			</ActionButton>
 			<ActionButton
 				icon="icon-delete"
@@ -65,6 +70,7 @@ import logger from '../logger'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { matchError } from '../errors/match'
 import { html, plain } from '../util/text'
+import Send from 'vue-material-design-icons/Send'
 
 export default {
 	name: 'OutboxMessageListItem',
@@ -72,6 +78,7 @@ export default {
 		ListItem,
 		Avatar,
 		ActionButton,
+		Send,
 	},
 	mixins: [
 		OutboxAvatarMixin,


### PR DESCRIPTION
Replace "send button in composer" with material design "send icon"

Replace "outbox send now" with material design "send icon"

fixes #6247 

![image](https://user-images.githubusercontent.com/6078378/164702253-a9f6b75b-34c2-4f4d-b79f-eb4513375c23.png)
![image](https://user-images.githubusercontent.com/6078378/164702267-22e890f5-dcb7-4c9b-a7fa-c52160c396e2.png)
![image](https://user-images.githubusercontent.com/6078378/164702316-f5c88f96-b0f7-4d6c-852b-3fbdde3c4c20.png)
