### PR TITLE
Implement undo for send now action in outbox message list

### DIFF
--- a/src/store/outbox/actions.js
+++ b/src/store/outbox/actions.js
@@ -22,7 +22,10 @@
 
 import * as OutboxService from '../../service/OutboxService'
 import logger from '../../logger'
+import { showError, showUndo } from '@nextcloud/dialogs'
+import { translate as t } from '@nextcloud/l10n'
 import { UNDO_DELAY } from '../constants'
+import { html, plain } from '../../util/text'
 
 export default {
 	async fetchMessages({ getters, commit }) {
@@ -87,18 +90,29 @@ export default {
 		return updatedMessage
 	},
 
+	/**
+	 * Send an outbox message right now.
+	 *
+	 * @param {object} store Vuex destructuring object
+	 * @param {function} store.commit Vuex commit object
+	 * @param {object} store.getters Vuex getters object
+	 * @param {object} data Action data
+	 * @param {number} data.id Id of outbox message to send
+	 * @param {boolean} data.force Force sending a message even if it has no sendAt timestamp
+	 * @returns {Promise<boolean>} Resolves to false if sending was skipped
+	 */
 	async sendMessage({ commit, getters }, { id, force = false }) {
 		// Skip if the message has been deleted/undone in the meantime
 		const message = getters.getMessage(id)
 		logger.debug('Sending message ' + id, { message, force })
 		if (!force && (!message || !message.sendAt)) {
 			logger.debug('Skipped sending message that was undone')
-			return
+			return false
 		}
 
 		if (message.sendAt * 1000 > new Date().getTime() + UNDO_DELAY) {
 			logger.debug('Skipped sending message that is scheduled for the future')
-			return
+			return false
 		}
 
 		try {
@@ -110,5 +124,53 @@ export default {
 		}
 
 		commit('deleteMessage', { id })
+		return true
+	},
+
+	/**
+	 * Wait for UNDO_DELAY before sending the message and show a toast with an undo action.
+	 *
+	 * @param {object} store Vuex destructuring object
+	 * @param {function} store.dispatch Vuex dispatch object
+	 * @param {object} store.getters Vuex getters object
+	 * @param {object} data Action data
+	 * @param {number} data.id Id of outbox message to send
+	 * @returns {Promise<boolean>} Resolves to false if sending was skipped. Resolves after UNDO_DELAY has elapsed and the message dispatch was triggered. Warning: This might take a long time, depending on UNDO_DELAY.
+	 */
+	async sendMessageWithUndo({ getters, dispatch }, { id }) {
+		return new Promise((resolve, reject) => {
+			const message = getters.getMessage(id)
+
+			showUndo(
+				t('mail', 'Message sent'),
+				async() => {
+					logger.info('Attempting to stop sending message ' + message.id)
+					const stopped = await dispatch('stopMessage', { message })
+					logger.info('Message ' + message.id + ' stopped', { message: stopped })
+					await dispatch('showMessageComposer', {
+						type: 'outbox',
+						data: {
+							...message,
+							// The composer expects rich body data and not just a string
+							body: message.isHtml ? html(message.body) : plain(message.body),
+						},
+					}, { root: true })
+				}, {
+					timeout: UNDO_DELAY,
+					close: true,
+				}
+			)
+
+			setTimeout(async() => {
+				try {
+					const wasSent = await dispatch('sendMessage', { id: message.id })
+					resolve(wasSent)
+				} catch (error) {
+					showError(t('mail', 'Could not send message'))
+					logger.error('Could not delay-send message ' + message.id, { message })
+					reject(error)
+				}
+			}, UNDO_DELAY)
+		})
 	},
 }


### PR DESCRIPTION
Fix #6248 

The action "Send now" in the action menu of the outbox message list now works exactly the same way as the "Send now" button of the composer modal.
