### PR TITLE
Fix sending messages to groups

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -410,16 +410,12 @@ class AccountsController extends Controller {
 		$account = $this->accountService->find($this->currentUserId, $id);
 		$alias = $aliasId ? $this->aliasesService->find($aliasId, $this->currentUserId) : null;
 
-		$expandedTo = $this->groupsIntegration->expand($to);
-		$expandedCc = $this->groupsIntegration->expand($cc);
-		$expandedBcc = $this->groupsIntegration->expand($bcc);
-
-		$count = substr_count($expandedTo, ',') + substr_count($expandedCc, ',') + 1;
+		$count = substr_count($to, ',') + substr_count($cc, ',') + 1;
 		if (!$force && $count >= 10) {
 			throw new ManyRecipientsException();
 		}
 
-		$messageData = NewMessageData::fromRequest($account, $expandedTo, $expandedCc, $expandedBcc, $subject, $body, $attachments, $isHtml, $requestMdn);
+		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments, $isHtml, $requestMdn);
 		if ($messageId !== null) {
 			try {
 				$repliedMessage = $this->mailManager->getMessage($this->currentUserId, $messageId);

--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -23,10 +23,16 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service;
 
+use OCA\Mail\Db\Recipient;
 use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\Group\IGroupService;
 use OCA\Mail\Service\Group\NextcloudGroupService;
 use OCA\Mail\Exception\ServiceException;
+use function array_map;
+use function mb_strlen;
+use function mb_strpos;
+use function mb_substr;
+use function OCA\Mail\array_flat_map;
 
 class GroupsIntegration {
 
@@ -82,34 +88,38 @@ class GroupsIntegration {
 	}
 
 	/**
-	 * Expands a string of group names to its members email addresses.
+	 * Expands group names to its members
 	 *
-	 * @param string $recipients
+	 * @param Recipient[] $recipients
 	 *
-	 * @return null|string
+	 * @return Recipient[]
 	 */
-	public function expand(string $recipients): ?string {
-		return array_reduce($this->groupServices,
-			function ($carry, $service) {
-				return preg_replace_callback(
-					'/' . preg_quote($this->servicePrefix($service)) . '([^,]+)(,?)/',
-					function ($matches) use ($service) {
-						if (empty($matches[1])) {
-							return '';
-						}
-						$members = $service->getUsers($matches[1]);
-						if (empty($members)) {
-							throw new ServiceException($matches[1] . " ({$service->getNamespace()}) has no members");
-						}
-						$addresses = [];
-						foreach ($members as $m) {
-							if (!empty($m['email'])) {
-								$addresses[] = $m['email'];
-							}
-						}
-						return implode(',', $addresses)
-							. (!empty($matches[2]) && !empty($addresses) ? ',' : '');
-					}, $carry);
-			}, $recipients);
+	public function expand(array $recipients): array {
+		return array_flat_map(function (Recipient $recipient) {
+			foreach ($this->groupServices as $service) {
+				if (mb_strpos($recipient->getEmail(), $this->servicePrefix($service)) !== false) {
+					$groupId = mb_substr(
+						$recipient->getEmail(),
+						mb_strlen($this->servicePrefix($service))
+					);
+					$members = array_filter($service->getUsers($groupId), function (array $member) {
+						return !empty($member['email']);
+					});
+					if (empty($members)) {
+						throw new ServiceException($groupId . " ({$service->getNamespace()}) has no members with email addresses");
+					}
+					return array_map(function (array $member) use ($recipient) {
+						return Recipient::fromParams([
+							'messageId' => $recipient->getMessageId(),
+							'type' => $recipient->getType(),
+							'label' => $member['name'] ?? $member['email'],
+							'email' => $member['email'],
+						]);
+					}, $members);
+				}
+			}
+
+			return [$recipient];
+		}, $recipients);
 	}
 }

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -40,9 +40,9 @@ use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Model\NewMessageData;
 use OCA\Mail\Model\RepliedMessageData;
-use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AliasesService;
 use OCA\Mail\Service\Attachment\UploadedFile;
+use OCA\Mail\Service\GroupsIntegration;
 use OCA\Mail\Service\MailTransmission;
 use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Support\PerformanceLogger;
@@ -109,7 +109,6 @@ class MailTransmissionIntegrationTest extends TestCase {
 
 		$this->transmission = new MailTransmission(
 			$userFolder,
-			OC::$server->query(AccountService::class),
 			$this->attachmentService,
 			OC::$server->query(IMailManager::class),
 			OC::$server->query(IMAPClientFactory::class),
@@ -119,7 +118,8 @@ class MailTransmissionIntegrationTest extends TestCase {
 			OC::$server->query(MessageMapper::class),
 			OC::$server->query(LoggerInterface::class),
 			OC::$server->query(PerformanceLogger::class),
-			OC::$server->get(AliasesService::class)
+			OC::$server->get(AliasesService::class),
+			OC::$server->get(GroupsIntegration::class)
 		);
 	}
 

--- a/tests/Unit/Service/GroupsIntegrationTest.php
+++ b/tests/Unit/Service/GroupsIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Matthias Rella <mrella@pisys.eu>
  *
@@ -22,6 +24,7 @@
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\Recipient;
 use OCA\Mail\Service\Group\ContactsGroupService;
 use OCA\Mail\Service\GroupsIntegration;
 use OCA\Mail\Service\Group\NextcloudGroupService;
@@ -53,7 +56,7 @@ class GroupsIntegrationTest extends TestCase {
 		);
 	}
 
-	public function testGetMatchingGroups() {
+	public function testGetMatchingGroups(): void {
 		$term = 'te'; // searching for: John Doe
 		$searchResult1 = [
 			[
@@ -61,52 +64,45 @@ class GroupsIntegrationTest extends TestCase {
 				'name' => "first test group"
 			]
 		];
-
 		$this->groupService1->expects($this->once())
 			->method('search')
 			->with($term)
-			->will($this->returnValue($searchResult1));
+			->willReturn($searchResult1);
 
-		$expected = [
-			[
-				'id' => 'namespace1:testgroup',
-				'label' => 'first test group (Namespace1)',
-				'email' => 'namespace1:testgroup',
-				'photo' => null,
-			]
-		];
 		$actual = $this->groupsIntegration->getMatchingGroups($term);
 
-		$this->assertEquals($expected, $actual);
+		$this->assertEquals(
+			[
+				[
+					'id' => 'namespace1:testgroup',
+					'label' => 'first test group (Namespace1)',
+					'email' => 'namespace1:testgroup',
+					'photo' => null,
+				]
+			],
+			$actual
+		);
 	}
 
-	public function testExpandNone() {
-		$recipients = "john@doe.com,alice@smith.net";
-		$members = [
-			[
-				'id' => 'bob',
-				'name' => "Bobby",
-				'email' => "bob@smith.net"
-			],
-			[
-				'id' => 'mary',
-				'name' => 'Mary',
-				'email' => 'mary@smith.net'
-			]
+	public function testExpandNone(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'alice@smith.net', 'email' => 'alice@smith.net']),
 		];
 		$this->groupService1->expects($this->never())
-			->method('getUsers')
-			->willReturn($members);
+			->method('getUsers');
 
-		$expected = $recipients;
+		$expanded = $this->groupsIntegration->expand($recipients);
 
-		$actual = $this->groupsIntegration->expand($recipients);
-
-		$this->assertEquals($expected, $actual);
+		$this->assertEquals($recipients, $expanded);
 	}
 
-	public function testExpand() {
-		$recipients = "john@doe.com,namespace1:testgroup,alice@smith.net";
+	public function testExpand(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'testgroup (namespace1)', 'email' => 'namespace1:testgroup']),
+			Recipient::fromParams(['label' => 'alice@smith.net', 'email' => 'alice@smith.net']),
+		];
 		$members = [
 			[
 				'id' => 'bob',
@@ -123,15 +119,25 @@ class GroupsIntegrationTest extends TestCase {
 			->method('getUsers')
 			->willReturn($members);
 
-		$expected = "john@doe.com,bob@smith.net,mary@smith.net,alice@smith.net";
+		$expanded = $this->groupsIntegration->expand($recipients);
 
-		$actual = $this->groupsIntegration->expand($recipients);
-
-		$this->assertEquals($expected, $actual);
+		$this->assertEquals(
+			[
+				Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+				Recipient::fromParams(['label' => 'Bobby', 'email' => 'bob@smith.net']),
+				Recipient::fromParams(['label' => 'Mary', 'email' => 'mary@smith.net']),
+				Recipient::fromParams(['label' => 'alice@smith.net', 'email' => 'alice@smith.net']),
+			],
+			$expanded
+		);
 	}
 
-	public function testExpand2() {
-		$recipients = "john@doe.com,namespace1:testgroup,alice@smith.net";
+	public function testExpandUmlauts(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'ümlaut (namespace1)', 'email' => 'namespace1:ümlaut']),
+			Recipient::fromParams(['label' => 'alice@smith.net', 'email' => 'alice@smith.net']),
+		];
 		$members = [
 			[
 				'id' => 'bob',
@@ -148,40 +154,24 @@ class GroupsIntegrationTest extends TestCase {
 			->method('getUsers')
 			->willReturn($members);
 
-		$expected = "john@doe.com,bob@smith.net,mary@smith.net,alice@smith.net";
+		$expanded = $this->groupsIntegration->expand($recipients);
 
-		$actual = $this->groupsIntegration->expand($recipients);
-
-		$this->assertEquals($expected, $actual);
-	}
-
-	public function testExpandUmlauts() {
-		$recipients = "john@doe.com,namespace1:ümlaut";
-		$members = [
+		$this->assertEquals(
 			[
-				'id' => 'bob',
-				'name' => "Bobby",
-				'email' => "bob@smith.net"
+				Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+				Recipient::fromParams(['label' => 'Bobby', 'email' => 'bob@smith.net']),
+				Recipient::fromParams(['label' => 'Mary', 'email' => 'mary@smith.net']),
+				Recipient::fromParams(['label' => 'alice@smith.net', 'email' => 'alice@smith.net']),
 			],
-			[
-				'id' => 'mary',
-				'name' => 'Mary',
-				'email' => 'mary@smith.net'
-			]
-		];
-		$this->groupService1->expects($this->once())
-			->method('getUsers')
-			->willReturn($members);
-
-		$expected = "john@doe.com,bob@smith.net,mary@smith.net";
-
-		$actual = $this->groupsIntegration->expand($recipients);
-
-		$this->assertEquals($expected, $actual);
+			$expanded
+		);
 	}
 
-	public function testExpandSpace() {
-		$recipients = "john@doe.com,namespace1:test group";
+	public function testExpandSpace(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'test group (namespace1)', 'email' => 'namespace1:test group']),
+		];
 		$members = [
 			[
 				'id' => 'bob',
@@ -199,36 +189,54 @@ class GroupsIntegrationTest extends TestCase {
 			->with('test group')
 			->willReturn($members);
 
-		$expected = "john@doe.com,bob@smith.net,mary@smith.net";
+		$expanded = $this->groupsIntegration->expand($recipients);
 
-		$actual = $this->groupsIntegration->expand($recipients);
-
-		$this->assertEquals($expected, $actual);
+		$this->assertEquals(
+			[
+				Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+				Recipient::fromParams(['label' => 'Bobby', 'email' => 'bob@smith.net']),
+				Recipient::fromParams(['label' => 'Mary', 'email' => 'mary@smith.net']),
+			],
+			$expanded
+		);
 	}
 
-	public function testExpandEmpty() {
-		$this->expectException(ServiceException::class);
-		$recipients = "john@doe.com,namespace1:testgroup,alice@smith.net";
-		$members = [
+	public function testExpandEmpty(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'testgroup (namespace1)', 'email' => 'namespace1:testgroup']),
 		];
+		$members = [];
 		$this->groupService1->expects($this->once())
 			->method('getUsers')
 			->willReturn($members);
+		$this->expectException(ServiceException::class);
+
 		$this->groupsIntegration->expand($recipients);
 	}
 
-	public function testExpandWrong() {
-		$recipients = "john@doe.com,nons:testgroup,alice@smith.net";
-		$expected = "john@doe.com,nons:testgroup,alice@smith.net";
+	public function testExpandWrong(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'testgroup (nons)', 'email' => 'nons:testgroup']),
+		];
 
 		$actual = $this->groupsIntegration->expand($recipients);
 
-		$this->assertEquals($expected, $actual);
+		$this->assertEquals(
+			[
+				Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+				Recipient::fromParams(['label' => 'testgroup (nons)', 'email' => 'nons:testgroup']),
+			],
+			$actual
+		);
 	}
 
-	public function testExpandWrong2() {
+	public function testExpandWrong2(): void {
+		$recipients = [
+			Recipient::fromParams(['label' => 'John Doe', 'email' => 'john@doe.com']),
+			Recipient::fromParams(['label' => 'nogroup (namespace1)', 'email' => 'namespace1:nogroup']),
+		];
 		$this->expectException(ServiceException::class);
-		$recipients = "john@doe.com,namespace1:nogroup,alice@smith.net";
 
 		$this->groupsIntegration->expand($recipients);
 	}

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -41,8 +41,8 @@ use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Model\Message;
 use OCA\Mail\Model\NewMessageData;
-use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AliasesService;
+use OCA\Mail\Service\GroupsIntegration;
 use OCA\Mail\Service\MailTransmission;
 use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Support\PerformanceLogger;
@@ -55,9 +55,6 @@ class MailTransmissionTest extends TestCase {
 
 	/** @var Folder|MockObject */
 	private $userFolder;
-
-	/** @var AccountService|MockObject */
-	private $accountService;
 
 	/** @var IAttachmentService|MockObject */
 	private $attachmentService;
@@ -89,11 +86,13 @@ class MailTransmissionTest extends TestCase {
 	/** @var AliasesService|MockObject */
 	private $aliasService;
 
+	/** @var GroupsIntegration|MockObject */
+	private $groupsIntegration;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->userFolder = $this->createMock(Folder::class);
-		$this->accountService = $this->createMock(AccountService::class);
 		$this->attachmentService = $this->createMock(IAttachmentService::class);
 		$this->mailManager = $this->createMock(IMailManager::class);
 		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
@@ -104,10 +103,10 @@ class MailTransmissionTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->performanceLogger = $this->createMock(PerformanceLogger::class);
 		$this->aliasService = $this->createMock(AliasesService::class);
+		$this->groupsIntegration = $this->createMock(GroupsIntegration::class);
 
 		$this->transmission = new MailTransmission(
 			$this->userFolder,
-			$this->accountService,
 			$this->attachmentService,
 			$this->mailManager,
 			$this->imapClientFactory,
@@ -117,7 +116,8 @@ class MailTransmissionTest extends TestCase {
 			$this->messageMapper,
 			$this->logger,
 			$this->performanceLogger,
-			$this->aliasService
+			$this->aliasService,
+			$this->groupsIntegration,
 		);
 	}
 
@@ -416,7 +416,7 @@ class MailTransmissionTest extends TestCase {
 		$this->assertEquals(13, $newId);
 	}
 
-	public function testSendLocalMessage() {
+	public function testSendLocalMessage(): void {
 		$mailAccount = new MailAccount();
 		$mailAccount->setId(10);
 		$mailAccount->setUserId('testuser');


### PR DESCRIPTION
Groups were expanded in the accounts controller. Since moving over to
the outbox logic this feature was missing and internal group identifiers
were passed to SMTP.

With this patch groups are expanded again just before a message is sent.
This means the group memberships are read as late as possible and
editing an outbox message looks like the original message because
members have not been expanded there yet.

## How to test
* Create a few contacts and form a group
* Compose a new message, add the group as recipient
* Send the message

On main/v1.12.0: :boom: 
Here: :sunglasses: 

Regression of https://github.com/nextcloud/mail/pull/6031
Fixes https://github.com/nextcloud/mail/issues/6382