### PR TITLE
Add 4px padding left/right to envelope list

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -267,6 +267,7 @@ export default {
 }
 .envelope-list {
 	overflow-y: auto;
+	padding: 0 4px;
 }
 .information-icon {
 	opacity: .7;


### PR DESCRIPTION
Contributes part 2/2 of https://github.com/nextcloud/mail/issues/6973.

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-01 09-00-00](https://user-images.githubusercontent.com/1374172/187852127-38964e4b-d58a-4057-b59b-33a664df13a5.png)|![Bildschirmfoto vom 2022-09-01 08-59-22](https://user-images.githubusercontent.com/1374172/187852156-96140f16-19aa-41bf-b4d3-e0007b3f02dd.png)|
