### PR TITLE
Fix spreading of non-array event payload

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -192,7 +192,7 @@
 				:has-multiple-accounts="hasMultipleAccounts"
 				:selected-envelopes="selectedEnvelopes"
 				@delete="$emit('delete', env.databaseId)"
-				@update:selected="onEnvelopeSelectToggle(env, index, ...$event)"
+				@update:selected="onEnvelopeSelectToggle(env, index, $event)"
 				@select-multiple="onEnvelopeSelectMultiple(env, index)" />
 			<div
 				v-if="loadMoreButton && !loadingMore"


### PR DESCRIPTION
## How to test

1) Open the app
2) Open the actions menu of an envelope
3) Click *Select*

Main: 

```
TypeError: Invalid attempt to spread non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
    at _nonIterableSpread (EnvelopeList.vue?b2bb:3:1)
    at _toConsumableArray (EnvelopeList.vue?b2bb:1:1)
    at updateSelected (EnvelopeList.vue?b2bb:247:1)
    at invokeWithErrorHandling (vue.runtime.esm.js:2988:1)
    at VueComponent.invoker (vue.runtime.esm.js:1786:1)
    at invokeWithErrorHandling (vue.runtime.esm.js:2988:1)
    at Vue.$emit (vue.runtime.esm.js:3677:1)
    at VueComponent.toggleSelected (Envelope.vue?a108:267:1)
    at click (Envelope.vue?a7ba:246:1)
    at invokeWithErrorHandling (vue.runtime.esm.js:2988:1)
```

Here: :sunglasses: 