### PR TITLE
Render default subtitle when a message has no subject

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -55,7 +55,7 @@
 			<span v-if="draft" class="draft">
 				<em>{{ t('mail', 'Draft: ') }}</em>
 			</span>
-			{{ data.subject }}
+			{{ subjectForSubtitle }}
 		</template>
 		<template #actions>
 			<EnvelopePrimaryActions v-if="!moreActionsOpen">
@@ -378,6 +378,15 @@ export default {
 				label += ` (${sender})`
 			}
 			return label
+		},
+		/**
+		 * Subject of envelope or "No Subject".
+		 * @returns {string}
+		 */
+		subjectForSubtitle() {
+			// We have to use || here (instead of ??) because the subject might be '', null
+			// or undefined.
+			return this.data.subject || this.t('mail', 'No subject')
 		},
 	},
 	methods: {

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -34,7 +34,7 @@
 			<Avatar :display-name="avatarDisplayName" :email="avatarEmail" />
 		</template>
 		<template #subtitle>
-			{{ message.subject }}
+			{{ subjectForSubtitle }}
 		</template>
 		<template slot="actions">
 			<ActionButton
@@ -111,6 +111,15 @@ export default {
 				return ''
 			}
 			return moment.unix(this.message.sendAt).fromNow()
+		},
+		/**
+		 * Subject of message or "No Subject".
+		 * @returns {string}
+		 */
+		subjectForSubtitle() {
+			// We have to use || here (instead of ??) because the subject might be '', null
+			// or undefined.
+			return this.message.subject || this.t('mail', 'No subject')
 		},
 	},
 	methods: {


### PR DESCRIPTION
Fix #6263 

This applies to the default envelope list and outbox message list.

![image](https://user-images.githubusercontent.com/1479486/170696262-117af5ed-9266-4fba-a86d-87bbf620b3ea.png)
