### PR TITLE
Migrate icons to material design icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3541,17 +3541,17 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "6.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.3.tgz",
-      "integrity": "sha512-Fnenptz/55KIcXP8kDcjUz8Xcm0EARfSkvnpgQvJh12fd1Xkf8B8ziHQAfAPozsV3RmXDbTeGiuQ4VQCQ/rSzw==",
+      "version": "6.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.4.tgz",
+      "integrity": "sha512-1TdzH0++/gIcBzot8iNT3AnweR/1EykpCfBwkJNhMgoiY4HlMLxBj7bpe2D4ul24XTCoXVEdGMYyB32GNVc9WA==",
       "dependencies": {
-        "@nextcloud/auth": "^1.3.0",
-        "@nextcloud/axios": "^1.10.0",
+        "@nextcloud/auth": "^2.0.0",
+        "@nextcloud/axios": "^2.0.0",
         "@nextcloud/browser-storage": "^0.1.1",
         "@nextcloud/calendar-js": "^3.0.0",
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
-        "@nextcloud/event-bus": "^2.1.1",
+        "@nextcloud/event-bus": "^3.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
         "@nextcloud/router": "^2.0.0",
@@ -3559,14 +3559,13 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
-        "focus-trap": "^6.9.4",
+        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^3.0.4",
         "md5": "^2.3.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
-        "style-loader": "^3.3.1",
         "tributejs": "^5.1.3",
         "v-click-outside": "^3.2.0",
         "vue": "^2.7.8",
@@ -3715,48 +3714,16 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/auth": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-      "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
+    "node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.0.tgz",
+      "integrity": "sha512-wtlVyE5CY8fnzrBws1j5zWAYiiGLylVghDkj4bGPa5NUdUXtD7QrRBb20GEW8sIn1s/TwaS7+DHGvRUUCjIJeg==",
       "dependencies": {
-        "@nextcloud/event-bus": "^1.1.3",
-        "@nextcloud/typings": "^0.2.2",
-        "core-js": "^3.6.4"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-      "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-      "dependencies": {
-        "@types/semver": "^7.3.5",
-        "core-js": "^3.11.2",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-      "dependencies": {
-        "@nextcloud/auth": "^1.3.0",
-        "axios": "^0.27.1",
-        "core-js": "^3.6.4"
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^16.0.0",
         "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-2.1.1.tgz",
-      "integrity": "sha512-YEui6N+23uyjBSIUZhf8rEjG9vol7UGgxcgxMddEbO0HS7M/sh1cocRqtn+ZVi/yPybeToGmt68SDPCgwHQHKw==",
-      "dependencies": {
-        "@types/semver": "^7.1.0",
-        "core-js": "^3.6.2",
-        "semver": "^7.3.2"
       }
     },
     "node_modules/@nextcloud/vue/node_modules/ansi-regex": {
@@ -3817,9 +3784,9 @@
       }
     },
     "node_modules/@nextcloud/vue/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -7934,11 +7901,11 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-      "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+      "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
       "dependencies": {
-        "tabbable": "^5.3.3"
+        "tabbable": "^6.0.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -12989,6 +12956,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "dev": true,
       "engines": {
         "node": ">= 12.13.0"
       },
@@ -13418,9 +13386,9 @@
       "dev": true
     },
     "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.0.tgz",
+      "integrity": "sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw=="
     },
     "node_modules/table": {
       "version": "6.8.0",
@@ -17499,17 +17467,17 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "6.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.3.tgz",
-      "integrity": "sha512-Fnenptz/55KIcXP8kDcjUz8Xcm0EARfSkvnpgQvJh12fd1Xkf8B8ziHQAfAPozsV3RmXDbTeGiuQ4VQCQ/rSzw==",
+      "version": "6.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-6.0.0-beta.4.tgz",
+      "integrity": "sha512-1TdzH0++/gIcBzot8iNT3AnweR/1EykpCfBwkJNhMgoiY4HlMLxBj7bpe2D4ul24XTCoXVEdGMYyB32GNVc9WA==",
       "requires": {
-        "@nextcloud/auth": "^1.3.0",
-        "@nextcloud/axios": "^1.10.0",
+        "@nextcloud/auth": "^2.0.0",
+        "@nextcloud/axios": "^2.0.0",
         "@nextcloud/browser-storage": "^0.1.1",
         "@nextcloud/calendar-js": "^3.0.0",
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
-        "@nextcloud/event-bus": "^2.1.1",
+        "@nextcloud/event-bus": "^3.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
         "@nextcloud/router": "^2.0.0",
@@ -17517,14 +17485,13 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
-        "focus-trap": "^6.9.4",
+        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^3.0.4",
         "md5": "^2.3.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
-        "style-loader": "^3.3.1",
         "tributejs": "^5.1.3",
         "v-click-outside": "^3.2.0",
         "vue": "^2.7.8",
@@ -17534,46 +17501,12 @@
         "vue2-datepicker": "^3.11.0"
       },
       "dependencies": {
-        "@nextcloud/auth": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-          "integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-          "requires": {
-            "@nextcloud/event-bus": "^1.1.3",
-            "@nextcloud/typings": "^0.2.2",
-            "core-js": "^3.6.4"
-          },
-          "dependencies": {
-            "@nextcloud/event-bus": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-              "integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-              "requires": {
-                "@types/semver": "^7.3.5",
-                "core-js": "^3.11.2",
-                "semver": "^7.3.5"
-              }
-            }
-          }
-        },
-        "@nextcloud/axios": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-          "integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-          "requires": {
-            "@nextcloud/auth": "^1.3.0",
-            "axios": "^0.27.1",
-            "core-js": "^3.6.4"
-          }
-        },
         "@nextcloud/event-bus": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-2.1.1.tgz",
-          "integrity": "sha512-YEui6N+23uyjBSIUZhf8rEjG9vol7UGgxcgxMddEbO0HS7M/sh1cocRqtn+ZVi/yPybeToGmt68SDPCgwHQHKw==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.0.tgz",
+          "integrity": "sha512-wtlVyE5CY8fnzrBws1j5zWAYiiGLylVghDkj4bGPa5NUdUXtD7QrRBb20GEW8sIn1s/TwaS7+DHGvRUUCjIJeg==",
           "requires": {
-            "@types/semver": "^7.1.0",
-            "core-js": "^3.6.2",
-            "semver": "^7.3.2"
+            "semver": "^7.3.7"
           }
         },
         "ansi-regex": {
@@ -17617,9 +17550,9 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -20881,11 +20814,11 @@
       }
     },
     "focus-trap": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-      "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+      "integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
       "requires": {
-        "tabbable": "^5.3.3"
+        "tabbable": "^6.0.0"
       }
     },
     "follow-redirects": {
@@ -24508,6 +24441,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "dev": true,
       "requires": {}
     },
     "style-search": {
@@ -24810,9 +24744,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.0.tgz",
+      "integrity": "sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw=="
     },
     "table": {
       "version": "6.8.0",

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -220,23 +220,31 @@
 			</Tab>
 		</Tabs>
 		<div class="account-form__submit-buttons">
-			<button v-if="mode === 'auto'"
-				class="primary account-form__submit-button"
-				type="submit"
+			<ButtonVue v-if="mode === 'auto'"
+				class="account-form__submit-button"
+				type="primary"
+				native-type="submit"
 				:disabled="isDisabledAuto"
 				@click.prevent="onSubmit">
-				<span v-if="loading" class="icon-loading-small account-form__submit-button__spinner" />
+				<template #icon>
+					<IconLoading v-if="loading" :size="20" />
+					<IconCheck v-else :size="20" />
+				</template>
 				{{ submitButtonText }}
-			</button>
+			</ButtonVue>
 
-			<button v-else-if="mode === 'manual'"
-				class="primary account-form__submit-button"
-				type="submit"
+			<ButtonVue v-else-if="mode === 'manual'"
+				class="account-form__submit-button"
+				type="primary"
+				native-type="submit"
 				:disabled="isDisabledManual"
 				@click.prevent="onSubmit">
-				<span v-if="loading" class="icon-loading-small account-form__submit-button__spinner" />
+				<template #icon>
+					<IconLoading v-if="loading" :size="20" />
+					<IconCheck v-else :size="20" />
+				</template>
 				{{ submitButtonText }}
-			</button>
+			</ButtonVue>
 		</div>
 		<div v-if="feedback" class="account-form--feedback">
 			{{ feedback }}
@@ -246,6 +254,9 @@
 
 <script>
 import { Tab, Tabs } from 'vue-tabs-component'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconCheck from 'vue-material-design-icons/Check'
 import { translate as t } from '@nextcloud/l10n'
 
 import logger from '../logger'
@@ -256,6 +267,9 @@ export default {
 	components: {
 		Tab,
 		Tabs,
+		ButtonVue,
+		IconLoading,
+		IconCheck,
 	},
 	props: {
 		displayName: {
@@ -609,11 +623,6 @@ input[type='radio'][disabled] + label {
 .account-form__submit-button {
 	display: flex;
 	align-items: center;
-}
-.account-form__submit-button__spinner {
-	margin: 0 10px 0 0;
-	height: auto;
-	width: auto;
 }
 .account-form--feedback {
 	color: var(--color-text-maxcontrast);

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -111,6 +111,7 @@ import TrustedSenders from './TrustedSenders'
 import SieveAccountForm from './SieveAccountForm'
 import SieveFilterForm from './SieveFilterForm'
 import Logger from '../logger'
+
 export default {
 	name: 'AccountSettings',
 	components: {

--- a/src/components/AliasForm.vue
+++ b/src/components/AliasForm.vue
@@ -32,25 +32,37 @@
 					required>
 			</div>
 			<div class="button-group">
-				<button
-					class="icon"
-					type="submit"
-					:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark'"
-					:title="t('mail', 'Update alias')" />
+				<ButtonVue
+					type="tertiary-no-background"
+					native-type="submit"
+					:title="t('mail', 'Update alias')">
+					<template #icon>
+						<IconLoading v-if="loading" :size="20" />
+						<IconCheck v-else :size="20" />
+					</template>
+				</ButtonVue>
 			</div>
 		</form>
 		<div v-else class="alias-item">
 			<p><strong>{{ alias.name }}</strong> &lt;{{ alias.alias }}&gt;</p>
 			<div class="button-group">
-				<button
-					class="icon icon-rename"
+				<ButtonVue
+					type="tertiary-no-background"
 					:title="t('mail', 'Show update alias form')"
-					@click="showForm = true" />
-				<button v-if="!alias.provisioned"
-					class="icon"
+					@click="showForm = true">
+					<template #icon>
+						<IconRename :size="20" />
+					</template>
+				</ButtonVue>
+				<ButtonVue v-if="!alias.provisioned"
+					type="tertiary-no-background"
 					:title="t('mail', 'Delete alias')"
-					:class="loading ? 'icon-loading-small-dark' : 'icon-delete'"
-					@click="deleteAlias" />
+					@click="deleteAlias">
+					<template #icon>
+						<IconLoading v-if="loading" :size="20" />
+						<IconDelete v-else :size="20" />
+					</template>
+				</ButtonVue>
 			</div>
 		</div>
 	</div>
@@ -58,9 +70,20 @@
 
 <script>
 import logger from '../logger'
-
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconDelete from 'vue-material-design-icons/Delete'
+import IconRename from 'vue-material-design-icons/Pencil'
+import IconCheck from 'vue-material-design-icons/Check'
 export default {
 	name: 'AliasForm',
+	components: {
+		ButtonVue,
+		IconRename,
+		IconLoading,
+		IconDelete,
+		IconCheck,
+	},
 	props: {
 		account: {
 			type: Object,

--- a/src/components/AliasSettings.vue
+++ b/src/components/AliasSettings.vue
@@ -38,34 +38,41 @@
 		</ul>
 
 		<div v-if="!account.provisioningId">
-			<button v-if="!showForm" class="primary icon-add" @click="showForm = true">
+			<ButtonVue v-if="!showForm" type="primary" @click="showForm = true">
 				{{ t('mail', 'Add alias') }}
-			</button>
+			</ButtonVue>
 
-			<button v-if="showForm"
-				class="primary"
-				:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
-				type="submit"
+			<ButtonVue v-if="showForm"
+				native-type="submit"
+				type="primary"
 				form="createAliasForm"
 				:disabled="loading">
+				<template #icon>
+					<IconLoading v-if="loading" :size="20" />
+					<IconCheck v-else :size="20" />
+				</template>
 				{{ t('mail', 'Create alias') }}
-			</button>
-			<button v-if="showForm"
+			</ButtonVue>
+			<ButtonVue v-if="showForm"
+				type="tertiary-no-background"
 				class="button-text"
 				@click="resetCreate">
 				{{ t("mail", "Cancel") }}
-			</button>
+			</ButtonVue>
 		</div>
 	</div>
 </template>
 
 <script>
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconCheck from 'vue-material-design-icons/Check'
 import logger from '../logger'
 import AliasForm from './AliasForm'
 
 export default {
 	name: 'AliasSettings',
-	components: { AliasForm },
+	components: { AliasForm, ButtonVue, IconLoading, IconCheck },
 	props: {
 		account: {
 			type: Object,
@@ -139,8 +146,8 @@ export default {
 input {
 	width: 195px;
 }
-
-.icon-add {
-	background-image: var(--icon-add-fff);
+::v-deep.button-vue {
+	display: inline-block !important;
+	margin-top: 4px !important;
 }
 </style>

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -1,11 +1,12 @@
 <template>
 	<div>
-		<router-link to="/setup" class="icon-add-white app-settings-button button primary new-button">
+		<router-link to="/setup" class="app-settings-button button primary new-button">
+			<IconAdd :size="20" />
 			{{ t('mail', 'Add mail account') }}
 		</router-link>
 
 		<p v-if="loadingOptOutSettings" class="app-settings">
-			<span class="icon-loading-small" />
+			<IconLoading :size="20" />
 			{{ optOutSettingsText }}
 		</p>
 		<p v-else class="app-settings">
@@ -19,7 +20,7 @@
 		</p>
 
 		<p v-if="toggleAutoTagging" class="app-settings">
-			<span class="icon-loading-small" />
+			<IconLoading :size="20" />
 			{{ autoTaggingText }}
 		</p>
 		<p v-else class="app-settings">
@@ -33,7 +34,7 @@
 		</p>
 
 		<p v-if="loadingAvatarSettings" class="app-settings avatar-settings">
-			<span class="icon-loading-small" />
+			<IconLoading :size="20" />
 			{{ t('mail', 'Use Gravatar and favicon avatars') }}
 		</p>
 		<p v-else class="app-settings">
@@ -47,7 +48,7 @@
 		</p>
 
 		<p v-if="loadingReplySettings" class="app-settings reply-settings">
-			<span class="icon-loading-small" />
+			<IconLoading :size="20" />
 			{{ replySettingsText }}
 		</p>
 		<p v-else class="app-settings">
@@ -61,23 +62,24 @@
 		</p>
 
 		<p>
-			<Button class="app-settings-button" @click="registerProtocolHandler">
+			<ButtonVue type="secondary" class="app-settings-button" @click="registerProtocolHandler">
 				<template #icon>
 					<IconEmail :size="20" />
 				</template>
 				{{ t('mail', 'Register as application for mail links') }}
-			</Button>
+			</ButtonVue>
 		</p>
 
-		<Button
+		<ButtonVue
 			class="app-settings-button"
+			type="secondary"
 			@click.prevent.stop="showKeyboardShortcuts"
 			@shortkey="toggleKeyboardShortcuts">
 			<template #icon>
 				<IconInfo :size="20" />
 			</template>
 			{{ t('mail', 'Show keyboard shortcuts') }}
-		</Button>
+		</ButtonVue>
 		<KeyboardShortcuts v-if="displayKeyboardShortcuts" @close="closeKeyboardShortcuts" />
 
 		<p class="mailvelope-section">
@@ -95,9 +97,12 @@
 <script>
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
-import Button from '@nextcloud/vue/dist/Components/NcButton'
+
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 
 import IconInfo from 'vue-material-design-icons/Information'
+import IconAdd from 'vue-material-design-icons/Plus'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import IconEmail from 'vue-material-design-icons/Email'
 import Logger from '../logger'
 import KeyboardShortcuts from '../views/KeyboardShortcuts'
@@ -105,10 +110,12 @@ import KeyboardShortcuts from '../views/KeyboardShortcuts'
 export default {
 	name: 'AppSettingsMenu',
 	components: {
-		Button,
+		ButtonVue,
 		KeyboardShortcuts,
 		IconInfo,
 		IconEmail,
+		IconAdd,
+		IconLoading,
 	},
 	data() {
 		return {
@@ -230,7 +237,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-p.app-settings span.icon-loading-small {
+p.app-settings span.loading-icon {
 	display: inline-block;
 	vertical-align: middle;
 	padding: 5px 0;
@@ -239,7 +246,7 @@ p.app-settings {
 	padding: 10px 0;
 }
 .app-settings-button {
-	display: block;
+	display: inline-flex;
 width: 100%;
 	background-position: 10px center;
 	text-align: left;
@@ -249,6 +256,7 @@ width: 100%;
 	color: var(--color-main-background);
 	//this style will be removed after we migrate also the  'add mail account' to material design
 	padding-left: 34px;
+	gap: 4px;
 }
 .app-settings-link {
 	text-decoration: underline;

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -214,22 +214,22 @@
 					<span v-else-if="!canSaveDraft" class="draft-status">{{ t('mail', 'Error saving draft') }}</span>
 					<span v-else-if="savingDraft === false" class="draft-status">{{ t('mail', 'Draft saved') }}</span>
 				</p>
-				<VButton v-if="!savingDraft && !canSaveDraft"
+				<ButtonVue v-if="!savingDraft && !canSaveDraft"
 					class="button"
 					type="tertiary"
 					@click="onSave">
 					<template #icon>
 						<Download :size="20" :title="t('mail', 'Save draft')" />
 					</template>
-				</VButton>
-				<VButton v-if="savingDraft === false"
+				</ButtonVue>
+				<ButtonVue v-if="savingDraft === false"
 					class="button"
 					type="tertiary"
 					@click="discardDraft">
 					<template #icon>
 						<Delete :size="20" :title="t('mail', 'Discard & close draft')" />
 					</template>
-				</VButton>
+				</ButtonVue>
 			</div>
 			<div class="composer-actions--secondary-actions">
 				<Actions @close="isMoreActionsOpen = false">
@@ -352,15 +352,17 @@
 					</template>
 				</Actions>
 
-				<Button :disabled="!canSend"
-					class="button primary send-button"
-					type="submit"
+				<ButtonVue :disabled="!canSend"
+					native-type="submit"
+					type="primary"
 					@click="onSend">
-					<Send
-						:title="submitButtonTitle"
-						:size="20" />
+					<template #icon>
+						<Send
+							:title="submitButtonTitle"
+							:size="20" />
+					</template>
 					{{ submitButtonTitle }}
-				</Button>
+				</ButtonVue>
 			</div>
 		</div>
 	</div>
@@ -374,24 +376,24 @@
 		<p v-if="errorText">
 			{{ errorText }}
 		</p>
-		<Button @click="state = STATES.EDITING">
+		<ButtonVue type="tertiary" @click="state = STATES.EDITING">
 			{{ t('mail', 'Go back') }}
-		</Button>
-		<Button @click="onSend">
+		</ButtonVue>
+		<ButtonVue type="tertiary" @click="onSend">
 			{{ t('mail', 'Retry') }}
-		</Button>
+		</ButtonVue>
 	</EmptyContent>
 	<div v-else-if="state === STATES.WARNING" class="emptycontent" role="alert">
 		<h2>{{ t('mail', 'Warning sending your message') }}</h2>
 		<p v-if="errorText">
 			{{ errorText }}
 		</p>
-		<Button @click="state = STATES.EDITING">
+		<ButtonVue type="tertiary" @click="state = STATES.EDITING">
 			{{ t('mail', 'Go back') }}
-		</Button>
-		<Button @click="onForceSend">
+		</ButtonVue>
+		<ButtonVue type="tertiary" @click="onForceSend">
 			{{ t('mail', 'Send anyway') }}
-		</Button>
+		</ButtonVue>
 	</div>
 	<EmptyContent v-else>
 		<template #icon>
@@ -408,12 +410,13 @@ import isArray from 'lodash/fp/isArray'
 import trimStart from 'lodash/fp/trimCharsStart'
 import Autosize from 'vue-autosize'
 import debouncePromise from 'debounce-promise'
+
 import Actions from '@nextcloud/vue/dist/Components/NcActions'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import ActionRadio from '@nextcloud/vue/dist/Components/NcActionRadio'
-import Button from '@nextcloud/vue/dist/Components/NcButton'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
 import Delete from 'vue-material-design-icons/Delete'
 import ComposerAttachments from './ComposerAttachments'
@@ -480,7 +483,7 @@ export default {
 		ActionCheckbox,
 		ActionInput,
 		ActionRadio,
-		VButton: Button,
+		ButtonVue,
 		ComposerAttachments,
 		ChevronLeft,
 		Delete,

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -240,7 +240,6 @@ import ListItem from '@nextcloud/vue/dist/Components/NcListItem'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon'
 import Avatar from './Avatar'
-import { calculateAccountColor } from '../util/AccountColor'
 import IconCreateEvent from 'vue-material-design-icons/Calendar'
 import CheckIcon from 'vue-material-design-icons/Check'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft'
@@ -362,10 +361,6 @@ export default {
 				email: this.account.emailAddress,
 			})
 			return recipients.to.concat(recipients.cc).length > 1
-		},
-		accountColor() {
-			const account = this.$store.getters.getAccount(this.data.accountId)
-			return calculateAccountColor(account?.emailAddress ?? '')
 		},
 		draft() {
 			return this.data.flags.draft
@@ -631,7 +626,7 @@ export default {
 .junk-icon-style {
 	opacity: .2;
 	display: flex;
-	top: 17px;
+	top: 14px;
 	left: 34px;
 	background-size: 16px;
 	height: 20px;
@@ -650,17 +645,6 @@ list-item-style.draft .app-content-list-item-line-two {
 .list-item-style.active {
 	background-color: var(--color-primary-light);
 	border-radius: 16px;
-}
-
-.icon-reply,
-.icon-attachment {
-	display: inline-block;
-	vertical-align: text-top;
-}
-
-.icon-reply {
-	-ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=25)';
-	opacity: 0.25;
 }
 
 .icon-attachment {
@@ -731,7 +715,7 @@ list-item-style.draft .app-content-list-item-line-two {
 }
 ::v-deep.icon-important.app-content-list-item-star {
 	position: absolute;
-	top: 17px;
+	top: 14px;
 	z-index: 1;
 }
 .app-content-list-item-star.favorite-icon-style {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -178,10 +178,7 @@
 			</div>
 		</transition>
 		<transition-group name="list">
-			<div id="list-refreshing"
-				key="loading"
-				class="icon-loading-small"
-				:class="{refreshing: refreshing}" />
+			<IconLoading v-if="refreshing" key="loading-icon" />
 			<Envelope
 				v-for="(env, index) in envelopes"
 				:key="env.databaseId"
@@ -212,6 +209,7 @@ import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import { showError } from '@nextcloud/dialogs'
 import Envelope from './Envelope'
 import IconDelete from 'vue-material-design-icons/Delete'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import ImportantIcon from './icons/ImportantIcon'
 import IconSelect from 'vue-material-design-icons/CloseThick'
 import IconFavorite from 'vue-material-design-icons/Star'
@@ -235,6 +233,7 @@ export default {
 		ImportantIcon,
 		IconFavorite,
 		IconSelect,
+		IconLoading,
 		MoveModal,
 		OpenInNewIcon,
 		ShareIcon,
@@ -522,30 +521,9 @@ div {
 }
 
 /* TODO: put this in core icons.css as general rule for buttons with icons */
-#load-more-mail-messages.icon-loading-small {
+#load-more-mail-messages {
 	padding-left: 32px;
 	background-position: 9px center;
-}
-
-#list-refreshing {
-	position: absolute;
-	left: calc(50% - 8px);
-	overflow: hidden;
-	padding: 12px;
-	background-color: var(--color-main-background);
-	z-index: 1;
-	border-radius: var(--border-radius-pill);
-	border: 1px solid var(--color-border);
-	top: -24px;
-	opacity: 0;
-	transition-property: top, opacity;
-	transition-duration: 0.5s;
-	transition-timing-function: ease-in-out;
-
-	&.refreshing {
-		top: 4px;
-		opacity: 1;
-	}
 }
 
 .multiselect-header-enter-active,

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -1,19 +1,23 @@
 <template>
 	<div class="wrapper">
 		<div v-if="hint" class="emptycontent">
-			<a class="icon-loading" />
+			<IconLoading :size="20" />
 			<h2>{{ hint }}</h2>
 			<transition name="fade">
 				<em v-if="slowHint && slow">{{ slowHint }}</em>
 			</transition>
 		</div>
-		<div v-else class="container icon-loading" />
+		<IconLoading v-else class="container" />
 	</div>
 </template>
 
 <script>
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 export default {
 	name: 'Loading',
+	components: {
+		IconLoading,
+	},
 	props: {
 		hint: {
 			type: String,

--- a/src/components/MailboxPicker.vue
+++ b/src/components/MailboxPicker.vue
@@ -49,16 +49,20 @@
 				<h2>{{ t('mail', 'No more submailboxes in here') }}</h2>
 			</div>
 			<div class="buttons">
-				<button class="primary" :disabled="loading || (!allowRoot && !selectedMailboxId)" @click="onSelect">
-					<span v-if="loading" class="icon-loading-small spinner" />
+				<ButtonVue type="primary" :disabled="loading || (!allowRoot && !selectedMailboxId)" @click="onSelect">
+					<template #icon>
+						<IconLoading v-if="loading" :size="20" />
+					</template>
 					{{ loading ? labelSelectLoading : labelSelect }}
-				</button>
+				</ButtonVue>
 			</div>
 		</div>
 	</Modal>
 </template>
 <script>
 import Modal from '@nextcloud/vue/dist/Components/NcModal'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import IconBreadcrumb from 'vue-material-design-icons/ChevronRight'
 import IconInbox from 'vue-material-design-icons/Home'
 import IconDraft from 'vue-material-design-icons/Pencil'
@@ -73,6 +77,7 @@ import { translate as translateMailboxName } from '../i18n/MailboxTranslator'
 export default {
 	name: 'MailboxPicker',
 	components: {
+		ButtonVue,
 		Modal,
 		IconInbox,
 		IconDraft,
@@ -81,6 +86,7 @@ export default {
 		IconTrash,
 		IconFolder,
 		IconBreadcrumb,
+		IconLoading,
 	},
 	props: {
 		account: {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -24,14 +24,14 @@
 					<div class="app-content-list-item">
 						<SectionTitle class="important" :name="t('mail', 'Important')" />
 						<Popover trigger="hover focus">
-							<Button slot="trigger"
+							<ButtonVue slot="trigger"
 								type="tertiary-no-background"
 								:aria-label="t('mail', 'Important info')"
 								class="button">
 								<template #icon>
 									<IconInfo :size="20" />
 								</template>
-							</Button>
+							</ButtonVue>
 							<p class="important-info">
 								{{ importantInfo }}
 							</p>
@@ -67,8 +67,9 @@
 <script>
 import AppContent from '@nextcloud/vue/dist/Components/NcAppContent'
 import AppContentList from '@nextcloud/vue/dist/Components/NcAppContentList'
-import Button from '@nextcloud/vue/dist/Components/NcButton'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import Popover from '@nextcloud/vue/dist/Components/NcPopover'
+
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import SectionTitle from './SectionTitle'
 import NewMessageButtonHeader from './NewMessageButtonHeader'
@@ -95,7 +96,7 @@ export default {
 	components: {
 		AppContent,
 		AppContentList,
-		Button,
+		ButtonVue,
 		IconInfo,
 		Mailbox,
 		NoMessageSelected,

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -34,28 +34,41 @@
 			<ActionButton
 				v-if="isCalendarEvent"
 				class="attachment-import calendar"
-				:icon="{'icon-add': !loadingCalendars, 'icon-loading-small': loadingCalendars}"
 				:disabled="loadingCalendars"
 				@click.stop="loadCalendars">
+				<template #icon>
+					<IconAdd v-if="!loadingCalendars" :size="20" />
+					<IconLoading v-else-if="loadingCalendars" :size="20" />
+				</template>
 				{{ t('mail', 'Import into calendar') }}
 			</ActionButton>
-			<ActionButton icon="icon-download"
+			<ActionButton
 				class="attachment-download"
 				@click="download">
+				<template #icon>
+					<IconDownload :size="20" />
+				</template>
 				{{ t('mail', 'Download attachment') }}
 			</ActionButton>
 			<ActionButton
 				class="attachment-save-to-cloud"
-				:icon="{'icon-folder': !savingToCloud, 'icon-loading-small': savingToCloud}"
 				:disabled="savingToCloud"
 				@click.stop="saveToCloud">
+				<template #icon>
+					<IconSave v-if="!savingToCloud" :size="20" />
+					<IconLoading v-else-if="savingToCloud" :size="20" />
+				</template>
 				{{ t('mail', 'Save to Files') }}
 			</ActionButton>
 			<div
 				v-on-click-outside="closeCalendarPopover"
 				class="popovermenu bubble attachment-import-popover hidden"
 				:class="{open: showCalendarPopover}">
-				<PopoverMenu :menu="calendarMenuEntries" />
+				<PopoverMenu :menu="calendarMenuEntries">
+					<template #icon>
+						<IconAdd :size="20" />
+					</template>
+				</PopoverMenu>
 			</div>
 		</Actions>
 	</div>
@@ -67,10 +80,15 @@ import { formatFileSize } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
 import { getFilePickerBuilder } from '@nextcloud/dialogs'
 import { mixin as onClickOutside } from 'vue-on-click-outside'
+
 import PopoverMenu from '@nextcloud/vue/dist/Components/NcPopoverMenu'
 import Actions from '@nextcloud/vue/dist/Components/NcActions'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconAdd from 'vue-material-design-icons/Plus'
+import IconSave from 'vue-material-design-icons/Folder'
+import IconDownload from 'vue-material-design-icons/Download'
 import Logger from '../logger'
 
 import { downloadAttachment, saveAttachmentToFiles } from '../service/AttachmentService'
@@ -82,6 +100,10 @@ export default {
 		PopoverMenu,
 		Actions,
 		ActionButton,
+		IconAdd,
+		IconLoading,
+		IconSave,
+		IconDownload,
 	},
 	mixins: [onClickOutside],
 	props: {
@@ -143,7 +165,6 @@ export default {
 		calendarMenuEntries() {
 			return this.calendars.map((cal) => {
 				return {
-					icon: 'icon-add',
 					text: cal.displayname,
 					action: this.importCalendar(cal.url),
 				}

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -39,23 +39,34 @@
 				@close="showPreview = false" />
 		</div>
 		<p v-if="moreThanOne" class="attachments-button-wrapper">
-			<button
+			<ButtonVue
+				type="secondary"
 				class="attachments-save-to-cloud"
-				:class="{'icon-folder': !savingToCloud, 'icon-loading-small': savingToCloud}"
 				:disabled="savingToCloud"
 				@click="saveAll">
+				<template #icon>
+					<IconLoading v-if="savingToCloud" :size="20" />
+					<IconFolder v-else-if="!savingToCloud" :size="20" />
+				</template>
 				{{ t('mail', 'Save all to Files') }}
-			</button>
-			<button
-				class="attachments-save-to-cloud icon-folder"
+			</ButtonVue>
+			<ButtonVue
+				type="secondary"
+				class="attachments-save-to-cloud"
 				@click="downloadZip">
+				<template #icon>
+					<IconFolder :size="20" />
+				</template>
 				{{ t('mail', 'Download Zip') }}
-			</button>
+			</ButtonVue>
 		</p>
 	</div>
 </template>
 
 <script>
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconFolder from 'vue-material-design-icons/Folder'
 import { generateUrl } from '@nextcloud/router'
 import { getFilePickerBuilder } from '@nextcloud/dialogs'
 import { saveAttachmentsToFiles } from '../service/AttachmentService'
@@ -69,6 +80,9 @@ export default {
 	components: {
 		AttachmentImageViewer,
 		MessageAttachment,
+		ButtonVue,
+		IconLoading,
+		IconFolder,
 	},
 	props: {
 		envelope: {
@@ -139,20 +153,16 @@ export default {
 <style lang="scss">
 .attachments {
 	width: 230px;
-  position: relative;
-  display: flex;
+	position: relative;
+	display: flex;
 }
 
 /* show icon + text for Download all button
 		as well as when there is only one attachment */
 .attachments-button-wrapper {
-	text-align: center;
-}
-.attachments-save-to-cloud {
-	display: inline-block;
-	margin: 16px;
-	background-position: 16px center;
-  padding: 12px 12px 12px 37px !important;
+	gap: 4px;
+	display: flex;
+	justify-content: center;
 }
 .oc-dialog {
 	z-index: 10000000;

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -27,7 +27,7 @@
 				</ActionButton>
 			</Actions>
 		</div>
-		<div v-if="loading" class="icon-loading" />
+		<IconLoading v-if="loading" />
 		<div id="message-container" :class="{hidden: loading, scroll: !fullHeight}">
 			<iframe ref="iframe"
 				class="message-frame"
@@ -48,6 +48,7 @@ import Actions from '@nextcloud/vue/dist/Components/NcActions'
 import IconImage from 'vue-material-design-icons/ImageSizeSelectActual'
 import IconMail from 'vue-material-design-icons/Email'
 import IconDomain from 'vue-material-design-icons/Domain'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 
 import logger from '../logger'
 import MdnRequest from './MdnRequest'
@@ -62,6 +63,7 @@ export default {
 		IconImage,
 		IconMail,
 		IconDomain,
+		IconLoading,
 	},
 	props: {
 		url: {

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -73,7 +73,10 @@
 						:size="20" />
 				</template>
 			</ActionInput>
-			<ActionText v-if="showSaving" icon="icon-loading-small">
+			<ActionText v-if="showSaving">
+				<template #icon>
+					<IconLoading :size="20" />
+				</template>
 				{{ t('mail', 'Saving') }}
 			</ActionText>
 			<ActionButton v-if="!isFirst" @click="changeAccountOrderUp">
@@ -105,11 +108,13 @@
 </template>
 
 <script>
+
 import AppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import ActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox'
 import ActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import ActionText from '@nextcloud/vue/dist/Components/NcActionText'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import { formatFileSize } from '@nextcloud/files'
 import { generateUrl } from '@nextcloud/router'
 
@@ -143,6 +148,7 @@ export default {
 		IconDelete,
 		IconError,
 		IconBullet,
+		IconLoading,
 	},
 	props: {
 		account: {

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -122,7 +122,11 @@
 						:size="20" />
 				</template>
 			</ActionInput>
-			<ActionText v-if="showSaving" icon="icon-loading-small">
+			<ActionText v-if="showSaving">
+				<template #icon>
+					<IconLoading
+						:size="20" />
+				</template>
 				{{ t('mail', 'Saving') }}
 			</ActionText>
 			<ActionButton v-if="!account.isUnified && hasDelimiter && !mailbox.specialRole && !hasSubMailboxes"
@@ -217,6 +221,7 @@ import IconInbox from 'vue-material-design-icons/Home'
 import IconAllInboxes from 'vue-material-design-icons/InboxMultiple'
 import ImportantIcon from './icons/ImportantIcon'
 import IconSend from 'vue-material-design-icons/Send'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import MoveMailboxModal from './MoveMailboxModal'
 import { UNIFIED_INBOX_ID } from '../store/constants'
 
@@ -253,6 +258,7 @@ export default {
 		IconArchive,
 		IconInbox,
 		ImportantIcon,
+		IconLoading,
 		MoveMailboxModal,
 	},
 	directives: {

--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -28,27 +28,40 @@
 			<span class="user-bubble-email">{{ email }}</span>
 		</UserBubble>
 		<div class="contact-wrapper">
-			<div v-if="contactsWithEmail && contactsWithEmail.length > 0" class="contact-existing">
-				<span class="icon-details">
-					{{ t('mail', 'Contacts with this address') }}:
-				</span>
+			<ButtonVue v-if="contactsWithEmail && contactsWithEmail.length > 0" type="tertiary-no-background" class="contact-existing">
+				<template #icon>
+					<IconDetails :size="20" />
+				</template>
+				{{ t('mail', 'Contacts with this address') }}:
 				<span>
 					{{ contactsWithEmailComputed }}
 				</span>
-			</div>
+			</ButtonVue>
 			<div v-if="selection === ContactSelectionStateEnum.select" class="contact-menu">
-				<a class="icon-reply" @click="onClickReply">
-					<span class="action-label">{{ t('mail', 'Reply') }}</span>
-				</a>
-				<a class="icon-user" @click="selection = ContactSelectionStateEnum.existing">
-					<span class="action-label">{{ t('mail', 'Add to Contact') }}</span>
-				</a>
-				<a class="icon-add" @click="selection = ContactSelectionStateEnum.new">
-					<span class="action-label">{{ t('mail', 'New Contact') }}</span>
-				</a>
-				<a class="icon-clippy" @click="onClickCopyToClipboard">
-					<span class="action-label">{{ t('mail', 'Copy to clipboard') }}</span>
-				</a>
+				<ButtonVue type="tertiary-no-background" @click="onClickReply">
+					<template #icon>
+						<IconReply :size="20" />
+					</template>
+					{{ t('mail', 'Reply') }}
+				</ButtonVue>
+				<ButtonVue type="tertiary-no-background" @click="selection = ContactSelectionStateEnum.existing">
+					<template #icon>
+						<IconUser :size="20" />
+					</template>
+					{{ t('mail', 'Add to Contact') }}
+				</ButtonVue>
+				<ButtonVue type="tertiary-no-background" @click="selection = ContactSelectionStateEnum.new">
+					<template #icon>
+						<IconAdd :size="20" />
+					</template>
+					{{ t('mail', 'New Contact') }}
+				</ButtonVue>
+				<ButtonVue type="tertiary-no-background" @click="onClickCopyToClipboard">
+					<template #icon>
+						<IconClipboard :size="20" />
+					</template>
+					{{ t('mail', 'Copy to clipboard') }}
+				</ButtonVue>
 			</div>
 			<div v-else class="contact-input-wrapper">
 				<Multiselect
@@ -70,17 +83,23 @@
 				<input v-else-if="selection === ContactSelectionStateEnum.new" v-model="newContactName">
 			</div>
 			<div v-if="selection !== ContactSelectionStateEnum.select">
-				<a class="icon-close" type="button" @click="selection = ContactSelectionStateEnum.select">
+				<ButtonVue type="tertiary-no-background" @click="selection = ContactSelectionStateEnum.select">
+					<template #icon>
+						<IconClose :size="20" />
+					</template>
 					{{ t('mail', 'Go back') }}
-				</a>
-				<a
+				</ButtonVue>
+
+				<ButtonVue
 					v-close-popover
 					:disabled="addButtonDisabled"
-					class="icon-checkmark"
-					type="button"
+					type="tertiary-no-background"
 					@click="onClickAddToContact">
+					<template #icon>
+						<IconCheck :size="20" />
+					</template>
 					{{ t('mail', 'Add') }}
-				</a>
+				</ButtonVue>
 			</div>
 		</div>
 	</Popover>
@@ -88,10 +107,19 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
+
 import UserBubble from '@nextcloud/vue/dist/Components/NcUserBubble'
 import Popover from '@nextcloud/vue/dist/Components/NcPopover'
 import Multiselect from '@nextcloud/vue/dist/Components/NcMultiselect'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 
+import IconReply from 'vue-material-design-icons/Reply'
+import IconAdd from 'vue-material-design-icons/Plus'
+import IconClose from 'vue-material-design-icons/Close'
+import IconClipboard from 'vue-material-design-icons/ClipboardText'
+import IconDetails from 'vue-material-design-icons/Information'
+import IconCheck from 'vue-material-design-icons/Check'
+import IconUser from 'vue-material-design-icons/Account'
 import { fetchAvatarUrlMemoized } from '../service/AvatarService'
 import { addToContact, findMatches, newContact, autoCompleteByName } from '../service/ContactIntegrationService'
 import uniqBy from 'lodash/fp/uniqBy'
@@ -104,9 +132,17 @@ const ContactSelectionStateEnum = Object.freeze({ new: 1, existing: 2, select: 3
 export default {
 	name: 'RecipientBubble',
 	components: {
+		ButtonVue,
 		UserBubble,
 		Popover,
 		Multiselect,
+		IconReply,
+		IconUser,
+		IconAdd,
+		IconClose,
+		IconClipboard,
+		IconDetails,
+		IconCheck,
 	},
 	props: {
 		email: {
@@ -251,38 +287,11 @@ export default {
 		width: 100%;
 	}
 }
-.icon-clippy,
-.icon-user,
-.icon-reply,
-.icon-checkmark,
-.icon-close,
-.icon-add {
-	display: flex;
-	align-items: center;
-	height: 44px;
-	min-width: 44px;
-	margin: 0;
-	padding: 9px 18px 10px 32px;
-}
-@media only screen and (min-width: 600px) {
-	.icon-clippy,
-	.icon-user,
-	.icon-reply,
-	.icon-checkmark,
-	.icon-close,
-	.icon-add {
-		background-position: 12px center;
-	}
-}
 
 .contact-existing {
-	margin-bottom: 10px;
-	font-size: small;
-	.icon-details {
-		padding-left: 34px;
-		background-position: 10px center;
-		text-align: left;
-	}
+	font-size: small !important;
 }
-
+::v-deep .button-vue__text {
+	font-weight: normal !important;
+}
 </style>

--- a/src/components/RecipientListItem.vue
+++ b/src/components/RecipientListItem.vue
@@ -51,9 +51,8 @@ export default {
 	width: auto;
 	min-width: 24px;
 	height: 24px;
-	min-height: 24px;
 	position: absolute;
-	right: 0;
+	right: -7px;
 }
 .multiselect__tag--recipient .action-item--single .material-design-icon {
 	height: 24px;

--- a/src/components/SieveAccountForm.vue
+++ b/src/components/SieveAccountForm.vue
@@ -125,17 +125,21 @@
 			{{ t('mail', 'Oh Snap!') }}
 			{{ errorMessage }}
 		</p>
-		<input type="submit"
-			class="primary"
+		<ButtonVue type="primary"
 			:disabled="loading"
-			:value="submitButtonText"
 			@click.prevent="onSubmit">
+			{{ t('mail', 'Save sieve settings') }}
+		</ButtonVue>
 	</form>
 </template>
 
 <script>
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 export default {
 	name: 'SieveAccountForm',
+	components: {
+		ButtonVue,
+	},
 	props: {
 		account: {
 			type: Object,
@@ -155,7 +159,6 @@ export default {
 			loading: false,
 			useImapCredentials: !this.account.sieveUser,
 			errorMessage: '',
-			submitButtonText: t('mail', 'Save sieve settings'),
 		}
 	},
 	methods: {

--- a/src/components/SieveFilterForm.vue
+++ b/src/components/SieveFilterForm.vue
@@ -10,21 +10,31 @@
 			{{ t('mail', 'Oh Snap!') }}
 			{{ errorMessage }}
 		</p>
-		<button
+		<ButtonVue
 			class="primary"
-			:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
 			:disabled="loading"
 			@click="saveActiveScript">
+			<template #icon>
+				<IconLoading v-if="loading" :size="20" />
+				<IconCheck v-else :size="20" />
+			</template>
 			{{ t('mail', 'Save sieve script') }}
-		</button>
+		</ButtonVue>
 	</div>
 </template>
 
 <script>
 import { getActiveScript, updateActiveScript } from '../service/SieveService'
-
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconCheck from 'vue-material-design-icons/Check'
 export default {
 	name: 'SieveFilterForm',
+	components: {
+		ButtonVue,
+		IconLoading,
+		IconCheck,
+	},
 	props: {
 		account: {
 			type: Object,

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -45,16 +45,22 @@
 			:html="true"
 			:placeholder="t('mail', 'Signature …')"
 			:bus="bus" />
-		<button
-			class="primary"
-			:class="loading ? 'icon-loading-small-dark' : 'icon-checkmark-white'"
+		<ButtonVue
+			type="primary"
 			:disabled="loading"
 			@click="saveSignature">
-			{{ t("mail", "Save signature") }}
-		</button>
-		<button v-if="signature" class="button-text" @click="deleteSignature">
-			{{ t("mail", "Delete") }}
-		</button>
+			<template #icon>
+				<IconLoading v-if="loading" :size="20" fill-color="white" />
+				<IconCheck v-else :size="20" />
+			</template>
+			{{ t('mail', 'Save signature') }}
+		</ButtonVue>
+		<ButtonVue v-if="signature"
+			type="tertiary-no-background"
+			class="button-text"
+			@click="deleteSignature">
+			{{ t('mail', 'Delete') }}
+		</ButtonVue>
 	</div>
 </template>
 
@@ -63,13 +69,20 @@ import logger from '../logger'
 import TextEditor from './TextEditor'
 import { detect, toHtml } from '../util/text'
 import Vue from 'vue'
+
 import Multiselect from '@nextcloud/vue/dist/Components/NcMultiselect'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconCheck from 'vue-material-design-icons/Check'
 
 export default {
 	name: 'SignatureSettings',
 	components: {
 		TextEditor,
 		Multiselect,
+		ButtonVue,
+		IconLoading,
+		IconCheck,
 	},
 	props: {
 		account: {
@@ -204,9 +217,11 @@ export default {
 .multiselect--single {
   width: 100%;
 }
-</style>
-<style>
 .ck-balloon-panel {
-  z-index: 10000 !important;
+	 z-index: 10000 !important;
+ }
+::v-deep.button-vue {
+	display: inline-block !important;
+	margin-top: 4px !important;
 }
 </style>

--- a/src/components/TagModal.vue
+++ b/src/components/TagModal.vue
@@ -50,8 +50,10 @@
 						</template>
 					</ActionInput>
 					<ActionText
-						v-if="showSaving"
-						icon="icon-loading-small">
+						v-if="showSaving">
+						<template #icon>
+							<IconLoading :size="20" />
+						</template>
 						{{ t('mail', 'Saving new tag name …') }}
 					</ActionText>
 				</Actions>
@@ -79,8 +81,10 @@
 					<IconTag :size="20" />
 				</ActionInput>
 				<ActionText
-					v-if="showSaving"
-					icon="icon-loading-small">
+					v-if="showSaving">
+					<template #icon>
+						<IconLoading :size="20" />
+					</template>
 					{{ t('mail', 'Saving tag …') }}
 				</ActionText>
 			</div>
@@ -96,6 +100,7 @@ import ActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
 import IconRename from 'vue-material-design-icons/Pencil'
 import IconTag from 'vue-material-design-icons/Tag'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import { showError, showInfo } from '@nextcloud/dialogs'
 import { hiddenTags } from './tags.js'
 
@@ -116,6 +121,7 @@ export default {
 		ActionButton,
 		IconRename,
 		IconTag,
+		IconLoading,
 	},
 	props: {
 		envelope: {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -258,12 +258,6 @@ export default {
 <style lang="scss">
 #mail-message {
 	flex-grow: 1;
-
-	.icon-loading {
-		&:only-child:after {
-			margin-top: 20px;
-		}
-	}
 }
 
 .mail-message-body {
@@ -347,14 +341,6 @@ export default {
 	border-bottom: 1px dotted #07d;
 	text-decoration: none;
 	word-wrap: break-word;
-}
-
-.icon-reply-white,
-.icon-reply-all-white {
-	height: 44px;
-	min-width: 44px;
-	margin: 0 !important;
-	padding: 9px 18px 10px 32px !important;
 }
 
 /* Show action button label and move icon to the left

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -78,7 +78,7 @@
 			<div class="right">
 				<Moment class="timestamp" :timestamp="envelope.dateInt" />
 				<template v-if="expanded">
-					<Button
+					<ButtonVue
 						:class="{ primary: expanded}"
 						:title="hasMultipleRecipients ? t('mail', 'Reply all') : t('mail', 'Reply')"
 						type="tertiary-no-background"
@@ -89,8 +89,8 @@
 							<ReplyIcon v-else
 								:size="20" />
 						</template>
-					</Button>
-					<Button
+					</ButtonVue>
+					<ButtonVue
 						type="tertiary-no-background"
 						class="action--primary"
 						:title="envelope.flags.flagged ? t('mail', 'Mark as unfavorite') : t('mail', 'Mark as favorite')"
@@ -102,8 +102,8 @@
 							<IconFavorite v-else
 								:size="20" />
 						</template>
-					</Button>
-					<Button
+					</ButtonVue>
+					<ButtonVue
 						type="tertiary-no-background"
 						class="action--primary"
 						:title="envelope.flags.seen ? t('mail', 'Mark as unread') : t('mail', 'Mark as read')"
@@ -115,8 +115,8 @@
 							<EmailUnread v-else
 								:size="20" />
 						</template>
-					</Button>
-					<Button :close-after-click="true"
+					</ButtonVue>
+					<ButtonVue :close-after-click="true"
 						type="tertiary-no-background"
 						@click.prevent="onDelete">
 						<template #icon>
@@ -124,7 +124,7 @@
 								:title="t('mail', 'Delete message')"
 								:size="20" />
 						</template>
-					</Button>
+					</ButtonVue>
 					<MenuEnvelope class="app-content-list-item-menu"
 						:envelope="envelope"
 						:with-reply="false"
@@ -148,7 +148,7 @@
 </template>
 <script>
 import Avatar from './Avatar'
-import Button from '@nextcloud/vue/dist/Components/NcButton'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import Error from './Error'
 import importantSvg from '../../img/important.svg'
 import IconFavorite from 'vue-material-design-icons/Star'
@@ -174,7 +174,7 @@ export default {
 	name: 'ThreadEnvelope',
 	components: {
 		Avatar,
-		Button,
+		ButtonVue,
 		Error,
 		IconFavorite,
 		JunkIcon,

--- a/src/components/TrustedSenders.vue
+++ b/src/components/TrustedSenders.vue
@@ -25,10 +25,11 @@
 			:key="sender.email">
 			{{ sender.email }}
 			{{ senderType(sender.type) }}
-			<button class="button"
+			<ButtonVue type="tertiary"
+				class="button"
 				@click="removeSender(sender)">
 				{{ t('mail','Remove') }}
-			</button>
+			</ButtonVue>
 		</div>
 		<span v-if="!sortedSenders.length"> {{ t('mail', 'No senders are trusted at the moment.') }}</span>
 	</div>
@@ -37,6 +38,7 @@
 <script>
 
 import { fetchTrustedSenders, trustSender } from '../service/TrustedSenderService'
+import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import prop from 'lodash/fp/prop'
 import sortBy from 'lodash/fp/sortBy'
 import logger from '../logger'
@@ -46,6 +48,9 @@ const sortByEmail = sortBy(prop('email'))
 
 export default {
 	name: 'TrustedSenders',
+	components: {
+		ButtonVue,
+	},
 
 	data() {
 		return {
@@ -95,5 +100,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
+::v-deep.button-vue {
+	display: inline-block !important;
+}
 </style>

--- a/src/components/itinerary/CalendarImport.vue
+++ b/src/components/itinerary/CalendarImport.vue
@@ -20,20 +20,30 @@
   -->
 
 <template>
-	<Actions v-if="calendars.length" default-icon="icon-add">
+	<Actions v-if="calendars.length">
+		<template #icon>
+			<IconAdd :size="20" />
+		</template>
 		<ActionButton
 			v-for="(calendar, idx) in cals"
 			:key="idx"
-			:icon="calendar.loading ? 'icon-loading-small' : 'icon-add'"
 			@click="onImport(calendar)">
+			<template #icon>
+				<IconLoading v-if="calendar.loading" :size="20" />
+				<IconAdd v-else :size="20" />
+			</template>
 			{{ t('mail', 'Import into {calendar}', {calendar: calendar.displayname}) }}
 		</ActionButton>
 	</Actions>
 </template>
 
 <script>
+
 import Actions from '@nextcloud/vue/dist/Components/NcActions'
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton'
+
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
+import IconAdd from 'vue-material-design-icons/Plus'
 import ical from 'ical.js'
 import moment from '@nextcloud/moment'
 
@@ -42,6 +52,8 @@ export default {
 	components: {
 		Actions,
 		ActionButton,
+		IconAdd,
+		IconLoading,
 	},
 	props: {
 		calendars: {


### PR DESCRIPTION
Ref https://github.com/nextcloud/groupware/issues/38
To do
- [x] All the Loading icons
- [x] some leftovers (icons on attachments)
- [x] change button to buttonvue - for the icon parts
- [x] Requires https://github.com/nextcloud/mail/pull/7060
- [x] Requires https://github.com/nextcloud/nextcloud-vue/pull/3092 because https://github.com/nextcloud/nextcloud-vue/pull/3066

there are some bugs because of nc/vue update but not connected to this pr, those bugs can be found here: https://github.com/nextcloud/mail/pull/7071

test carefully composer(send email, drafts and stuff) and loading envelopes
