### PR TITLE
Use npm@7 in all workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 14.x
+    - name: Set up npm
+      run: npm install -g npm@7
     - name: npm install
       run: npm ci
     - name: eslint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,8 @@ jobs:
             uses: actions/setup-node@v3
             with:
                 node-version: 14.x
+          - name: Set up npm
+            run: npm install -g npm@7
           - name: npm install
             run: npm install
           - name: run tests


### PR DESCRIPTION
We required Node >= 14 and npm >= 7 but our eslint and frontend test workflows were using npm 6 because it is the default version of Node 14.

`$ jq .engines package.json`
```json
{
  "node": ">=14.0.0",
  "npm": ">=7.0.0"
}
```