### PR TITLE
Remove unneccessary account check

### DIFF
--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -75,7 +75,6 @@ class OutboxController extends Controller {
 	 */
 	public function show(int $id): JsonResponse {
 		$message = $this->service->getMessage($id, $this->userId);
-		$this->accountService->find($this->userId, $message->getAccountId());
 		return JsonResponse::success($message);
 	}
 

--- a/tests/Unit/Controller/OutboxControllerTest.php
+++ b/tests/Unit/Controller/OutboxControllerTest.php
@@ -98,8 +98,6 @@ class OutboxControllerTest extends TestCase {
 			->method('getMessage')
 			->with($message->getId(), $this->userId)
 			->willReturn($message);
-		$this->accountService->expects(self::once())
-			->method('find');
 
 		$expected = JsonResponse::success($message);
 		$actual = $this->controller->show($message->getId());
@@ -115,27 +113,8 @@ class OutboxControllerTest extends TestCase {
 			->method('getMessage')
 			->with($message->getId(), $this->userId)
 			->willThrowException(new DoesNotExistException(''));
-		$this->accountService->expects(self::never())
-			->method('find');
 
 		$this->expectException(DoesNotExistException::class);
-		$this->controller->show($message->getId());
-	}
-
-	public function testShowAccountNotFound(): void {
-		$message = new LocalMessage();
-		$message->setId(1);
-		$message->setAccountId(1);
-
-		$this->service->expects(self::once())
-			->method('getMessage')
-			->with($message->getId(), $this->userId)
-			->willReturn($message);
-		$this->accountService->expects(self::once())
-			->method('find')
-			->willThrowException(new ClientException('', 400));
-
-		$this->expectException(ClientException::class);
 		$this->controller->show($message->getId());
 	}
 


### PR DESCRIPTION
Stumbled upon this while working on the Drafts, as discussed with @juliushaertl before.

As we're already joining on the user accounts table in `findById`, the account doesn't need to be queried again for the Controller's `show`.

This is a mini performance optimistation.

The complete account data could also be returned with the JOIN queries as a second
performance improvement, instead of querying the entity fromt he DB again. The update method does just that at the moment, which could be optimised for further performance improvements.