### PR TITLE
Prevent causal read for outbox message and recipient inserts

### DIFF
--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -32,6 +32,7 @@ use function array_map;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use function array_merge;
 
 /**
  * @template-extends QBMapper<LocalMessage>
@@ -177,8 +178,11 @@ class LocalMessageMapper extends QBMapper {
 			$this->db->rollBack();
 			throw $e;
 		}
-		$recipients = $this->recipientMapper->findByLocalMessageId($message->getId());
-		$message->setRecipients($recipients);
+		$message->setRecipients(array_merge(
+			$to,
+			$cc,
+			$bcc,
+		));
 		return $message;
 	}
 

--- a/lib/Db/RecipientMapper.php
+++ b/lib/Db/RecipientMapper.php
@@ -84,9 +84,6 @@ class RecipientMapper extends QBMapper {
 	 * @param Recipient[] $recipients
 	 */
 	public function saveRecipients(int $localMessageId, array $recipients): void {
-		if (empty($recipients)) {
-			return;
-		}
 		foreach ($recipients as $recipient) {
 			$recipient->setLocalMessageId($localMessageId);
 			$this->insert($recipient);

--- a/tests/Integration/Service/OutboxServiceIntegrationTest.php
+++ b/tests/Integration/Service/OutboxServiceIntegrationTest.php
@@ -160,9 +160,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$this->assertNotEmpty($message->getRecipients());
 		$this->assertEmpty($message->getAttachments());
 
-		$retrieved->resetUpdatedFields();
-		$saved->resetUpdatedFields();
-		$this->assertEquals($saved, $retrieved); // Assure both operations are identical
+		self::assertCount(1, $retrieved->getRecipients());
 	}
 
 	public function testSaveAndGetMessages(): void {


### PR DESCRIPTION
The message and the recipients are inserted in one transaction but the
recipients are read another time outside a transaction. Read-write split
database clusters might not be in full sync mode and then reading the
recipients gives partial or no results.

The insert will assign the primary key value to the recipient entities.
Therefore we can skip reading the data.

Ref https://github.com/nextcloud/groupware/issues/24