### PR TITLE
Debug log the account ID threads will be built for

### DIFF
--- a/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
+++ b/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
@@ -63,6 +63,7 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 		}
 
 		$accountId = $event->getAccount()->getId();
+		$logger->debug("Building threads for account $accountId");
 		$messages = $this->mapper->findThreadingData($event->getAccount());
 		$logger->debug("Account $accountId has " . count($messages) . " messages for threading");
 		$threads = $this->builder->build($messages, $logger);


### PR DESCRIPTION
It's helpful to know where in the sync/threading process we run out of memory

```
...
[debug] Unlocking mailbox 2490 from new messages sync
[debug] Building threads for account 3151
[debug] Account 3151 has 619689 messages for threading
[debug] Threading 619689 messages - build ID table took 1s. 423/440MB memory used
PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 20971520 bytes) in /apps/mail/lib/IMAP/Threading/Container.php on line 102
```