### PR TITLE
Preview message content in the thread view

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -37,7 +37,6 @@
 				:key="env.databaseId"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
-				:thread-subject="threadSubject"
 				:expanded="expandedThreads.includes(env.databaseId)"
 				:full-height="thread.length === 1"
 				@delete="$emit('delete', env.databaseId)"


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/2579

![Bildschirmfoto vom 2022-08-18 09-10-27](https://user-images.githubusercontent.com/1374172/185330837-aea2143e-8cf1-40d5-a91c-d9ef35a9c6de.png)

## Todo

* [x] Go in the subline below the sender
* [x] Be in color-text-maxcontrast
* [x] Only show for collapsed mails cause for expanded ones it would duplicate otherwise
* [x] Fix width/overflow
