### PR TITLE
Fix download all as zip

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -609,7 +609,7 @@ class MessageMapper {
 			$attachments[] = [
 				'content' => $part->getContents(),
 				'name' => $part->getName(),
-				'size' => $part->getSize()
+				'size' => $part->getBytes()
 			];
 			fclose($stream);
 		}


### PR DESCRIPTION
Fix #6755 

Horde_Nls is listed as optional dependency for horde/mime but unavailable via composer.
Horde_Mime_Part.getSize is uses a class from Horde_Nls without a runtime check if the dependency is available.

Horde_Mime_Part.getSize will return the size of the attachment as KB. For ZipResponse we need the size in bytes anyway so this patch switch getSize to getBytes to bypass the Horde_Nls dependency.

