### PR TITLE
Fix attachment loss during outbox message update

### DIFF
--- a/lib/Db/LocalAttachment.php
+++ b/lib/Db/LocalAttachment.php
@@ -59,6 +59,7 @@ class LocalAttachment extends Entity implements JsonSerializable {
 	public function jsonSerialize() {
 		return [
 			'id' => $this->id,
+			'type' => 'local',
 			'fileName' => $this->fileName,
 			'mimeType' => $this->mimeType,
 			'createdAt' => $this->createdAt,

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Attachment;
 
 use finfo;
+use InvalidArgumentException;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IAttachmentService;
 use OCA\Mail\Contracts\IMailManager;
@@ -241,7 +242,7 @@ class AttachmentService implements IAttachmentService {
 
 		foreach ($attachments as $attachment) {
 			if (!isset($attachment['type'])) {
-				continue;
+				throw new InvalidArgumentException('Attachment does not have a type');
 			}
 
 			if ($attachment['type'] === 'local' && isset($attachment['id'])) {


### PR DESCRIPTION
Local messages had no `type` and AttachmentService::handleAttachments
silently ignored them. Afterwards OutboxService::updateMessage saw an
empty array of attachments and deleted the previous attachment(s).

Now local attachments have a type, the outbox update no longer discards
them and if we see an attachment without a type the process fails hard.

Fixes https://github.com/nextcloud/mail/issues/6494

This bug was introduced with https://github.com/nextcloud/mail/pull/6031.