### PR TITLE
Fix whitespace insertion on mailbox names 

### DIFF
--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -36,8 +36,6 @@ use function ltrim;
 use function strtolower;
 
 /**
- * @method string getName()
- * @method void setName(string $name)
  * @method int getAccountId()
  * @method void setAccountId(int $accountId)
  * @method string|null getSyncNewToken()
@@ -145,6 +143,14 @@ class Mailbox extends Entity implements JsonSerializable {
 	 */
 	public function getStats(): MailboxStats {
 		return new MailboxStats($this->getMessages(), $this->getUnseen());
+	}
+
+	public function getName(): string {
+		return trim($this->name);
+	}
+
+	public function setName(string $name): void {
+		$this->name = trim($name);
 	}
 
 	#[ReturnTypeWillChange]

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -58,7 +58,7 @@ class Folder {
 	 * @return string
 	 */
 	public function getMailbox() {
-		return $this->mailbox->utf8;
+		return trim($this->mailbox->utf8);
 	}
 
 	public function getDelimiter(): ?string {


### PR DESCRIPTION
which are causing issues when looking for folders.

The sync logic doesn't find the mailbox / folder in the DB (afaik MySQL/ MariaDB only) if the name was created with whitespace because of the way MySQL handles whitespace at the end of strings. (See https://github.com/nextcloud/mail/issues/5200)
This then leads to a unique constraint violation when trying to insert the mailbox.

Signed-off-by: Anna Larch <anna@nextcloud.com>