### PR TITLE
Fix contacts photo integration picking wrong PHOTO entry

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -107,11 +107,13 @@ class ContactsIntegration {
 	 */
 	public function getPhoto(string $email) {
 		$result = $this->contactsManager->search($email, ['EMAIL']);
-		if (count($result) > 0) {
-			if (isset($result[0]['PHOTO'])) {
-				return $this->getPhotoUri($result[0]['PHOTO']);
+		foreach ($result as $contact) {
+			if (!isset($contact['PHOTO']) || empty($contact['PHOTO'])) {
+				continue;
 			}
+			return $this->getPhotoUri($contact['PHOTO']);
 		}
+
 		return null;
 	}
 


### PR DESCRIPTION
Hello everyone! =)

I found in 2 places that avatars are loaded incorrectly.

1) ~~In the list of recipients in the letter
**How to reproduce**: add 1 contact with the address all@example.com (in my case, this is a mailing group) and сall@example.com and set avatars for them
Write to all@example.com from your email
Open this email and see that the wrong avatar is in the recipient list. Click on "details" and see that in the list of "identical contacts" all@ and call@~~ 
Move to https://github.com/nextcloud/mail/pull/6714

2) In a message and in the list of message
**How to reproduce**: There should be 2 contacts with the same e-mail (one of them with an avatar). I have this bug when creating my adressbook + recent contacts (which appeared themselves earlier than my address book)
The problem is that if an array > 1 element can fall into the $result variable, then the first element is returned. if the photo is in the second element, the first one will be returned WITHOUT the photo.

Thank you!

It may also occur in https://github.com/nextcloud/mail/issues/4580

Signed-off-by: Mikhail Sazanov <m@sazanof.ru>