### PR TITLE
Fix text format when closing the composer modal

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -385,7 +385,7 @@ export default {
 				id: message.data.id,
 				message: {
 					...message.data,
-					body: message.data.isHtml ? body.value : toPlain(body),
+					body: message.data.isHtml ? body.value : toPlain(body).value,
 					sendAt: message.options.originalSendAt,
 				},
 			})


### PR DESCRIPTION
When plain editing mode is selected, rescheduling an outbox message sent
the text object to the server, while that data structure is only known
on the front-end. HTML had already been handled correctly, only plain
missed the conversion to string.

## How to test
* Set your account to *plain text* editing
* Compose a new message
* Schedule it
* Click send
* Open the outbox
* Open the message
* Click outside the modal

Main: modal vanishes but background overlay stays; js error on console shows; request to server fails and message is *not* rescheduled.
Here: modal closes and message is correctly rescheduled.

---

Leftover of https://github.com/nextcloud/mail/pull/6350. This needs a backport.
Fixes https://github.com/nextcloud/mail/issues/6457