### PR TITLE
👌 IMPROVE: don't open first mail by default

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -97,10 +97,6 @@ export default {
 			type: Number,
 			default: 20,
 		},
-		openFirst: {
-			type: Boolean,
-			default: true,
-		},
 		searchQuery: {
 			type: String,
 			required: false,
@@ -142,27 +138,6 @@ export default {
 		},
 	},
 	watch: {
-		// Force the envelope list to re-render when user clicks on the folder it's currently in
-		$route(to) {
-			if (to.params.threadId === undefined && !this.isMobile) {
-				const first = this.envelopes[0]
-				if (typeof first !== 'undefined') {
-					logger.debug('refreshing mailbox')
-					if (this.$route.params.mailboxId === this.account.draftsMailboxId) {
-						// Don't navigate
-					} else {
-						this.$router.replace({
-							name: 'message',
-							params: {
-								mailboxId: this.$route.params.mailboxId,
-								filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-								threadId: first.databaseId,
-							},
-						})
-					}
-				}
-			}
-		},
 		account() {
 			this.loadEnvelopes()
 		},
@@ -227,34 +202,6 @@ export default {
 				logger.debug(envelopes.length + ' envelopes fetched', { envelopes })
 
 				this.loadingEnvelopes = false
-				if (this.openFirst && !this.isMobile && this.$route.name !== 'message' && envelopes.length > 0) {
-					// Show first message
-					const first = envelopes[0]
-
-					// Keep the selected account-mailbox combination, but navigate to the message
-					// (it's not a bug that we don't use first.accountId and first.mailboxId here)
-					logger.debug('showing the first message of mailbox ' + this.$route.params.mailboxId)
-					if (this.$route.params.mailboxId === this.account.draftsMailboxId) {
-						this.$router.replace({
-							name: 'message',
-							params: {
-								mailboxId: this.$route.params.mailboxId,
-								filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-								threadId: 'new',
-								draftId: first.databaseId,
-							},
-						})
-					} else {
-						this.$router.replace({
-							name: 'message',
-							params: {
-								mailboxId: this.$route.params.mailboxId,
-								filter: this.$route.params.filter ? this.$route.params.filter : undefined,
-								threadId: first.databaseId,
-							},
-						})
-					}
-				}
 			} catch (error) {
 				await matchError(error, {
 					[MailboxLockedError.getName()]: async (error) => {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -57,7 +57,6 @@
 						class="nameother"
 						:account="unifiedAccount"
 						:mailbox="unifiedInbox"
-						:open-first="false"
 						:search-query="appendToSearch(priorityOtherQuery)"
 						:is-priority-inbox="true"
 						:bus="bus" />

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -147,6 +147,10 @@ export default {
 			return this.$store.getters.getMailbox(UNIFIED_INBOX_ID)
 		},
 		hasEnvelopes() {
+			if (this.mailbox.isPriorityInbox) {
+				return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.appendToSearch(priorityImportantQuery)).length > 0
+					|| this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.appendToSearch(priorityOtherQuery)).length > 0
+			}
 			return this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery).length > 0
 		},
 		hasImportantEnvelopes() {
@@ -167,7 +171,7 @@ export default {
 		query() {
 			if (this.$route.params.filter === 'starred') {
 				if (this.searchQuery) {
-					return this.searchQuery + ' is:starred'
+					return this.appendToSearch('is:starred')
 				}
 				return 'is:starred'
 			}

--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -22,24 +22,36 @@
 <template>
 	<AppContentDetails>
 		<NcEmptyContent
-			:title="t('mail', 'No message selected')">
+			:title="t('mail', 'Welcome to Nextcloud Mail')">
 			<template #icon>
 				<IconMail :size="65" />
 			</template>
 		</NcEmptyContent>
+		<NewMessageButtonHeader />
 	</AppContentDetails>
 </template>
 
 <script>
 import { NcAppContentDetails as AppContentDetails, NcEmptyContent } from '@nextcloud/vue'
 import IconMail from 'vue-material-design-icons/Email'
+import NewMessageButtonHeader from './NewMessageButtonHeader'
 
 export default {
 	name: 'NoMessageSelected',
 	components: {
+		NewMessageButtonHeader,
 		AppContentDetails,
 		NcEmptyContent,
 		IconMail,
 	},
 }
 </script>
+<style lang="scss" scoped>
+::v-deep .refresh__button {
+	display: none !important;
+}
+.header {
+	display: grid !important;
+	justify-content: center !important;
+}
+</style>


### PR DESCRIPTION
fix #6526 

This removes the logic to automatically open the first message of a mailbox

In contrary to #2794, this also doesn't open the first mail, when the current folder is reloaded as this would be unexpected: If I open a mailbox, don't select any mail and click on the same mailbox again I don't want the first message to be opened at that time. (Also the current implementation would've lead to first messages being opened while navigation between mailboxes.)

There is one remaining bug: on the initial load of the priority mailbox, `this.$store.getters.getEnvelopes(this.mailbox.databaseId, this.searchQuery)` returns an empty list even though there are mails in the inbox. Therefore `hasEnvelopes` is false and the "No message selected" placeholder isn't displayed. After a few seconds (after the third or fourth `sync` request; but I'm not sure that's actually related) the `getEnvelopes` getter suddenly returns the correct answer and the view gets updated. I couldn't find out why this getter isn't working at initial load.
Any idea on how to debug this further ?