### PR TITLE
Always save outbox message or draft when closing the composer modal

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -829,11 +829,13 @@ export default {
 					return uid
 				})
 				.catch(async(error) => {
+					logger.debug('Failed to save draft', { error })
 					await matchError(error, {
 						[NoDraftsMailboxConfiguredError.getName()]() {
 							return false
 						},
 						default() {
+							showError(t('mail', 'Error saving draft'))
 							return true
 						},
 					})
@@ -852,8 +854,8 @@ export default {
 				return this.saveDraft(...args)
 			}
 		},
-		onSave() {
-			this.callSaveDraft(false, this.getMessageData)
+		async onSave() {
+			await this.callSaveDraft(false, this.getMessageData)
 		},
 		onInputChanged() {
 			this.callSaveDraft(true, this.getMessageData)
@@ -980,6 +982,7 @@ export default {
 							return [t('mail', 'You are trying to send to many recipients in To and/or Cc. Consider using Bcc to hide recipient addresses.'), STATES.WARNING]
 						},
 						default(error) {
+							showError(t('mail', 'Error sending your message'))
 							if (error && error.toString) {
 								return [error.toString(), STATES.ERROR]
 							}

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -2,8 +2,9 @@
 	<Modal
 		size="normal"
 		:title="modalTitle"
-		@close="$emit('close', { restoreOriginalSendAt: true })">
+		@close="onClose">
 		<Composer
+			ref="composer"
 			:from-account="composerData.accountId"
 			:to="composerData.to"
 			:cc="composerData.cc"
@@ -179,6 +180,22 @@ export default {
 			} catch (error) {
 				console.error(error)
 				showError(t('mail', 'Could not discard message'))
+			}
+		},
+		async onClose() {
+			// Warning: Ultra hacky! At the moment, there is no other way because the message state
+			// is managed by the Composer component. Otherwise, we could just do something like
+			// this.sendMessage(this.data) or this.saveDraft(this.data).
+			try {
+				if (this.composerMessage.type === 'outbox') {
+					await this.$refs.composer.onSend()
+				} else {
+					await this.$refs.composer.onSave()
+				}
+			} finally {
+				// Error is already logged and displayed in both methods so we just have to make
+				// sure to close the modal here.
+				this.$emit('close')
 			}
 		},
 	},

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -358,9 +358,7 @@ export default {
 		}
 
 		// Stop schedule when editing outbox messages and backup sendAt timestamp
-		let originalSendAt
 		if (type === 'outbox' && data.id && data.sendAt) {
-			originalSendAt = data.sendAt
 			const message = {
 				...data,
 				body: data.isHtml ? data.body.value : toPlain(data.body).value,
@@ -373,24 +371,9 @@ export default {
 			data,
 			forwardedMessages,
 			templateMessageId,
-			originalSendAt,
 		})
 	},
-	async closeMessageComposer({ commit, dispatch, getters }, { restoreOriginalSendAt }) {
-		// Restore original sendAt timestamp when requested
-		const message = getters.composerMessage
-		if (restoreOriginalSendAt && message.type === 'outbox' && message.options?.originalSendAt) {
-			const body = message.data.body
-			await dispatch('outbox/updateMessage', {
-				id: message.data.id,
-				message: {
-					...message.data,
-					body: message.data.isHtml ? body.value : toPlain(body).value,
-					sendAt: message.options.originalSendAt,
-				},
-			})
-		}
-
+	closeMessageComposer({ commit }) {
 		commit('hideMessageComposer')
 	},
 	async fetchEnvelope({ commit, getters }, id) {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -181,13 +181,12 @@ export default {
 		}
 		removeRec(account)
 	},
-	showMessageComposer(state, { type, data, forwardedMessages, originalSendAt }) {
+	showMessageComposer(state, { type, data, forwardedMessages }) {
 		Vue.set(state, 'newMessage', {
 			type,
 			data,
 			options: {
 				forwardedMessages,
-				originalSendAt,
 			},
 		})
 	},

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -7,7 +7,7 @@
 			:mailbox="activeMailbox" />
 		<NewMessageModal
 			v-if="$store.getters.showMessageComposer"
-			@close="onCloseModal" />
+			@close="$store.dispatch('closeMessageComposer')" />
 	</Content>
 </template>
 
@@ -102,9 +102,6 @@ export default {
 					filter: this.$route.params?.filter,
 				},
 			})
-		},
-		async onCloseModal(opts) {
-			await this.$store.dispatch('closeMessageComposer', opts ?? {})
 		},
 	},
 }


### PR DESCRIPTION
Fix #6470 

Closing the composer modal now is the same as clicking the save button. That also applies to clicking outside the modal.