### PR TITLE
Prevent unwanted live timestamp replacement

### DIFF
--- a/src/components/Moment.vue
+++ b/src/components/Moment.vue
@@ -1,5 +1,5 @@
 <template>
-	<span class="live-relative-timestamp" :data-timestamp="timestamp * 1000" :title="title">{{ formatted }}</span>
+	<span :data-timestamp="timestamp * 1000" :title="title">{{ formatted }}</span>
 </template>
 
 <script>


### PR DESCRIPTION
Regression of https://github.com/nextcloud/mail/pull/7105.

## Steps to reproduce
1) Open a message thread
2) Wait ~1m

Main: the timestamp will be replaced by a long version
Here: the timestamp stays short

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-06 15-13-48](https://user-images.githubusercontent.com/1374172/188644878-d5c79419-9df7-44bf-b827-444b22921ae8.png) | ![Bildschirmfoto vom 2022-09-06 15-13-24](https://user-images.githubusercontent.com/1374172/188644911-22840f1e-0a64-43fc-b04e-87f86ff72ae6.png) |

