### PR TITLE
Revert "Bump @ckeditor/ckeditor5-vue2 from 3.0.0 to 3.0.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@ckeditor/ckeditor5-paragraph": "~34.0.0",
         "@ckeditor/ckeditor5-remove-format": "~34.0.0",
         "@ckeditor/ckeditor5-theme-lark": "~34.0.0",
-        "@ckeditor/ckeditor5-vue2": "^3.0.1",
+        "@ckeditor/ckeditor5-vue2": "^3.0.0",
         "@nextcloud/auth": "^1.3.0",
         "@nextcloud/axios": "^1.10.0",
         "@nextcloud/calendar-js": "^3.0.0",
@@ -3211,9 +3211,9 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-vue2": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue2/-/ckeditor5-vue2-3.0.1.tgz",
-      "integrity": "sha512-vS9ffP3rOFgM8oeG9XVFD+UtcYAhkgFDfBHjswJuCgUM0Iw8uqLlCiDPbs4PeJsend8GcmmtNeFdcQaSPkOtpw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue2/-/ckeditor5-vue2-3.0.0.tgz",
+      "integrity": "sha512-Q7ZkRZYZRhAN6Ll0WQoR49+yUPlrgWJxHw9Y6lwoU4RMAUvyZ180G50PL6FMg/Hi4hhwwCF4338EiCGKus1KIg==",
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=5.7.1"
@@ -23029,9 +23029,9 @@
       }
     },
     "@ckeditor/ckeditor5-vue2": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue2/-/ckeditor5-vue2-3.0.1.tgz",
-      "integrity": "sha512-vS9ffP3rOFgM8oeG9XVFD+UtcYAhkgFDfBHjswJuCgUM0Iw8uqLlCiDPbs4PeJsend8GcmmtNeFdcQaSPkOtpw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-vue2/-/ckeditor5-vue2-3.0.0.tgz",
+      "integrity": "sha512-Q7ZkRZYZRhAN6Ll0WQoR49+yUPlrgWJxHw9Y6lwoU4RMAUvyZ180G50PL6FMg/Hi4hhwwCF4338EiCGKus1KIg=="
     },
     "@ckeditor/ckeditor5-widget": {
       "version": "34.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-paragraph": "~34.0.0",
     "@ckeditor/ckeditor5-remove-format": "~34.0.0",
     "@ckeditor/ckeditor5-theme-lark": "~34.0.0",
-    "@ckeditor/ckeditor5-vue2": "^3.0.1",
+    "@ckeditor/ckeditor5-vue2": "^3.0.0",
     "@nextcloud/auth": "^1.3.0",
     "@nextcloud/axios": "^1.10.0",
     "@nextcloud/calendar-js": "^3.0.0",


### PR DESCRIPTION
Reverts nextcloud/mail#6519

Fixes https://github.com/nextcloud/mail/issues/6588