### PR TITLE
"Reply to sender only" replies to all if hasMultipleRecipients is true

### DIFF
--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -37,7 +37,7 @@
 					@click="onReply">
 					<template #icon>
 						<ReplyAllIcon v-if="hasMultipleRecipients"
-							:title="t('mail', 'Reply')"
+							:title="t('mail', 'Reply all')"
 							:size="20" />
 						<ReplyIcon v-else
 							:title="t('mail', 'Reply')"
@@ -47,7 +47,7 @@
 				</ActionButton>
 				<ActionButton v-if="hasMultipleRecipients"
 					:close-after-click="true"
-					@click="onReply">
+					@click="onReply(true)">
 					<template #icon>
 						<ReplyIcon
 							:title="t('mail', 'Reply to sender only')"
@@ -435,10 +435,10 @@ export default {
 		onOpenTagModal() {
 			this.showTagModal = true
 		},
-		onReply() {
+		onReply(onlySender = false) {
 			this.$store.dispatch('showMessageComposer', {
 				reply: {
-					mode: this.hasMultipleRecipients ? 'replyAll' : 'reply',
+					mode: onlySender ? 'reply' : 'replyAll',
 					data: this.envelope,
 				},
 			})

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -79,7 +79,7 @@
 					}"
 					class="button"
 					@click="onReply">
-					<span class="action-label"> {{ t('mail', 'Reply') }}</span>
+					<span class="action-label"> {{ hasMultipleRecipients ? t('mail', 'Reply all') : t('mail', 'Reply') }}</span>
 				</button>
 				<MenuEnvelope class="app-content-list-item-menu"
 					:envelope="envelope"


### PR DESCRIPTION
Signed-off-by: Mikhail Sazanov <m@sazanof.ru>

**Good morning!**
![image](https://user-images.githubusercontent.com/3595562/170811897-32dbcec3-e977-4af9-9da2-50753f3ac4c2.png)
If the message contains several recipients, then if you click the "reply to sender only" button, everyone gets into the "to" field, so the `onReply` method checks the hasMultipleRecipients value, which in the case of multiple recipients will always return `true`

Thanks!

-----

_I also changed "Reply" to "Reply all" in case there are multiple recipients. If you don't need it, tell me, I'll put it back in place._