### PR TITLE
Use ICompositeExpression for self join to properly encode columns

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -641,8 +641,14 @@ class MessageMapper extends QBMapper {
 			$select = $qb->select(['m.id', 'm.sent_at']);
 		}
 
+		$selfJoin = $select->expr()->andX(
+			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+		);
+
 		$select->from($this->getTableName(), 'm')
-			->leftJoin('m', $this->getTableName(), 'm2', 'm.mailbox_id = m2.mailbox_id and m.thread_root_id = m2.thread_root_id and m.sent_at < m2.sent_at');
+			->leftJoin('m', $this->getTableName(), 'm2', $selfJoin);
 
 		if (!empty($query->getFrom())) {
 			$select->innerJoin('m', 'mail_recipients', 'r0', 'm.id = r0.message_id');
@@ -750,8 +756,14 @@ class MessageMapper extends QBMapper {
 			$select = $qb->select(['m.id', 'm.sent_at']);
 		}
 
+		$selfJoin = $select->expr()->andX(
+			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+		);
+
 		$select->from($this->getTableName(), 'm')
-			->leftJoin('m', $this->getTableName(), 'm2', 'm.mailbox_id = m2.mailbox_id and m.thread_root_id = m2.thread_root_id and m.sent_at < m2.sent_at');
+			->leftJoin('m', $this->getTableName(), 'm2', $selfJoin);
 
 		if (!empty($query->getFrom())) {
 			$select->innerJoin('m', 'mail_recipients', 'r0', 'm.id = r0.message_id');
@@ -1054,10 +1066,16 @@ class MessageMapper extends QBMapper {
 				)
 			);
 
+		$selfJoin = $select->expr()->andX(
+			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
+			$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+		);
+
 		$select
 			->select('m.id')
 			->from($this->getTableName(), 'm')
-			->leftJoin('m', $this->getTableName(), 'm2', 'm.mailbox_id = m2.mailbox_id and m.thread_root_id = m2.thread_root_id and m.sent_at < m2.sent_at')
+			->leftJoin('m', $this->getTableName(), 'm2', $selfJoin)
 			->where(
 				$select->expr()->eq('m.mailbox_id', $select->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),
 				$select->expr()->andX($subSelect->expr()->notIn('m.id', $select->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY)),


### PR DESCRIPTION
**Main**
```
SELECT "m"."id", "m"."sent_at"
      FROM "oc_mail_messages" "m"
               LEFT JOIN "oc_mail_messages" "m2"
                         ON m.mailbox_id = m2.mailbox_id and
                            m.thread_root_id = m2.thread_root_id and
                            m.sent_at < m2.sent_at
      WHERE ("m"."mailbox_id" = 4)
        AND ("m"."flag_deleted" = 0)
        AND ("m2"."id" IS NULL)
      ORDER BY "m"."sent_at" desc;
```

**This PR**
```
SELECT "m"."id", "m"."sent_at"
      FROM "oc_mail_messages" "m"
               LEFT JOIN "oc_mail_messages" "m2"
                         ON "m"."mailbox_id" = "m2"."mailbox_id" and
                            "m"."thread_root_id" = "m2"."thread_root_id" and
                            "m"."sent_at" < "m2"."sent_at"
      WHERE ("m"."mailbox_id" = 4)
        AND ("m"."flag_deleted" = 0)
        AND ("m2"."id" IS NULL)
      ORDER BY "m"."sent_at" desc;
```

Before this patch the fields in the self join condition are not properly surrounded by quotes :see_no_evil:  