### PR TITLE
Add more detailed performance logging to occ sync

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -36,6 +36,7 @@ use Horde_Mime_Part;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Model\IMAPMessage;
+use OCA\Mail\Support\PerformanceLoggerTask;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 use function array_filter;
@@ -81,6 +82,7 @@ class MessageMapper {
 	 *
 	 * @param int $maxResults
 	 * @param int $highestKnownUid
+	 * @param PerformanceLoggerTask $perf
 	 *
 	 * @return array
 	 * @throws Horde_Imap_Client_Exception
@@ -88,10 +90,12 @@ class MessageMapper {
 	public function findAll(Horde_Imap_Client_Socket $client,
 							string $mailbox,
 							int $maxResults,
-							int $highestKnownUid): array {
+							int $highestKnownUid,
+							LoggerInterface $logger,
+							PerformanceLoggerTask $perf): array {
 		/**
 		 * To prevent memory exhaustion, we don't want to just ask for a list of
-		 * all UIDs and limit them client-side. Instead we can (hopefully
+		 * all UIDs and limit them client-side. Instead, we can (hopefully
 		 * efficiently) query the min and max UID as well as the number of
 		 * messages. Based on that we assume that UIDs are somewhat distributed
 		 * equally and build a page to fetch.
@@ -110,6 +114,7 @@ class MessageMapper {
 				]
 			]
 		);
+		$perf->step('mailbox meta search');
 		/** @var int $min */
 		$min = (int) $metaResults['min'];
 		/** @var int $max */
@@ -143,7 +148,7 @@ class MessageMapper {
 			$lower + $estimatedPageSize
 		);
 		if ($lower > $upper) {
-			$this->logger->debug("Range for findAll did not find any (not already known) messages and all messages of mailbox $mailbox have been fetched.");
+			$logger->debug("Range for findAll did not find any (not already known) messages and all messages of mailbox $mailbox have been fetched.");
 			return [
 				'messages' => [],
 				'all' => true,
@@ -151,7 +156,7 @@ class MessageMapper {
 			];
 		}
 
-		$this->logger->debug("Built range for findAll: min=$min max=$max total=$total totalRange=$totalRange estimatedPageSize=$estimatedPageSize lower=$lower upper=$upper highestKnownUid=$highestKnownUid");
+		$logger->debug("Built range for findAll: min=$min max=$max total=$total totalRange=$totalRange estimatedPageSize=$estimatedPageSize lower=$lower upper=$upper highestKnownUid=$highestKnownUid");
 
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
@@ -162,6 +167,7 @@ class MessageMapper {
 				'ids' => new Horde_Imap_Client_Ids($lower . ':' . $upper)
 			]
 		);
+		$perf->step('fetch UIDs');
 		if (count($fetchResult) === 0) {
 			/*
 			 * There were no messages in this range.
@@ -171,8 +177,8 @@ class MessageMapper {
 			 * We take $upper as the lowest known UID as we just found out that
 			 * there is nothing to fetch in $highestKnownUid:$upper
 			 */
-			$this->logger->debug("Range for findAll did not find any messages. Trying again with a succeeding range");
-			return $this->findAll($client, $mailbox, $maxResults, $upper);
+			$logger->debug("Range for findAll did not find any messages. Trying again with a succeeding range");
+			return $this->findAll($client, $mailbox, $maxResults, $upper, $logger, $perf);
 		}
 		$uidCandidates = array_filter(
 			array_map(
@@ -192,19 +198,22 @@ class MessageMapper {
 			0,
 			$maxResults
 		);
+		$perf->step('calculate UIDs to fetch');
 		$highestUidToFetch = $uidsToFetch[count($uidsToFetch) - 1];
-		$this->logger->debug(sprintf("Range for findAll min=$min max=$max found %d messages, %d left after filtering. Highest UID to fetch is %d", count($uidCandidates), count($uidsToFetch), $highestUidToFetch));
+		$logger->debug(sprintf("Range for findAll min=$min max=$max found %d messages, %d left after filtering. Highest UID to fetch is %d", count($uidCandidates), count($uidsToFetch), $highestUidToFetch));
 		if ($highestUidToFetch === $max) {
-			$this->logger->debug("All messages of mailbox $mailbox have been fetched");
+			$logger->debug("All messages of mailbox $mailbox have been fetched");
 		} else {
-			$this->logger->debug("Mailbox $mailbox has more messages to fetch");
+			$logger->debug("Mailbox $mailbox has more messages to fetch");
 		}
+		$messages = $this->findByIds(
+			$client,
+			$mailbox,
+			$uidsToFetch
+		);
+		$perf->step('find IMAP messages by UID');
 		return [
-			'messages' => $this->findByIds(
-				$client,
-				$mailbox,
-				$uidsToFetch
-			),
+			'messages' => $messages,
 			'all' => $highestUidToFetch === $max,
 			'total' => $total,
 		];

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -33,6 +33,7 @@ use Horde_Imap_Client_Socket;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Model\IMAPMessage;
+use OCA\Mail\Support\PerformanceLoggerTask;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use function range;
@@ -114,7 +115,9 @@ class MessageMapperTest extends TestCase {
 			$client,
 			$mailbox,
 			5000,
-			0
+			0,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(PerformanceLoggerTask::class)
 		);
 
 		$this->assertSame(
@@ -183,7 +186,9 @@ class MessageMapperTest extends TestCase {
 			$client,
 			$mailbox,
 			5000,
-			0
+			0,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(PerformanceLoggerTask::class)
 		);
 
 		self::assertTrue($result['all']);
@@ -245,7 +250,9 @@ class MessageMapperTest extends TestCase {
 			$client,
 			$mailbox,
 			5000,
-			300
+			300,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(PerformanceLoggerTask::class)
 		);
 
 		self::assertTrue($result['all']);
@@ -314,7 +321,9 @@ class MessageMapperTest extends TestCase {
 			$client,
 			$mailbox,
 			5000,
-			92000
+			92000,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(PerformanceLoggerTask::class)
 		);
 
 		// This chunk returns 8k messages, when we only expected 5k. So the process
@@ -353,7 +362,9 @@ class MessageMapperTest extends TestCase {
 			$client,
 			$mailbox,
 			5000,
-			99999
+			99999,
+			$this->createMock(LoggerInterface::class),
+			$this->createMock(PerformanceLoggerTask::class)
 		);
 
 		self::assertTrue($result['all']);


### PR DESCRIPTION
This was done for https://github.com/nextcloud/mail/issues/6400 but I think it makes sense to keep in general. We previously had the issue that some of the logging, especially from the mapper's `findAll`, was not shown on the console output and we had to match the info from the nextcloud log. Now the lines are shown with the console output and it's a lot easier to trace what happens during a sync.