### PR TITLE
Overwrite z-index for CKEditor

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -224,3 +224,13 @@ export default {
 	cursor: text;
 }
 </style>
+
+<style>
+/*
+Overwrite the default z-index for CKEditor
+https://github.com/ckeditor/ckeditor5/issues/1142
+ */
+:root {
+	--ck-z-default: 10000;
+}
+</style>


### PR DESCRIPTION
A recent nextcloud/vue update changed the z-index for the modal component.