### PR TITLE
[POC] for threading messages prefetch

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -334,6 +334,20 @@ export default {
 				await this.fetchItineraries()
 			}
 		},
+		async fetchPartialThread() {
+			this.loading = true
+
+			logger.debug(`fetching partial thread messages ${this.envelope.databaseId}`)
+
+			try {
+				this.messages = await this.$store.dispatch('fetchPartialThread', this.envelope.databaseId)
+				logger.debug(`first and second to last messages in thread for ${this.envelope.databaseId} fetched`, { message: this.message })
+
+				this.loading = false
+			} catch (error) {
+				logger.error('Could not fetch message', { error })
+			}
+		},
 		async fetchItineraries() {
 			// Sanity check before actually making the request
 			if (!this.message.hasHtmlBody && this.message.attachments.length === 0) {

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -61,6 +61,22 @@ export const fetchThread = async (id) => {
 	return resp.data
 }
 
+export const fetchPartialThread = async (id) => {
+	const url = generateUrl('apps/mail/api/messages/{id}/partialthread', {
+		id,
+	})
+	const resp = await axios.get(url)
+	return resp.data
+}
+
+export const fetchThreadSiblings = async (id) => {
+	const url = generateUrl('apps/mail/api/messages/{id}/threadsiblings', {
+		id,
+	})
+	const resp = await axios.get(url)
+	return resp.data
+}
+
 export async function syncEnvelopes(accountId, id, ids, query, init = false) {
 	const url = generateUrl('/apps/mail/api/mailboxes/{id}/sync', {
 		id,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -896,11 +896,43 @@ export default {
 		return thread
 	},
 	async fetchMessage({ getters, commit }, id) {
-		const message = await fetchMessage(id)
-		// Only commit if not undefined (not found)
-		if (message) {
+		let message = getters.getMessage(id)
+		if(!message) {
+			message = await fetchMessage(id)
+			// Only commit if not undefined (not found)
+			if (message) {
+				commit('addMessage', {
+					message,
+				})
+			}
+		}
+
+		const messages = getters.getThreadEnvelopesByMessageId(id)
+		const index = messages.findIndex(x => x.databaseId === id)
+		const isLast = (messages.length - 1) === index
+		if(isLast) {
+			let firstMessage = getters.getMessage(messages[0].databaseId) ?? await fetchMessage(messages[0].databaseId)
+			console.log(firstMessage)
 			commit('addMessage', {
-				message,
+				message: firstMessage,
+			})
+			if(messages.length > 2) {
+				let secondToLast = getters.getMessage(messages[messages.length - 2].databaseId) ?? await fetchMessage(messages[messages.length - 2].databaseId)
+				console.log(secondToLast)
+				commit('addMessage', {
+					message: secondToLast,
+				})
+			}
+		} else {
+			if((index - 1) <= 0) {
+				let firstMessage = getters.getMessage(messages[index -1].databaseId) ?? await fetchMessage(messages[index -1].databaseId)
+				commit('addMessage', {
+					message: firstMessage,
+				})
+			}
+			const secondMessage = getters.getMessage(messages[index + 1].databaseId) ?? await fetchMessage(messages[index + 1].databaseId)
+			commit('addMessage', {
+				message: secondMessage,
 			})
 		}
 		return message

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -76,6 +76,13 @@ export const getters = {
 			Object.values(state.envelopes).filter(envelope => envelope.accountId === accountId && envelope.threadRootId === threadRootId)
 		)
 	},
+	getThreadEnvelopesByMessageId: (state) => (id) => {
+		const envelope = state.envelopes[id]
+		return sortBy(
+			prop('dateInt'),
+			Object.values(state.envelopes).filter(x => x.accountId === envelope.accountId && x.threadRootId === envelope.threadRootId)
+		)
+	},
 	getMessage: (state) => (id) => {
 		return state.messages[id]
 	},


### PR DESCRIPTION
Still has some issues with fetching the first message - but POC so :shrug: 

The idea is to prefetch a predetermined set of thread messages in the background to speed up threading.

Prefetch logic:

If the message is the last in the thread, get the second to last message and the first message of a thread. Reason: the user might want to look at the previous message to see what someone else said before them, or go back to the beginning to see what the thread is about.

If the message is in the middle of a thread, fetch the previous and following message. Reason: the user might search for a message that is somewhere in the middle and could concievably click one message further up or down to find what they are looking for.

The pre- fetched messages won't always be 100% what is needed, but it might still speed up rendering considerably.

Fixes https://github.com/nextcloud/mail/issues/7055