### PR TITLE
Migrate icons to material design icons

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -100,7 +100,7 @@ import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 import Button from '@nextcloud/vue/dist/Components/Button'
 
-import IconInfo from 'vue-material-design-icons/InformationOutline'
+import IconInfo from 'vue-material-design-icons/Information'
 import IconEmail from 'vue-material-design-icons/Email'
 import Lock from 'vue-material-design-icons/Lock'
 import Logger from '../logger'

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -191,7 +191,7 @@
 				<ActionButton :close-after-click="true"
 					@click.prevent="showEventModal = true">
 					<template #icon>
-						<CalendarBlankIcon
+						<IconCreateEvent
 							:title="t('mail', 'Create event')"
 							:size="20" />
 					</template>
@@ -235,7 +235,7 @@ import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon'
 import Avatar from './Avatar'
 import { calculateAccountColor } from '../util/AccountColor'
-import CalendarBlankIcon from 'vue-material-design-icons/CalendarBlank'
+import IconCreateEvent from 'vue-material-design-icons/Calendar'
 import CheckIcon from 'vue-material-design-icons/Check'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
 import DeleteIcon from 'vue-material-design-icons/Delete'
@@ -271,7 +271,7 @@ export default {
 	components: {
 		AlertOctagonIcon,
 		Avatar,
-		CalendarBlankIcon,
+		IconCreateEvent,
 		CheckIcon,
 		ChevronLeft,
 		DeleteIcon,

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -79,7 +79,7 @@ import SectionTitle from './SectionTitle'
 import Vue from 'vue'
 
 import infiniteScroll from '../directives/infinite-scroll'
-import IconInfo from 'vue-material-design-icons/InformationOutline'
+import IconInfo from 'vue-material-design-icons/Information'
 import logger from '../logger'
 import Mailbox from './Mailbox'
 import NoMessageSelected from './NoMessageSelected'
@@ -276,5 +276,10 @@ export default {
 .envelope-list {
 	max-height: calc(100vh - var(--header-height));
 	overflow-y: auto;
+}
+.information-icon {
+	opacity: .7;
+	margin-bottom: 3px;
+	margin-right: 9px;
 }
 </style>

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -67,7 +67,7 @@
 			</ActionButton>
 			<ActionInput v-if="editing" @submit.prevent.stop="createMailbox">
 				<template #icon>
-					<Folder
+					<IconFolderAdd
 						:size="20" />
 				</template>
 			</ActionInput>
@@ -116,11 +116,11 @@ import { calculateAccountColor } from '../util/AccountColor'
 import logger from '../logger'
 import { fetchQuota } from '../service/AccountService'
 import AccountSettings from './AccountSettings'
-import IconInfo from 'vue-material-design-icons/InformationOutline'
-import IconSettings from 'vue-material-design-icons/CogOutline'
+import IconInfo from 'vue-material-design-icons/Information'
+import IconSettings from 'vue-material-design-icons/Cog'
 import IconFolderAdd from 'vue-material-design-icons/Folder'
-import MenuDown from 'vue-material-design-icons/MenuDown'
-import MenuUp from 'vue-material-design-icons/MenuUp'
+import MenuDown from 'vue-material-design-icons/ChevronDown'
+import MenuUp from 'vue-material-design-icons/ChevronUp'
 import IconDelete from 'vue-material-design-icons/Delete'
 
 export default {

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -40,6 +40,9 @@
 			<div class="sidebar-opacity-icon">
 				<ImportantIcon v-if="mailbox.isPriorityInbox"
 					:size="20" />
+				<IconAllInboxes
+					v-else-if="mailbox.id === UNIFIED_INBOX_ID"
+					:size="20" />
 				<IconInbox
 					v-else-if="mailbox.specialRole === 'inbox' && !mailbox.isPriorityInbox && filter !=='starred'"
 					:size="20" />
@@ -47,7 +50,7 @@
 					:size="20" />
 				<IconDraft v-else-if="mailbox.specialRole === 'drafts'"
 					:size="20" />
-				<CheckIcon v-else-if="mailbox.specialRole === 'sent'"
+				<IconSend v-else-if="mailbox.specialRole === 'sent'"
 					:size="20" />
 				<IconArchive v-else-if="mailbox.specialRole === 'archive'"
 					:size="20" />
@@ -196,7 +199,6 @@ import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/ActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/ActionInput'
 import ActionText from '@nextcloud/vue/dist/Components/ActionText'
-import CheckIcon from 'vue-material-design-icons/Check'
 import IconEmailCheck from 'vue-material-design-icons/EmailCheck'
 import IconExternal from 'vue-material-design-icons/OpenInNew'
 import IconFolder from 'vue-material-design-icons/Folder'
@@ -205,12 +207,15 @@ import IconFavorite from 'vue-material-design-icons/Star'
 import IconFolderRename from 'vue-material-design-icons/FolderEdit'
 import IconFolderSync from 'vue-material-design-icons/FolderSync'
 import IconDelete from 'vue-material-design-icons/Delete'
-import IconInfo from 'vue-material-design-icons/InformationOutline'
-import IconDraft from 'vue-material-design-icons/LeadPencil'
-import IconArchive from 'vue-material-design-icons/TrayFull'
+import IconInfo from 'vue-material-design-icons/Information'
+import IconDraft from 'vue-material-design-icons/Pencil'
+import IconArchive from 'vue-material-design-icons/Archive'
 import IconInbox from 'vue-material-design-icons/Home'
+import IconAllInboxes from 'vue-material-design-icons/InboxMultiple'
 import ImportantIcon from './icons/ImportantIcon'
+import IconSend from 'vue-material-design-icons/Send'
 import MoveMailboxModal from './MoveMailboxModal'
+import { UNIFIED_INBOX_ID } from '../store/constants'
 
 import { clearCache } from '../service/MessageService'
 import { getMailboxStatus } from '../service/MailboxService'
@@ -230,7 +235,7 @@ export default {
 		ActionButton,
 		ActionCheckbox,
 		ActionInput,
-		CheckIcon,
+		IconSend,
 		IconDelete,
 		IconEmailCheck,
 		IconExternal,
@@ -238,6 +243,7 @@ export default {
 		IconFolderRename,
 		IconFolderSync,
 		IconInfo,
+		IconAllInboxes,
 		IconFavorite,
 		IconFolder,
 		IconDraft,
@@ -281,6 +287,7 @@ export default {
 			mailboxName: this.mailbox.displayName,
 			showMoveModal: false,
 			hasDelimiter: !!this.mailbox.delimiter,
+			UNIFIED_INBOX_ID,
 		}
 	},
 	computed: {

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -38,7 +38,6 @@
 		</template>
 		<template slot="actions">
 			<ActionButton
-				icon="icon-checkmark"
 				:close-after-click="true"
 				@click="sendMessageNow">
 				{{ t('mail', 'Send now') }}
@@ -49,9 +48,11 @@
 				</template>
 			</ActionButton>
 			<ActionButton
-				icon="icon-delete"
 				:close-after-click="true"
 				@click="deleteMessage">
+				<template #icon>
+					<IconDelete :size="20" />
+				</template>
 				{{ t('mail', 'Delete') }}
 			</ActionButton>
 		</template>
@@ -62,6 +63,7 @@
 import ListItem from '@nextcloud/vue/dist/Components/ListItem'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import Avatar from './Avatar'
+import IconDelete from 'vue-material-design-icons/Delete'
 import { calculateAccountColor } from '../util/AccountColor'
 import { getLanguage, translate as t } from '@nextcloud/l10n'
 import OutboxAvatarMixin from '../mixins/OutboxAvatarMixin'
@@ -79,6 +81,7 @@ export default {
 		ListItem,
 		Avatar,
 		ActionButton,
+		IconDelete,
 		Send,
 	},
 	mixins: [


### PR DESCRIPTION
this pr replaces some icons with different ones after Jan's review

Info Icon -  Action manu on mailbox and important and unread
Settings icon on account settings menu
Archive icon on left side bar
delete icon on outbox action menu
create event on envelope list action menu
send icon on left sidebar


quick review, just make sure all the icons are shown and its the full version(filled dark grey) of it and not the outline.

Ref https://github.com/nextcloud/groupware/issues/38