### PR TITLE
Render default 'no subject' when a thread has no subject

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -126,7 +126,7 @@ export default {
 				console.warn('thread is empty')
 				return ''
 			}
-			return thread[0].subject
+			return thread[0].subject || this.t('mail', 'No subject')
 		},
 	},
 	watch: {


### PR DESCRIPTION
before
![nosubjetcno](https://user-images.githubusercontent.com/12728974/172593523-b4ac3b26-65b0-4f09-977d-ae02c200d134.png)
after
![nosubjet](https://user-images.githubusercontent.com/12728974/172593531-6c5bd6f9-c8f4-461a-9d49-993a86429f1a.png)

follow up on: https://github.com/nextcloud/mail/pull/6567
