### PR TITLE
Fix conversion of imip data charset encoding

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @author Robin McCorkell <rmccorkell@karoshi.org.uk>
  * @author Thomas Mueller <thomas.mueller@tmit.eu>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * Mail
  *
@@ -649,7 +650,12 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$p->setContents($data);
 		$data = $p->getContents();
 
-		$data = mb_convert_encoding($data, 'UTF-8', $p->getCharset());
+		// Only convert encoding if it is explicitly specified in the header because text/calendar
+		// data is utf-8 by default.
+		$charset = $p->getContentTypeParameter('charset');
+		if ($charset !== null && strtoupper($charset) !== 'UTF-8') {
+			$data = mb_convert_encoding($data, 'UTF-8', $charset);
+		}
 		return $data;
 	}
 


### PR DESCRIPTION
Data of type `text/calendar` is encoded as utf-8 by default. The encoding has to be converted only if there is a header which explicitly specifies a different charset.

| Before | After |
| --- | --- |
| ![Screenshot 2022-07-22 at 10-20-56 Mail - Nextcloud](https://user-images.githubusercontent.com/1479486/180398023-da3029c7-ad0d-4249-ab41-1f92db042a06.png) | ![Screenshot 2022-07-22 at 10-19-43 Mail - Nextcloud](https://user-images.githubusercontent.com/1479486/180398020-69e36e44-c326-4894-a39c-c8a4b949fd30.png) |

