### PR TITLE
Retrying to send fail messages (enh)

### DIFF
--- a/src/components/NavigationOutbox.vue
+++ b/src/components/NavigationOutbox.vue
@@ -109,8 +109,8 @@ export default {
 			this.attempts++
 			this.failedMessaged.map(async (message) => {
 				if (!message.pending) {
-					promises.push(this.$store.dispatch('outbox/sendMessage', { id: message.id }).catch((err) => {
-						console.log(err)
+					promises.push(this.$store.dispatch('outbox/sendMessage', { id: message.id }).catch(() => {
+						// TODO write pending state
 					}))
 				}
 				return message
@@ -119,7 +119,6 @@ export default {
 				this.sending = false
 			})
 		},
-
 	},
 }
 </script>

--- a/src/components/NavigationOutbox.vue
+++ b/src/components/NavigationOutbox.vue
@@ -27,7 +27,7 @@
 		:title="t('mail', 'Outbox')"
 		:to="to">
 		<template #icon>
-			<IconLoading v-if="sending"
+			<NcLoadingIcon v-if="sending"
 				class="outbox-sending-icon"
 				:size="20" />
 			<IconOutbox v-else
@@ -45,7 +45,7 @@
 <script>
 import { NcAppNavigationItem as AppNavigationItem, NcCounterBubble as CounterBubble } from '@nextcloud/vue'
 import IconOutbox from 'vue-material-design-icons/InboxArrowUp'
-import IconLoading from 'vue-material-design-icons/Loading'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 
 const RETRY_COUNT = 5
 const RETRY_TIMEOUT = 10000
@@ -56,7 +56,7 @@ export default {
 		AppNavigationItem,
 		CounterBubble,
 		IconOutbox,
-		IconLoading,
+		NcLoadingIcon,
 	},
 	data() {
 		return {
@@ -124,7 +124,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-:deep(.counter-bubble__counter) {
+::v-deep(.counter-bubble__counter) {
 	margin-right: 43px;
 }
 .outbox-opacity-icon {
@@ -132,17 +132,6 @@ export default {
 
 	&:hover {
 		opacity: 1;
-	}
-}
-.outbox-sending-icon {
-	animation:spin 0.4s linear infinite;
-}
-@keyframes spin {
-	0% {
-		transform: rotate(0deg)
-	}
-	100% {
-		transform: rotate(360deg)
 	}
 }
 </style>

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -29,7 +29,6 @@
 		<!-- List -->
 		<template #list>
 			<div slot="list" class="header__button">
-				<NewMessageButtonHeader />
 				<div class="outbox-retry">
 					<div v-if="!sending" class="outbox-retry--info">
 						{{
@@ -47,15 +46,6 @@
 						@click="sendFailedMessages">
 						{{ t('mail', 'Retry') }}
 					</span>
-					<NcButton
-						class="outbox-retry--btn"
-						:title="t('mail', 'Send failed messages')"
-						:disabled="sending"
-						@click="sendFailedMessages">
-						<template #icon>
-							<EmailFastOutlineIcon :size="22" />
-						</template>
-					</NcButton>
 				</div>
 				<AppContentList>
 					<Error
@@ -85,7 +75,6 @@ import Error from './Error'
 import EmptyMailbox from './EmptyMailbox'
 import OutboxMessageContent from './OutboxMessageContent'
 import OutboxMessageListItem from './OutboxMessageListItem'
-import NewMessageButtonHeader from './NewMessageButtonHeader'
 import logger from '../logger'
 
 export default {
@@ -98,7 +87,6 @@ export default {
 		EmptyMailbox,
 		OutboxMessageListItem,
 		OutboxMessageContent,
-		NewMessageButtonHeader,
 	},
 	data() {
 		return {
@@ -208,6 +196,10 @@ export default {
 	align-items: center;
 	justify-content: space-between;
 	border-right: 1px solid var(--color-border);
+	min-height: 52px;
+	margin: 3px 0 0 52px;
+	border-right: 1px solid var(--color-border);
+	position: relative;
 
 	.outbox-retry--info {
 		margin: 4px;

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -37,11 +37,12 @@
 				<LoadingSkeleton
 					v-else-if="loading" />
 				<EmptyMailbox v-else-if="messages.length === 0" />
-				<OutboxMessageListItem
-					v-for="message in messages"
-					v-else
-					:key="message.id"
-					:message="message" />
+				<div class="outbox-container" v-else>
+					<OutboxMessageListItem
+						v-for="message in messages"
+						:key="message.id"
+						:message="message" />
+				</div>
 			</AppContentList>
 		</template>
 	</AppContent>
@@ -88,6 +89,11 @@ export default {
 		messages() {
 			return this.$store.getters['outbox/getAllMessages']
 		},
+		failedMessages() {
+			return this.messages.map((message) => {
+				return message.failed
+			})
+		}
 	},
 	created() {
 		// Reload outbox contents every 60 seconds

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -41,6 +41,12 @@
 							n('mail', 'Retrying send message', 'Retrying send {count} messages', failedMessages.length, {count: failedMessages.length})
 						}}
 					</div>
+					<span
+						class="outbox-retry--btn"
+						:class="{sending: sending}"
+						@click="sendFailedMessages">
+						{{ t('mail', 'Retry') }}
+					</span>
 					<NcButton
 						class="outbox-retry--btn"
 						:title="t('mail', 'Send failed messages')"
@@ -80,8 +86,6 @@ import EmptyMailbox from './EmptyMailbox'
 import OutboxMessageContent from './OutboxMessageContent'
 import OutboxMessageListItem from './OutboxMessageListItem'
 import NewMessageButtonHeader from './NewMessageButtonHeader'
-import NcButton from '@nextcloud/vue/dist/Components/NcButton'
-import EmailFastOutlineIcon from 'vue-material-design-icons/EmailFastOutline'
 import logger from '../logger'
 
 export default {
@@ -95,8 +99,6 @@ export default {
 		OutboxMessageListItem,
 		OutboxMessageContent,
 		NewMessageButtonHeader,
-		NcButton,
-		EmailFastOutlineIcon,
 	},
 	data() {
 		return {
@@ -159,6 +161,9 @@ export default {
 			this.loading = false
 		},
 		sendFailedMessages() {
+			if (this.sending) {
+				return false
+			}
 			this.sending = true
 			const promises = []
 			this.failedMessages.map(async (msg) => {
@@ -212,7 +217,14 @@ export default {
 	}
 
 	.outbox-retry--btn {
-		margin-right: 8px;
+		cursor:pointer;
+		color: var(--color-primary-element);
+		font-weight: bold;
+		padding:0 8px;
+
+		&.sending {
+			opacity: 0.5;
+		}
 	}
 }
 </style>

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -258,7 +258,7 @@ export default {
 		justify-content: center;
 		font-weight: bold;
 		font-size: 12px;
-		color: var(--color-primary-element-light);
+		color: var(--color-primary-element);
 
 		svg {
 			position: absolute;
@@ -273,7 +273,7 @@ export default {
 			stroke-dashoffset: 0;
 			stroke-linecap: round;
 			stroke-width: 2px;
-			stroke: var(--color-primary-element-lighter);
+			stroke: var(--color-primary-element-light);
 			fill: none;
 			animation: countdown 10s linear infinite forwards;
 		}

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -25,13 +25,18 @@
 		class="outbox-message"
 		:class="{ selected }"
 		:title="title"
-		:details="details"
 		@click="openModal">
 		<template #icon>
 			<Avatar :display-name="avatarDisplayName" :email="avatarEmail" />
 		</template>
 		<template #subtitle>
 			{{ subjectForSubtitle }}
+		</template>
+		<template #indicator>
+			<IconAlertCircleOutline v-if="message.failed"
+				:title="details"
+				:size="20"
+				class="error-icon" />
 		</template>
 		<template slot="actions">
 			<ActionButton
@@ -60,6 +65,7 @@
 import { NcListItem as ListItem, NcActionButton as ActionButton } from '@nextcloud/vue'
 import Avatar from './Avatar'
 import IconDelete from 'vue-material-design-icons/Delete'
+import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline'
 import { getLanguage, translate as t } from '@nextcloud/l10n'
 import OutboxAvatarMixin from '../mixins/OutboxAvatarMixin'
 import moment from '@nextcloud/moment'
@@ -77,6 +83,7 @@ export default {
 		Avatar,
 		ActionButton,
 		IconDelete,
+		IconAlertCircleOutline,
 		Send,
 	},
 	mixins: [
@@ -164,6 +171,19 @@ export default {
 	&.active {
 		background-color: var(--color-background-dark);
 		border-radius: 16px;
+	}
+
+	.error-icon {
+		position: absolute;
+		top:0;
+		bottom:0;
+		right: 20px;
+		display: flex;
+		align-items: center;
+
+		::v-deep svg {
+			fill: var(--color-error);
+		}
 	}
 
 	.account-color {

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -33,19 +33,21 @@
 			{{ subjectForSubtitle }}
 		</template>
 		<template #indicator>
-			<IconAlertCircleOutline v-if="message.failed && !message.pending"
-				:title="details"
-				:size="20"
-				class="failed-icon error" />
-			<LoadingIcon v-else-if="message.failed && message.pending"
-				:title="details"
-				:size="20"
-				class="failed-icon pending" />
-			<div v-else-if="counter > 0 && !message?.aborted" class="failed-icon countdown">
-				<svg>
-					<circle r="12" cx="20" cy="20" />
-				</svg>
-				{{ counter }}
+			<div class="indicator">
+				<IconAlertCircleOutline v-if="message.failed && !message.pending"
+					:title="details"
+					:size="20"
+					class="failed-icon error" />
+				<NcLoadingIcon v-else-if="message.failed && message.pending"
+					:title="details"
+					:size="20"
+					class="failed-icon pending" />
+				<div v-else-if="counter > 0 && !message?.aborted" class="failed-icon countdown">
+					<svg>
+						<circle r="12" cx="20" cy="20" />
+					</svg>
+					{{ counter }}
+				</div>
 			</div>
 		</template>
 		<template v-if="!message.pending" slot="actions">
@@ -76,7 +78,7 @@ import { NcListItem as ListItem, NcActionButton as ActionButton } from '@nextclo
 import Avatar from './Avatar'
 import IconDelete from 'vue-material-design-icons/Delete'
 import IconAlertCircleOutline from 'vue-material-design-icons/AlertCircleOutline'
-import LoadingIcon from 'vue-material-design-icons/Loading'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon'
 import { getLanguage, translate as t } from '@nextcloud/l10n'
 import OutboxAvatarMixin from '../mixins/OutboxAvatarMixin'
 import moment from '@nextcloud/moment'
@@ -95,7 +97,7 @@ export default {
 		ActionButton,
 		IconDelete,
 		IconAlertCircleOutline,
-		LoadingIcon,
+		NcLoadingIcon,
 		Send,
 	},
 	mixins: [
@@ -213,6 +215,11 @@ export default {
 <style lang="scss" scoped>
 .outbox-message {
 	list-style: none;
+
+	.indicator {
+		padding: 0 8px;
+	}
+
 	&.active {
 		background-color: var(--color-background-dark);
 		border-radius: 16px;

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -249,6 +249,8 @@ export default {
 	.countdown {
 		width: 20px;
 		justify-content: center;
+		font-weight: bold;
+		font-size: 12px;
 		color: var(--color-primary-element-light);
 
 		svg {

--- a/src/store/outbox/actions.js
+++ b/src/store/outbox/actions.js
@@ -33,6 +33,7 @@ export default {
 		const { messages } = await OutboxService.fetchMessages()
 
 		for (const message of messages) {
+			message.pending = false
 			if (existingMessageIds.indexOf(message.id) === -1) {
 				commit('addMessage', { message })
 			} else {
@@ -80,7 +81,7 @@ export default {
 			...message,
 			sentAt: undefined,
 		}, message.id)
-		commit('updateMessage', { message: updatedMessage })
+		commit('updateMessage', { message: Object.assign({ aborted: true }, updatedMessage) })
 		return updatedMessage
 	},
 


### PR DESCRIPTION
**Hello everyone!**
I will be glad if you consider this improvement and give your comments. =)
Maybe it refers to https://github.com/nextcloud/mail/issues/6401

Basically there are 2.5 improvements:

- Batch sending of emails with the failed status
- - The interface for sending a single message has been slightly redesigned
- Background sending of emails with the failed status when the page loads

And here are the screenshots:

![Peek 2022-09-06 16-03](https://user-images.githubusercontent.com/3595562/188642782-3ac9002d-b6e1-4dad-8878-bd514da567f3.gif)

![Peek 2022-09-06 16-04](https://user-images.githubusercontent.com/3595562/188642795-d70f3c89-d4cb-4f67-9034-e04223fb3633.gif)


Perhaps another processing logic is needed here, so I would like to discuss this. 
Thanks!