### PR TITLE
 Give email thread some spacing at the bottom

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -259,6 +259,7 @@ export default {
 #mail-message {
 	flex-grow: 1;
 	max-height: calc(100vh - 50px);
+	margin-bottom: 30vh;
 
 	.icon-loading {
 		&:only-child:after {


### PR DESCRIPTION
Long threads or small windows put the thread messages very close to the bottom. It might look better if we give them some space.

| Before | After |
|---|---|
![Bildschirmfoto vom 2022-09-06 09-48-18](https://user-images.githubusercontent.com/1374172/188577719-26d2f9c8-15ba-4a04-b3d9-52e8fd424037.png) | ![Bildschirmfoto vom 2022-09-06 09-48-12](https://user-images.githubusercontent.com/1374172/188577691-20a2230f-2b26-4fb1-9520-16f3c790478c.png) |
