### PR TITLE
Fix active state on envelope

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -12,6 +12,7 @@
 		:to="link"
 		:data-envelope-id="data.databaseId"
 		:title="addresses"
+		:active="isActive"
 		:details="formatted()"
 		@click="onClick">
 		<template #icon>
@@ -460,6 +461,9 @@ export default {
 				id: this.data.databaseId,
 			})
 		},
+		isActive() {
+			return parseInt(this.$route.params.threadId) === this.data.databaseId
+		},
 	},
 	methods: {
 		setSelected(value) {
@@ -646,10 +650,6 @@ export default {
 }
 list-item-style.draft .app-content-list-item-line-two {
 	font-style: italic;
-}
-.list-item-style.active {
-	background-color: var(--color-primary-light);
-	border-radius: 16px;
 }
 
 .icon-reply,


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/7098

for some reasons, the active state on envelope is not handled by vue router, i dont know why.
Adding the :active on listitem on evelope makes it work again(aka using the style from nc/vue component without forcing style on mail side)
