### PR TITLE
Mark avatar has immutable

### DIFF
--- a/lib/Controller/AvatarsController.php
+++ b/lib/Controller/AvatarsController.php
@@ -82,7 +82,7 @@ class AvatarsController extends Controller {
 		$response = new JSONResponse($avatar);
 
 		// Let the browser cache this for a week
-		$response->cacheFor(7 * 24 * 60 * 60);
+		$response->cacheFor(7 * 24 * 60 * 60, false, true);
 
 		return $response;
 	}
@@ -112,7 +112,7 @@ class AvatarsController extends Controller {
 		$resp->addHeader('Content-Type', $avatar->getMime());
 
 		// Let the browser cache this for a week
-		$resp->cacheFor(7 * 24 * 60 * 60);
+		$resp->cacheFor(7 * 24 * 60 * 60, false, true);
 
 		return $resp;
 	}

--- a/tests/Unit/Controller/AvatarControllerTest.php
+++ b/tests/Unit/Controller/AvatarControllerTest.php
@@ -83,7 +83,7 @@ class AvatarControllerTest extends TestCase {
 		$resp = $this->controller->url($email);
 
 		$expected = new JSONResponse($avatar);
-		$expected->cacheFor(7 * 24 * 60 * 60);
+		$expected->cacheFor(7 * 24 * 60 * 60, false, true);
 		$this->assertEquals($expected, $resp);
 	}
 
@@ -112,7 +112,7 @@ class AvatarControllerTest extends TestCase {
 
 		$expected = new AvatarDownloadResponse('data');
 		$expected->addHeader('Content-Type', 'image/jpeg');
-		$expected->cacheFor(7 * 24 * 60 * 60);
+		$expected->cacheFor(7 * 24 * 60 * 60, false, true);
 		$this->assertEquals($expected, $resp);
 	}
 


### PR DESCRIPTION
This will prevent firefox and safari generating a requests that is hitting the DB on each page load just to check if the etag changed