### PR TITLE
 Check account for currentness before reprovisioning it

### DIFF
--- a/tests/Unit/Service/Provisioning/ManagerTest.php
+++ b/tests/Unit/Service/Provisioning/ManagerTest.php
@@ -68,6 +68,7 @@ class ManagerTest extends TestCase {
 		$config->setEmailTemplate('%USER%@batman.com');
 		$configs = [$config];
 		$account = new MailAccount();
+		$account->setProvisioningId(2);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->once())
 			->method('findProvisionedAccount')


### PR DESCRIPTION
If it's ugly but it works is it still ugly? Strings are interned in PHP so the string comparison should be fast,

Fixes https://github.com/nextcloud/mail/issues/6308

To Do:

- [ ] Run a performance evaluation against it