### PR TITLE
Add textarea to global v-shortkey ignore list

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -46,7 +46,7 @@ sync(store, router)
 
 Vue.mixin(Nextcloud)
 
-Vue.use(VueShortKey, { prevent: ['input', 'div'] })
+Vue.use(VueShortKey, { prevent: ['input', 'div', 'textarea'] })
 Vue.use(vToolTip)
 Vue.use(VueClipboard)
 


### PR DESCRIPTION
Prevent keyboard shortcuts (e.g. "r") from being captured while editing text inside a textarea.

Backport is not strictly required because I discovered this while developing an upcoming feature.

Ref https://www.npmjs.com/package/vue-shortkey#avoided-fields