### PR TITLE
Remember last/start mailbox

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -165,6 +165,7 @@ class PageController extends Controller {
 				'external-avatars' => $this->preferences->getPreference($this->currentUserId, 'external-avatars', 'true'),
 				'reply-mode' => $this->preferences->getPreference($this->currentUserId, 'reply-mode', 'top'),
 				'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
+				'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
 				'tag-classified-messages' => $this->preferences->getPreference($this->currentUserId, 'tag-classified-messages', 'true'),
 			]);
 		$this->initialStateService->provideInitialState(

--- a/src/main.js
+++ b/src/main.js
@@ -78,6 +78,11 @@ store.commit('savePreference', {
 	key: 'collect-data',
 	value: getPreferenceFromPage('collect-data'),
 })
+const startMailboxId = getPreferenceFromPage('start-mailbox-id')
+store.commit('savePreference', {
+	key: 'start-mailbox-id',
+	value: startMailboxId ? parseInt(startMailboxId, 10) : null,
+})
 store.commit('savePreference', {
 	key: 'tag-classified-messages',
 	value: getPreferenceFromPage('tag-classified-messages'),

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -44,8 +44,21 @@ export default {
 	},
 	created() {
 		const accounts = this.$store.getters.accounts
+		let startMailboxId = this.$store.getters.getPreference('start-mailbox-id')
+		if (startMailboxId && !this.$store.getters.getMailbox(startMailboxId)) {
+			// The start ID is set but the mailbox doesn't exist anymore
+			startMailboxId = null
+		}
 
-		if (this.$route.name === 'home' && accounts.length > 1) {
+		if (this.$route.name === 'home' && accounts.length > 1 && startMailboxId) {
+			logger.debug('Loading start mailbox', { id: startMailboxId })
+			this.$router.replace({
+				name: 'mailbox',
+				params: {
+					mailboxId: startMailboxId,
+				},
+			})
+		} else if (this.$route.name === 'home' && accounts.length > 1) {
 			// Show first account
 			const firstAccount = accounts[0]
 			// FIXME: this assumes that there's at least one mailbox

--- a/templates/index.php
+++ b/templates/index.php
@@ -32,4 +32,5 @@ script('mail', 'mail');
 <input type="hidden" id="config-installed-version" value="<?php p($_['app-version']); ?>">
 <input type="hidden" id="external-avatars" value="<?php p($_['external-avatars']); ?>">
 <input type="hidden" id="collect-data" value="<?php p($_['collect-data']); ?>">
+<input type="hidden" id="start-mailbox-id" value="<?php p($_['start-mailbox-id']); ?>">
 <input type="hidden" id="tag-classified-messages" value="<?php p($_['tag-classified-messages']); ?>">

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -132,13 +132,14 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
-		$this->preferences->expects($this->exactly(5))
+		$this->preferences->expects($this->exactly(6))
 			->method('getPreference')
 			->willReturnMap([
 				[$this->userId, 'account-settings', '[]', json_encode([])],
 				[$this->userId, 'external-avatars', 'true', 'true'],
 				[$this->userId, 'reply-mode', 'top', 'bottom'],
 				[$this->userId, 'collect-data', 'true', 'true'],
+				[$this->userId, 'start-mailbox-id', null, '123'],
 				[$this->userId, 'tag-classified-messages', 'true', 'true'],
 			]);
 		$this->accountService->expects($this->once())
@@ -250,6 +251,7 @@ class PageControllerTest extends TestCase {
 				'reply-mode' => 'bottom',
 				'app-version' => '1.2.3',
 				'collect-data' => 'true',
+				'start-mailbox-id' => '123',
 				'tag-classified-messages' => 'true',
 			]);
 		$csp = new ContentSecurityPolicy();


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/1665

## Logic
* Open setup if no accounts are configured
* Open unified mailbox if no start mailbox is known
* Open mailbox from URL parameter if set
* Open start mailbox otherwise

## Todo

- [x] Save start mailbox after 5s
- [x] Restore start mailbox at page load and initial routing
- [x] Fix tests

## How to test

1) Open the app
2) Configure an account if you haven't already
3) Open an arbitrary mailbox
4) Wait 6s
5) Click on the Mail icon in the top bar

Master: unified inbox is opened.
Here: your previously selected mailbox is opened.