### PR TITLE
Improve text contrast and spacing of envelope list

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -578,12 +578,14 @@ export default {
 		gap: 4px;
 
 		&__subject {
+			color: var(--color-main-text);
+			line-height: 130%;
 			overflow: hidden;
 			text-overflow: ellipsis;
 		}
 	}
 	&__preview-text {
-		color: var(--color-text-lighter);
+		color: var(--color-text-maxcontrast);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;


### PR DESCRIPTION
- Subject text in regular text color instead of maxcontrast
- Slightly reduced line height (to nice 130%), so lines of a single mail belong together, while mails are more clearly separated

(Also just FYI @ChristophWurst, `--color-text-lighter` is deprecated, we only use either `--color-main-text` or `--color-text-maxcontrast`.)

Before | After
-|-
![image](https://user-images.githubusercontent.com/925062/188442091-04a350a3-9da2-420b-8af4-4752cbd53a58.png)|![image](https://user-images.githubusercontent.com/925062/188442055-92b6584f-d4d3-436d-b86d-edd82e07e4b3.png)
