### PR TITLE
Add avatars in composer

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -40,6 +40,7 @@
 					:hide-selected="true"
 					:loading="loadingIndicatorTo"
 					:auto-limit="autoLimit"
+					:options-limit="30"
 					@input="callSaveDraft(true, getMessageData)"
 					@tag="onNewToAddr"
 					@search-change="onAutocomplete($event, 'to')">
@@ -54,6 +55,7 @@
 								:no-margin="true"
 								:title="option.label"
 								:subtitle="option.email"
+								:url="option.photo"
 								:avatar-size="24" />
 						</div>
 					</template>
@@ -87,6 +89,7 @@
 					:loading="loadingIndicatorCc"
 					:auto-limit="autoLimit"
 					:hide-selected="true"
+					:options-limit="30"
 					@input="callSaveDraft(true, getMessageData)"
 					@tag="onNewCcAddr"
 					@search-change="onAutocomplete($event, 'cc')">
@@ -101,6 +104,7 @@
 								:no-margin="true"
 								:title="option.label"
 								:subtitle="option.email"
+								:url="option.photo"
 								:avatar-size="24" />
 						</div>
 					</template>
@@ -127,6 +131,7 @@
 					:preserve-search="true"
 					:loading="loadingIndicatorBcc"
 					:hide-selected="true"
+					:options-limit="30"
 					@input="callSaveDraft(true, getMessageData)"
 					@tag="onNewBccAddr"
 					@search-change="onAutocomplete($event, 'bcc')">
@@ -141,6 +146,7 @@
 								:no-margin="true"
 								:title="option.label"
 								:subtitle="option.email"
+								:url="option.photo"
 								:avatar-size="24" />
 						</div>
 					</template>

--- a/src/components/RecipientListItem.vue
+++ b/src/components/RecipientListItem.vue
@@ -3,6 +3,7 @@
 		<ListItemIcon
 			:no-margin="true"
 			:title="option.label"
+			:url="option.photo"
 			:avatar-size="24" />
 		<Close
 			class="delete-recipient"


### PR DESCRIPTION
The third part of "The Avatar. The Uprising in the Composer" 

I tried to show avatars from contacts, if there are any. The `:url` parameter is not present in the List Item Icon, but as I understand it, it is passed on to the child parameter Avatar. And it works. 

I want to say that I diluted the PR a bit by adding to it ` :options-limit="30"`

Why I did it: I have 500 contacts, and if you type one letter into the search or clear the search field after that, the browser freezes for 10-15 minutes, and the PROCESSOR accelerates to 3.2, eating up RAM (8gb) and 10gb swap. If it needs to be taken out by a separate PR - tell me. 

Thanks!

Link to https://github.com/nextcloud/mail/pull/6714 https://github.com/nextcloud/mail/pull/6686

Signed-off-by: Mikhail Sazanov <m@sazanof.ru>