### PR TITLE
Fix quoting forwarded messages

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -13,6 +13,7 @@
 			:body="composerData.body"
 			:in-reply-to-message-id="composerData.inReplyToMessageId"
 			:reply-to="composerData.replyTo"
+			:forward-from="composerData.forwardFrom"
 			:draft-id="composerData.draftId"
 			:send-at="composerData.sendAt * 1000"
 			:draft="saveDraft"


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/pull/6663#issuecomment-1148630058.

Regression of https://github.com/nextcloud/mail/pull/2854.

Composer.vue received a new prop `forwardFrom` that never got filled. Therefore neither reply nor forward quoting was used in Composer.vue::initBody.