### PR TITLE
Drop Nextcloud 21 support

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,7 +12,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-master', 'dev-stable24', 'dev-stable23', 'dev-stable22', 'dev-stable21' ]
+              ocp-version: [ 'dev-master', 'dev-stable24', 'dev-stable23', 'dev-stable22' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-versions: [7.4]
-        nextcloud-versions: ['stable21', 'stable22', 'stable23']
+        nextcloud-versions: ['stable22', 'stable23']
         include:
             - php-versions: 7.4
               nextcloud-versions: stable24

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@
 	<screenshot>https://user-images.githubusercontent.com/1374172/79554966-278e1600-809f-11ea-82ea-7a0d72a2704f.png</screenshot>
 	<dependencies>
 		<php min-version="7.4" max-version="8.0" />
-		<nextcloud min-version="21" max-version="25" />
+		<nextcloud min-version="22" max-version="25" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Mail\BackgroundJob\CleanupJob</job>


### PR DESCRIPTION
It has reached EOL.

Ref https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule

As with PHP7.3 support to v1.8.x line will be used for any critical backportable fixes.