### PR TITLE
Modify attachements view at thread envelope

### DIFF
--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -21,14 +21,18 @@
 
 <template>
 	<div class="attachment" :class="{'message-attachment--can-preview': canPreview }" @click="$emit('click', $event)">
-		<img v-if="isImage"
-			class="mail-attached-image"
-			:src="url">
-		<img class="attachment-icon" :src="mimeUrl">
-		<span class="attachment-name"
-			:title="label">{{ name }}
-			<span class="attachment-size">({{ humanReadable(size) }})</span>
-		</span>
+		<div class="mail-attachment-img--wrapper">
+			<img v-if="isImage"
+				class="mail-attached-image"
+				:src="url">
+			<img v-else class="attachment-icon" :src="mimeUrl">
+		</div>
+		<div class="mail-attached--content">
+			<span class="attachment-name"
+				:title="label">{{ name }}
+			</span>
+			<span class="attachment-size">{{ humanReadable(size) }}</span>
+		</div>
 		<Actions :boundaries-element="boundariesElement">
 			<ActionButton
 				v-if="isCalendarEvent"
@@ -233,11 +237,21 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 .attachment {
-	position: relative;
-	display: inline-block;
-	width: calc(100% - 32px);
-	padding: 16px;
+	height: auto;
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    width: calc(33.3334% - 4px);
+    margin: 2px;
+	padding: 5px;
+    position: relative;
+    align-items: center;
+
+	&:hover {
+		border-radius: 6px;
+	}
 }
 
 .attachment:hover,
@@ -247,6 +261,33 @@ export default {
 	&.message-attachment--can-preview * {
 		cursor: pointer;
 	}
+}
+
+.mail-attachment-img--wrapper {
+	height: 44px;
+	width: 44px;
+	overflow: hidden;
+	display:flex;
+	justify-content: center;
+	position: relative;
+	border-radius: 6px;
+
+	img {
+		transition: 0.3s;
+		opacity: 1;
+		width: 44px;
+		height: 44px;
+	}
+
+	.mail-attached-image {
+		width: 100px;
+	}
+}
+
+.mail-attached--content {
+	width: calc(100% - 100px);
+	display: flex;
+    flex-direction: column;
 }
 
 .mail-attached-image {
@@ -263,18 +304,19 @@ export default {
 }
 .attachment-name {
 	display: inline-block;
-	width: calc(100% - 72px);
+	width: 100%;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	vertical-align: middle;
-	margin-bottom: 20px;
 }
 
 /* show attachment size less prominent */
 .attachment-size {
 	-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)';
 	opacity: 0.5;
+	font-size: 12px;
+	line-height: 14px;
 }
 
 .attachment-icon {
@@ -283,8 +325,7 @@ export default {
 	margin-bottom: 20px;
 }
 .action-item {
-	display: inline-block !important;
-	position: relative !important;
+	transition: 0.4s;
 }
 .mail-message-attachments {
 	overflow-x: auto;

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -258,6 +258,13 @@ export default {
 <style lang="scss">
 #mail-message {
 	flex-grow: 1;
+	max-height: calc(100vh - 50px);
+
+	.icon-loading {
+		&:only-child:after {
+			margin-top: 20px;
+		}
+	}
 }
 
 .mail-message-body {


### PR DESCRIPTION
Hello! I don't know whether to open a PR or ISSUE, but as a suggestion, I decided to experiment a little with the visual arrangement of attachments in the message.
I don't know if my PR will be useful, but if there is an opportunity, please read it.
![attachements-env-thread](https://user-images.githubusercontent.com/3595562/165348696-5ac543f0-054c-43df-baaa-965ae085107f.png)

I'll try to attach a GIF to fully show the logic of the work. In this drop-down menu, it may be worth moving the preview as well

![Peek 2022-04-26 19-33](https://user-images.githubusercontent.com/3595562/165349122-0a72a740-2a2d-4775-b629-22303484e060.gif)

As an option - it would be possible to use vertical scrolling of two rows ...
Thank you!

Fixes https://github.com/nextcloud/mail/issues/7120