### PR TITLE
Escape double quotes and backslashes

### DIFF
--- a/src/tests/data/sieve-vacation-on-special-chars-message.txt
+++ b/src/tests/data/sieve-vacation-on-special-chars-message.txt
@@ -1,0 +1,20 @@
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+require "date";
+require "relational";
+require "vacation";
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}
+
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation","message":"I'm on vacation.\n\"Hello, World!\"\n\\ escaped backslash"}
+if currentdate :value "ge" "date" "2022-09-02" {
+	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.
+\"Hello, World!\"
+\\ escaped backslash";
+}
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/src/tests/data/sieve-vacation-on-special-chars-subject.txt
+++ b/src/tests/data/sieve-vacation-on-special-chars-subject.txt
@@ -1,0 +1,18 @@
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+require "date";
+require "relational";
+require "vacation";
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+
+require "fileinto";
+
+if address "From" "marketing@company.org" {
+    fileinto "INBOX.marketing";
+}
+
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation, \"Hello, World!\", \\ escaped backslash","message":"I'm on vacation."}
+if currentdate :value "ge" "date" "2022-09-02" {
+	vacation :days 4 :subject "On vacation, \"Hello, World!\", \\ escaped backslash" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+}
+### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/src/tests/unit/util/outOfOffice.spec.js
+++ b/src/tests/unit/util/outOfOffice.spec.js
@@ -21,7 +21,7 @@
  */
 
 import {
-	buildOutOfOfficeSieveScript,
+	buildOutOfOfficeSieveScript, escapeStringForSieve,
 	formatDateForSieve,
 	parseOutOfOfficeState,
 } from '../../../util/outOfOffice'
@@ -107,6 +107,38 @@ describe('outOfOffice', () => {
 			expect(actual).toEqual(expected)
 		})
 
+		it('should build a correct sieve script when the vacation responder is enabled and the message contains special chars', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = readTestData('sieve-vacation-on-special-chars-message.txt')
+			const actual = buildOutOfOfficeSieveScript(script, {
+				enabled: true,
+				start: new Date('2022-09-02'),
+				subject: 'On vacation',
+				message: 'I\'m on vacation.\n"Hello, World!"\n\\ escaped backslash',
+				allowedRecipients: [
+					'Test Test <test@test.org>',
+					'Test Alias <alias@test.org>',
+				]
+			})
+			expect(actual).toEqual(expected)
+		})
+
+		it('should build a correct sieve script when the vacation responder is enabled and the subject contains special chars', () => {
+			const script = readTestData('sieve-vacation-cleaned.txt')
+			const expected = readTestData('sieve-vacation-on-special-chars-subject.txt')
+			const actual = buildOutOfOfficeSieveScript(script, {
+				enabled: true,
+				start: new Date('2022-09-02'),
+				subject: 'On vacation, \"Hello, World!\", \\ escaped backslash',
+				message: 'I\'m on vacation.',
+				allowedRecipients: [
+					'Test Test <test@test.org>',
+					'Test Alias <alias@test.org>',
+				]
+			})
+			expect(actual).toEqual(expected)
+		})
+
 		it('should build a correct sieve script when the vacation responder is disabled', () => {
 			const script = readTestData('sieve-vacation-cleaned.txt')
 			const expected = readTestData('sieve-vacation-off.txt')
@@ -124,6 +156,22 @@ describe('outOfOffice', () => {
 			const date = new Date('2022-09-02T08:58:01+0000')
 			const expected = '2022-09-02'
 			const actual = formatDateForSieve(date)
+			expect(actual).toEqual(expected)
+		})
+	})
+
+	describe('escapeStringForSieve', () => {
+		it('should escape double quotes', () => {
+			const string = 'A string with "quotes"'
+			const expected = 'A string with \\"quotes\\"'
+			const actual = escapeStringForSieve(string)
+			expect(actual).toEqual(expected)
+		})
+
+		it('should escape backslashes', () => {
+			const string = 'A string with \\ backslashes'
+			const expected = 'A string with \\\\ backslashes'
+			const actual = escapeStringForSieve(string)
 			expect(actual).toEqual(expected)
 		})
 	})

--- a/src/util/outOfOffice.js
+++ b/src/util/outOfOffice.js
@@ -132,7 +132,7 @@ export function buildOutOfOfficeSieveScript(sieveScript, {
 	const vacation = [
 		'vacation',
 		':days 4',
-		`:subject "${subject}"`,
+		`:subject "${escapeStringForSieve(subject)}"`,
 	]
 
 	if (allowedRecipients?.length) {
@@ -140,7 +140,7 @@ export function buildOutOfOfficeSieveScript(sieveScript, {
 		vacation.push(`:addresses [${formattedRecipients}]`)
 	}
 
-	vacation.push(`"${message}"`)
+	vacation.push(`"${escapeStringForSieve(message)}"`)
 
 	// Build sieve script
 	const requireSection = [
@@ -175,4 +175,17 @@ export function buildOutOfOfficeSieveScript(sieveScript, {
  */
 export function formatDateForSieve(date) {
 	return date.toISOString().slice(0, 10)
+}
+
+/**
+ * Escape a string for use in a sieve script.
+ * The string has to be surrounded by double quotes (`"`) manually.
+ *
+ * @param {string} string String to escape
+ * @return {string} Escaped string
+ */
+export function escapeStringForSieve(string) {
+	return string
+		.replaceAll(/\\/g, '\\\\')
+		.replaceAll(/"/g, '\\"')
 }


### PR DESCRIPTION
Fix #7174 

According to the RFC these are the only two chars that need to be escaped.

Ref https://www.rfc-editor.org/rfc/rfc5228#section-2.4.2