### PR TITLE
Fix inclusion of mail.scss and mobile.scss

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -304,23 +304,6 @@
 	opacity: .5;
 }
 
-/* icons */
-@include icon-black-white('inbox', 'mail', 1);
-@include icon-black-white('important', 'mail', 1);
-
-.icon-flagged {
-	@include icon-color('star', 'mail', $color-black);
-}
-
-@include icon-black-white('drafts', 'mail', 1);
-@include icon-black-white('sent', 'mail', 1);
-@include icon-black-white('archive', 'mail', 1);
-@include icon-black-white('junk', 'mail', 1);
-@include icon-black-white('trash', 'mail', 1);
-@include icon-black-white('reply', 'mail', 1);
-@include icon-black-white('reply-all', 'mail', 1);
-@include icon-black-white('forward', 'mail', 1);
-
 // FIXES for core apps.scss
 
 .app-navigation {
@@ -360,7 +343,7 @@
 				&,
 				> a {
 					opacity: 1;
-					box-shadow: inset 2px 0 $color-primary;
+					box-shadow: inset 2px 0 var(--color-primary);
 				}
 			}
 

--- a/css/mobile.scss
+++ b/css/mobile.scss
@@ -1,4 +1,4 @@
-@media only screen and (max-width: $breakpoint-mobile) {
+@media only screen and (max-width: var(--breakpoint-mobile)) {
 	.app-content-list {
 		max-width: 100vw;
 	}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -13,8 +13,11 @@
 
 <script>
 import Content from '@nextcloud/vue/dist/Components/NcContent'
-
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
+
+import '../../css/mail.scss'
+import '../../css/mobile.scss'
+
 import logger from '../logger'
 import MailboxThread from '../components/MailboxThread'
 import NewMessageModal from '../components/NewMessageModal'

--- a/templates/index.php
+++ b/templates/index.php
@@ -23,8 +23,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-style('mail', 'mail');
-style('mail', 'mobile');
 script('mail', 'mail');
 ?>
 


### PR DESCRIPTION
When server dropped the SCSS compilation those styles silently vanished. They are now moved into the bundle. So this can also seen as a micro optimization and removing two request per page load.

Fixes https://github.com/nextcloud/mail/issues/7172