### PR TITLE
Use workaround for boolean and oci

### DIFF
--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -104,7 +104,7 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'sendAt' => $this->getSendAt(),
 			'subject' => $this->getSubject(),
 			'body' => $this->getBody(),
-			'isHtml' => $this->isHtml(),
+			'isHtml' => ($this->isHtml() === true),
 			'inReplyToMessageId' => $this->getInReplyToMessageId(),
 			'attachments' => $this->getAttachments(),
 			'from' => array_values(


### PR DESCRIPTION
Need the same workaround as https://github.com/nextcloud/mail/pull/4903 to make boolean and oci work. 
For some reason false is stored as null.