### PR TITLE
Make it clear that not all attachments will be sent

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1035,8 +1035,8 @@ export default {
 			this.attachmentsPromise = this.attachmentsPromise
 				.then(() => uploaded)
 				.then(() => this.callSaveDraft(true, this.getMessageData))
-				.catch((error) => logger.error('could not upload attachments', { error }))
 				.then(() => logger.debug('attachments uploaded'))
+				.catch((error) => logger.error('could not upload attachments', { error }))
 		},
 		async onMailvelopeLoaded(mailvelope) {
 			this.encrypt = isPgpgMessage(this.body)

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -22,14 +22,21 @@
 
 <template>
 	<div class="new-message-attachments">
-		<div v-if="hasNextLine" class="message-attachments-count" @click="isToggle = !isToggle">
+		<div v-if="hasNextLine"
+			class="new-message-attachments--counter"
+			:class="{ 'new-message-attachments--counter--with-errors': hasAttachmentErrors }"
+			@click="isToggle = !isToggle">
 			<span>
 				{{ n('mail', '{count} attachment', '{count} attachments', attachments.length, { count: attachments.length }) }} ({{ formatBytes(totalSizeOfUpload()) }})
 			</span>
 			<ChevronUp v-if="isToggle" :size="24" />
 			<ChevronDown v-if="!isToggle" :size="24" />
 		</div>
-		<ul class="new-message-attachments--list" :class="isToggle ? 'hide' : (hasNextLine ? 'active' : '')">
+		<ul class="new-message-attachments--list"
+			:class="{
+				hide: isToggle,
+				active: !isToggle && hasNextLine,
+			}">
 			<ComposerAttachment
 				v-for="attachment in attachments"
 				ref="attachments"
@@ -110,6 +117,9 @@ export default {
 		}
 	},
 	computed: {
+		hasAttachmentErrors() {
+			return this.attachments.some(attachment => attachment.error)
+		},
 		uploadProgress() {
 			let uploaded = 0
 			let total = 0
@@ -268,7 +278,7 @@ export default {
 							}])
 						})
 				} catch (error) {
-
+					logger.error('Could not upload file', { file, error })
 				}
 			}, e.target.files)
 
@@ -422,7 +432,19 @@ export default {
 <style scoped lang="scss">
 
 .new-message-attachments {
-	ul.new-message-attachments--list {
+	&--counter {
+		color: var(--color-text-maxcontrast);
+		padding: 10px 20px;
+		cursor:pointer;
+		display:flex;
+		align-items: center;
+
+		&--with-errors {
+			color:red;
+		}
+	}
+
+	&--list {
 		display: flex;
 		flex-wrap: wrap;
 		// 2 and a half attachment height
@@ -440,14 +462,6 @@ export default {
 			overflow: auto;
 			max-height: 287px;
 		}
-	}
-
-	.message-attachments-count {
-		color: var(--color-text-maxcontrast);
-		padding: 10px 20px;
-		cursor:pointer;
-		display:flex;
-		align-items: center;
 	}
 }
 </style>


### PR DESCRIPTION
If you upload a handful of attachments, the list collapses due to https://github.com/nextcloud/mail/pull/6660 and upload errors are not noticeable visibly anymore. This changes the color of the collapse handle to reflect errors.

![Bildschirmfoto vom 2022-08-25 14-25-58](https://user-images.githubusercontent.com/1374172/186664266-fe69bc01-d5ca-4753-87ad-c1c86221bd50.png)

![Bildschirmfoto vom 2022-08-25 14-26-12](https://user-images.githubusercontent.com/1374172/186664291-4e73ddd3-ea6e-47de-bfa2-1bd9e84ec7b3.png)

I believe the flow and error handling has still a lot of potential for improvement. E.g. to disable the send button until all errors are handled (user needs to remove the faulty attachment or we never add it) but that requires larger restructuring.