### PR TITLE
Filter out range uids

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -246,6 +246,10 @@ class MessageMapper {
 			'ids' => $ids,
 		]), false);
 
+		$fetchResults = array_values(array_filter($fetchResults, static function (Horde_Imap_Client_Data_Fetch $fetchResult) {
+			return $fetchResult->exists(Horde_Imap_Client::FETCH_ENVELOPE);
+		}));
+
 		if (empty($fetchResults)) {
 			$this->logger->debug("findByIds in $mailbox got " . count($ids) . " UIDs but found none");
 		} else {

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -70,15 +70,61 @@ class MessageMapperTest extends TestCase {
 			->willReturn($fetchResults);
 		$fetchResults[0] = $fetchResult1;
 		$fetchResults[1] = $fetchResult2;
+		$fetchResult1->expects(self::once())
+			->method('exists')
+			->with(Horde_Imap_Client::FETCH_ENVELOPE)
+			->willReturn(true);
+		$fetchResult2->expects(self::once())
+			->method('exists')
+			->with(Horde_Imap_Client::FETCH_ENVELOPE)
+			->willReturn(true);
 		$fetchResult1->method('getUid')
 			->willReturn(1);
 		$fetchResult2->method('getUid')
 			->willReturn(3);
+
 		$message1 = new IMAPMessage($imapClient, $mailbox, 1, $fetchResult1);
 		$message2 = new IMAPMessage($imapClient, $mailbox, 3, $fetchResult2);
 		$expected = [
 			$message1,
 			$message2,
+		];
+
+		$result = $this->mapper->findByIds($imapClient, $mailbox, new Horde_Imap_Client_Ids($ids));
+
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testGetByIdsWithEmpty(): void {
+		/** @var Horde_Imap_Client_Socket|MockObject $imapClient */
+		$imapClient = $this->createMock(Horde_Imap_Client_Socket::class);
+		$mailbox = 'inbox';
+		$ids = [1, 3];
+
+		$fetchResults = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult1 = $this->createMock(Horde_Imap_Client_Data_Fetch::class);
+		$fetchResult2 = $this->createMock(Horde_Imap_Client_Data_Fetch::class);
+		$imapClient->expects(self::once())
+			->method('fetch')
+			->willReturn($fetchResults);
+		$fetchResults[0] = $fetchResult1;
+		$fetchResults[1] = $fetchResult2;
+		$fetchResult1->expects(self::once())
+			->method('exists')
+			->with(Horde_Imap_Client::FETCH_ENVELOPE)
+			->willReturn(true);
+		$fetchResult2->expects(self::once())
+			->method('exists')
+			->with(Horde_Imap_Client::FETCH_ENVELOPE)
+			->willReturn(false);
+		$fetchResult1->method('getUid')
+			->willReturn(1);
+		$fetchResult2->expects(self::never())
+			->method('getUid');
+
+		$message1 = new IMAPMessage($imapClient, $mailbox, 1, $fetchResult1);
+		$expected = [
+			$message1
 		];
 
 		$result = $this->mapper->findByIds($imapClient, $mailbox, new Horde_Imap_Client_Ids($ids));


### PR DESCRIPTION
Fix #6938 

Alternative approach: https://github.com/nextcloud/mail/pull/6945

runInitialSync and Horde_Imap_Client_Cache_Backend_Null may return uids for non existing messages.

For example: 3 messages UID 4, UID 8, UID 12

Range to request is 4:12 and should return 3 messages.

Sometimes a list of messages like UID 4, UID 5, UID 6, UID 7, UID 8, UID 9, UID 10, UID 11 and UID 12.

However valid information are only there for UID 4, UID 8 and UID 12.