### PR TITLE
Fix Vue custom even casing

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -486,14 +486,14 @@ export default {
 				if (!this.account) {
 					const account = await this.$store.dispatch('createAccount', data)
 					this.feedback = t('mail', 'Account created')
-					this.$emit('accountCreated', account)
+					this.$emit('account-created', account)
 				} else {
 					const account = await this.$store.dispatch('updateAccount', {
 						...data,
 						accountId: this.account.id,
 					})
 					this.feedback = t('mail', 'Account updated')
-					this.$emit('accountUpdated', account)
+					this.$emit('account-updated', account)
 				}
 				this.feedback = t('mail', 'Changes saved')
 			} catch (error) {

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -66,7 +66,7 @@
 					:display-name="displayName"
 					:email="email"
 					:account="account"
-					@accountUpdated="onAccountUpdated" />
+					@account-updated="onAccountUpdated" />
 			</div>
 		</AppSettingsSection>
 		<AppSettingsSection v-if="account && !account.provisioningId" :title="t('mail', 'Sieve filter server')">

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -945,7 +945,7 @@ export default {
 		handleAppendSignature() {
 			if (this.appendSignature) {
 				const signatureValue = toHtml(detect(this.selectedAlias.signature)).value
-				this.bus.$emit('insertSignature', signatureValue, this.selectedAlias.signatureAboveQuote)
+				this.bus.$emit('insert-signature', signatureValue, this.selectedAlias.signatureAboveQuote)
 				this.appendSignature = false
 			}
 		},
@@ -977,15 +977,15 @@ export default {
 			this.handleAppendSignature()
 		},
 		onAddLocalAttachment() {
-			this.bus.$emit('onAddLocalAttachment')
+			this.bus.$emit('on-add-local-attachment')
 			this.callSaveDraft(true, this.getMessageData)
 		},
 		onAddCloudAttachment() {
-			this.bus.$emit('onAddCloudAttachment')
+			this.bus.$emit('on-add-cloud-attachment')
 			this.callSaveDraft(true, this.getMessageData)
 		},
 		onAddCloudAttachmentLink() {
-			this.bus.$emit('onAddCloudAttachmentLink')
+			this.bus.$emit('on-add-cloud-attachment-link')
 		},
 		onAutocomplete(term, loadingIndicator) {
 			if (term === undefined || term === '') {

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -153,9 +153,9 @@ export default {
 		},
 	},
 	created() {
-		this.bus.$on('onAddLocalAttachment', this.onAddLocalAttachment)
-		this.bus.$on('onAddCloudAttachment', this.onAddCloudAttachment)
-		this.bus.$on('onAddCloudAttachmentLink', this.onAddCloudAttachmentLink)
+		this.bus.$on('on-add-local-attachment', this.onAddLocalAttachment)
+		this.bus.$on('on-add-cloud-attachment', this.onAddCloudAttachment)
+		this.bus.$on('on-add-cloud-attachment-link', this.onAddCloudAttachmentLink)
 		this.value.map(attachment => {
 			this.attachments.push({
 				id: attachment.id,
@@ -379,7 +379,7 @@ export default {
 			)
 		},
 		appendToBodyAtCursor(toAppend) {
-			this.bus.$emit('appendToBodyAtCursor', toAppend)
+			this.bus.$emit('append-to-body-at-cursor', toAppend)
 		},
 		formatBytes(bytes, decimals = 2) {
 			if (bytes === 0) return '0 B'

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -198,7 +198,7 @@
 				v-if="loadMoreButton && !loadingMore"
 				:key="'list-collapse-' + searchQuery"
 				class="load-more"
-				@click="$emit('loadMore')">
+				@click="$emit('load-more')">
 				{{ t('mail', 'Load more') }}
 			</div>
 			<div id="load-more-mail-messages" key="loadingMore" :class="{'icon-loading-small': loadingMore}" />
@@ -328,10 +328,10 @@ export default {
 		},
 	},
 	mounted() {
-		dragEventBus.$on('envelopesDropped', this.unselectAll)
+		dragEventBus.$on('envelopes-dropped', this.unselectAll)
 	},
 	beforeDestroy() {
-		dragEventBus.$off('envelopesDropped', this.unselectAll)
+		dragEventBus.$off('envelopes-dropped', this.unselectAll)
 	},
 	methods: {
 		isEnvelopeSelected(idx) {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -41,7 +41,7 @@
 		:loading-more="loadingMore"
 		:load-more-button="showLoadMore"
 		@delete="onDelete"
-		@loadMore="loadMore" />
+		@load-more="loadMore" />
 </template>
 
 <script>
@@ -173,7 +173,7 @@ export default {
 		},
 	},
 	created() {
-		this.bus.$on('loadMore', this.onScroll)
+		this.bus.$on('load-more', this.onScroll)
 		this.bus.$on('delete', this.onDelete)
 		this.bus.$on('shortcut', this.handleShortcut)
 		this.loadMailboxInterval = setInterval(this.loadMailbox, 60000)
@@ -186,7 +186,7 @@ export default {
 			})
 	},
 	destroyed() {
-		this.bus.$off('loadMore', this.onScroll)
+		this.bus.$off('load-more', this.onScroll)
 		this.bus.$off('delete', this.onDelete)
 		this.bus.$off('shortcut', this.handleShortcut)
 		this.stopInterval()

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -179,7 +179,7 @@ export default {
 		onScroll(event) {
 			logger.debug('scroll', { event })
 
-			this.bus.$emit('loadMore')
+			this.bus.$emit('load-more')
 		},
 		onShortcut(e) {
 			this.bus.$emit('shortcut', e)

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -374,14 +374,14 @@ export default {
 		},
 	},
 	mounted() {
-		dragEventBus.$on('dragStart', this.onDragStart)
-		dragEventBus.$on('dragEnd', this.onDragEnd)
-		dragEventBus.$on('envelopesMoved', this.onEnvelopesMoved)
+		dragEventBus.$on('drag-start', this.onDragStart)
+		dragEventBus.$on('drag-end', this.onDragEnd)
+		dragEventBus.$on('envelopes-moved', this.onEnvelopesMoved)
 	},
 	beforeDestroy() {
-		dragEventBus.$off('dragStart', this.onDragStart)
-		dragEventBus.$off('dragEnd', this.onDragEnd)
-		dragEventBus.$off('envelopesMoved', this.onEnvelopesMoved)
+		dragEventBus.$off('drag-start', this.onDragStart)
+		dragEventBus.$off('drag-end', this.onDragEnd)
+		dragEventBus.$off('envelopes-moved', this.onEnvelopesMoved)
 	},
 	methods: {
 		/**

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -193,8 +193,8 @@ export default {
 
 			logger.debug(`setting TextEditor contents to <${this.text}>`)
 
-			this.bus.$on('appendToBodyAtCursor', this.appendToBodyAtCursor)
-			this.bus.$on('insertSignature', this.onInsertSignature)
+			this.bus.$on('append-to-body-at-cursor', this.appendToBodyAtCursor)
+			this.bus.$on('insert-signature', this.onInsertSignature)
 		},
 		onInput() {
 			logger.debug(`TextEditor input changed to <${this.text}>`)

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -42,7 +42,7 @@
 				:full-height="thread.length === 1"
 				@delete="$emit('delete', env.databaseId)"
 				@move="onMove(env.databaseId)"
-				@toggleExpand="toggleExpand(env.databaseId)" />
+				@toggle-expand="toggleExpand(env.databaseId)" />
 		</template>
 	</AppContentDetails>
 </template>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -55,7 +55,7 @@
 				event=""
 				class="left"
 				:class="{seen: envelope.flags.seen}"
-				@click.native.prevent="$emit('toggleExpand', $event)">
+				@click.native.prevent="$emit('toggle-expand', $event)">
 				<div class="sender"
 					:class="{ 'centered-sender': centeredSender }">
 					{{ envelope.from && envelope.from[0] ? envelope.from[0].label : '' }}

--- a/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
+++ b/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
@@ -55,7 +55,7 @@ export class DraggableEnvelope {
 		event.dataTransfer.setData('text/plain', JSON.stringify(envelopes))
 		this.attachGhost({ event, envelopes })
 
-		dragEventBus.$emit('dragStart', {
+		dragEventBus.$emit('drag-start', {
 			accountId,
 			mailboxId,
 			itemCount: envelopes.length,
@@ -63,7 +63,7 @@ export class DraggableEnvelope {
 	}
 
 	onDragEnd(event) {
-		dragEventBus.$emit('dragEnd', { accountId: this.options.accountId })
+		dragEventBus.$emit('drag-end', { accountId: this.options.accountId })
 	}
 
 	attachGhost({ event, envelopes }) {

--- a/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
@@ -22,8 +22,8 @@ export class DroppableMailbox {
 	}
 
 	registerListeners(el) {
-		dragEventBus.$on('dragStart', this.onDragStart.bind(this))
-		dragEventBus.$on('dragEnd', this.onDragEnd.bind(this))
+		dragEventBus.$on('drag-start', this.onDragStart.bind(this))
+		dragEventBus.$on('drag-end', this.onDragEnd.bind(this))
 
 		// event listeners need to be attached to the first child element
 		// (a button or an anchor tag) instead of the root el, because there
@@ -34,8 +34,8 @@ export class DroppableMailbox {
 	}
 
 	removeListeners(el) {
-		dragEventBus.$off('dragStart', this.onDragStart)
-		dragEventBus.$off('dragEnd', this.onDragEnd)
+		dragEventBus.$off('drag-start', this.onDragStart)
+		dragEventBus.$off('drag-end', this.onDragEnd)
 
 		el.firstChild.removeEventListener('dragover', this.onDragOver)
 		el.firstChild.removeEventListener('dragleave', this.onDragLeave)
@@ -96,7 +96,7 @@ export class DroppableMailbox {
 
 		this.setInitialAttributes()
 		const envelopesBeingDragged = JSON.parse(event.dataTransfer.getData('text'))
-		dragEventBus.$emit('envelopesDropped', { envelopes: envelopesBeingDragged })
+		dragEventBus.$emit('envelopes-dropped', { envelopes: envelopesBeingDragged })
 
 		try {
 			const processedEnvelopes = envelopesBeingDragged.map(async envelope => {
@@ -107,7 +107,7 @@ export class DroppableMailbox {
 		} catch (error) {
 			logger.error('could not process dropped messages', error)
 		} finally {
-			dragEventBus.$emit('envelopesMoved', {
+			dragEventBus.$emit('envelopes-moved', {
 				mailboxId: this.options.mailboxId,
 				movedEnvelopes: envelopesBeingDragged,
 			})

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -8,7 +8,7 @@
 					<AccountForm :display-name="displayName"
 						:email="email"
 						:error.sync="error"
-						@accountCreated="onAccountCreated" />
+						@account-created="onAccountCreated" />
 				</template>
 			</EmptyContent>
 		</div>


### PR DESCRIPTION
They should be kebab case.

For https://github.com/nextcloud/mail/pull/6842.

ESLint would otherwise complain about lots of wrong casings, like

```
mail/src/components/Composer.vue
  948:20  error  Custom event name 'insertSignature' must be kebab-case           vue/custom-event-name-casing
  980:19  error  Custom event name 'onAddLocalAttachment' must be kebab-case      vue/custom-event-name-casing
  984:19  error  Custom event name 'onAddCloudAttachment' must be kebab-case      vue/custom-event-name-casing
  988:19  error  Custom event name 'onAddCloudAttachmentLink' must be kebab-case  vue/custom-event-name-casing
```