### PR TITLE
Make sure the account provisioning ID is an integer

### DIFF
--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -196,7 +196,7 @@ class MailAccount extends Entity {
 		$this->addType('inboundPort', 'integer');
 		$this->addType('outboundPort', 'integer');
 		$this->addType('lastMailboxSync', 'integer');
-		$this->addType('provisioning_id', 'integer');
+		$this->addType('provisioningId', 'integer');
 		$this->addType('order', 'integer');
 		$this->addType('showSubscribedOnly', 'boolean');
 		$this->addType('personalNamespace', 'string');


### PR DESCRIPTION
If the database driver doesn't automagically cast the field to an int,
Nextcloud's entity mapper will take care of this.

Otherwise the field might be represented as string. This leads to an
wrong change detection when provisioned accounts are updated. The
assumption was that if the entity has no changes, we save the update.
Due to the type mispatch, there was still one updated field.

https://github.com/nextcloud/mail/blob/27fe2975aac226aad344d7a54b0858d136565d91/lib/Service/Provisioning/Manager.php#L180-L182 is where the update happens.
https://github.com/nextcloud/server/blob/12272780ed2664da44078af0098491ca9708962c/lib/public/AppFramework/Db/QBMapper.php#L186-L189 is what skips the unnecessary update.

Supersedes https://github.com/nextcloud/mail/pull/6324

Fixes https://github.com/nextcloud/mail/issues/6308