### PR TITLE
Add support for XOAUTH2

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>1.14.0-alpha.3</version>
+	<version>1.14.0-alpha.4</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Command/CreateAccount.php
+++ b/lib/Command/CreateAccount.php
@@ -36,6 +36,7 @@ class CreateAccount extends Command {
 	public const ARGUMENT_USER_ID = 'user-id';
 	public const ARGUMENT_NAME = 'name';
 	public const ARGUMENT_EMAIL = 'email';
+	public const ARGUMENT_AUTH_METHOD = 'auth-method';
 	public const ARGUMENT_IMAP_HOST = 'imap-host';
 	public const ARGUMENT_IMAP_PORT = 'imap-port';
 	public const ARGUMENT_IMAP_SSL_MODE = 'imap-ssl-mode';
@@ -87,12 +88,15 @@ class CreateAccount extends Command {
 		$this->addArgument(self::ARGUMENT_SMTP_SSL_MODE, InputArgument::REQUIRED);
 		$this->addArgument(self::ARGUMENT_SMTP_USER, InputArgument::REQUIRED);
 		$this->addArgument(self::ARGUMENT_SMTP_PASSWORD, InputArgument::REQUIRED);
+
+		$this->addArgument(self::ARGUMENT_AUTH_METHOD, InputArgument::OPTIONAL, 'password or xoauth2', 'password');
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userId = $input->getArgument(self::ARGUMENT_USER_ID);
 		$name = $input->getArgument(self::ARGUMENT_NAME);
 		$email = $input->getArgument(self::ARGUMENT_EMAIL);
+		$authMethod = $input->getArgument(self::ARGUMENT_AUTH_METHOD);
 
 		$imapHost = $input->getArgument(self::ARGUMENT_IMAP_HOST);
 		$imapPort = $input->getArgument(self::ARGUMENT_IMAP_PORT);
@@ -115,6 +119,7 @@ class CreateAccount extends Command {
 		$account->setUserId($userId);
 		$account->setName($name);
 		$account->setEmail($email);
+		$account->setAuthMethod($authMethod);
 
 		$account->setInboundHost($imapHost);
 		$account->setInboundPort((int) $imapPort);

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -91,6 +91,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSievePassword(?string $sievePassword)
  * @method bool|null isSignatureAboveQuote()
  * @method void setSignatureAboveQuote(bool $signatureAboveQuote)
+ * @method string getAuthMethod()
+ * @method void setAuthMethod(string $method)
  */
 class MailAccount extends Entity {
 	protected $userId;
@@ -112,6 +114,7 @@ class MailAccount extends Entity {
 	protected $order;
 	protected $showSubscribedOnly;
 	protected $personalNamespace;
+	protected $authMethod;
 
 	/** @var int|null */
 	protected $draftsMailboxId;

--- a/lib/Migration/Version1140Date20220701103556.php
+++ b/lib/Migration/Version1140Date20220701103556.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1140Date20220701103556 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		if (!$accountsTable->hasColumn('auth_method')) {
+			$accountsTable->addColumn(
+				'auth_method',
+				Types::STRING,
+				[
+					'notnull' => true,
+					'default' => 'password',
+				],
+			);
+		}
+
+		return $schema;
+	}
+}

--- a/tests/Unit/Command/CreateAccountTest.php
+++ b/tests/Unit/Command/CreateAccountTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -46,6 +48,7 @@ class CreateAccountTest extends TestCase {
 		'smtp-ssl-mode',
 		'smtp-user',
 		'smtp-password',
+		'auth-method',
 	];
 
 	protected function setUp(): void {
@@ -72,8 +75,12 @@ class CreateAccountTest extends TestCase {
 		$actual = $this->command->getDefinition()->getArguments();
 
 		foreach ($actual as $actArg) {
-			$this->assertTrue($actArg->isRequired());
-			$this->assertTrue(in_array($actArg->getName(), $this->args));
+			if ($actArg->getName() === 'auth-method') {
+				self::assertFalse($actArg->isRequired());
+			} else {
+				self::assertTrue($actArg->isRequired());
+			}
+			self::assertTrue(in_array($actArg->getName(), $this->args));
 		}
 	}
 
@@ -98,7 +105,7 @@ class CreateAccountTest extends TestCase {
 		$input = $this->createMock(InputInterface::class);
 		$input->method('getArgument')
 			->willReturnCallback(function ($arg) use ($data) {
-				return $data[$arg];
+				return $data[$arg] ?? null;
 			});
 		$output = $this->createMock(OutputInterface::class);
 		$output->expects($this->once())


### PR DESCRIPTION
This is the foundation for https://github.com/nextcloud/mail/issues/6454 and https://github.com/nextcloud/mail/issues/6591.

You can now add an account via CLI if you know the OAUTH access token. Horde will successfully authenticate using the token.

The process of acquiring the token will be specific to each service. We will have to implement those parts for Google and Microsoft.