### PR TITLE
Fix double <ul> in nav

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -22,49 +22,47 @@
 <template>
 	<AppNavigation>
 		<template #list>
-			<ul id="accounts-list">
-				<!-- Special mailboxes first -->
-				<NavigationMailbox
-					v-for="mailbox in unifiedMailboxes"
-					:key="'mailbox-' + mailbox.databaseId"
-					:account="unifiedAccount"
-					:mailbox="mailbox" />
-				<NavigationOutbox />
-				<AppNavigationSpacer />
+			<!-- Special mailboxes first -->
+			<NavigationMailbox
+				v-for="mailbox in unifiedMailboxes"
+				:key="'mailbox-' + mailbox.databaseId"
+				:account="unifiedAccount"
+				:mailbox="mailbox" />
+			<NavigationOutbox />
+			<AppNavigationSpacer />
 
-				<!-- All other mailboxes grouped by their account -->
-				<template v-for="group in menu">
-					<NavigationAccount
-						v-if="group.account"
-						:key="group.account.id"
+			<!-- All other mailboxes grouped by their account -->
+			<template v-for="group in menu">
+				<NavigationAccount
+					v-if="group.account"
+					:key="group.account.id"
+					:account="group.account"
+					:first-mailbox="group.mailboxes[0]"
+					:is-first="isFirst(group.account)"
+					:is-last="isLast(group.account)" />
+				<template v-for="item in group.mailboxes">
+					<NavigationMailbox
+						v-show="
+							!group.isCollapsible ||
+								!group.account.collapsed ||
+								!isCollapsed(group.account, item)
+						"
+						:key="'mailbox-' + item.databaseId"
 						:account="group.account"
-						:first-mailbox="group.mailboxes[0]"
-						:is-first="isFirst(group.account)"
-						:is-last="isLast(group.account)" />
-					<template v-for="item in group.mailboxes">
-						<NavigationMailbox
-							v-show="
-								!group.isCollapsible ||
-									!group.account.collapsed ||
-									!isCollapsed(group.account, item)
-							"
-							:key="'mailbox-' + item.databaseId"
-							:account="group.account"
-							:mailbox="item" />
-						<NavigationMailbox
-							v-if="!group.account.isUnified && item.specialRole === 'inbox'"
-							:key="item.databaseId + '-starred'"
-							:account="group.account"
-							:mailbox="item"
-							filter="starred" />
-					</template>
-					<NavigationAccountExpandCollapse
-						v-if="!group.account.isUnified && group.isCollapsible"
-						:key="'collapse-' + group.account.id"
-						:account="group.account" />
-					<AppNavigationSpacer :key="'spacer-' + group.account.id" />
+						:mailbox="item" />
+					<NavigationMailbox
+						v-if="!group.account.isUnified && item.specialRole === 'inbox'"
+						:key="item.databaseId + '-starred'"
+						:account="group.account"
+						:mailbox="item"
+						filter="starred" />
 				</template>
-			</ul>
+				<NavigationAccountExpandCollapse
+					v-if="!group.account.isUnified && group.isCollapsible"
+					:key="'collapse-' + group.account.id"
+					:account="group.account" />
+				<AppNavigationSpacer :key="'spacer-' + group.account.id" />
+			</template>
 		</template>
 		<template #footer>
 			<AppNavigationSettings :title="t('mail', 'Mail settings')">


### PR DESCRIPTION
The slot renders our provided `<li>`s into a `<ul>`. We don't have to wrap it ourselves.

| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-06 16-59-19](https://user-images.githubusercontent.com/1374172/188669088-83b10d08-a608-4aa2-a53d-41a22e606546.png) | ![Bildschirmfoto vom 2022-09-06 16-59-02](https://user-images.githubusercontent.com/1374172/188669119-1fbab411-3cd8-4f01-aeb2-a89da0ed6142.png) |

Ref https://github.com/nextcloud/nextcloud-vue/issues/3184