### PR TITLE
Skip not requested parts

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -530,6 +530,11 @@ class MessageMapper {
 				continue;
 			}
 
+			if (!empty($attachmentIds) && !in_array($part->getMimeId(), $attachmentIds, true)) {
+				// We are looking for specific parts only and this is not one of them
+				continue;
+			}
+
 			$stream = $messageData->getBodyPart($key, true);
 			$mimeHeaders = $messageData->getMimeHeader($key, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
 			if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
@@ -588,6 +593,11 @@ class MessageMapper {
 				continue;
 			}
 
+			if (!empty($attachmentIds) && !in_array($part->getMimeId(), $attachmentIds, true)) {
+				// We are looking for specific parts only and this is not one of them
+				continue;
+			}
+
 			$stream = $messageData->getBodyPart($key, true);
 			$mimeHeaders = $messageData->getMimeHeader($key, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
 			if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
@@ -622,7 +632,8 @@ class MessageMapper {
 				// Ignore message header
 				continue;
 			}
-			if (!empty($attachmentIds) && !in_array($part->getMIMEId(), $attachmentIds, true)) {
+
+			if (!empty($attachmentIds) && !in_array($part->getMimeId(), $attachmentIds, true)) {
 				// We are looking for specific parts only and this is not one of them
 				continue;
 			}


### PR DESCRIPTION
:warning: Forwarding emails is broken in Mail 1.12. Please review this patch with Mail 1.11. 

**How to reproduce / test**

1. Sent a message to yourself with three attachments.
2. Forward the message to yourself
3. Note that in the forwarded message only the first attachment is correct, attachment two and three are 0 byte. 

**When forwarding a message** 

`handleAttachments` is calling `getRawAttachments` (via `handleForwardedAttachment`) for each attachment to forward. `getRawAttachments` get the attachment id (which references a mime part of the original message) as argument. 

`getRawAttachments` fetch the structure for the message. 
In a second query we request the actual body for the attachment (`buildAttachmentsPartsQuery`).

`getRawAttachments` for Attachment 1

![image](https://user-images.githubusercontent.com/3902676/170135142-63b7e242-e0c9-4d83-9f40-6a7f5c176582.png)

`getRawAttachments` for Attachment 2

![image](https://user-images.githubusercontent.com/3902676/170135365-caae665e-b7c7-440b-a47f-b48e7e5414cc.png)

`getRawAttachments` for Attachment 3

![image](https://user-images.githubusercontent.com/3902676/170135433-fde183d0-afd1-44ad-8602-bbca62215b7f.png)

We see in the $attachments array that attachment 1 is at position 0, attachment 2 at 1 and attachment 3 at 2. The reason is that `$structure->partIterator()` always returns all parts of a message regardless if mail request the data for it or not.

For example `getRawAttachments` for attachment 3 is also reading the data for attachment 1 and get an empty string because we do not request to fetch the data for it. 

https://github.com/nextcloud/mail/blob/1752cbbba12285a4e93ec257d6e06ac1f790b171/lib/Service/MailTransmission.php#L549-L550

In `handleForwardedAttachment` mail always uses the attachment at position 0 for the data. for attachment 3 we add the empty data for attachment 1. 

This patch changes the behavior to skip parts we did not request. 


