### PR TITLE
Migrate icons to material design icons

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -87,9 +87,9 @@
 					:close-after-click="true"
 					@click.prevent="onToggleSeen">
 					<template #icon>
-						<Email v-if="showImportantIconVariant"
+						<EmailUnread v-if="showImportantIconVariant"
 							:size="20" />
-						<EmailOutline v-else
+						<EmailRead v-else
 							:size="20" />
 					</template>
 					{{
@@ -254,8 +254,8 @@ import OpenInNewIcon from 'vue-material-design-icons/OpenInNew'
 import StarOutline from 'vue-material-design-icons/StarOutline'
 import Star from 'vue-material-design-icons/Star'
 import Reply from 'vue-material-design-icons/Reply'
-import EmailOutline from 'vue-material-design-icons/EmailOutline'
-import Email from 'vue-material-design-icons/Email'
+import EmailRead from 'vue-material-design-icons/EmailOpen'
+import EmailUnread from 'vue-material-design-icons/Email'
 import IconAttachment from 'vue-material-design-icons/Paperclip'
 import ImportantIcon from './icons/ImportantIcon'
 import JunkIcon from './icons/JunkIcon'
@@ -289,8 +289,8 @@ export default {
 		TagModal,
 		Star,
 		StarOutline,
-		EmailOutline,
-		Email,
+		EmailRead,
+		EmailUnread,
 		IconAttachment,
 		Reply,
 	},
@@ -432,7 +432,7 @@ export default {
 		/**
 		 * Subject of envelope or "No Subject".
 		 *
-		 * @return {string}
+		 * @returns {string}
 		 */
 		subjectForSubtitle() {
 			// We have to use || here (instead of ??) because the subject might be '', null

--- a/src/components/MailboxPicker.vue
+++ b/src/components/MailboxPicker.vue
@@ -5,13 +5,14 @@
 				{{ t('mail', 'Choose target mailbox') }}
 			</h2>
 			<span class="crumbs">
-				<div class="level icon-breadcrumb">
-					<a class="icon-home" @click.prevent="onClickHome" />
+				<div @click.prevent="onClickHome">
+					<IconInbox :size="20" />
 				</div>
 				<div
 					v-for="(box, index) in mailboxCrumbs"
 					:key="box.databaseId"
-					class="level icon-breadcrumb">
+					class="level">
+					<IconBreadcrumb :size="20" />
 					<a @click.prevent="onClickCrumb(index)">
 						{{ getMailboxTitle(box) }}
 					</a>
@@ -23,16 +24,29 @@
 						v-for="box in filteredMailboxes "
 						:key="box.databaseId"
 						@click.prevent="onClickMailbox(box)">
-						<div :class="['mailbox-icon', getMailboxIcon(box)]" />
+						<IconInbox v-if="box.specialRole === 'inbox'" :size="20" />
+						<IconDraft
+							v-else-if="box.specialRole === 'drafts'"
+							:size="20" />
+						<IconSent
+							v-else-if="box.specialRole === 'sent'"
+							:size="20" />
+						<IconArchive
+							v-else-if="box.specialRole === 'archive'"
+							:size="20" />
+						<IconTrash
+							v-else-if="box.specialRole === 'trash'"
+							:size="20" />
+						<IconFolder v-else
+							:size="20" />
 						<div class="mailbox-title">
 							{{ getMailboxTitle(box) }}
 						</div>
 					</li>
 				</ul>
-				<div v-else class="empty">
-					<div class="empty-icon icon-folder" />
-					<h2>{{ t('mail', 'No more submailboxes in here') }}</h2>
-				</div>
+				<IconFolder v-else :size="65" />
+				<div class="empty-icon empty" />
+				<h2>{{ t('mail', 'No more submailboxes in here') }}</h2>
 			</div>
 			<div class="buttons">
 				<button class="primary" :disabled="loading || (!allowRoot && !selectedMailboxId)" @click="onSelect">
@@ -45,6 +59,13 @@
 </template>
 <script>
 import Modal from '@nextcloud/vue/dist/Components/Modal'
+import IconBreadcrumb from 'vue-material-design-icons/ChevronRight'
+import IconInbox from 'vue-material-design-icons/Home'
+import IconDraft from 'vue-material-design-icons/Pencil'
+import IconSent from 'vue-material-design-icons/Send'
+import IconArchive from 'vue-material-design-icons/PackageDown'
+import IconTrash from 'vue-material-design-icons/Delete'
+import IconFolder from 'vue-material-design-icons/Folder'
 
 import { translate as t } from '@nextcloud/l10n'
 import { translate as translateMailboxName } from '../i18n/MailboxTranslator'
@@ -53,6 +74,13 @@ export default {
 	name: 'MailboxPicker',
 	components: {
 		Modal,
+		IconInbox,
+		IconDraft,
+		IconSent,
+		IconArchive,
+		IconTrash,
+		IconFolder,
+		IconBreadcrumb,
 	},
 	props: {
 		account: {
@@ -159,7 +187,6 @@ export default {
 
 .crumbs {
 	display: inline-flex;
-	padding-left: 12px;
 	padding-right: 0px;
 	flex-wrap: wrap;
 
@@ -172,6 +199,7 @@ export default {
 		padding-right: 7px;
 		background-position: right center;
 		background-size: auto 24px;
+		margin-top: -10px;
 	}
 
 	a {
@@ -216,19 +244,14 @@ export default {
 		}
 	}
 
-	.empty {
+	h2 {
 		width: 100%;
 		color: var(--color-text-maxcontrast);
 		text-align: center;
 		margin-top: 80px;
-	}
-
-	.empty-icon {
 		opacity: 0.4;
 		background-size: 64px;
 		height: 64px;
-		width: 64px;
-		margin: 0 auto 15px;
 	}
 
 	.mailbox-icon {
@@ -256,5 +279,9 @@ export default {
 	.spinner {
 		margin-right: 5px;
 	}
+}
+.material-design-icon {
+	opacity: .7;
+	margin-right: 6px;
 }
 </style>

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -238,10 +238,6 @@ export default {
 	z-index: 1;
 }
 
-.icon-info {
-	background-image: var(--icon-info-000);
-}
-
 .important-info {
 	max-width: 230px;
 	padding: 16px;
@@ -279,7 +275,5 @@ export default {
 }
 .information-icon {
 	opacity: .7;
-	margin-bottom: 3px;
-	margin-right: 9px;
 }
 </style>

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -209,7 +209,7 @@ import IconFolderSync from 'vue-material-design-icons/FolderSync'
 import IconDelete from 'vue-material-design-icons/Delete'
 import IconInfo from 'vue-material-design-icons/Information'
 import IconDraft from 'vue-material-design-icons/Pencil'
-import IconArchive from 'vue-material-design-icons/Archive'
+import IconArchive from 'vue-material-design-icons/PackageDown'
 import IconInbox from 'vue-material-design-icons/Home'
 import IconAllInboxes from 'vue-material-design-icons/InboxMultiple'
 import ImportantIcon from './icons/ImportantIcon'
@@ -395,7 +395,7 @@ export default {
 		 * Generate unique key id for a specific mailbox
 		 *
 		 * @param {object} mailbox the mailbox to gen id for
-		 * @return {string}
+		 * @returns {string}
 		 */
 		genId(mailbox) {
 			return 'mailbox-' + mailbox.databaseId

--- a/src/components/NavigationOutbox.vue
+++ b/src/components/NavigationOutbox.vue
@@ -42,7 +42,7 @@
 <script>
 import AppNavigationItem from '@nextcloud/vue/dist/Components/AppNavigationItem'
 import CounterBubble from '@nextcloud/vue/dist/Components/CounterBubble'
-import IconOutbox from 'vue-material-design-icons/Email'
+import IconOutbox from 'vue-material-design-icons/InboxArrowUp'
 
 export default {
 	name: 'NavigationOutbox',


### PR DESCRIPTION
this pr migrates:

- read/unread - Jan changed the icons
- outbox/archive - jan proposed 2 new ones
- Mialboxpicker icons
- Info icon for PI - fixed the misaligment