### PR TITLE
Drop dead message sending code

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -80,11 +80,6 @@ return [
 			'verb' => 'GET'
 		],
 		[
-			'name' => 'accounts#send',
-			'url' => '/api/accounts/{id}/send',
-			'verb' => 'POST'
-		],
-		[
 			'name' => 'accounts#draft',
 			'url' => '/api/accounts/{id}/draft',
 			'verb' => 'POST'

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -195,19 +195,6 @@ export async function saveDraft(accountId, data) {
 	}
 }
 
-export async function sendMessage(accountId, data) {
-	const url = generateUrl('/apps/mail/api/accounts/{accountId}/send', {
-		accountId,
-	})
-
-	try {
-		const resp = await axios.post(url, data)
-		return resp.data
-	} catch (e) {
-		throw convertAxiosError(e)
-	}
-}
-
 export async function deleteMessage(id) {
 	const url = generateUrl('/apps/mail/api/messages/{id}', {
 		id,


### PR DESCRIPTION
This code was used before the outbox. Now it's dead.

This shows that we also opened a feature gap between the old and the new message sending code: https://github.com/nextcloud/mail/issues/6461.

This is a leftover of https://github.com/nextcloud/mail/pull/6031.