### PR TITLE
Fix losing the reply message ID when editing an outbox message

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -522,6 +522,10 @@ export default {
 			type: Function,
 			required: true,
 		},
+		inReplyToMessageId: {
+			type: String,
+			default: undefined,
+		},
 		replyTo: {
 			type: Object,
 			required: false,
@@ -857,7 +861,7 @@ export default {
 				subject: this.subjectVal,
 				body: this.encrypt ? plain(this.bodyVal) : html(this.bodyVal),
 				attachments: this.attachments,
-				inReplyToMessageId: this.replyTo ? this.replyTo.messageId : undefined,
+				inReplyToMessageId: this.inReplyToMessageId ?? (this.replyTo ? this.replyTo.messageId : undefined),
 				isHtml: !this.editorPlainText,
 				requestMdn: this.requestMdn,
 				sendAt: this.sendAtVal ? Math.floor(this.sendAtVal / 1000) : undefined,

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -11,6 +11,7 @@
 			:subject="composerData.subject"
 			:attachments-data="composerData.attachments"
 			:body="composerData.body"
+			:in-reply-to-message-id="composerData.inReplyToMessageId"
 			:reply-to="composerData.replyTo"
 			:draft-id="composerData.draftId"
 			:send-at="composerData.sendAt * 1000"


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6499

Reproduction steps are in the ticket.

We now pipe the previous value of the ID through the composer component and therefore no longer lose its value when an outbox message is edited.