### PR TITLE
Fix html editor being always selected

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -753,8 +753,8 @@ export default {
 			} else {
 				this.selectedAlias = this.aliases[0]
 			}
-			// only overwrite editormode if no body provided
-			if (previous === NO_ALIAS_SET && !this.body) {
+			// Only overwrite editormode if body is empty
+			if (previous === NO_ALIAS_SET && (!this.body || this.body.value === '')) {
 				this.editorMode = this.selectedAlias.editorMode
 			}
 		},


### PR DESCRIPTION
Fix #6264

The composer tries to guess the editor type from opened envelope otherweise it will default to the value of the account (configured via the account settings modal). However, it seems that the fallback check was incorrect. 

The body is always initialized to a value:
```js
body: {
	type: Object,
	default: () => html(''),
},
```