### PR TITLE
Move encrypted label to icon

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -50,6 +50,11 @@
 			</div>
 		</template>
 		<template #subtitle>
+			<span v-if="isEncrypted"
+				class="icon-encrypted"
+				:title="t('mail','Message encrypted.')">
+				<LockCheckOutline :size="20" fill-color="#98b379" />
+			</span>
 			<span v-if="data.flags.answered" class="icon-reply" />
 			<span v-if="data.flags.hasAttachments === true" class="icon-public icon-attachment" />
 			<span v-if="draft" class="draft">
@@ -228,6 +233,7 @@ import MoveModal from './MoveModal'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew'
 import PlusIcon from 'vue-material-design-icons/Plus'
 import TagIcon from 'vue-material-design-icons/Tag'
+import LockCheckOutline from 'vue-material-design-icons/LockCheckOutline'
 import TagModal from './TagModal'
 import EventModal from './EventModal'
 import EnvelopePrimaryActions from './EnvelopePrimaryActions'
@@ -250,6 +256,7 @@ export default {
 		OpenInNewIcon,
 		PlusIcon,
 		TagIcon,
+		LockCheckOutline,
 		TagModal,
 	},
 	directives: {
@@ -368,8 +375,13 @@ export default {
 				.getEnvelopeTags(this.data.databaseId)
 				.some((tag) => tag.imapLabel === '$label1')
 		},
+		isEncrypted() {
+			return this.$store.getters
+				.getEnvelopeTags(this.data.databaseId)
+				.some((tag) => tag.imapLabel === 'encrypted')
+		},
 		tags() {
-			return this.$store.getters.getEnvelopeTags(this.data.databaseId).filter((tag) => tag.imapLabel && tag.imapLabel !== '$label1')
+			return this.$store.getters.getEnvelopeTags(this.data.databaseId).filter((tag) => (tag.imapLabel && tag.imapLabel !== '$label1' && tag.imapLabel && tag.imapLabel !== 'encrypted'))
 		},
 		draggableLabel() {
 			let label = this.data.subject
@@ -546,7 +558,8 @@ list-item-style.draft .app-content-list-item-line-two {
 }
 
 .icon-reply,
-.icon-attachment {
+.icon-attachment,
+.icon-encrypted {
 	display: inline-block;
 	vertical-align: text-top;
 }

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -70,6 +70,11 @@
 				</div>
 			</router-link>
 			<div class="right">
+				<span v-if="isEncrypted"
+					class="label-encrypted"
+					:title="t('mail','Message encrypted.')">
+					<LockCheckOutline :size="20" fill-color="#98b379" />
+				</span>
 				<Moment class="timestamp" :timestamp="envelope.dateInt" />
 				<button
 					:class="{
@@ -110,6 +115,7 @@ import MenuEnvelope from './MenuEnvelope'
 import Moment from './Moment'
 import Avatar from './Avatar'
 import importantSvg from '../../img/important.svg'
+import LockCheckOutline from 'vue-material-design-icons/LockCheckOutline'
 import { buildRecipients as buildReplyRecipients } from '../ReplyBuilder'
 
 export default {
@@ -121,6 +127,7 @@ export default {
 		Moment,
 		Message,
 		Avatar,
+		LockCheckOutline,
 	},
 	props: {
 		envelope: {
@@ -189,8 +196,13 @@ export default {
 				.getEnvelopeTags(this.envelope.databaseId)
 				.find((tag) => tag.imapLabel === '$label1')
 		},
+		isEncrypted() {
+			return this.$store.getters
+				.getEnvelopeTags(this.envelope.databaseId)
+				.find((tag) => tag.imapLabel === 'encrypted')
+		},
 		tags() {
-			return this.$store.getters.getEnvelopeTags(this.envelope.databaseId).filter((tag) => tag.imapLabel !== '$label1')
+			return this.$store.getters.getEnvelopeTags(this.envelope.databaseId).filter((tag) => (tag.imapLabel !== '$label1' && tag.imapLabel !== 'encrypted'))
 		},
 		hasChangedSubject() {
 			return this.cleanSubject !== this.threadSubject
@@ -441,5 +453,9 @@ export default {
 	}
 	.envelope--header.list-item-style {
 		border-radius: 16px;
+	}
+	.label-encrypted {
+		display: inline-block;
+		margin-right: 4px;
 	}
 </style>


### PR DESCRIPTION
Signed-off-by: Mikhail Sazanov <m@sazanof.ru>

Hello! 
I ask you to consider transferring the "encrypted" label. There is more free space if there are no other labels. When hovering - a hint. Maybe there are other suggestions. Maybe it will be useful.
Thanks!

it was

![image](https://user-images.githubusercontent.com/3595562/170261069-089d3c30-9d5d-46d2-b9c7-584746d934d3.png)

became

![image](https://user-images.githubusercontent.com/3595562/170260525-ffccaa21-55fe-4923-b7ed-9ac5d4b724a5.png)
====

it was

![image](https://user-images.githubusercontent.com/3595562/170261431-0094b903-f104-4684-aa86-58de685ea7ae.png)

became

![image](https://user-images.githubusercontent.com/3595562/170260576-796a3e96-46b1-4082-8659-17b55fc2f9a0.png)
