### PR TITLE
Fix important messages showing in PI's *Other* section

### DIFF
--- a/lib/Service/Search/FilterStringParser.php
+++ b/lib/Service/Search/FilterStringParser.php
@@ -68,8 +68,6 @@ class FilterStringParser {
 					return true;
 				}
 				if ($param === 'pi-important') {
-					// We assume this is about 'is' and not 'not'
-					// imp && ~read
 					$query->addFlagExpression(
 						FlagExpression::and(
 							Flag::is(Flag::IMPORTANT),
@@ -79,19 +77,8 @@ class FilterStringParser {
 					return true;
 				}
 				if ($param === 'pi-other') {
-					// We assume this is about 'is' and not 'not'
-					// ~fav && (~imp || (imp && read))
-					$query->addFlagExpression(
-						FlagExpression::and(
-							Flag::not(Flag::FLAGGED),
-							FlagExpression::or(
-								Flag::not(Flag::IMPORTANT),
-								FlagExpression::and(
-									Flag::is(Flag::IMPORTANT),
-									Flag::is(Flag::SEEN)
-								)
-							)
-						)
+					$query->addFlag(
+						Flag::not(Flag::IMPORTANT),
 					);
 
 					return true;


### PR DESCRIPTION
Regression of https://github.com/nextcloud/mail/pull/6967.

Before: *Other* shows important but unread messages.
After: *Other* never shows any messages marked as important.