### PR TITLE
Change the 'show image' styling

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -3,19 +3,26 @@
 		<MdnRequest :message="message" />
 		<div v-if="hasBlockedContent" id="mail-message-has-blocked-content" style="color: #000000">
 			{{ t('mail', 'The images have been blocked to protect your privacy.') }}
-			<Actions default-icon="icon-toggle" :menu-title="t('mail', 'Show')">
-				<ActionButton icon="icon-toggle"
+			<Actions type="tertiary" :menu-title="t('mail', 'Show images')">
+				<ActionButton
 					@click="displayIframe">
+					<template #icon>
+						<IconImage :size="20" />
+					</template>
 					{{ t('mail', 'Show images temporarily') }}
 				</ActionButton>
 				<ActionButton v-if="sender"
-					icon="icon-toggle"
 					@click="onShowBlockedContent">
+					<template #icon>
+						<IconMail :size="20" />
+					</template>
 					{{ t('mail', 'Always show images from {sender}', { sender }) }}
 				</ActionButton>
 				<ActionButton v-if="domain"
-					icon="icon-toggle"
 					@click="onShowBlockedContentForDomain">
+					<template #icon>
+						<IconDomain :size="20" />
+					</template>
 					{{ t('mail', 'Always show images from {domain}', { domain }) }}
 				</ActionButton>
 			</Actions>
@@ -38,6 +45,9 @@ import PrintScout from 'printscout'
 import { trustSender } from '../service/TrustedSenderService'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
+import IconImage from 'vue-material-design-icons/ImageSizeSelectActual'
+import IconMail from 'vue-material-design-icons/Email'
+import IconDomain from 'vue-material-design-icons/Domain'
 
 import logger from '../logger'
 import MdnRequest from './MdnRequest'
@@ -49,6 +59,9 @@ export default {
 		MdnRequest,
 		Actions,
 		ActionButton,
+		IconImage,
+		IconMail,
+		IconDomain,
 	},
 	props: {
 		url: {
@@ -152,6 +165,7 @@ export default {
 }
 #mail-message-has-blocked-content {
 	margin-left: 8px;
+	color: var(--color-text-maxcontrast) !important;
 }
 
 #message-container {
@@ -165,13 +179,18 @@ export default {
 		overflow-y: auto;
 	}
 }
-::v-deep .icon-toggle {
-	background-image: var(--icon-toggle-000) !important;
-}
 ::v-deep .action-item__menutoggle--with-title {
-	background-color: var(--color-background-hover) !important;
+	background-color: var(--color-main-background) !important;
+	border: none !important;
+	font-weight: normal !important;
+	padding-left: 14px !important;
+	padding-right: 10px !important;
+	text-decoration: underline !important;
 }
 .message-frame {
 	width: 100%;
+}
+::v-deep .dots-horizontal-icon {
+	display: none !important;
 }
 </style>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6122

this is how i tried to make it work with the state of actions we have now.
But i agree with Marco's comment here: https://github.com/nextcloud/mail/issues/6122#issuecomment-1202480324

before
![Screenshot from 2022-08-02 15-35-35](https://user-images.githubusercontent.com/12728974/182388026-c76d2815-3f1f-4329-9f76-fc0286dfb16d.png)
![Screenshot from 2022-08-02 15-35-22](https://user-images.githubusercontent.com/12728974/182388029-c5ddf85a-c6ea-41ea-a097-8f64fd7a9a42.png)

after
![hvcfgh](https://user-images.githubusercontent.com/12728974/184897887-d8754502-6338-4197-83f8-9d35e1700536.png)

![png](https://user-images.githubusercontent.com/12728974/184897966-e2b171c6-bfb3-4b88-953a-e69041b90752.png)


~~- [ ] Requires https://github.com/nextcloud/nextcloud-vue/pull/2911~~