### PR TITLE
Send oldest outbox message first

### DIFF
--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -131,7 +131,8 @@ class LocalMessageMapper extends QBMapper {
 			->where(
 				$qb->expr()->isNotNull('send_at'),
 				$qb->expr()->lte('send_at', $qb->createNamedParameter($time, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
-			);
+			)
+			->orderBy('send_at', 'asc');
 		$messages = $this->findEntities($select);
 
 		if (empty($messages)) {


### PR DESCRIPTION
Messages sent instantly have a natural order of their primary key. But messages scheduled do not show a correlation between their primary ID and their send time. Therefore it makes sense to explicitly order by send time to give priority to messages that should be sent first.

This isn't quite a fix nor a feature. I won't backport.