### PR TITLE
Add attachments objects on message forward

### DIFF
--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -312,13 +312,12 @@ class AttachmentService implements IAttachmentService {
 	 * @throws DoesNotExistException
 	 */
 	private function handleForwardedAttachment(Account $account, array $attachment, \Horde_Imap_Client_Socket $client): ?int {
-		$attachmentMessage = $this->mailManager->getMessage($account->getUserId(), (int)$attachment['messageId']);
-		$mailbox = $this->mailManager->getMailbox($account->getUserId(), $attachmentMessage->getMailboxId());
+		$mailbox = $this->mailManager->getMailbox($account->getUserId(), $attachment['mailboxId']);
 
 		$attachments = $this->messageMapper->getRawAttachments(
 			$client,
 			$mailbox->getName(),
-			$attachmentMessage->getUid(),
+			(int)$attachment['uid'],
 			[
 				$attachment['id'] ?? []
 			]

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -70,7 +70,8 @@ import {
 	removeEnvelopeTag,
 	setEnvelopeFlag,
 	setEnvelopeTag,
-	syncEnvelopes, updateEnvelopeTag,
+	syncEnvelopes,
+	updateEnvelopeTag,
 } from '../service/MessageService'
 import * as AliasService from '../service/AliasService'
 import logger from '../logger'
@@ -331,6 +332,13 @@ export default {
 						body: data.body,
 						originalBody: data.body,
 						forwardFrom: reply.data,
+						attachments: original.attachments.map(attachment => ({
+							...attachment,
+							mailboxId: original.mailboxId,
+							// messageId for attachments is actually the uid
+							uid: attachment.messageId,
+							type: 'message-attachment',
+						})),
 					},
 				})
 				return

--- a/tests/Unit/Service/Attachment/AttachmentServiceTest.php
+++ b/tests/Unit/Service/Attachment/AttachmentServiceTest.php
@@ -356,31 +356,27 @@ class AttachmentServiceTest extends TestCase {
 		$account = $this->createConfiguredMock(Account::class, [
 			'getUserId' => $userId
 		]);
-		$message = new Message();
-		$message->setUid(123);
-		$message->setMailboxId(1);
+
 		$mailbox = new Mailbox();
+		$mailbox->setId(9);
 		$mailbox->setName('INBOX');
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$attachments = [
 			'type' => 'message-attachment',
-			'messageId' => 999,
+			'mailboxId' => $mailbox->getId(),
+			'uid' => 999,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
 		];
 		$imapAttachment = ['sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'];
 
 		$this->mailManager->expects(self::once())
-			->method('getMessage')
-			->with($account->getUserId(), 999)
-			->willReturn($message);
-		$this->mailManager->expects(self::once())
 			->method('getMailbox')
-			->with($account->getUserId())
+			->with($account->getUserId(), $mailbox->getId())
 			->willReturn($mailbox);
 		$this->messageMapper->expects(self::once())
 			->method('getRawAttachments')
-			->with($client, $mailbox->getName(), $message->getUid())
+			->with($client, $mailbox->getName(), 999)
 			->willReturn($imapAttachment);
 		$this->mapper->expects($this->once())
 			->method('insert')


### PR DESCRIPTION
~Blocked by https://github.com/nextcloud/mail/pull/6543~

On message forward the attachment objects are missing. 

Draft because I'm unhappy how we mix Nextcloud with IMAP ids (attachment.databaseId) to reference the attachment. Still looking for a better approach. 