### PR TITLE
Move mailvelope hint from composer to app settings

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -73,6 +73,18 @@
 			{{ t('mail', 'Show keyboard shortcuts') }}
 		</button>
 		<KeyboardShortcuts v-if="displayKeyboardShortcuts" @close="closeKeyboardShortcuts" />
+
+		<p class="mailvelope-section">
+			{{ t('mail', 'Looking for a way to encrypt your emails?') }}
+
+			<a
+				class="icon-password button app-settings-button"
+				href="https://www.mailvelope.com/"
+				target="_blank"
+				rel="noopener noreferrer">
+				{{ t('mail', 'Install Mailvelope browser extension') }}
+			</a>
+		</p>
 	</div>
 </template>
 
@@ -207,7 +219,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 p.app-settings span.icon-loading-small {
 	display: inline-block;
 	vertical-align: middle;
@@ -228,5 +240,15 @@ p.app-settings {
 }
 .app-settings-link {
 	text-decoration: underline;
+}
+.mailvelope-section {
+	padding-top: 15px;
+
+	a.button {
+		display: flex;
+		align-items: center;
+		line-height: normal;
+		min-height: 34px;
+	}
 }
 </style>

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -224,14 +224,6 @@
 							@uncheck="encrypt = false">
 							{{ t('mail', 'Encrypt message with Mailvelope') }}
 						</ActionCheckbox>
-						<ActionLink v-else
-							href="https://www.mailvelope.com/"
-							target="_blank"
-							icon="icon-password">
-							{{
-								t('mail', 'Looking for a way to encrypt your emails? Install the Mailvelope browser extension!')
-							}}
-						</ActionLink>
 					</template>
 					<template v-if="isMoreActionsOpen">
 						<ActionButton :close-after-click="false"
@@ -357,7 +349,6 @@ import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
-import ActionLink from '@nextcloud/vue/dist/Components/ActionLink'
 import ActionRadio from '@nextcloud/vue/dist/Components/ActionRadio'
 import Button from '@nextcloud/vue/dist/Components/Button'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
@@ -417,7 +408,6 @@ export default {
 		ActionButton,
 		ActionCheckbox,
 		ActionInput,
-		ActionLink,
 		ActionRadio,
 		VButton: Button,
 		ComposerAttachments,


### PR DESCRIPTION
Fix #6265 

| New hint in app settings | Composer three dot menu |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/167373449-61c64f4d-d120-4e58-af4f-cd8cf09391a1.png) | ![image](https://user-images.githubusercontent.com/1479486/167372107-6e04dbac-c278-4256-b45b-4d5b3de4b444.png) |
