### PR TITLE
Implement __serialize for the Horde cache

### DIFF
--- a/lib/Cache/Cache.php
+++ b/lib/Cache/Cache.php
@@ -508,4 +508,9 @@ class Cache extends Horde_Imap_Client_Cache_Backend {
 		$this->save();
 		return parent::serialize();
 	}
+
+	public function __serialize(): array {
+		$this->save();
+		return parent::__serialize();
+	}
 }


### PR DESCRIPTION
Fixes

```json
{
  "reqId": "WJZrwiLZIaPTvExZNhbl",
  "level": 0,
  "time": "2022-05-25T13:34:58+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "PHP",
  "method": "",
  "url": "--",
  "message": "OCA\\Mail\\Cache\\Cache implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) at /home/christoph/workspace/nextcloud/apps/mail/lib/Cache/Cache.php#35",
  "userAgent": "--",
  "version": "25.0.0.1"
}
``` 

- [x] Requires https://github.com/bytestream/Imap_Client/pull/5
- [x] Requires https://github.com/nextcloud/mail/pull/6713