### PR TITLE
Fix not being able to edit drafts

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -188,10 +188,10 @@ export default {
 			}
 		},
 		convertEditorBody(composerData) {
-			if (composerData.editorBody !== null) {
+			if (composerData.editorBody) {
 				return composerData.editorBody
 			}
-			if (composerData.body === null) {
+			if (!composerData.body) {
 				return ''
 			}
 			return toHtml(composerData.body).value


### PR DESCRIPTION
Fix #6780

A null check is not sufficient because `editorBody` and `body` can be undefined.