### PR TITLE
Fix missing Composer.vue::initBody call after mount

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -752,6 +752,7 @@ export default {
 	},
 	async beforeMount() {
 		this.setAlias()
+		this.initBody()
 		await this.onMailvelopeLoaded(await getMailvelope())
 	},
 	mounted() {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6622

Regression of https://github.com/nextcloud/mail/pull/6596 due to an incorrect revert. 

13896384e2ffd86600f2ce984036f8d660d72b8f moved the method call into a deferred callback, the revert https://github.com/nextcloud/mail/pull/6596/commits/db2b08c29d9bd37d94eac7145933de068c8ddbc9 fully removed the method call. Therefore we never initialized the body.