### PR TITLE
Implement automatic out-of-office replies

### DIFF
--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -1,0 +1,315 @@
+<!--
+  - @copyright Copyright (c) 2022 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<!-- Wait until sieve script has been fetched before showing form. -->
+	<form v-if="sieveScriptData" class="form" @submit.prevent="submit">
+		<div class="form__multi-row">
+			<fieldset class="form__fieldset">
+				<input
+					id="ooo-disabled"
+					class="radio"
+					type="radio"
+					name="enabled"
+					:checked="!enabled"
+					@change="enabled = false">
+				<label for="ooo-disabled">{{ t('mail', 'Vacation responder off') }}</label>
+			</fieldset>
+
+			<fieldset class="form__fieldset">
+				<input
+					id="ooo-enabled"
+					class="radio"
+					type="radio"
+					name="enabled"
+					:checked="enabled"
+					@change="enabled = true">
+				<label for="ooo-enabled">{{ t('mail', 'Vacation responder on') }}</label>
+			</fieldset>
+		</div>
+
+		<div class="form__multi-row">
+			<fieldset class="form__fieldset">
+				<label for="ooo-first-day">{{ t('mail', 'First day') }}</label>
+				<DatetimePicker
+					id="ooo-first-day"
+					v-model="firstDay"
+					:disabled="!enabled" />
+			</fieldset>
+
+			<fieldset class="form__fieldset">
+				<div class="form__fieldset__label">
+					<input
+						id="ooo-enable-last-day"
+						v-model="enableLastDay"
+						type="checkbox"
+						:disabled="!enabled">
+					<label for="ooo-enable-last-day">
+						{{ t('mail', 'Last day (optional)') }}
+					</label>
+				</div>
+				<DatetimePicker
+					id="ooo-last-day"
+					v-model="lastDay"
+					:disabled="!enabled || !enableLastDay" />
+			</fieldset>
+		</div>
+
+		<fieldset class="form__fieldset">
+			<label for="ooo-subject">{{ t('mail', 'Subject') }}</label>
+			<input
+				id="ooo-subject"
+				v-model="subject"
+				type="text"
+				:disabled="!enabled">
+		</fieldset>
+
+		<fieldset class="form__fieldset">
+			<label for="ooo-message">{{ t('mail', 'Message') }}</label>
+			<TextEditor
+				id="ooo-message"
+				v-model="message"
+				:html="false"
+				:disabled="!enabled"
+				:bus="{ '$on': () => { /* noop */ } }" />
+		</fieldset>
+
+		<p v-if="errorMessage">
+			{{ t('mail', 'Oh Snap!') }}
+			{{ errorMessage }}
+		</p>
+
+		<Button type="primary" native-type="submit" :disabled="loading || !valid">
+			<template #icon>
+				<CheckIcon :size="20" />
+			</template>
+			{{ t('mail', 'Save vacation responder') }}
+		</Button>
+	</form>
+</template>
+
+<script>
+import DatetimePicker from '@nextcloud/vue/dist/Components/NcDatetimePicker'
+import TextEditor from './TextEditor'
+import Button from '@nextcloud/vue/dist/Components/NcButton'
+import CheckIcon from 'vue-material-design-icons/Check'
+import { buildOutOfOfficeSieveScript, parseOutOfOfficeState } from '../util/outOfOffice'
+import logger from '../logger'
+import { html, toPlain } from '../util/text'
+
+export default {
+	name: 'OutOfOfficeForm',
+	components: {
+		DatetimePicker,
+		TextEditor,
+		Button,
+		CheckIcon,
+	},
+	props: {
+		account: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			enabled: false,
+			enableLastDay: false,
+			firstDay: new Date(),
+			lastDay: null,
+			subject: '',
+			message: '',
+			loading: false,
+			errorMessage: '',
+		}
+	},
+	computed: {
+		/**
+		 * @return {boolean}
+		 */
+		valid() {
+			return !!(this.firstDay
+				&& (!this.enableLastDay || (this.enableLastDay && this.lastDay))
+				&& (!this.enableLastDay || (this.lastDay >= this.firstDay))
+				&& this.subject
+				&& this.message)
+		},
+
+		/**
+		 * @return {{script: string, scriptName: string}|undefined}
+		 */
+		sieveScriptData() {
+			return this.$store.getters.getActiveSieveScript(this.account.id)
+		},
+
+		/**
+		 * @return {object|undefined}
+		 */
+		parsedState() {
+			if (!this.sieveScriptData?.script) {
+				return undefined
+			}
+
+			try {
+				return parseOutOfOfficeState(this.sieveScriptData.script).data
+			} catch (error) {
+				logger.warn('Failed to parse OOO state', { error })
+			}
+
+			return undefined
+		},
+
+		/**
+		 * Main address and all aliases formatted for use with sieve.
+		 *
+		 * @return {string[]}
+		 */
+		aliases() {
+			 return [
+				 {
+					 name: this.account.name,
+					 alias: this.account.emailAddress,
+				 },
+				 ...this.account.aliases,
+			 ].map(({ name, alias }) => `${name} <${alias}>`)
+		},
+	},
+	watch: {
+		parsedState: {
+			immediate: true,
+			handler(state) {
+				state ??= {}
+				this.enabled = !!state.enabled ?? false
+				this.firstDay = state.start ?? new Date()
+				this.lastDay = state.end ?? null
+				this.subject = state.subject ?? ''
+				this.message = state.message ?? ''
+			},
+		},
+		enableLastDay(enableLastDay) {
+			if (enableLastDay) {
+				this.lastDay = new Date(this.firstDay)
+				this.lastDay.setDate(this.lastDay.getDate() + 6)
+			} else {
+				this.lastDay = null
+			}
+		},
+		firstDay(firstDay, previousFirstDay) {
+			if (!this.enableLastDay) {
+				return
+			}
+
+			const dayInMillis = 24 * 60 * 60 * 1000
+			const diffDays = Math.floor((this.lastDay - previousFirstDay) / dayInMillis)
+			if (diffDays < 0) {
+				return
+			}
+
+			this.lastDay = new Date(firstDay)
+			this.lastDay.setDate(firstDay.getDate() + diffDays)
+		},
+	},
+	methods: {
+		async submit() {
+			this.loading = true
+			this.errorMessage = ''
+
+			const state = parseOutOfOfficeState(this.sieveScriptData.script)
+			const originalScript = state.sieveScript
+
+			const enrichedScript = buildOutOfOfficeSieveScript(originalScript, {
+				enabled: this.enabled,
+				start: this.firstDay,
+				end: this.lastDay,
+				subject: this.subject,
+				message: toPlain(html(this.message)).value, // CKEditor always returns html data
+				allowedRecipients: this.aliases,
+			})
+
+			try {
+				await this.$store.dispatch('updateActiveSieveScript', {
+					accountId: this.account.id,
+					scriptData: {
+						...this.sieveScriptData,
+						script: enrichedScript,
+					},
+				})
+			} catch (error) {
+				this.errorMessage = error.message
+			} finally {
+				this.loading = false
+			}
+
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.form {
+	display: flex;
+	flex-direction: column;
+	gap: 15px;
+
+	&__fieldset {
+		display: flex;
+		flex-direction: column;
+
+		&__label {
+			display: flex;
+			align-items: center;
+			gap: 5px;
+		}
+
+		&__input {
+			flex: 1 auto;
+		}
+	}
+
+	&__multi-row {
+		display: flex;
+		align-items: end;
+		gap: 15px;
+	}
+
+	#ooo-enable-last-day {
+		cursor: pointer;
+		min-height: unset;
+	}
+
+	#ooo-subject {
+		width: 100%;
+	}
+
+	#ooo-message {
+		width: 100%;
+		min-height: 100px;
+		border: 1px solid var(--color-border);
+
+		&:active,
+		&:focus,
+		&:hover {
+			border-color: var(--color-primary-element) !important;
+		}
+	}
+}
+</style>

--- a/src/components/SieveFilterForm.vue
+++ b/src/components/SieveFilterForm.vue
@@ -2,7 +2,7 @@
 	<div class="section">
 		<textarea
 			id="sieve-text-area"
-			v-model="active.script"
+			v-model="script"
 			v-shortkey.avoid
 			rows="20"
 			:disabled="loading" />
@@ -24,7 +24,6 @@
 </template>
 
 <script>
-import { getActiveScript, updateActiveScript } from '../service/SieveService'
 import ButtonVue from '@nextcloud/vue/dist/Components/NcButton'
 import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import IconCheck from 'vue-material-design-icons/Check'
@@ -43,13 +42,28 @@ export default {
 	},
 	data() {
 		return {
-			active: {},
-			loading: false,
+			script: '',
+			loading: true,
 			errorMessage: '',
 		}
 	},
-	async mounted() {
-		this.active = await getActiveScript(this.account.id)
+	computed: {
+		scriptData() {
+			return this.$store.getters.getActiveSieveScript(this.account.id)
+		},
+	},
+	watch: {
+		scriptData: {
+			immediate: true,
+			handler(scriptData) {
+				if (!scriptData) {
+					return
+				}
+
+				this.script = scriptData.script
+				this.loading = false
+			},
+		},
 	},
 	methods: {
 		async saveActiveScript() {
@@ -57,7 +71,13 @@ export default {
 			this.errorMessage = ''
 
 			try {
-				await updateActiveScript(this.account.id, this.active)
+				await this.$store.dispatch('updateActiveSieveScript', {
+					accountId: this.account.id,
+					scriptData: {
+						...this.scriptData,
+						script: this.script,
+					},
+				})
 			} catch (error) {
 				this.errorMessage = error.message
 			}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -2,6 +2,7 @@
   - @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
   -
   - @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  - @author 2022 Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license AGPL-3.0-or-later
   -
@@ -25,6 +26,7 @@
 		:value="value"
 		:config="config"
 		:editor="editor"
+		:disabled="disabled"
 		@input="onEditorInput"
 		@ready="onEditorReady" />
 </template>
@@ -80,6 +82,10 @@ export default {
 		bus: {
 			type: Object,
 			required: true,
+		},
+		disabled: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/service/SieveService.js
+++ b/src/service/SieveService.js
@@ -33,6 +33,12 @@ export async function updateAccount(id, data) {
 	}
 }
 
+/**
+ * Fetch active sieve script of given account id.
+ *
+ * @param {string} id Account id
+ * @return {Promise<{script: string, scriptName: string}>}
+ */
 export async function getActiveScript(id) {
 	const url = generateUrl('/apps/mail/api/sieve/active/{id}', {
 		id,
@@ -45,6 +51,13 @@ export async function getActiveScript(id) {
 	}
 }
 
+/**
+ * Update active sieve script of given account id.
+ *
+ * @param {string} id Account id
+ * @param {{script: string, scriptName: string}} data Script data object
+ * @return {Promise<void>}
+ */
 export async function updateActiveScript(id, data) {
 	const url = generateUrl('/apps/mail/api/sieve/active/{id}', {
 		id,

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -83,7 +83,11 @@ import { matchError } from '../errors/match'
 import SyncIncompleteError from '../errors/SyncIncompleteError'
 import MailboxLockedError from '../errors/MailboxLockedError'
 import { wait } from '../util/wait'
-import { updateAccount as updateSieveAccount } from '../service/SieveService'
+import {
+	getActiveScript,
+	updateAccount as updateSieveAccount,
+	updateActiveScript,
+} from '../service/SieveService'
 import { PAGE_SIZE, UNIFIED_INBOX_ID } from './constants'
 import * as ThreadService from '../service/ThreadService'
 import {
@@ -985,6 +989,14 @@ export default {
 		await moveMessage(id, destMailboxId)
 		commit('removeEnvelope', { id })
 		commit('removeMessage', { id })
+	},
+	async fetchActiveSieveScript({ commit }, { accountId }) {
+		const scriptData = await getActiveScript(accountId)
+		commit('setActiveSieveScript', { accountId, scriptData })
+	},
+	async updateActiveSieveScript({ commit }, { accountId, scriptData }) {
+		await updateActiveScript(accountId, scriptData)
+		commit('setActiveSieveScript', { accountId, scriptData })
 	},
 	async updateSieveAccount({ commit }, { account, data }) {
 		logger.debug(`update sieve settings for account ${account.id}`)

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -95,4 +95,5 @@ export const getters = {
 		return state.tagList.map(tagId => state.tags[tagId])
 	},
 	isScheduledSendingDisabled: (state) => state.isScheduledSendingDisabled,
+	getActiveSieveScript: (state) => (accountId) => state.sieveScript[accountId],
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -94,6 +94,7 @@ export default new Store({
 				tags: {},
 				tagList: [],
 				isScheduledSendingDisabled: false,
+				sieveScript: {},
 			},
 			getters,
 			mutations,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -391,4 +391,7 @@ export default {
 	setScheduledSendingDisabled(state, value) {
 		state.isScheduledSendingDisabled = value
 	},
+	setActiveSieveScript(state, { accountId, scriptData }) {
+		Vue.set(state.sieveScript, accountId, scriptData)
+	},
 }

--- a/src/tests/data/.editorconfig
+++ b/src/tests/data/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/src/tests/data/sieve-vacation-cleaned.txt
+++ b/src/tests/data/sieve-vacation-cleaned.txt
@@ -1,0 +1,6 @@
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}

--- a/src/tests/data/sieve-vacation-off.txt
+++ b/src/tests/data/sieve-vacation-off.txt
@@ -1,0 +1,10 @@
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}
+
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+# DATA: {"version":1,"enabled":false,"subject":"On vacation","message":"I'm on vacation."}
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/src/tests/data/sieve-vacation-on-no-end-date.txt
+++ b/src/tests/data/sieve-vacation-on-no-end-date.txt
@@ -1,0 +1,18 @@
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+require "date";
+require "relational";
+require "vacation";
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}
+
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation","message":"I'm on vacation."}
+if currentdate :value "ge" "date" "2022-09-02" {
+	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+}
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/src/tests/data/sieve-vacation-on.txt
+++ b/src/tests/data/sieve-vacation-on.txt
@@ -1,0 +1,18 @@
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+require "date";
+require "relational";
+require "vacation";
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}
+
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02","end":"2022-09-08","subject":"On vacation","message":"I'm on vacation."}
+if allof(currentdate :value "ge" "date" "2022-09-02", currentdate :value "le" "date" "2022-09-08") {
+	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+}
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -2,6 +2,7 @@
  * @copyright 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2018 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2022 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0-or-later
  *
@@ -19,6 +20,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
 global.OC = {
 	getLocale: () => 'en',
 	getLanguage: () => 'en_US',
@@ -31,4 +35,13 @@ global.OC = {
 		},
 	},
 	isUserAdmin: () => false,
+}
+
+/**
+ * @param {string} path Path to file relative to src/tests/data/
+ * @return {string} File contents
+ */
+global.readTestData = function(path) {
+	path = join('src', 'tests', 'data', path)
+	return readFileSync(path).toString('utf-8')
 }

--- a/src/tests/unit/util/outOfOffice.spec.js
+++ b/src/tests/unit/util/outOfOffice.spec.js
@@ -1,0 +1,130 @@
+/**
+ * @copyright Copyright (c) 2022 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {
+	buildOutOfOfficeSieveScript,
+	formatDateForSieve,
+	parseOutOfOfficeState,
+} from '../../../util/outOfOffice'
+
+describe('outOfOffice', () => {
+	describe('parseOutOfOfficeState', () => {
+		it('should parse a sieve script containing an enabled vacation responder', () => {
+			const script = readTestData('sieve-vacation-on.txt')
+			const cleanedScript = readTestData('sieve-vacation-cleaned.txt')
+			const expected = {
+				sieveScript: cleanedScript,
+				data: {
+					version: 1,
+					enabled: true,
+					start: new Date('2022-09-02'),
+					end: new Date('2022-09-08'),
+					subject: 'On vacation',
+					message: 'I\'m on vacation.',
+				},
+			}
+			const actual = parseOutOfOfficeState(script)
+			expect(actual).toEqual(expected)
+		})
+
+		it('should parse a sieve script containing a disabled vacation responder', () => {
+			const script = readTestData('sieve-vacation-off.txt')
+			const cleanedScript = readTestData('sieve-vacation-cleaned.txt')
+			const expected = {
+				sieveScript: cleanedScript,
+				data: {
+					version: 1,
+					enabled: false,
+					subject: 'On vacation',
+					message: 'I\'m on vacation.',
+				},
+			}
+			const actual = parseOutOfOfficeState(script)
+			expect(actual).toEqual(expected)
+		})
+
+		it('should leave a foreign script untouched', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = {
+				sieveScript: script,
+				data: undefined,
+			}
+			const actual = parseOutOfOfficeState(script)
+			expect(actual).toEqual(expected)
+		})
+	})
+
+	describe('buildOutOfOfficeSieveScript', () => {
+		it('should build a correct sieve script when the vacation responder is enabled', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = readTestData('sieve-vacation-on.txt')
+			const actual = buildOutOfOfficeSieveScript(script, {
+				enabled: true,
+				start: new Date('2022-09-02'),
+				end: new Date('2022-09-08'),
+				subject: 'On vacation',
+				message: 'I\'m on vacation.',
+				allowedRecipients: [
+					'Test Test <test@test.org>',
+					'Test Alias <alias@test.org>',
+				]
+			})
+			expect(actual).toEqual(expected)
+		})
+
+		it('should build a correct sieve script when the vacation responder is enabled and no end date is given', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = readTestData('sieve-vacation-on-no-end-date.txt')
+			const actual = buildOutOfOfficeSieveScript(script, {
+				enabled: true,
+				start: new Date('2022-09-02'),
+				subject: 'On vacation',
+				message: 'I\'m on vacation.',
+				allowedRecipients: [
+					'Test Test <test@test.org>',
+					'Test Alias <alias@test.org>',
+				]
+			})
+			expect(actual).toEqual(expected)
+		})
+
+		it('should build a correct sieve script when the vacation responder is disabled', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = readTestData('sieve-vacation-off.txt')
+			const actual = buildOutOfOfficeSieveScript(script, {
+				enabled: false,
+				subject: 'On vacation',
+				message: 'I\'m on vacation.',
+			})
+			expect(actual).toEqual(expected)
+		})
+	})
+
+	describe('formatDateForSieve', () => {
+		it('should format js dates according to YYYY-MM-DD', () => {
+			const date = new Date('2022-09-02T08:58:01+0000')
+			const expected = '2022-09-02'
+			const actual = formatDateForSieve(date)
+			expect(actual).toEqual(expected)
+		})
+	})
+})

--- a/src/util/outOfOffice.js
+++ b/src/util/outOfOffice.js
@@ -1,0 +1,178 @@
+/**
+ * @copyright Copyright (c) 2022 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const MARKER = '### Nextcloud Mail: Vacation Responder ### DON\'T EDIT ###'
+const DATA_MARKER = '# DATA: '
+const VERSION = 1
+
+// Parser states
+const PARSER_COPY = 0
+const PARSER_SKIP = 1
+
+export class OOOParserError extends Error {}
+
+/**
+ * Parse embedded out of office state from the given sieve script.
+ * Return the original sieve script without any out of office data/script.
+ *
+ * @param {string} sieveScript
+ * @return {{data: object|undefined, sieveScript: string}}
+ */
+export function parseOutOfOfficeState(sieveScript) {
+	const lines = sieveScript.split(/\r?\n/)
+
+	const out = []
+	let data
+
+	let state = PARSER_COPY
+	let nextState = state
+
+	for (const line of lines) {
+		switch (state) {
+		case PARSER_COPY:
+			if (line.startsWith(MARKER)) {
+				nextState = PARSER_SKIP
+				break
+			}
+			out.push(line)
+			break
+		case PARSER_SKIP:
+			if (line.startsWith(MARKER)) {
+				nextState = PARSER_COPY
+			} else if (line.startsWith(DATA_MARKER)) {
+				const json = line.slice(DATA_MARKER.length)
+				data = JSON.parse(json)
+				if (data.start) data.start = new Date(data.start)
+				if (data.end) data.end = new Date(data.end)
+			}
+			break
+		default:
+			throw new OOOParserError('Reached an invalid state')
+		}
+		state = nextState
+	}
+
+	return {
+		sieveScript: out.join('\n'),
+		data,
+	}
+}
+
+/**
+ * Embed vacation responder action and out of office state into the given sieve script.
+ *
+ * @param {string} sieveScript
+ * @param {object} data
+ * @param {bool} data.enabled
+ * @param {Date=} data.start First day (inclusive)
+ * @param {Date=} data.end Last day (inclusive)
+ * @param {string} data.subject
+ * @param {string} data.message
+ * @param {string[]=} data.allowedRecipients Only respond if recipient of incoming mail is in this list. Format: `Test Test <test@test.com>`
+ * @return {string} Sieve script
+ */
+export function buildOutOfOfficeSieveScript(sieveScript, {
+	enabled,
+	start,
+	end,
+	subject,
+	message,
+	allowedRecipients,
+}) {
+	// State to be embedded in the sieve script
+	const data = {
+		version: VERSION,
+		enabled,
+		start: start ? formatDateForSieve(start) : undefined,
+		end: end ? formatDateForSieve(end) : undefined,
+		subject,
+		message,
+	}
+
+	// Save only state if vacation responder is disabled
+	if (!enabled) {
+		delete data.start
+		delete data.end
+		return [
+			sieveScript,
+			MARKER,
+			DATA_MARKER + JSON.stringify(data),
+			MARKER,
+		].join('\n')
+	}
+
+	// Build if condition for start and end dates
+	let condition
+	if (end) {
+		condition = `allof(currentdate :value "ge" "date" "${formatDateForSieve(start)}", currentdate :value "le" "date" "${formatDateForSieve(end)}")`
+	} else {
+		condition = `currentdate :value "ge" "date" "${formatDateForSieve(start)}"`
+	}
+
+	// Build vacation command
+	const vacation = [
+		'vacation',
+		':days 4',
+		`:subject "${subject}"`,
+	]
+
+	if (allowedRecipients?.length) {
+		const formattedRecipients = allowedRecipients.map(recipient => `"${recipient}"`).join(', ')
+		vacation.push(`:addresses [${formattedRecipients}]`)
+	}
+
+	vacation.push(`"${message}"`)
+
+	// Build sieve script
+	const requireSection = [
+		MARKER,
+		'require "date";',
+		'require "relational";',
+		'require "vacation";',
+		MARKER,
+	].join('\n')
+
+	const vacationSection = [
+		MARKER,
+		DATA_MARKER + JSON.stringify(data),
+		`if ${condition} {`,
+		`\t${vacation.join(' ')};`,
+		'}',
+		MARKER,
+	].join('\n')
+
+	return [
+		requireSection,
+		sieveScript,
+		vacationSection,
+	].join('\n')
+}
+
+/**
+ * Format a JavaScript date object to use with the sieve :vacation action.
+ *
+ * @param {Date} date JavaScript date object
+ * @return {string} YYYY-MM-DD
+ */
+export function formatDateForSieve(date) {
+	return date.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
Fix #5441 

## To-do
* [x] UI skeleton
* [x] Write the script
* [x] Read metadata to restore UI state
* [x] Fill out `:addresses ["main@domain.tld", "alias@domain.tld"]` from account email and aliases so no emails to mailing lists get auto-responded (has to be implemented; the mail server won't send a single response)

## To-do from design review

### Vacation responder review
- [x] Sorting of settings sections
  - …
  - Vacation responder
  - Filter rules
  - Trusted senders
  - Mail server
  - Filter server
- [x] Wording detail: "Out of office replies" → "Vacation responder"
- [x] Heading subline in color-text-maxcontrast: "Automated reply to incoming messages. If someone sends you several messages, this automated reply will be sent at most once every 4 days."
- [x] "Vacation responder on" and "Vacation responder off"
- [x] "Last day" → "Last day (optional)"
- [x] Default "Last day" always +6 days from "First day"
- [x] Ensure that last day is always after first day (either keep the previous distance, or if difficult, just use +6 here as well)
- [x] Message field is a bit large, reduce to 100px default
- [x] When not enabled, set all fields to "disabled" instead of hiding all
- [x] Make sure that Subject and Message are saved even when disabled
- [x] "Save" → "Save vacation responder"
- [x] Filter rule needs to have individual heading/comment box probably? Not generic `Don’t edit above …` but rather `### Nextcloud Mail: Vacation responder DO NOT EDIT! ###`

### Out of scope for now
- Supporting rich formatting in vacation responder
- Checkbox like Gmail "Only send a response to people in my Contacts" – also for privacy reasons, so not everyone knows you are away
- Ability to add vacation replacement via account picker
- Connecting with Nextcloud Status feature
- Adding the dates to the message programmatically