### PR TITLE
Move from box-shadow to border for threads

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -463,15 +463,15 @@ export default {
 	.envelope {
 		display: flex;
 		flex-direction: column;
-		box-shadow: 0 0 10px var(--color-box-shadow);
+		border: 2px solid var(--color-border);
 		border-radius: 16px;
 		margin-left: 10px;
 		margin-right: 10px;
 		background-color: var(--color-main-background);
-		padding-bottom: 20px;
+		padding-bottom: 28px;
 
 		& + .envelope {
-			margin-top: -20px;
+			margin-top: -28px;
 		}
 
 		&:last-of-type {


### PR DESCRIPTION
Looks nice with the new design, not so overbearing, but still offers nice separation.
Replaces https://github.com/nextcloud/mail/pull/7189

Before | After
-|-
![Screenshot from 2022-09-06 16-12-14](https://user-images.githubusercontent.com/925062/188659364-301921a2-4013-41b2-a708-035bc4a18138.png)|![image](https://user-images.githubusercontent.com/925062/188697954-a66efef4-58f4-493b-b87e-a63b1e49fbef.png)


Please review @ChristophWurst @GretaD @nimishavijay 

