### PR TITLE
Fix missing default value for `failed` of outbox messages

### DIFF
--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -155,7 +155,7 @@ class OutboxController extends Controller {
 						   string  $subject,
 						   string  $body,
 						   bool    $isHtml,
-						   bool    $failed,
+						   bool    $failed = false,
 						   array   $to = [],
 						   array   $cc = [],
 						   array   $bcc = [],


### PR DESCRIPTION
Messages that only exist in the browser might not have an initial value
for `failed`, so when we update them in the outbox the server needs a
default value for it.

## Steps to reproduce
1) Compose a new message
2) Schedule it for later
3) Go to the outbox
4) Open the message
5) Click *Send* again

Main: HTTP500 due to missing required parameter.
Here: message is updated successfully.

This bug was introduced with https://github.com/nextcloud/mail/pull/6602.