### PR TITLE
Fix recipients in users-bubble

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -112,7 +112,6 @@ class ContactsIntegration {
 			}
 			return $this->getPhotoUri($contact['PHOTO']);
 		}
-
 		return null;
 	}
 
@@ -199,10 +198,12 @@ class ContactsIntegration {
 	/**
 	 * @param string[] $fields
 	 */
-	private function doSearch(string $term, array $fields): array {
+	private function doSearch(string $term, array $fields, bool $strictSearch): array {
 		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
 
-		$result = $this->contactsManager->search($term, $fields);
+		$result = $this->contactsManager->search($term, $fields, [
+			'strict_search' => $strictSearch
+		]);
 		$matches = [];
 		foreach ($result as $r) {
 			if (!$allowSystemUsers && isset($r['isLocalSystemBook']) && $r['isLocalSystemBook']) {
@@ -225,7 +226,7 @@ class ContactsIntegration {
 	 * @return array
 	 */
 	public function getContactsWithMail(string $mailAddr) {
-		return $this->doSearch($mailAddr, ['EMAIL']);
+		return $this->doSearch($mailAddr, ['EMAIL'], true);
 	}
 
 	/**
@@ -235,6 +236,6 @@ class ContactsIntegration {
 	 * @return array
 	 */
 	public function getContactsWithName(string $name) {
-		return $this->doSearch($name, ['FN']);
+		return $this->doSearch($name, ['FN'], false);
 	}
 }


### PR DESCRIPTION
The second part of "Avatar" trylogy. Named "The Avatar: Way of lost recipients in user bubble"

Linked with https://github.com/nextcloud/mail/pull/6686

![image](https://user-images.githubusercontent.com/3595562/172890049-808c3390-f7d6-4b2a-9807-d8d46e711bdb.png)

In the list of recipients in the letter
**How to reproduce**: add 1 contact with the address all@example.com (in my case, this is a mailing group) and сall@example.com and set avatars for them
Write to all@example.com from your email
Open this email and see that the wrong avatar is in the recipient list. Click on "details" and see that in the list of "identical contacts" all@ and call@