### PR TITLE
Do not override existing aliases

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -122,7 +122,7 @@ export default {
 		// Save the mailboxes to the store, but only keep IDs in the account's mailboxes list
 		const mailboxes = sortMailboxes(account.mailboxes || [])
 		Vue.set(account, 'mailboxes', [])
-		Vue.set(account, 'aliases', [])
+		Vue.set(account, 'aliases', account.aliases ?? [])
 		mailboxes.map(addMailboxToState(state, account))
 	},
 	editAccount(state, account) {


### PR DESCRIPTION
We have to initialize the list of aliases as empty array for new
accounts, but for existing ones we want to respect the given value.

## How to test
* Open your account settings
* Add an alias
* Reload the page
* Open your account settings

Main: the alias is gone
Here: the alias is still there

---

Regression of https://github.com/nextcloud/mail/pull/6028

Fixes https://github.com/nextcloud/mail/issues/6430