### PR TITLE
Fix modal size in different size of the screen

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -193,10 +193,6 @@ export default {
 		max-width: 80%;
 	}
 }
-::v-deep .modal-container {
-	width: 80%;
-	min-height: 60%;
-}
 ::v-deep .modal-wrapper .modal-container {
 	overflow-y: auto !important;
 	overflow-x: auto !important;


### PR DESCRIPTION
fixes #6273 

width: 80% its overwritten by modal.vue style, 
min-height:60% is causing the modal to extend if the screen is too high, but doesnt do anything else