### PR TITLE
Show primary color dot in subject line for unread messages in envelope list

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -68,6 +68,14 @@
 				{{ data.previewText }}
 			</div>
 		</template>
+		<template #indicator>
+			<!-- Color dot -->
+			<IconBullet v-if="!data.flags.seen"
+				:size="16"
+				:aria-hidden="false"
+				:aria-label="t('mail', 'This message is unread')"
+				fill-color="var(--color-primary-element)" />
+		</template>
 		<template #actions>
 			<EnvelopePrimaryActions v-if="!moreActionsOpen">
 				<ActionButton
@@ -263,6 +271,7 @@ import EmailRead from 'vue-material-design-icons/EmailOpen'
 import EmailUnread from 'vue-material-design-icons/Email'
 import IconAttachment from 'vue-material-design-icons/Paperclip'
 import ImportantIcon from './icons/ImportantIcon'
+import IconBullet from 'vue-material-design-icons/CheckboxBlankCircle'
 import JunkIcon from './icons/JunkIcon'
 import PlusIcon from 'vue-material-design-icons/Plus'
 import TagIcon from 'vue-material-design-icons/Tag'
@@ -300,6 +309,7 @@ export default {
 		EmailRead,
 		EmailUnread,
 		IconAttachment,
+		IconBullet,
 		Reply,
 		ActionLink,
 		DownloadIcon,


### PR DESCRIPTION
Resolves https://github.com/nextcloud/mail/issues/6982

- [x] Requires https://github.com/nextcloud/nextcloud-vue/pull/3132
- [x] Requires https://github.com/nextcloud/mail/pull/7127

looks like this: 

![image](https://user-images.githubusercontent.com/6078378/187683878-1697b04c-1a53-411d-866e-df270905fd14.png)
![image](https://user-images.githubusercontent.com/6078378/187684023-a4987d62-a30e-420d-8a71-669c3f18c2fb.png)

![Peek 2022-08-31 11-23](https://user-images.githubusercontent.com/6078378/187645941-2e86ca74-4ac0-47f7-b115-ce16439f6391.gif)
