### PR TITLE
Duplicity validation

### DIFF
--- a/src/components/TagModal.vue
+++ b/src/components/TagModal.vue
@@ -173,7 +173,10 @@ export default {
 		async createTag(event) {
 			this.editing = true
 			const displayName = event.target.querySelector('input[type=text]').value
-
+			if (this.$store.getters.getTags.some(tag => tag.displayName === displayName)) {
+				showError(this.t('mail', 'Tag already exists'))
+				return
+			}
 			try {
 				await this.$store.dispatch('createTag', {
 					displayName,


### PR DESCRIPTION
Fix #6024

Here is my solution to the [issue](https://github.com/nextcloud/mail/issues/6024)

Add a validation when trying to create a new tag, in case the imapLabel already exists in the list of tags it is rejected