### PR TITLE
Use node and npm versions from package.json in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,10 +56,18 @@ jobs:
     name: ESLint
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Node
-      uses: actions/setup-node@v3
+    - name: Read package.json node and npm engines version
+      uses: skjnldsv/read-package-engines-version-actions@v1.1
+      id: versions
       with:
-        node-version: 14.x
+        fallbackNode: '^14'
+        fallbackNpm: '^7'
+    - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ steps.versions.outputs.nodeVersion }}
+    - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+      run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
     - name: npm install
       run: npm ci
     - name: eslint

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,12 +17,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set up Node
-        uses: actions/setup-node@v3
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@v1.1
+        id: versions
         with:
-          node-version: 14.x
-      - name: Set up npm
-        run: npm install -g npm@7
+          fallbackNode: '^14'
+          fallbackNpm: '^7'
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
       - name: Set up php$
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,10 +196,18 @@ jobs:
       name: Front-end unit tests
       steps:
           - uses: actions/checkout@v3
-          - name: Set up Node
-            uses: actions/setup-node@v3
+          - name: Read package.json node and npm engines version
+            uses: skjnldsv/read-package-engines-version-actions@v1.1
+            id: versions
             with:
-                node-version: 14.x
+              fallbackNode: '^14'
+              fallbackNpm: '^7'
+          - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+            uses: actions/setup-node@v2
+            with:
+              node-version: ${{ steps.versions.outputs.nodeVersion }}
+          - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+            run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
           - name: npm install
             run: npm install
           - name: run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,8 +118,8 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
+        "node": "^14.0.0",
+        "npm": "^7.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "extends @nextcloud/browserslist-config"
   ],
   "engines": {
-    "node": ">=14.0.0",
-    "npm": ">=7.0.0"
+    "node": "^14.0.0",
+    "npm": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",


### PR DESCRIPTION
Alternative to #6910 

This requires a stricter engine version lock. I'm fine with this change because we should be using nvm anyways and it only produces a warning when a different version of node/npm is used.

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'nextcloud-mail@1.12.0',
npm WARN EBADENGINE   required: { node: '^14.0.0', npm: '^7.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.16.0', npm: '7.24.2' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@nextcloud/axios@1.10.0',
npm WARN EBADENGINE   required: { node: '^14', npm: '^7' },
npm WARN EBADENGINE   current: { node: 'v16.16.0', npm: '7.24.2' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@nextcloud/vue@5.3.1',
npm WARN EBADENGINE   required: { node: '^14.0.0', npm: '^7.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.16.0', npm: '7.24.2' }
npm WARN EBADENGINE }
```

Thanks for the hint @kesselb 