### PR TITLE
Fix sending outbox message of deleted user accounts

### DIFF
--- a/lib/Listener/AntiAbuseListener.php
+++ b/lib/Listener/AntiAbuseListener.php
@@ -62,6 +62,7 @@ class AntiAbuseListener implements IEventListener {
 				'user' => $event->getAccount()->getUserId(),
 				'id' => $event->getAccount()->getId(),
 			]);
+			return;
 		}
 
 		$this->service->onBeforeMessageSent(


### PR DESCRIPTION
A message of a deleted account currently triggers an error due to a
missing return.

Fixes 

```
{
  "reqId": "biQnusn0XRQ9B9rRgx8Z",
  "level": 2,
  "time": "2022-05-31T07:04:54+00:00",
  "remoteAddr": "",
  "user": "--",
  "app": "mail",
  "method": "",
  "url": "--",
  "message": "Could not send outbox message 396: OCA\\Mail\\Service\\AntiAbuseService::onBeforeMessageSent(): Argument #1 ($user) must be of type OCP\\IUser, null given, called in /home/christoph/workspace/nextcloud/apps/mail/lib/Listener/AntiAbuseListener.php on line 69",
  "userAgent": "--",
  "version": "25.0.0.1",
  "exception": {
    "Exception": "TypeError",
    "Message": "OCA\\Mail\\Service\\AntiAbuseService::onBeforeMessageSent(): Argument #1 ($user) must be of type OCP\\IUser, null given, called in /home/christoph/workspace/nextcloud/apps/mail/lib/Listener/AntiAbuseListener.php on line 69",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/Listener/AntiAbuseListener.php",
        "line": 69,
        "function": "onBeforeMessageSent",
        "class": "OCA\\Mail\\Service\\AntiAbuseService",
        "type": "->",
        "args": [
          null,
          {
            "__class__": "OCA\\Mail\\Model\\NewMessageData"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 87,
        "function": "handle",
        "class": "OCA\\Mail\\Listener\\AntiAbuseListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 251,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          },
          "OCA\\Mail\\Events\\BeforeMessageSentEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            }
          ],
          "OCA\\Mail\\Events\\BeforeMessageSentEvent",
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 88,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          },
          "OCA\\Mail\\Events\\BeforeMessageSentEvent"
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 100,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCA\\Mail\\Events\\BeforeMessageSentEvent",
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/Service/MailTransmission.php",
        "line": 204,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Events\\BeforeMessageSentEvent"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/Service/MailTransmission.php",
        "line": 277,
        "function": "sendMessage",
        "class": "OCA\\Mail\\Service\\MailTransmission",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Model\\NewMessageData"
          },
          "abcd",
          null
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/Service/OutboxService.php",
        "line": 129,
        "function": "sendLocalMessage",
        "class": "OCA\\Mail\\Service\\MailTransmission",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Account"
          },
          {
            "__class__": "OCA\\Mail\\Db\\LocalMessage",
            "id": 396
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/Service/OutboxService.php",
        "line": 206,
        "function": "sendMessage",
        "class": "OCA\\Mail\\Service\\OutboxService",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Mail\\Db\\LocalMessage",
            "id": 396
          },
          {
            "__class__": "OCA\\Mail\\Account"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/apps/mail/lib/BackgroundJob/OutboxWorkerJob.php",
        "line": 55,
        "function": "flush",
        "class": "OCA\\Mail\\Service\\OutboxService",
        "type": "->",
        "args": []
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/public/BackgroundJob/Job.php",
        "line": 79,
        "function": "run",
        "class": "OCA\\Mail\\BackgroundJob\\OutboxWorkerJob",
        "type": "->",
        "args": [
          null
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/lib/public/BackgroundJob/TimedJob.php",
        "line": 95,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\Job",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      },
      {
        "file": "/home/christoph/workspace/nextcloud/cron.php",
        "line": 151,
        "function": "execute",
        "class": "OCP\\BackgroundJob\\TimedJob",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\BackgroundJob\\JobList"
          },
          {
            "__class__": "OC\\Log"
          }
        ]
      }
    ],
    "File": "/home/christoph/workspace/nextcloud/apps/mail/lib/Service/AntiAbuseService.php",
    "Line": 62,
    "CustomMessage": "Could not send outbox message 396: OCA\\Mail\\Service\\AntiAbuseService::onBeforeMessageSent(): Argument #1 ($user) must be of type OCP\\IUser, null given, called in /home/christoph/workspace/nextcloud/apps/mail/lib/Listener/AntiAbuseListener.php on line 69"
  }
}
``` 