### PR TITLE
Revert race condition for initBody

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -748,10 +748,6 @@ export default {
 	},
 	async beforeMount() {
 		this.setAlias()
-		// there's a race condition on the ckeditor initialization and we need to delay it for the initBody to work
-		this.$nextTick(() => {
-			this.initBody()
-		})
 		await this.onMailvelopeLoaded(await getMailvelope())
 	},
 	mounted() {


### PR DESCRIPTION
ref: https://github.com/nextcloud/mail/pull/6590#issuecomment-1141333604

removing the condition loads the body for reply and forward like it used to be, so this condition is not needed anymore