### PR TITLE
👌 IMPROVE: hide system tags from UI

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -264,6 +264,7 @@ import TagIcon from 'vue-material-design-icons/Tag'
 import TagModal from './TagModal'
 import EventModal from './EventModal'
 import EnvelopePrimaryActions from './EnvelopePrimaryActions'
+import { hiddenTags } from './tags.js'
 
 export default {
 	name: 'Envelope',
@@ -416,7 +417,9 @@ export default {
 				.some((tag) => tag.imapLabel === '$label1')
 		},
 		tags() {
-			return this.$store.getters.getEnvelopeTags(this.data.databaseId).filter((tag) => tag.imapLabel && tag.imapLabel !== '$label1')
+			return this.$store.getters.getEnvelopeTags(this.data.databaseId).filter(
+				(tag) => tag.imapLabel && tag.imapLabel !== '$label1' && !(tag.displayName.toLowerCase() in hiddenTags)
+			)
 		},
 		draggableLabel() {
 			let label = this.data.subject

--- a/src/components/TagModal.vue
+++ b/src/components/TagModal.vue
@@ -2,6 +2,7 @@
   - @copyright 2021 Greta Doci <gretadoci@gmail.com>
   -
   - @author 2021 Greta Doci <gretadoci@gmail.com>
+  - @author 2022 Jonas Sulzer <jonas@violoncello.ch>
   -
   - @license AGPL-3.0-or-later
   -
@@ -87,6 +88,7 @@ import ActionText from '@nextcloud/vue/dist/Components/ActionText'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import { showError, showInfo } from '@nextcloud/dialogs'
+import { hiddenTags } from './tags.js'
 
 function randomColor() {
 	let randomHexColor = ((1 << 24) * Math.random() | 0).toString(16)
@@ -125,7 +127,7 @@ export default {
 	},
 	computed: {
 		tags() {
-			return this.$store.getters.getTags.filter((tag) => tag.imapLabel !== '$label1').sort((a, b) => {
+			return this.$store.getters.getTags.filter((tag) => tag.imapLabel !== '$label1' && !(tag.displayName.toLowerCase() in hiddenTags)).sort((a, b) => {
 				if (a.isDefaultTag && !b.isDefaultTag) {
 					return -1
 				}
@@ -173,6 +175,10 @@ export default {
 		async createTag(event) {
 			this.editing = true
 			const displayName = event.target.querySelector('input[type=text]').value
+			if (displayName.toLowerCase() in hiddenTags) {
+				showError(this.t('mail', 'Tag name is a hidden system tag'))
+				return
+			}
 			if (this.$store.getters.getTags.some(tag => tag.displayName === displayName)) {
 				showError(this.t('mail', 'Tag already exists'))
 				return

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -3,6 +3,7 @@
   -
   - @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
   - @author 2021 Richard Steinmetz <richard@steinmetz.cloud>
+  - @author 2022 Jonas Sulzer <jonas@violoncello.ch>
   -
   - @license AGPL-3.0-or-later
   -
@@ -124,6 +125,7 @@ import Moment from './Moment'
 import ReplyIcon from 'vue-material-design-icons/Reply'
 import ReplyAllIcon from 'vue-material-design-icons/ReplyAll'
 import { buildRecipients as buildReplyRecipients } from '../ReplyBuilder'
+import { hiddenTags } from './tags.js'
 
 export default {
 	name: 'ThreadEnvelope',
@@ -209,7 +211,9 @@ export default {
 				.find((tag) => tag.imapLabel === '$label1')
 		},
 		tags() {
-			return this.$store.getters.getEnvelopeTags(this.envelope.databaseId).filter((tag) => tag.imapLabel !== '$label1')
+			return this.$store.getters.getEnvelopeTags(this.envelope.databaseId).filter(
+				(tag) => tag.imapLabel !== '$label1' && !(tag.displayName.toLowerCase() in hiddenTags)
+			)
 		},
 		hasChangedSubject() {
 			return this.cleanSubject !== this.threadSubject

--- a/src/components/tags.js
+++ b/src/components/tags.js
@@ -1,0 +1,28 @@
+/**
+ * @copyright 2022 Jonas Sulzer <jonas@violoncello.ch>
+ *
+ * @author 2022 Jonas Sulzer <jonas@violoncello.ch>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const hiddenTags = {
+	forwarded: '',
+	hasattachment: '',
+	hasnoattachment: '',
+	loadremoteimages: '',
+	'unsubscribe newsletter': '',
+}


### PR DESCRIPTION
fix #6020 

I've implemented the proposed solution with a list of keywords to filter out. 
I've also added a check on the creation of new tags to prevent people from adding tags which would not be visible afterwards.

However I'm not completely sure if we should compare `tag.displayName` or rather `tag.imapLabel` ?

Also the list of keywords might not be complete yet; I've just picked the ones from  #6020 (with exception of "Newsletter" as this seems to be a bit too generic to prohibit people from using it manually).
