### PR TITLE
Close streams after reading message parts

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -41,6 +41,7 @@ use Psr\Log\LoggerInterface;
 use function array_filter;
 use function array_map;
 use function count;
+use function fclose;
 use function in_array;
 use function iterator_to_array;
 use function max;
@@ -529,6 +530,7 @@ class MessageMapper {
 				'usestream' => true,
 			]);
 			$decoded = $part->getContents();
+			fclose($stream);
 
 			$attachments[] = $decoded;
 		}
@@ -590,6 +592,7 @@ class MessageMapper {
 				'name' => $part->getName(),
 				'size' => $part->getSize()
 			];
+			fclose($stream);
 		}
 		return $attachments;
 	}


### PR DESCRIPTION
We ask Horde for a stream of the message parts but those streams are not
closed. Closing the stream frees memory.

Discovered while I work on https://github.com/nextcloud/mail/issues/6400. This applies the pattern of https://github.com/nextcloud/mail/pull/6408 to other areas. However, this doesn't contribute to the sync memory leak.