### PR TITLE
Change sender position to be centered with the avatar and timestamps

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -51,7 +51,8 @@
 				class="left"
 				:class="{seen: envelope.flags.seen}"
 				@click.native.prevent="$emit('toggleExpand', $event)">
-				<div class="sender">
+				<div class="sender"
+					:class="{ 'centered-sender': centeredSender }">
 					{{ envelope.from && envelope.from[0] ? envelope.from[0].label : '' }}
 				</div>
 				<div v-if="hasChangedSubject" class="subject">
@@ -198,6 +199,9 @@ export default {
 		cleanSubject() {
 			return this.envelope.subject.replace(/((?:[\t ]*(?:R|RE|F|FW|FWD):[\t ]*)*)/i, '')
 		},
+		centeredSender() {
+			  return (!this.hasChangedSubject || this.cleanSubject.length === 0) && this.tags.length === 0
+		},
 	},
 	watch: {
 		expanded(expanded) {
@@ -297,6 +301,9 @@ export default {
 <style lang="scss" scoped>
 	.sender {
 		margin-left: 8px;
+	}
+	.centered-sender {
+		margin-top: 8px;
 	}
 
 	.right {
@@ -442,4 +449,5 @@ export default {
 	.envelope--header.list-item-style {
 		border-radius: 16px;
 	}
+
 </style>


### PR DESCRIPTION
**before**
![before-nosubject-notag](https://user-images.githubusercontent.com/12728974/173525953-985b888e-7888-4846-a23e-bdc6604d0965.png)

**after**
no subjet no tag
![nosubjetc](https://user-images.githubusercontent.com/12728974/173524942-4d711eac-053e-4927-852a-1c7de265da4a.png)

the last 2 are the same as before, this pr fixes only when theres no subject or tags the sender should be centered.
subject+tag
![subject-tag-](https://user-images.githubusercontent.com/12728974/173524938-e14a44d5-9505-4d2b-9b5c-a9beb108433f.png)
tag, no subject
![nosubject tag](https://user-images.githubusercontent.com/12728974/173524940-deccfc03-1c43-43ce-86a3-b1eeb57ecf0b.png)


fixes #6621 