### PR TITLE
Drop Nextcloud 22-24 support

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-master', 'dev-stable24', 'dev-stable23', 'dev-stable22' ]
+              ocp-version: [ 'dev-master' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout
@@ -28,10 +28,6 @@ jobs:
           - name: Install dependencies
             run: composer i
           - name: Install OCP package
-            if: ${{ matrix.ocp-version != 'dev-master' && matrix.ocp-version != 'dev-stable24'  }}
-            run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }}
-          - name: Install OCP package
-            if: ${{ matrix.ocp-version == 'dev-master' || matrix.ocp-version == 'dev-stable24' }}
             run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }} --ignore-platform-reqs
           - name: Run coding standards check
             run: composer run psalm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0']
-        nextcloud-versions: ['stable22', 'stable23']
-        include:
-            - php-versions: 7.4
-              nextcloud-versions: stable24
-            - php-versions: 8.1
-              nextcloud-versions: master
-            - php-versions: 8.2
-              nextcloud-versions: master
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        nextcloud-versions: ['master']
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests
     steps:
     - name: Set up php${{ matrix.php-versions }}
@@ -39,10 +32,6 @@ jobs:
       run: echo "<?php" > nextcloud/lib/versioncheck.php
     - name: Install Nextcloud
       run: php -f nextcloud/occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-    - name: Fix php-parser on stable20 incompatibility with phpunit 9.3+
-      if: ${{ matrix.nextcloud-versions == 'stable20' }}
-      working-directory: nextcloud/3rdparty
-      run: composer require nikic/php-parser:4.10
     - name: Checkout Mail
       uses: actions/checkout@v3
       with:
@@ -79,13 +68,13 @@ jobs:
               db: ['sqlite', 'mysql', 'pgsql']
               include:
                 - php-versions: 7.4
-                  nextcloud-versions: stable22
+                  nextcloud-versions: master
                   db: 'mysql'
                 - php-versions: 8.0
-                  nextcloud-versions: stable23
+                  nextcloud-versions: master
                   db: 'mysql'
                 - php-versions: 8.1
-                  nextcloud-versions: stable24
+                  nextcloud-versions: master
                   db: 'pgsql'
                 - php-versions: 8.2
                   nextcloud-versions: master

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@
 	<screenshot>https://user-images.githubusercontent.com/1374172/79554966-278e1600-809f-11ea-82ea-7a0d72a2704f.png</screenshot>
 	<dependencies>
 		<php min-version="7.4" max-version="8.1" />
-		<nextcloud min-version="22" max-version="25" />
+		<nextcloud min-version="25" max-version="25" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Mail\BackgroundJob\CleanupJob</job>


### PR DESCRIPTION
The new design doesn't work with 24 and older, so we need to drop their support from `main` and the upcoming release.

Ref https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule