### PR TITLE
Update column definition for oci compatibility

### DIFF
--- a/lib/Migration/Version0156Date20190828140357.php
+++ b/lib/Migration/Version0156Date20190828140357.php
@@ -77,8 +77,7 @@ class Version0156Date20190828140357 extends SimpleMigrationStep {
 			'length' => 4,
 		]);
 		$mailboxTable->addColumn('selectable', 'boolean', [
-			'notnull' => true,
-			'length' => 1,
+			'notnull' => false,
 			'default' => true,
 		]);
 		// We allow each mailbox name just once

--- a/lib/Migration/Version0161Date20190902103701.php
+++ b/lib/Migration/Version0161Date20190902103701.php
@@ -85,8 +85,7 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 			'length' => 4,
 		]);
 		$mailboxTable->addColumn('selectable', 'boolean', [
-			'notnull' => true,
-			'length' => 1,
+			'notnull' => false,
 			'default' => true,
 		]);
 		$mailboxTable->setPrimaryKey(['id']);


### PR DESCRIPTION
I met our old friend `Column "oc_mailbox.selectable" is type Bool and also NotNull, so it can not store "false"` when installing Mail 1.11.7 on Nextcloud 23 :see_no_evil: 