### PR TITLE
Fix sync tokens missing highestmodseq

### DIFF
--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP;
 
+use Horde_Imap_Client_Cache_Backend_Null;
 use Horde_Imap_Client_Password_Xoauth2;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
@@ -99,6 +100,15 @@ class IMAPClientFactory {
 				'backend' => new Cache([
 					'cacheob' => $this->cacheFactory->createDistributed(md5((string)$account->getId())),
 				])];
+		} else {
+			/**
+			 * If we don't use a cache we use a null cache to trick Horde into
+			 * using QRESYNC/CONDSTORE if they are available
+			 * @see \Horde_Imap_Client_Socket::_loginTasks
+			 */
+			$params['cache'] = [
+				'backend' => new Horde_Imap_Client_Cache_Backend_Null(),
+			];
 		}
 		if ($this->config->getSystemValue('debug', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';


### PR DESCRIPTION
If the Horde socket object is initialized without a cache object,
CONDSTORE and QRESYNC are not used for faster synchronization. Due to
the memory leak and having to disable cache for the initial
synchronization, Horde generated sync tokens that only had a message
count (M) and no higestmodseq(H). Using a null cache object makes Horde
generate correct (fast) sync tokens.

Ref https://github.com/nextcloud/mail/pull/6410

## How to test
1) Add a new account via cli
2) Sync that account once via cli
  * Optional: observe the horde_imap.log

Main: base64-decoded sync tokens for new/changed/vanished look like `U621809,V1638421987,M619694`
Here: base64-decoded sync tokens for new/changed/vanished look like `U621809,V1638421987,H621865`

``\Horde_Imap_Client_Data_Sync::$map`` explains the notation

```php
    public static $map = array(
        'H' => 'highestmodseq',
        'M' => 'messages',
        'U' => 'uidnext',
        'V' => 'uidvalidity'
    );
```

That means on master the sync token after initial sync contain info about `uidnext`, `uidvalidity` and `messages`. Here it's `uidnext`, `uidvalidity` and `highestmodseq`. With the help of the `highestmodseq` value Horde can do a differential sync. This means only the messages that actually changed will be fetched from IMAP and updated in the DB. Without this value Horde has to assume that all messages could have changed, and all messages of the mailbox will be fetched and updated. The latter leads to out of memory problems with large mailboxes.
