### PR TITLE
Only print debug logs at debug verbosity

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -135,7 +135,7 @@ In this example, `1393` is the *account ID*.
 To troubleshoot synchronization or threading problems it's helpful to run the sync from the command line while the user does not use the web interface (reduces chances of a conflict):
 
 ```bash
-php -f occ mail:account:sync 1393
+php -f occ mail:account:sync -vvv 1393
 ```
 
 1393 represents the [account ID](#get-account-ids).

--- a/lib/Support/ConsoleLoggerDecorator.php
+++ b/lib/Support/ConsoleLoggerDecorator.php
@@ -85,6 +85,10 @@ class ConsoleLoggerDecorator implements LoggerInterface {
 	}
 
 	public function debug($message, array $context = []) {
+		if ($this->consoleOutput->getVerbosity() < OutputInterface::VERBOSITY_DEBUG) {
+			return;
+		}
+
 		$this->consoleOutput->writeln("[debug] $message");
 
 		$this->inner->debug($message, $context);

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -345,10 +345,10 @@
     </MissingDependency>
   </file>
   <file src="lib/Support/ConsoleLoggerDecorator.php">
-    <UndefinedClass occurrences="1">
+    <UndefinedClass occurrences="2">
       <code>OutputInterface</code>
     </UndefinedClass>
-    <UndefinedDocblockClass occurrences="10">
+    <UndefinedDocblockClass occurrences="11">
       <code>$this-&gt;consoleOutput</code>
       <code>$this-&gt;consoleOutput</code>
       <code>$this-&gt;consoleOutput</code>


### PR DESCRIPTION
Ref https://symfony.com/doc/current/console/verbosity.html

This keeps the output clean for production but also allows more insights when requested. Running a command with `-vvv` means running it with debug verbosity.