### PR TITLE
Build threads conditionally

### DIFF
--- a/lib/Events/SynchronizationEvent.php
+++ b/lib/Events/SynchronizationEvent.php
@@ -37,12 +37,17 @@ class SynchronizationEvent extends Event {
 	/** @var LoggerInterface */
 	private $logger;
 
+	/** @var bool */
+	private $rebuildThreads;
+
 	public function __construct(Account $account,
-								LoggerInterface $logger) {
+								LoggerInterface $logger,
+								bool $rebuildThreads) {
 		parent::__construct();
 
 		$this->account = $account;
 		$this->logger = $logger;
+		$this->rebuildThreads = $rebuildThreads;
 	}
 
 	public function getAccount(): Account {
@@ -51,5 +56,9 @@ class SynchronizationEvent extends Event {
 
 	public function getLogger(): LoggerInterface {
 		return $this->logger;
+	}
+
+	public function isRebuildThreads(): bool {
+		return $this->rebuildThreads;
 	}
 }

--- a/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
+++ b/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
@@ -56,9 +56,13 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 			// Unrelated
 			return;
 		}
+		$logger = $event->getLogger();
+		if (!$event->isRebuildThreads()) {
+			$event->getLogger()->debug('Skipping threading as there were no significant changes');
+			return;
+		}
 
 		$accountId = $event->getAccount()->getId();
-		$logger = $event->getLogger();
 		$messages = $this->mapper->findThreadingData($event->getAccount());
 		$logger->debug("Account $accountId has " . count($messages) . " messages for threading");
 		$threads = $this->builder->build($messages, $logger);


### PR DESCRIPTION
* If there are new or vanished messages, rebuild all threads
* Skip the process otherwise

This will speed up account and mailbox synchronization in most cases,
especially when the front-end triggers a sync twice a minute. Blackfire has shown that for some production instances the threading can take 46% of the request's time. If nothing changes, this time is wasted.

When there are changes

```
...
[debug] Skipping mailbox sync for 1233
[debug] Skipping mailbox sync for 1237
[debug] Account 2829 has 631 messages for threading
[debug] Threading 631 messages - build ID table took 0s
[debug] Threading 631 messages - build root container took 0s
[debug] Threading 631 messages - free ID table took 0s
[debug] Threading 631 messages - prune containers took 0s
[debug] Threading 631 messages - group by subject took 0s
[debug] Threading 631 messages took 0s
[debug] Account 2829 has 556 threads
[debug] Account 2829 has 1 messages with a new thread IDs
[debug] Chunk of 500 messages updated
18MB of memory used
```

When there are no changes

```
...
[debug] Skipping mailbox sync for 1233
[debug] Skipping mailbox sync for 1237
[debug] Skipping threading as there were no significant changes
18MB of memory used
```

![Bildschirmfoto vom 2022-04-27 11-43-22](https://user-images.githubusercontent.com/1374172/165490660-a4857a7e-6cbe-4b94-938f-7303108c172c.png)

Fixes https://github.com/nextcloud/mail/issues/6305