### PR TITLE
Add an occ mail:account:update command

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -59,6 +59,7 @@
 		<command>OCA\Mail\Command\SyncAccount</command>
 		<command>OCA\Mail\Command\TrainAccount</command>
 		<command>OCA\Mail\Command\Thread</command>
+		<command>OCA\Mail\Command\UpdateAccount</command>
 	</commands>
 	<settings>
 		<admin>OCA\Mail\Settings\AdminSettings</admin>

--- a/lib/Command/UpdateAccount.php
+++ b/lib/Command/UpdateAccount.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Maadix
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+use OCP\Security\ICrypto;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateAccount extends Command {
+	public const ARGUMENT_USER_ID = 'user-id';
+        public const ARGUMENT_NAME = 'name';
+        public const ARGUMENT_EMAIL = 'email';
+        public const ARGUMENT_IMAP_HOST = 'imap-host';
+        public const ARGUMENT_IMAP_PORT = 'imap-port';
+        public const ARGUMENT_IMAP_SSL_MODE = 'imap-ssl-mode';
+        public const ARGUMENT_IMAP_USER = 'imap-user';
+        public const ARGUMENT_IMAP_PASSWORD = 'imap-password';
+        public const ARGUMENT_SMTP_HOST = 'smtp-host';
+        public const ARGUMENT_SMTP_PORT = 'smtp-port';
+        public const ARGUMENT_SMTP_SSL_MODE = 'smtp-ssl-mode';
+        public const ARGUMENT_SMTP_USER = 'smtp-user';
+        public const ARGUMENT_SMTP_PASSWORD = 'smtp-password';
+
+	/** @var mapper */
+        private $mapper;
+
+	/** @var ICrypto */
+	private $crypto;
+
+	public function __construct(MailAccountMapper $mapper, ICrypto $crypto) {
+		parent::__construct();
+
+                $this->mapper = $mapper;
+		$this->crypto = $crypto;
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function configure() {
+		$this->setName('mail:account:update');
+		$this->setDescription('Update a user\'s IMAP account(s)');
+		$this->addArgument(self::ARGUMENT_USER_ID, InputArgument::REQUIRED);
+                $this->addArgument(self::ARGUMENT_EMAIL, InputArgument::REQUIRED);
+
+
+                $this->addOption(self::ARGUMENT_IMAP_HOST,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_IMAP_PORT,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_IMAP_SSL_MODE,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_IMAP_USER,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_IMAP_PASSWORD,'', InputOption::VALUE_REQUIRED);
+               
+                $this->addOption(self::ARGUMENT_SMTP_HOST,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_SMTP_PORT,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_SMTP_SSL_MODE,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_SMTP_USER,'', InputOption::VALUE_REQUIRED);
+                $this->addOption(self::ARGUMENT_SMTP_PASSWORD,'',InputOption::VALUE_REQUIRED);
+
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+
+                $userId = $input->getArgument(self::ARGUMENT_USER_ID);
+                $email = $input->getArgument(self::ARGUMENT_EMAIL);
+
+
+                $imapHost = $input->getOption(self::ARGUMENT_IMAP_HOST);
+                $imapPort = $input->getOption(self::ARGUMENT_IMAP_PORT);
+                $imapSslMode = $input->getOption(self::ARGUMENT_IMAP_SSL_MODE);
+                $imapUser = $input->getOption(self::ARGUMENT_IMAP_USER);
+                $imapPassword = $input->getOption(self::ARGUMENT_IMAP_PASSWORD);
+
+                $smtpHost = $input->getOption(self::ARGUMENT_SMTP_HOST);
+                $smtpPort = $input->getOption(self::ARGUMENT_SMTP_PORT);
+                $smtpSslMode = $input->getOption(self::ARGUMENT_SMTP_SSL_MODE);
+                $smtpUser = $input->getOption(self::ARGUMENT_SMTP_USER);
+                $smtpPassword = $input->getOption(self::ARGUMENT_SMTP_PASSWORD);
+
+                $accounts = $this->mapper->findByUserId($userId);
+
+		foreach ($accounts as $account) {
+                # User may have have more than one email account. Only update the given one
+                        if ($account->getEmail() == $email) {
+                            $mailAccount = $account;
+                            break;
+                        }
+                  }
+                  if ($mailAccount) {
+                    //INBOUND
+                    if ($input->getOption(self::ARGUMENT_IMAP_HOST)) {
+                        $mailAccount->setInboundHost($imapHost);
+                    }
+
+                    if ($input->getOption(self::ARGUMENT_IMAP_PORT)) {
+                        $mailAccount->setInboundPort((int) $imapPort);
+                    }
+
+                    if ($input->getOption(self::ARGUMENT_IMAP_SSL_MODE)) {
+                      $mailAccount->setInboundSslMode($imapSslMode);
+                    }
+                    if ($input->getOption(self::ARGUMENT_IMAP_PASSWORD)) {
+                        $mailAccount->setInboundPassword($this->crypto->encrypt($imapPassword));
+                    }
+
+                    if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
+                        $mailAccount->setInboundUser($imapUser);
+                    }
+
+                    // OUTBOUND
+  
+                    if ($input->getOption(self::ARGUMENT_SMTP_HOST)) {
+                        $mailAccount->setOutboundHost($smtpHost);
+                    }
+
+                    if ($input->getOption(self::ARGUMENT_SMTP_PORT)) {
+                        $mailAccount->setOutboundPort((int) $smtpPort);
+                    }
+                    if ($input->getOption(self::ARGUMENT_SMTP_SSL_MODE)) {
+                        $mailAccount->setOutboundSslMode($smtpSslMode);
+                    }
+                    
+                    if ($input->getOption(self::ARGUMENT_SMTP_PASSWORD)) {    
+                        $mailAccount->setOutboundPassword($this->crypto->encrypt($smtpPassword));
+                    }
+                    if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
+                      $mailAccount->setOutboundUser($smtpUser);
+                    }
+
+                    $this->mapper->save($mailAccount);
+
+                    $output->writeln("<info>Account $email for user $userId succesfully updated </info>");
+
+                  } else {
+                        $output->writeln("<info>No Email Account $email found for user $userId </info>");
+                  }
+
+		return 0;
+	}
+}

--- a/lib/Command/UpdateAccount.php
+++ b/lib/Command/UpdateAccount.php
@@ -22,7 +22,6 @@
 
 namespace OCA\Mail\Command;
 
-use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
 use OCP\Security\ICrypto;
 use Symfony\Component\Console\Command\Command;
@@ -33,21 +32,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateAccount extends Command {
 	public const ARGUMENT_USER_ID = 'user-id';
-        public const ARGUMENT_NAME = 'name';
-        public const ARGUMENT_EMAIL = 'email';
-        public const ARGUMENT_IMAP_HOST = 'imap-host';
-        public const ARGUMENT_IMAP_PORT = 'imap-port';
-        public const ARGUMENT_IMAP_SSL_MODE = 'imap-ssl-mode';
-        public const ARGUMENT_IMAP_USER = 'imap-user';
-        public const ARGUMENT_IMAP_PASSWORD = 'imap-password';
-        public const ARGUMENT_SMTP_HOST = 'smtp-host';
-        public const ARGUMENT_SMTP_PORT = 'smtp-port';
-        public const ARGUMENT_SMTP_SSL_MODE = 'smtp-ssl-mode';
-        public const ARGUMENT_SMTP_USER = 'smtp-user';
-        public const ARGUMENT_SMTP_PASSWORD = 'smtp-password';
+	public const ARGUMENT_EMAIL = 'email';
+	public const ARGUMENT_IMAP_HOST = 'imap-host';
+	public const ARGUMENT_IMAP_PORT = 'imap-port';
+	public const ARGUMENT_IMAP_SSL_MODE = 'imap-ssl-mode';
+	public const ARGUMENT_IMAP_USER = 'imap-user';
+	public const ARGUMENT_IMAP_PASSWORD = 'imap-password';
+	public const ARGUMENT_SMTP_HOST = 'smtp-host';
+	public const ARGUMENT_SMTP_PORT = 'smtp-port';
+	public const ARGUMENT_SMTP_SSL_MODE = 'smtp-ssl-mode';
+	public const ARGUMENT_SMTP_USER = 'smtp-user';
+	public const ARGUMENT_SMTP_PASSWORD = 'smtp-password';
 
 	/** @var mapper */
-        private $mapper;
+	private $mapper;
 
 	/** @var ICrypto */
 	private $crypto;
@@ -55,7 +53,7 @@ class UpdateAccount extends Command {
 	public function __construct(MailAccountMapper $mapper, ICrypto $crypto) {
 		parent::__construct();
 
-                $this->mapper = $mapper;
+		$this->mapper = $mapper;
 		$this->crypto = $crypto;
 	}
 
@@ -64,100 +62,92 @@ class UpdateAccount extends Command {
 	 */
 	protected function configure() {
 		$this->setName('mail:account:update');
-		$this->setDescription('Update a user\'s IMAP account(s)');
+		$this->setDescription('Update a user\'s IMAP account');
 		$this->addArgument(self::ARGUMENT_USER_ID, InputArgument::REQUIRED);
-                $this->addArgument(self::ARGUMENT_EMAIL, InputArgument::REQUIRED);
+		$this->addArgument(self::ARGUMENT_EMAIL, InputArgument::REQUIRED);
 
+		$this->addOption(self::ARGUMENT_IMAP_HOST, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_IMAP_PORT, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_IMAP_SSL_MODE, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_IMAP_USER, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_IMAP_PASSWORD, '', InputOption::VALUE_OPTIONAL);
 
-                $this->addOption(self::ARGUMENT_IMAP_HOST,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_IMAP_PORT,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_IMAP_SSL_MODE,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_IMAP_USER,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_IMAP_PASSWORD,'', InputOption::VALUE_REQUIRED);
-               
-                $this->addOption(self::ARGUMENT_SMTP_HOST,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_SMTP_PORT,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_SMTP_SSL_MODE,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_SMTP_USER,'', InputOption::VALUE_REQUIRED);
-                $this->addOption(self::ARGUMENT_SMTP_PASSWORD,'',InputOption::VALUE_REQUIRED);
-
+		$this->addOption(self::ARGUMENT_SMTP_HOST, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_SMTP_PORT, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_SMTP_SSL_MODE, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_SMTP_USER, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_SMTP_PASSWORD, '', InputOption::VALUE_OPTIONAL);
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument(self::ARGUMENT_USER_ID);
+		$email = $input->getArgument(self::ARGUMENT_EMAIL);
 
-                $userId = $input->getArgument(self::ARGUMENT_USER_ID);
-                $email = $input->getArgument(self::ARGUMENT_EMAIL);
+		$imapHost = $input->getOption(self::ARGUMENT_IMAP_HOST);
+		$imapPort = $input->getOption(self::ARGUMENT_IMAP_PORT);
+		$imapSslMode = $input->getOption(self::ARGUMENT_IMAP_SSL_MODE);
+		$imapUser = $input->getOption(self::ARGUMENT_IMAP_USER);
+		$imapPassword = $input->getOption(self::ARGUMENT_IMAP_PASSWORD);
 
+		$smtpHost = $input->getOption(self::ARGUMENT_SMTP_HOST);
+		$smtpPort = $input->getOption(self::ARGUMENT_SMTP_PORT);
+		$smtpSslMode = $input->getOption(self::ARGUMENT_SMTP_SSL_MODE);
+		$smtpUser = $input->getOption(self::ARGUMENT_SMTP_USER);
+		$smtpPassword = $input->getOption(self::ARGUMENT_SMTP_PASSWORD);
 
-                $imapHost = $input->getOption(self::ARGUMENT_IMAP_HOST);
-                $imapPort = $input->getOption(self::ARGUMENT_IMAP_PORT);
-                $imapSslMode = $input->getOption(self::ARGUMENT_IMAP_SSL_MODE);
-                $imapUser = $input->getOption(self::ARGUMENT_IMAP_USER);
-                $imapPassword = $input->getOption(self::ARGUMENT_IMAP_PASSWORD);
+		$mailAccount = $this->mapper->findByUserIdAndEmail($userId, $email);
 
-                $smtpHost = $input->getOption(self::ARGUMENT_SMTP_HOST);
-                $smtpPort = $input->getOption(self::ARGUMENT_SMTP_PORT);
-                $smtpSslMode = $input->getOption(self::ARGUMENT_SMTP_SSL_MODE);
-                $smtpUser = $input->getOption(self::ARGUMENT_SMTP_USER);
-                $smtpPassword = $input->getOption(self::ARGUMENT_SMTP_PASSWORD);
+		if ($mailAccount) {
+			//INBOUND
+			if ($input->getOption(self::ARGUMENT_IMAP_HOST)) {
+				$mailAccount->setInboundHost($imapHost);
+			}
 
-                $accounts = $this->mapper->findByUserId($userId);
+			if ($input->getOption(self::ARGUMENT_IMAP_PORT)) {
+				$mailAccount->setInboundPort((int) $imapPort);
+			}
 
-		foreach ($accounts as $account) {
-                # User may have have more than one email account. Only update the given one
-                        if ($account->getEmail() == $email) {
-                            $mailAccount = $account;
-                            break;
-                        }
-                  }
-                  if ($mailAccount) {
-                    //INBOUND
-                    if ($input->getOption(self::ARGUMENT_IMAP_HOST)) {
-                        $mailAccount->setInboundHost($imapHost);
-                    }
+			if ($input->getOption(self::ARGUMENT_IMAP_SSL_MODE)) {
+				$mailAccount->setInboundSslMode($imapSslMode);
+			}
 
-                    if ($input->getOption(self::ARGUMENT_IMAP_PORT)) {
-                        $mailAccount->setInboundPort((int) $imapPort);
-                    }
+			if ($input->getOption(self::ARGUMENT_IMAP_PASSWORD)) {
+				$mailAccount->setInboundPassword($this->crypto->encrypt($imapPassword));
+			}
 
-                    if ($input->getOption(self::ARGUMENT_IMAP_SSL_MODE)) {
-                      $mailAccount->setInboundSslMode($imapSslMode);
-                    }
-                    if ($input->getOption(self::ARGUMENT_IMAP_PASSWORD)) {
-                        $mailAccount->setInboundPassword($this->crypto->encrypt($imapPassword));
-                    }
+			if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
+				$mailAccount->setInboundUser($imapUser);
+			}
 
-                    if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
-                        $mailAccount->setInboundUser($imapUser);
-                    }
+			// OUTBOUND
 
-                    // OUTBOUND
-  
-                    if ($input->getOption(self::ARGUMENT_SMTP_HOST)) {
-                        $mailAccount->setOutboundHost($smtpHost);
-                    }
+			if ($input->getOption(self::ARGUMENT_SMTP_HOST)) {
+				$mailAccount->setOutboundHost($smtpHost);
+			}
 
-                    if ($input->getOption(self::ARGUMENT_SMTP_PORT)) {
-                        $mailAccount->setOutboundPort((int) $smtpPort);
-                    }
-                    if ($input->getOption(self::ARGUMENT_SMTP_SSL_MODE)) {
-                        $mailAccount->setOutboundSslMode($smtpSslMode);
-                    }
-                    
-                    if ($input->getOption(self::ARGUMENT_SMTP_PASSWORD)) {    
-                        $mailAccount->setOutboundPassword($this->crypto->encrypt($smtpPassword));
-                    }
-                    if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
-                      $mailAccount->setOutboundUser($smtpUser);
-                    }
+			if ($input->getOption(self::ARGUMENT_SMTP_PORT)) {
+				$mailAccount->setOutboundPort((int) $smtpPort);
+			}
 
-                    $this->mapper->save($mailAccount);
+			if ($input->getOption(self::ARGUMENT_SMTP_SSL_MODE)) {
+				$mailAccount->setOutboundSslMode($smtpSslMode);
+			}
 
-                    $output->writeln("<info>Account $email for user $userId succesfully updated </info>");
+			if ($input->getOption(self::ARGUMENT_SMTP_PASSWORD)) {
+				$mailAccount->setOutboundPassword($this->crypto->encrypt($smtpPassword));
+			}
+			
+			if ($input->getOption(self::ARGUMENT_SMTP_USER)) {
+				$mailAccount->setOutboundUser($smtpUser);
+			}
 
-                  } else {
-                        $output->writeln("<info>No Email Account $email found for user $userId </info>");
-                  }
+			$this->mapper->save($mailAccount);
+
+			$output->writeln("<info>Account $email for user $userId succesfully updated </info>");
+			return 1;
+		} else {
+			$output->writeln("<info>No Email Account $email found for user $userId </info>");
+		}
 
 		return 0;
 	}

--- a/lib/Command/UpdateAccount.php
+++ b/lib/Command/UpdateAccount.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class UpdateAccount extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 	public const ARGUMENT_NAME = 'name';
+	public const ARGUMENT_EMAIL = 'email';
 	public const ARGUMENT_AUTH_METHOD = 'auth-method';
 	public const ARGUMENT_IMAP_HOST = 'imap-host';
 	public const ARGUMENT_IMAP_PORT = 'imap-port';
@@ -69,6 +70,8 @@ class UpdateAccount extends Command {
 		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED);
 
 		$this->addOption(self::ARGUMENT_NAME, '', InputOption::VALUE_OPTIONAL);
+		$this->addOption(self::ARGUMENT_EMAIL, '', InputOption::VALUE_OPTIONAL);
+
 		$this->addOption(self::ARGUMENT_IMAP_HOST, '', InputOption::VALUE_OPTIONAL);
 		$this->addOption(self::ARGUMENT_IMAP_PORT, '', InputOption::VALUE_OPTIONAL);
 		$this->addOption(self::ARGUMENT_IMAP_SSL_MODE, '', InputOption::VALUE_OPTIONAL);
@@ -88,6 +91,8 @@ class UpdateAccount extends Command {
 		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
 
 		$name = $input->getOption(self::ARGUMENT_NAME);
+		$email = $input->getOption(self::ARGUMENT_EMAIL);
+
 		$imapHost = $input->getOption(self::ARGUMENT_IMAP_HOST);
 		$imapPort = $input->getOption(self::ARGUMENT_IMAP_PORT);
 		$imapSslMode = $input->getOption(self::ARGUMENT_IMAP_SSL_MODE);
@@ -115,9 +120,12 @@ class UpdateAccount extends Command {
 			$mailAccount->setAuthMethod($authMethod);
 		}
 
-		//NAME
+		//ACCOUNT OPTIONS
 		if ($input->getOption(self::ARGUMENT_NAME)) {
 			$mailAccount->setName($name);
+		}
+		if ($input->getOption(self::ARGUMENT_EMAIL)) {
+			$mailAccount->setEmail($email);
 		}
 
 		//INBOUND

--- a/lib/Command/UpdateAccount.php
+++ b/lib/Command/UpdateAccount.php
@@ -33,6 +33,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateAccount extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
+	public const ARGUMENT_NAME = 'name';
 	public const ARGUMENT_AUTH_METHOD = 'auth-method';
 	public const ARGUMENT_IMAP_HOST = 'imap-host';
 	public const ARGUMENT_IMAP_PORT = 'imap-port';
@@ -67,6 +68,7 @@ class UpdateAccount extends Command {
 		$this->setDescription('Update a user\'s IMAP account');
 		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED);
 
+		$this->addOption(self::ARGUMENT_NAME, '', InputOption::VALUE_OPTIONAL);
 		$this->addOption(self::ARGUMENT_IMAP_HOST, '', InputOption::VALUE_OPTIONAL);
 		$this->addOption(self::ARGUMENT_IMAP_PORT, '', InputOption::VALUE_OPTIONAL);
 		$this->addOption(self::ARGUMENT_IMAP_SSL_MODE, '', InputOption::VALUE_OPTIONAL);
@@ -85,6 +87,7 @@ class UpdateAccount extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
 
+		$name = $input->getOption(self::ARGUMENT_NAME);
 		$imapHost = $input->getOption(self::ARGUMENT_IMAP_HOST);
 		$imapPort = $input->getOption(self::ARGUMENT_IMAP_PORT);
 		$imapSslMode = $input->getOption(self::ARGUMENT_IMAP_SSL_MODE);
@@ -110,6 +113,11 @@ class UpdateAccount extends Command {
 		//AUTH METHOD
 		if ($input->getOption(self::ARGUMENT_AUTH_METHOD)) {
 			$mailAccount->setAuthMethod($authMethod);
+		}
+
+		//NAME
+		if ($input->getOption(self::ARGUMENT_NAME)) {
+			$mailAccount->setName($name);
 		}
 
 		//INBOUND

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -97,6 +97,22 @@ class MailAccountMapper extends QBMapper {
 
 		return $this->findEntities($query);
 	}
+	/**
+	 * Finds an mail account by user id and email address
+	 *
+	 * @return MailAccount
+	 * @throws DoesNotExistException
+	 */
+	public function findByUserIdAndEmail(string $userId, string $email): MailAccount {
+		$qb = $this->db->getQueryBuilder();
+		$query = $qb
+			->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR))
+			->andWhere($qb->expr()->eq('email', $qb->createNamedParameter($email, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
+
+		return $this->findEntity($query);
+	}
 
 	/**
 	 * @throws DoesNotExistException

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -97,22 +97,6 @@ class MailAccountMapper extends QBMapper {
 
 		return $this->findEntities($query);
 	}
-	/**
-	 * Finds an mail account by user id and email address
-	 *
-	 * @return MailAccount
-	 * @throws DoesNotExistException
-	 */
-	public function findByUserIdAndEmail(string $userId, string $email): MailAccount {
-		$qb = $this->db->getQueryBuilder();
-		$query = $qb
-			->select('*')
-			->from($this->getTableName())
-			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR))
-			->andWhere($qb->expr()->eq('email', $qb->createNamedParameter($email, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
-
-		return $this->findEntity($query);
-	}
 
 	/**
 	 * @throws DoesNotExistException

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -88,6 +88,11 @@
       <code>Command</code>
     </UndefinedClass>
   </file>
+  <file src="lib/Command/UpdateAccount.php">
+    <UndefinedClass occurrences="1">
+      <code>Command</code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Db/AliasMapper.php">
     <ImplicitToStringCast occurrences="1">
       <code>$qb2-&gt;createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)</code>


### PR DESCRIPTION
### Additional  occ command 

The occ  mail:account:update command can be used to update a single parameter or several at once using the desired input  option.

### Usage  

Requires two arguments, to identify the account you want to edit:

- user-id
- name

Accepts all options included in mail:account:create eg:
	--imap-host
	--imap-port 
	--imap-ssl-mode 
	--imap-user
	--imap-password 
	--smtp-host
	--smtp-port
	--smtp-ssl-mode
	--smtp-user
	--smtp-password

eg:
occ mail:account:update <username> <user@example.com> --smtp-ssl-mode=ssl --smtp-port=465

**Why**  

It can happen that some email's  setting ( smtp servername, port, password...) changes in the course of time.
It would be useful to be able to apply these new settings while preserving the parameters that remain unaffected.

In large installations, if you were to change a connection parameter to the company mail server, it would be wasteful to do this manually or by deleting and recreating accounts.

