### PR TITLE
Revert raw references using horde header stream

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -184,9 +184,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 
 	private function getRawReferences(): string {
 		/** @var resource $headersStream */
-		$headersStream = $this->fetch->getHeaderText('0', Horde_Imap_Client_Data_Fetch::HEADER_STREAM);
-		$parsedHeaders = Horde_Mime_Headers::parseHeaders($headersStream);
-		fclose($headersStream);
+		$parsedHeaders = $this->fetch->getHeaderText('0', Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
 		$references = $parsedHeaders->getHeader('references');
 		if ($references === null) {
 			return '';


### PR DESCRIPTION
as this breaks new accounts being added.
Due to how streams are handled within the horde library, it looks like the
stream for each imip message is breaking somewhere in the code
possibly from an `fclose` or `_clone`.

I would not find out exactly where the stream breaks, but it will be a resource with type 'Unknown' instead of 'stream' and the resource data will be empty, leading to an exception in `\Horde_Imap_Client_Data_Fetch::_msgText:548`

The concerned files are `Horde_Stream` and inheriting classes `Horde_Stream_Temp` and `Horde_Stream_Existing`.

A more thorough investigation could be useful as the memory leaks that were fixed with a previous PR
to the ByteStream library might play a part.

This needs a thrtough test to see if this doesn't reincur the memory leak issues we had previously.

(Also... apps/mail/vendor/bytestream/horde-mime/lib/Horde/Mime/Headers.php:375 might be a point to investiagte?)

Test scenarios:
- [ ] Test adding a new account
- [ ] Test on existing account
- [ ] Test on account with few messages
- [ ] Test on account with a lot of messages

Fixes #6938 