### PR TITLE
Always serialize outbox message recipients into arrays

### DIFF
--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -107,18 +107,26 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'isHtml' => $this->isHtml(),
 			'inReplyToMessageId' => $this->getInReplyToMessageId(),
 			'attachments' => $this->getAttachments(),
-			'from' => array_filter($this->getRecipients(), function (Recipient $recipient) {
-				return $recipient->getType() === Recipient::TYPE_FROM;
-			}),
-			'to' => array_filter($this->getRecipients(), function (Recipient $recipient) {
-				return $recipient->getType() === Recipient::TYPE_TO;
-			}),
-			'cc' => array_filter($this->getRecipients(), function (Recipient $recipient) {
-				return $recipient->getType() === Recipient::TYPE_CC;
-			}),
-			'bcc' => array_filter($this->getRecipients(), function (Recipient $recipient) {
-				return $recipient->getType() === Recipient::TYPE_BCC;
-			}),
+			'from' => array_values(
+				array_filter($this->getRecipients(), function (Recipient $recipient) {
+					return $recipient->getType() === Recipient::TYPE_FROM;
+				})
+			),
+			'to' => array_values(
+				array_filter($this->getRecipients(), function (Recipient $recipient) {
+					return $recipient->getType() === Recipient::TYPE_TO;
+				})
+			),
+			'cc' => array_values(
+				array_filter($this->getRecipients(), function (Recipient $recipient) {
+					return $recipient->getType() === Recipient::TYPE_CC;
+				})
+			),
+			'bcc' => array_values(
+				array_filter($this->getRecipients(), function (Recipient $recipient) {
+					return $recipient->getType() === Recipient::TYPE_BCC;
+				})
+			),
 		];
 	}
 


### PR DESCRIPTION
array_filter keeps the index of array elements prior to the filtering.
So if you have a message with one *to* and one *cc* values, the *to*
will have index 0 and *cc* has 1. json_encode will later consider the
former as a simple PHP array and map it to a json array. Since the *cc*
value has a non-0 index for its first element, it would convert the
value to a json object and use the 1 index as key.

By running the values through array_value we can re-index all recipient
arrays before they run through json_encode.

Fixes https://github.com/nextcloud/mail/issues/6441.