### PR TITLE
Fix two-way binding for envelope unselect after delete

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -447,7 +447,7 @@ export default {
 		},
 		unselect() {
 			if (this.selected) {
-				this.$emit('updated:selected', false)
+				this.$emit('update:selected', false)
 			}
 		},
 		toggleSelected() {


### PR DESCRIPTION
Discovered by ESLint. ``Envelope::setSelected`` is called from ``Envelope::onDelete``.

Steps to reproduce

* Select a message
* Delete it (the message, **not** via the multiselect action)
* Inspect the ``EnvelopeList`` selected array

Expected: deleted message is not in there
Actual: deleted message is still in there