### PR TITLE
Use v2 instead of `master` of the setup-php action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up php${{ matrix.php-versions }}
-      uses: shivammathur/setup-php@master
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none
@@ -42,7 +42,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up php
-      uses: shivammathur/setup-php@master
+      uses: shivammathur/setup-php@v2
       with:
         php-version: '8.0'
         coverage: none

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up npm
         run: npm install -g npm@7
       - name: Set up php$
-        uses: shivammathur/setup-php@master
+        uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
           extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,7 @@ jobs:
           - name: Checkout
             uses: actions/checkout@v3
           - name: Set up php
-            uses: shivammathur/setup-php@master
+            uses: shivammathur/setup-php@v2
             with:
                 php-version: 7.4
                 coverage: none

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests
     steps:
     - name: Set up php${{ matrix.php-versions }}
-      uses: shivammathur/setup-php@master
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip,gmp
@@ -132,7 +132,7 @@ jobs:
                   --health-retries 5
       steps:
           - name: Set up php${{ matrix.php-versions }}
-            uses: shivammathur/setup-php@master
+            uses: shivammathur/setup-php@v2
             with:
                 php-version: ${{ matrix.php-versions }}
                 extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip,gmp


### PR DESCRIPTION
> It is highly discouraged to use the master branch as version, it might break your workflow after major releases as they have breaking changes.

https://github.com/shivammathur/setup-php#bookmark-versioning