### PR TITLE
Fix alignment of mailbox loading indicator

### DIFF
--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -1,12 +1,14 @@
 <template>
-	<div v-if="hint" class="emptycontent">
-		<a class="icon-loading" />
-		<h2>{{ hint }}</h2>
-		<transition name="fade">
-			<em v-if="slowHint && slow">{{ slowHint }}</em>
-		</transition>
+	<div class="wrapper">
+		<div v-if="hint" class="emptycontent">
+			<a class="icon-loading" />
+			<h2>{{ hint }}</h2>
+			<transition name="fade">
+				<em v-if="slowHint && slow">{{ slowHint }}</em>
+			</transition>
+		</div>
+		<div v-else class="container icon-loading" />
 	</div>
-	<div v-else class="container icon-loading" />
 </template>
 
 <script>
@@ -51,5 +53,12 @@ export default {
 .fade-enter,
 .fade-leave-to {
 	opacity: 0;
+}
+
+.wrapper {
+	display: flex;
+	justify-content: space-around;
+	flex-direction: column;
+	flex: 1 auto;
 }
 </style>

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -238,6 +238,11 @@ export default {
 	padding: 16px;
 }
 
+.app-content-list {
+	// Required for centering the loading indicator
+	display: flex;
+}
+
 .app-content-list-item:hover {
 	background: transparent;
 }


### PR DESCRIPTION
Fix #6205

This centers the loading indicator of all mailboxes including the outbox.

![Peek 2022-04-26 12-50](https://user-images.githubusercontent.com/1479486/165284209-183c0e6b-a4f9-4ddd-8651-beeea2012327.gif)