### PR TITLE
Turn off cache for initial sync to prevent a memory leak

### DIFF
--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -60,9 +60,10 @@ class IMAPClientFactory {
 	 * (and stale) connections at a minimum.
 	 *
 	 * @param Account $account
+	 * @param bool $useCache
 	 * @return Horde_Imap_Client_Socket
 	 */
-	public function getClient(Account $account): Horde_Imap_Client_Socket {
+	public function getClient(Account $account, bool $useCache = true): Horde_Imap_Client_Socket {
 		$host = $account->getMailAccount()->getInboundHost();
 		$user = $account->getMailAccount()->getInboundUser();
 		$password = $account->getMailAccount()->getInboundPassword();
@@ -87,7 +88,7 @@ class IMAPClientFactory {
 				],
 			],
 		];
-		if ($this->cacheFactory->isAvailable()) {
+		if ($useCache && $this->cacheFactory->isAvailable()) {
 			$params['cache'] = [
 				'backend' => new Cache([
 					'cacheob' => $this->cacheFactory->createDistributed(md5((string)$account->getId())),

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -294,7 +294,7 @@ class ImapToDbSynchronizer {
 		);
 
 		$highestKnownUid = $this->dbMapper->findHighestUid($mailbox);
-		$client = $this->clientFactory->getClient($account);
+		$client = $this->clientFactory->getClient($account, false);
 		try {
 			try {
 				$imapMessages = $this->imapMapper->findAll(


### PR DESCRIPTION
The cache implementation doesn't persist its values until the shutdown
of the process. For each iteration of the initial synchronization we
have to create one instance of the cache. Those two facts combined mean
that for each iteration Horde builds a new set of cache data for the
mailbox and therefore creates a memory leak.

Turning off cache isn't great but the data we need for the synchronization has to be fetched anyway.

Ref https://github.com/nextcloud/mail/issues/6400#issuecomment-1123773725