### PR TITLE
Improve the way attachment look

### DIFF
--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -1,0 +1,212 @@
+<template>
+	<li class="list-item--attachment" :class="{'error' : attachment.error }">
+		<div class="attachment-preview">
+			<img v-if="attachment.imageBlobURL !== false" :src="attachment.imageBlobURL" class="attachment-preview-image">
+			<img v-else-if="attachment.hasPreview" :src="previewURL" class="attachment-preview-image">
+			<img v-else :src="getIcon" class="attachment-preview-image">
+			<span v-if="attachment.type === 'cloud'" class="cloud-attachment-icon">
+				<Cloud :size="16" />
+			</span>
+		</div>
+		<div class="attachment-inner">
+			<span class="new-message-attachment-name">
+				{{ attachment.displayName ? attachment.displayName : attachment.fileName }}
+			</span>
+			<span v-if="!attachment.finished" class="attachments-upload-progress">
+				<span class="attachments-upload-progress--bar" :style="&quot;width:&quot; + attachment.percent + &quot;%&quot;" />
+			</span>
+			<span v-else class="new-message-attachment-size">{{ attachment.sizeString }}</span>
+		</div>
+		<button @click="onDelete(attachment)">
+			<Close :size="24" />
+		</button>
+	</li>
+</template>
+
+<script>
+import { generateUrl } from '@nextcloud/router'
+import Close from 'vue-material-design-icons/Close'
+import Cloud from 'vue-material-design-icons/Cloud'
+
+export default {
+	name: 'ComposerAttachment',
+	components: {
+		Close,
+		Cloud,
+	},
+	props: {
+		bus: {
+			type: Object,
+			required: true,
+		},
+		attachment: {
+			type: Object,
+			required: true,
+		},
+		uploading: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			progress: 0,
+			sizeString: '',
+			finished: false,
+		}
+	},
+	computed: {
+		previewURL() {
+			if (this.attachment.hasPreview && this.attachment.id > 0) {
+				return generateUrl(`/core/preview?fileId=${this.attachment.id}&x=100&y=100&a=0`)
+			}
+			return ''
+		},
+		getIcon() {
+			return OC.MimeType.getIconUrl(this.attachment.fileType)
+		},
+		extension() {
+			return this.attachment.fileName.split('.').pop()
+		},
+	},
+	methods: {
+		onDelete(attachment) {
+			this.$emit('on-delete-attachment', attachment)
+		},
+	},
+
+}
+</script>
+
+<style lang="scss" scoped>
+
+.list-item--attachment {
+	width: calc(50% - 20px);
+    box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin: 10px;
+    flex-wrap: wrap;
+
+	&.error {
+		color:red;
+		opacity: 0.5;
+	}
+
+	.cloud-attachment-icon {
+		position:absolute;
+		z-index: 2;
+		right: 2px;
+		top: 2px;
+		color: rgba(0, 0, 0, 1);
+	}
+
+	.attachment-preview {
+		display: inline-flex;
+		flex-wrap: wrap;
+		width: 50px;
+		height:50px;
+		overflow: hidden;
+		border-radius: 3px;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+
+		img {
+			display: block;
+			min-width: 50px;
+			min-height: 50px;
+			max-width: 72px;
+			max-height: 72px;
+			position: absolute;
+		}
+
+		span {
+			color: rgba(0,0,0,0.3);
+			font-size: 13px;
+			text-transform: uppercase;
+			font-weight: bold;
+		}
+
+	}
+
+	button {
+		padding: 0;
+		background: transparent;
+		border: none;
+		margin: 6px -2px 0 0;
+	}
+}
+
+a.list-item {
+	width:auto !important;
+}
+
+.attachments-upload-progress {
+	display: block;
+	height: 5px;
+	width: 100%;
+	position: relative;
+	border-radius: 5px;
+	background: var(--color-background-dark);
+	margin-top: 7px;
+
+	.attachments-upload-progress--bar {
+		height: 5px;
+		background: var(--color-primary-element-light);
+		position: absolute;
+		z-index: 1;
+		left: 0;
+		border-radius: 5px;
+	}
+}
+
+.attachments-upload-progress > div {
+	padding-left: 3px;
+}
+
+.new-message-attachments-action {
+	display: inline-block;
+	vertical-align: middle;
+	padding: 18px;
+	opacity: 0.5;
+}
+
+.attachment-inner {
+	display: flex;
+    flex-wrap: wrap;
+	width: calc(100% - 90px);
+	position: relative;
+
+}
+
+/* attachment filenames */
+.new-message-attachment-name {
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space:nowrap;
+	margin-bottom: 3px;
+}
+
+.new-message-attachment-size {
+	color: #6a6a6a;
+	width: 100%;
+}
+
+/* Colour the filename with a different color during attachment upload */
+.new-message-attachment-name.upload-ongoing {
+	color: #0082c9;
+}
+
+/* Colour the filename in red if the attachment upload failed */
+.new-message-attachment-name.upload-warning {
+	color: #d2322d;
+}
+
+/* Red ProgressBar for failed attachment uploads */
+.new-message-attachment-name.upload-warning .ui-progressbar-value {
+	border: 1px solid #e9322d;
+	background: #e9322d;
+}
+</style>

--- a/src/service/AttachmentService.js
+++ b/src/service/AttachmentService.js
@@ -45,11 +45,14 @@ export function downloadAttachment(url) {
 	return Axios.get(url).then((res) => res.data)
 }
 
-export const uploadLocalAttachment = (file, progress) => {
+export const uploadLocalAttachment = (file, progress, controller) => {
 	const url = generateUrl('/apps/mail/api/attachments')
 	const data = new FormData()
 	const opts = {
 		onUploadProgress: (prog) => progress(prog, prog.loaded, prog.total),
+	}
+	if (controller) {
+		opts.signal = controller.signal
 	}
 	data.append('attachment', file)
 

--- a/src/service/FileService.js
+++ b/src/service/FileService.js
@@ -35,3 +35,22 @@ export async function getFileSize(path) {
 
 	return response?.data?.props?.size
 }
+
+export async function getFileData(path) {
+	const response = await getClient('files').stat(path, {
+		data: `<?xml version="1.0"?>
+			<d:propfind  
+			xmlns:d="DAV:"
+			xmlns:oc="http://owncloud.org/ns" 
+			xmlns:nc="http://nextcloud.org/ns">
+				<d:prop>
+					<oc:size />
+					<oc:fileid />
+					<nc:has-preview />
+				</d:prop>
+			</d:propfind>`,
+		details: true,
+	})
+
+	return response?.data?.props
+}


### PR DESCRIPTION
Hello! **I will be glad if my PR will be useful in some way**. Based on https://github.com/nextcloud/mail/issues/5768
![Attachments_new2](https://user-images.githubusercontent.com/3595562/172105417-b067f4b7-6cfc-43fb-b6f8-24cf2b08f82a.gif)
Of the possible nuances of implementation:
- It is not possible to generate previews of downloaded files (except images)
-  If at the time of downloading some large file you try to download the same file in parallel - the previous download stops. However, if you move `Vue.set(this, 'uploads', {})` in `complete()`, then due to the fact that it is impossible to correctly identify the necessary object from two identical ones, the progress bar is buggy
- There is no possibility (yet) to show the beginning of the selection of cloud files ...

There is a parallel PR https://github.com/nextcloud/mail/pull/6310 which is related to this. It may be worth using the same component to display the attachment.

**If you have the opportunity, please take a look and give your comments. Thanks!**

BTW the previous version was a bit in a different style =) :
![image](https://user-images.githubusercontent.com/3595562/172108049-c973b15c-c1a4-466e-b4ed-166d9f854358.png)

_And yes, maybe I overdid it a bit in the code_ (he shrugs his shoulders)
Signed-off-by: Mikhail Sazanov <m@sazanof.ru>