### PR TITLE
Fix show-image styling

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -181,8 +181,7 @@ export default {
 		overflow-y: auto;
 	}
 }
-::v-deep .action-item__menutoggle--with-title {
-	background-color: var(--color-main-background) !important;
+::v-deep .button-vue__text {
 	border: none !important;
 	font-weight: normal !important;
 	padding-left: 14px !important;
@@ -192,7 +191,7 @@ export default {
 .message-frame {
 	width: 100%;
 }
-::v-deep .dots-horizontal-icon {
+::v-deep .button-vue__icon {
 	display: none !important;
 }
 </style>


### PR DESCRIPTION
because of changes in nc/vue and some classes got refactor, the styling of show images aka trusted sender got broken, this fixes it

before
![804-378-max](https://user-images.githubusercontent.com/12728974/188638369-801d6d6b-4a29-478b-baf4-166225250a45.png)


after
![Screenshot from 2022-09-06 14-42-43](https://user-images.githubusercontent.com/12728974/188638399-1cd7366a-ed12-4c33-8e1b-c0636f254327.png)
![Screenshot from 2022-09-06 14-42-29](https://user-images.githubusercontent.com/12728974/188638402-d545fa8b-9029-4b31-a845-8b68bc660b30.png)
