### PR TITLE
Fix using usual text contrast for envelopes

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -348,7 +348,7 @@ export default {
 
 		.timestamp {
 			margin-right: 10px;
-			font-size: small;
+			color: var(--color-text-maxcontrast);
 			white-space: nowrap;
 			margin-bottom: 0;
 		}
@@ -372,6 +372,7 @@ export default {
 	}
 	.subject {
 		margin-left: 8px;
+		color: var(--color-text-maxcontrast);
 		cursor: default;
 	}
 


### PR DESCRIPTION
**Before**, subline and date is color-main-text, and date is also smaller:
![image](https://user-images.githubusercontent.com/925062/180793872-085f2b1f-88ba-4bdf-8b20-341c1a81397a.png)

**After**, subline and date is color-text-maxcontrast as elsewhere:
![after](https://user-images.githubusercontent.com/925062/180794074-0eb2cfbb-5d64-4d84-889b-759866f7768d.png)


Please check @miaulalala @GretaD @nimishavijay 