### PR TITLE
Fix collecting addresses in the background

### DIFF
--- a/lib/Controller/AutoCompleteController.php
+++ b/lib/Controller/AutoCompleteController.php
@@ -33,12 +33,17 @@ class AutoCompleteController extends Controller {
 	/** @var AutoCompleteService */
 	private $service;
 
+	/** @var string|null */
+	private $userId;
+
 	public function __construct(string $appName,
 								IRequest $request,
-								AutoCompleteService $service) {
+								AutoCompleteService $service,
+								?string $userId) {
 		parent::__construct($appName, $request);
 
 		$this->service = $service;
+		$this->userId = $userId;
 	}
 
 	/**
@@ -49,6 +54,10 @@ class AutoCompleteController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function index(string $term): JSONResponse {
-		return new JSONResponse($this->service->findMatches($term));
+		if ($this->userId === null) {
+			return new JSONResponse([]);
+		}
+
+		return new JSONResponse($this->service->findMatches($this->userId, $term));
 	}
 }

--- a/lib/Listener/AddressCollectionListener.php
+++ b/lib/Listener/AddressCollectionListener.php
@@ -68,7 +68,7 @@ class AddressCollectionListener implements IEventListener {
 				->merge($message->getCC())
 				->merge($message->getBCC());
 
-			$this->collector->addAddresses($addresses);
+			$this->collector->addAddresses($event->getAccount()->getUserId(), $addresses);
 		} catch (Throwable $e) {
 			$this->logger->warning('Error while collecting mail addresses: ' . $e, [
 				'exception' => $e,

--- a/lib/Service/AutoCompletion/AddressCollector.php
+++ b/lib/Service/AutoCompletion/AddressCollector.php
@@ -35,17 +35,12 @@ class AddressCollector {
 	/** @var CollectedAddressMapper */
 	private $mapper;
 
-	/** @var string */
-	private $userId;
-
 	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(CollectedAddressMapper $mapper,
-								?string $UserId,
 								LoggerInterface $logger) {
 		$this->mapper = $mapper;
-		$this->userId = $UserId;
 		$this->logger = $logger;
 	}
 
@@ -54,24 +49,26 @@ class AddressCollector {
 	 *
 	 * Duplicates are ignored
 	 *
+	 * @param string $userId
 	 * @param AddressList $addressList
 	 *
 	 * @return void
 	 */
-	public function addAddresses(AddressList $addressList): void {
+	public function addAddresses(string $userId, AddressList $addressList): void {
 		$this->logger->debug("collecting " . count($addressList) . " email addresses");
 		foreach ($addressList->iterate() as $address) {
 			/* @var $address Address */
-			$this->saveAddress($address);
+			$this->saveAddress($userId, $address);
 		}
 	}
 
 	/**
+	 * @param string $userId
 	 * @param Address $address
 	 *
 	 * @return void
 	 */
-	private function saveAddress(Address $address): void {
+	private function saveAddress(string $userId, Address $address): void {
 		try {
 			$hordeAddress = $address->toHorde();
 			if (!$hordeAddress->valid) {
@@ -82,11 +79,11 @@ class AddressCollector {
 			$this->logger->debug("<" . $address->getEmail() . "> is not a valid RFC822 mail address");
 			return;
 		}
-		if ($address->getEmail() !== null && !$this->mapper->exists($this->userId, $address->getEmail())) {
+		if ($address->getEmail() !== null && !$this->mapper->exists($userId, $address->getEmail())) {
 			$this->logger->debug("saving new address <{$address->getEmail()}>");
 
 			$entity = new CollectedAddress();
-			$entity->setUserId($this->userId);
+			$entity->setUserId($userId);
 			if ($address->getLabel() !== $address->getEmail()) {
 				$entity->setDisplayName($address->getLabel());
 			}
@@ -101,9 +98,9 @@ class AddressCollector {
 	 * @param string $term
 	 * @return CollectedAddress[]
 	 */
-	public function searchAddress(string $term): array {
+	public function searchAddress(string $userId, string $term): array {
 		$this->logger->debug("searching for collected address <$term>");
-		$result = $this->mapper->findMatching($this->userId, $term);
+		$result = $this->mapper->findMatching($userId, $term);
 		$this->logger->debug("found " . count($result) . " matches in collected addresses");
 		return $result;
 	}

--- a/lib/Service/AutoCompletion/AutoCompleteService.php
+++ b/lib/Service/AutoCompletion/AutoCompleteService.php
@@ -45,10 +45,10 @@ class AutoCompleteService {
 		$this->addressCollector = $ac;
 	}
 
-	public function findMatches(string $term): array {
+	public function findMatches(string $userId, string $term): array {
 		$recipientsFromContacts = $this->contactsIntegration->getMatchingRecipient($term);
 		$recipientGroups = $this->groupsIntegration->getMatchingGroups($term);
-		$fromCollector = $this->addressCollector->searchAddress($term);
+		$fromCollector = $this->addressCollector->searchAddress($userId, $term);
 
 		// Convert collected addresses into same format as CI creates
 		$recipientsFromCollector = array_map(function (CollectedAddress $address) {

--- a/tests/Unit/Controller/AutoCompleteControllerTest.php
+++ b/tests/Unit/Controller/AutoCompleteControllerTest.php
@@ -37,8 +37,12 @@ class AutoCompleteControllerTest extends TestCase {
 		$this->service = $this->getMockBuilder('OCA\Mail\Service\AutoCompletion\AutoCompleteService')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->controller = new AutoCompleteController('mail', $this->request,
-			$this->service);
+		$this->controller = new AutoCompleteController(
+			'mail',
+			$this->request,
+			$this->service,
+			'testuser'
+		);
 	}
 
 	public function testAutoComplete() {
@@ -51,8 +55,11 @@ class AutoCompleteControllerTest extends TestCase {
 
 		$this->service->expects($this->once())
 			->method('findMatches')
-			->with($this->equalTo($term))
-			->will($this->returnValue($result));
+			->with(
+				'testuser',
+				$this->equalTo($term)
+			)
+			->willReturn($result);
 
 		$response = $this->controller->index($term);
 

--- a/tests/Unit/Listener/AddressCollectionListenerTest.php
+++ b/tests/Unit/Listener/AddressCollectionListenerTest.php
@@ -134,11 +134,14 @@ class AddressCollectionListenerTest extends TestCase {
 			->willReturn(new AddressList([Address::fromRaw('bcc', 'bcc@email')]));
 		$this->addressCollector->expects($this->once())
 			->method('addAddresses')
-			->with($this->equalTo(new AddressList([
-				Address::fromRaw('to', 'to@email'),
-				Address::fromRaw('cc', 'cc@email'),
-				Address::fromRaw('bcc', 'bcc@email'),
-			])));
+			->with(
+				'test',
+				$this->equalTo(new AddressList([
+					Address::fromRaw('to', 'to@email'),
+					Address::fromRaw('cc', 'cc@email'),
+					Address::fromRaw('bcc', 'bcc@email'),
+				]))
+			);
 		$this->logger->expects($this->never())->method($this->anything());
 
 		$this->listener->handle($event);

--- a/tests/Unit/Service/Autocompletion/AddressCollectorTest.php
+++ b/tests/Unit/Service/Autocompletion/AddressCollectorTest.php
@@ -44,7 +44,6 @@ class AddressCollectorTest extends TestCase {
 
 		$this->collector = new AddressCollector(
 			$this->mapper,
-			$this->userId,
 			$this->logger
 		);
 	}
@@ -81,7 +80,7 @@ class AddressCollectorTest extends TestCase {
 				[$address2]
 			);
 
-		$this->collector->addAddresses($addressList);
+		$this->collector->addAddresses($this->userId, $addressList);
 	}
 
 	public function testAddDuplicateAddresses() {
@@ -97,7 +96,7 @@ class AddressCollectorTest extends TestCase {
 		$this->mapper->expects($this->never())
 			->method('insert');
 
-		$this->collector->addAddresses($addressList);
+		$this->collector->addAddresses($this->userId, $addressList);
 	}
 
 	public function testSearchAddress() {
@@ -109,7 +108,7 @@ class AddressCollectorTest extends TestCase {
 			->with($this->userId, $term)
 			->will($this->returnValue($mapperResult));
 
-		$result = $this->collector->searchAddress($term);
+		$result = $this->collector->searchAddress($this->userId, $term);
 
 		$this->assertequals($mapperResult, $result);
 	}

--- a/tests/Unit/Service/Autocompletion/AutoCompleteServiceTest.php
+++ b/tests/Unit/Service/Autocompletion/AutoCompleteServiceTest.php
@@ -70,17 +70,20 @@ class AutoCompleteServiceTest extends TestCase {
 		$this->contactsIntegration->expects($this->once())
 			->method('getMatchingRecipient')
 			->with($term)
-			->will($this->returnValue($contactsResult));
+			->willReturn($contactsResult);
 		$this->groupsIntegration->expects($this->once())
 			->method('getMatchingGroups')
 			->with($term)
-			->will($this->returnValue($groupsResult));
+			->willReturn($groupsResult);
 		$this->addressCollector->expects($this->once())
 			->method('searchAddress')
-			->with($term)
-			->will($this->returnValue($collectedResult));
+			->with(
+				'testuser',
+				$term
+			)
+			->willReturn($collectedResult);
 
-		$response = $this->service->findMatches($term);
+		$response = $this->service->findMatches('testuser', $term);
 
 		$expected = [
 			['id' => 12, 'label' => '"john doe" <john@doe.cz>', 'email' => 'john@doe.cz'],


### PR DESCRIPTION
Nextcloud can inject the userId but only for web processes. Now that
messages are sent also in the background and not just from a web request,
the user ID can be null and make the address collection log an
exception.

Following the pattern that user ID should only be injected into a
controller, the user ID is now passed as argument of the collector,
making it suitable for background jobs too.

Ref https://github.com/nextcloud/mail/issues/6540#issuecomment-1141180344 for the original report.