### PR TITLE
Add local drafts backend

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -35,6 +35,7 @@ use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Dashboard\ImportantMailWidget;
 use OCA\Mail\Dashboard\UnreadMailWidget;
 use OCA\Mail\Events\BeforeMessageSentEvent;
+use OCA\Mail\Events\DraftMessageDeletedEvent;
 use OCA\Mail\Events\DraftSavedEvent;
 use OCA\Mail\Events\MailboxesSynchronizedEvent;
 use OCA\Mail\Events\OutboxMessageCreatedEvent;
@@ -106,6 +107,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeMessageSentEvent::class, AntiAbuseListener::class);
 		$context->registerEventListener(DraftSavedEvent::class, DeleteDraftListener::class);
 		$context->registerEventListener(OutboxMessageCreatedEvent::class, DeleteDraftListener::class);
+		$context->registerEventListener(DraftMessageDeletedEvent::class, DeleteDraftListener::class);
 		$context->registerEventListener(MailboxesSynchronizedEvent::class, MailboxesSynchronizedSpecialMailboxesUpdater::class);
 		$context->registerEventListener(MessageFlaggedEvent::class, MessageCacheUpdaterListener::class);
 		$context->registerEventListener(MessageFlaggedEvent::class, SpamReportListener::class);

--- a/lib/Controller/DraftsController.php
+++ b/lib/Controller/DraftsController.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mail App
+ *
+ * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Controller;
+
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Http\JsonResponse;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\DraftsService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+
+class DraftsController extends Controller {
+
+	/** @var DraftsService */
+	private $service;
+
+	/** @var string */
+	private $userId;
+
+	/** @var AccountService */
+	private $accountService;
+
+	public function __construct(string $appName,
+								$UserId,
+								IRequest $request,
+								DraftsService $service,
+								AccountService $accountService) {
+		parent::__construct($appName, $request);
+		$this->userId = $UserId;
+		$this->service = $service;
+		$this->accountService = $accountService;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @return JsonResponse
+	 */
+	public function index(): JsonResponse {
+		return JsonResponse::success(['messages' => $this->service->getMessages($this->userId)]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 * @return JsonResponse
+	 */
+	public function show(int $id): JsonResponse {
+		$message = $this->service->getMessage($id, $this->userId);
+		return JsonResponse::success($message);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $accountId
+	 * @param string $subject
+	 * @param string $body
+	 * @param string $editorBody
+	 * @param bool $isHtml
+	 * @param array $to i. e. [['label' => 'Linus', 'email' => 'tent@stardewvalley.com'], ['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']]
+	 * @param array $cc
+	 * @param array $bcc
+	 * @param array $attachments
+	 * @param int|null $aliasId
+	 * @param string|null $inReplyToMessageId
+	 * @param int|null $sendAt
+	 * @return JsonResponse
+	 */
+	public function create(
+		int     $accountId,
+		string  $subject,
+		string  $body,
+		string  $editorBody,
+		bool    $isHtml,
+		array   $to = [],
+		array   $cc = [],
+		array   $bcc = [],
+		array   $attachments = [],
+		?int    $aliasId = null,
+		?string $inReplyToMessageId = null,
+		?int $sendAt = null): JsonResponse {
+		$account = $this->accountService->find($this->userId, $accountId);
+
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($accountId);
+		$message->setAliasId($aliasId);
+		$message->setSubject($subject);
+		$message->setBody($body);
+		$message->setEditorBody($editorBody);
+		$message->setHtml($isHtml);
+		$message->setInReplyToMessageId($inReplyToMessageId);
+		$message->setSendAt($sendAt);
+
+		$this->service->saveMessage($account, $message, $to, $cc, $bcc, $attachments);
+
+		return JsonResponse::success($message, Http::STATUS_CREATED);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 * @param int $accountId
+	 * @param string $subject
+	 * @param string $body
+	 * @param string $editorBody
+	 * @param bool $isHtml
+	 * @param bool $failed
+	 * @param array $to i. e. [['label' => 'Linus', 'email' => 'tent@stardewvalley.com'], ['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']]
+	 * @param array $cc
+	 * @param array $bcc
+	 * @param array $attachments
+	 * @param int|null $aliasId
+	 * @param string|null $inReplyToMessageId
+	 * @param int|null $sendAt
+	 * @return JsonResponse
+	 */
+	public function update(int     $id,
+						   int     $accountId,
+						   string  $subject,
+						   string  $body,
+						   string  $editorBody,
+						   bool    $isHtml,
+						   bool    $failed = false,
+						   array   $to = [],
+						   array   $cc = [],
+						   array   $bcc = [],
+						   array   $attachments = [],
+						   ?int    $aliasId = null,
+						   ?string $inReplyToMessageId = null,
+						   ?int $sendAt = null): JsonResponse {
+		$message = $this->service->getMessage($id, $this->userId);
+		$account = $this->accountService->find($this->userId, $accountId);
+
+		$message->setAccountId($accountId);
+		$message->setAliasId($aliasId);
+		$message->setSubject($subject);
+		$message->setBody($body);
+		$message->setEditorBody($editorBody);
+		$message->setHtml($isHtml);
+		$message->setFailed($failed);
+		$message->setInReplyToMessageId($inReplyToMessageId);
+		$message->setSendAt($sendAt);
+
+		$message = $this->service->updateMessage($account, $message, $to, $cc, $bcc, $attachments);
+
+		return JsonResponse::success($message, Http::STATUS_ACCEPTED);
+	}
+
+	/**
+	 * Direct send without modification
+	 *
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 * @return JsonResponse
+	 */
+	public function send(int $id): JsonResponse {
+		$message = $this->service->getMessage($id, $this->userId);
+		$account = $this->accountService->find($this->userId, $message->getAccountId());
+		$this->service->sendMessage($message, $account);
+
+		return  JsonResponse::success(
+			'Message moved to Outbox', Http::STATUS_ACCEPTED
+		);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @param int $id
+	 * @return JsonResponse
+	 */
+	public function destroy(int $id): JsonResponse {
+		$message = $this->service->getMessage($id, $this->userId);
+		$account = $this->accountService->find($this->userId, $message->getAccountId());
+		$this->service->deleteMessage($this->userId, $message, $account);
+		return JsonResponse::success('Message deleted', Http::STATUS_ACCEPTED);
+	}
+}

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -37,8 +37,8 @@ use function array_filter;
  * @method void setAccountId(int $accountId)
  * @method int|null getAliasId()
  * @method void setAliasId(?int $aliasId)
- * @method int getSendAt()
- * @method void setSendAt(int $sendAt)
+ * @method int|null getSendAt()
+ * @method void setSendAt(?int $sendAt)
  * @method string getSubject()
  * @method void setSubject(string $subject)
  * @method string getBody()
@@ -51,6 +51,8 @@ use function array_filter;
  * @method void setFailed(bool $failed)
  * @method string|null getInReplyToMessageId()
  * @method void setInReplyToMessageId(?string $inReplyToId)
+ * @method setUid(?int $uid)
+ * @method int|null getUid()
  */
 class LocalMessage extends Entity implements JsonSerializable {
 	public const TYPE_OUTGOING = 0;
@@ -94,6 +96,9 @@ class LocalMessage extends Entity implements JsonSerializable {
 
 	/** @var bool|null */
 	protected $failed;
+
+	/** @var int|null */
+	protected $uid;
 
 	public function __construct() {
 		$this->addType('type', 'integer');

--- a/lib/Events/DraftMessageDeletedEvent.php
+++ b/lib/Events/DraftMessageDeletedEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Events;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\LocalMessage;
+use OCP\EventDispatcher\Event;
+
+/**
+ * @psalm-immutable
+ */
+class DraftMessageDeletedEvent extends Event {
+
+	/** @var Account */
+	private $account;
+
+	/** @var LocalMessage */
+	private $draft;
+
+	public function __construct(Account $account,
+								LocalMessage $draft) {
+		parent::__construct();
+		$this->account = $account;
+		$this->draft = $draft;
+	}
+
+	public function getAccount(): Account {
+		return $this->account;
+	}
+
+	public function getDraft(): ?LocalMessage {
+		return $this->draft;
+	}
+}

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -28,9 +28,12 @@ namespace OCA\Mail\Listener;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Exception;
 use OCA\Mail\Account;
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\LocalMessageMapper;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Events\DraftMessageDeletedEvent;
 use OCA\Mail\Events\DraftSavedEvent;
 use OCA\Mail\Events\MessageDeletedEvent;
 use OCA\Mail\Events\OutboxMessageCreatedEvent;
@@ -59,20 +62,25 @@ class DeleteDraftListener implements IEventListener {
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
+	private LocalMessageMapper $localMessageMapper;
+
 	public function __construct(IMAPClientFactory $imapClientFactory,
 								MailboxMapper $mailboxMapper,
 								MessageMapper $messageMapper,
 								LoggerInterface $logger,
-								IEventDispatcher $eventDispatcher) {
+								IEventDispatcher $eventDispatcher,
+								LocalMessageMapper $localMessageMapper
+								) {
 		$this->imapClientFactory = $imapClientFactory;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->logger = $logger;
 		$this->eventDispatcher = $eventDispatcher;
+		$this->localMessageMapper = $localMessageMapper;
 	}
 
 	public function handle(Event $event): void {
-		if (($event instanceof DraftSavedEvent || $event instanceof OutboxMessageCreatedEvent) && $event->getDraft() !== null) {
+		if (($event instanceof DraftSavedEvent || $event instanceof OutboxMessageCreatedEvent || $event instanceof DraftMessageDeletedEvent) && $event->getDraft() !== null) {
 			$this->deleteDraft($event->getAccount(), $event->getDraft());
 		}
 	}

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -28,7 +28,6 @@ namespace OCA\Mail\Listener;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Exception;
 use OCA\Mail\Account;
-use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Db\LocalMessageMapper;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;

--- a/lib/Migration/Version1140Date20220825093026.php
+++ b/lib/Migration/Version1140Date20220825093026.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1140Date20220825093026 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$localMessagesTable = $schema->getTable('mail_local_messages');
+
+		// add UID column for drafts
+		if (!$localMessagesTable->hasColumn('uid')) {
+			$localMessagesTable->addColumn('uid', Types::INTEGER,
+				[
+					'notnull' => false,
+				],
+			);
+		}
+
+		// Change sendat to allow null values - as drafts will not have sendAt set yet.
+		$localMessagesTable->changeColumn('send_at', [
+			'notnull' => false
+		]);
+
+		return $schema;
+	}
+}

--- a/lib/Service/DraftsService.php
+++ b/lib/Service/DraftsService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * *
+ *  * Mail App
+ *  *
+ *  * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *  *
+ *  * @author Anna Larch <anna.larch@gmx.net>
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ *  * License as published by the Free Software Foundation; either
+ *  * version 3 of the License, or any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *  *
+ *  * You should have received a copy of the GNU Affero General Public
+ *  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *  *
+ *
+ */
+
+namespace OCA\Mail\Service;
+
+use OC\EventDispatcher\EventDispatcher;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\ILocalMailboxService;
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\LocalMessageMapper;
+use OCA\Mail\Db\Recipient;
+use OCA\Mail\Events\DraftMessageDeletedEvent;
+use OCA\Mail\Events\OutboxMessageCreatedEvent;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Service\Attachment\AttachmentService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Psr\Log\LoggerInterface;
+
+class DraftsService implements ILocalMailboxService {
+
+	private LocalMessageMapper $mapper;
+	private LoggerInterface $logger;
+	private IMAPClientFactory $clientFactory;
+	private EventDispatcher $eventDispatcher;
+	private AttachmentService $attachmentService;
+
+	public function __construct(LocalMessageMapper $mapper,
+		AttachmentService $attachmentService,
+		IMAPClientFactory $clientFactory,
+		EventDispatcher $eventDispatcher,
+		LoggerInterface $logger) {
+		$this->mapper = $mapper;
+		$this->logger = $logger;
+		$this->clientFactory = $clientFactory;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->attachmentService = $attachmentService;
+	}
+
+	/**
+	 * @param array $recipients
+	 * @param int $type
+	 * @return Recipient[]
+	 */
+	private static function convertToRecipient(array $recipients, int $type): array {
+		return array_map(function ($recipient) use ($type) {
+			$r = new Recipient();
+			$r->setType($type);
+			$r->setLabel($recipient['label'] ?? $recipient['email']);
+			$r->setEmail($recipient['email']);
+			return $r;
+		}, $recipients);
+	}
+
+
+	/**
+	 * @param string $userId
+	 * @return LocalMessage[]
+	 */
+	public function getMessages(string $userId): array {
+		return $this->mapper->getAllForUser($userId,LocalMessage::TYPE_DRAFT);
+	}
+
+	public function getMessage(int $id, string $userId): LocalMessage {
+		return $this->mapper->findById($id, $userId, LocalMessage::TYPE_DRAFT);
+	}
+
+	/**
+	 * @param Account|null $account - null value allowed to correctly extend the Interface
+	 */
+	public function deleteMessage(string $userId, LocalMessage $message, Account $account = null): void {
+		// trigger a delete on IMAP
+		if($message->getUid() !== null && $account !== null) {
+			$this->eventDispatcher->dispatchTyped(new DraftMessageDeletedEvent($account, $message));
+
+		}
+		$this->attachmentService->deleteLocalMessageAttachments($userId, $message->getId());
+		$this->mapper->deleteWithRecipients($message);
+	}
+
+	public function sendMessage(LocalMessage $message, Account $account): void {
+		if (empty($message->getRecipients())) {
+			throw new ClientException('Could not send message as recipient is missing');
+		}
+
+		// We have an IMAP draft
+		if($message->getUid() !== null) {
+			$this->eventDispatcher->dispatchTyped(new DraftMessageDeletedEvent($account, $message));
+			$message->setUid(null);
+		}
+
+		$message->setType(LocalMessage::TYPE_OUTGOING);
+		$this->mapper->update($message);
+
+	}
+
+	public function saveMessage(Account $account, LocalMessage $message, array $to, array $cc, array $bcc, array $attachments = []): LocalMessage {
+		$toRecipients = self::convertToRecipient($to, Recipient::TYPE_TO);
+		$ccRecipients = self::convertToRecipient($cc, Recipient::TYPE_CC);
+		$bccRecipients = self::convertToRecipient($bcc, Recipient::TYPE_BCC);
+
+		$message = $this->mapper->saveWithRecipients($message, $toRecipients, $ccRecipients, $bccRecipients);
+
+		if(empty($attachments)) {
+			$message->setAttachments($attachments);
+			return $message;
+		}
+
+		$client = $this->clientFactory->getClient($account);
+		try {
+			$attachmentIds = $this->attachmentService->handleAttachments($account, $attachments, $client);
+		} finally {
+			$client->logout();
+		}
+
+		$message->setAttachments($this->attachmentService->saveLocalMessageAttachments($account->getUserId(), $message->getId(), $attachmentIds));
+		return $message;
+	}
+
+	public function updateMessage(Account $account, LocalMessage $message, array $to, array $cc, array $bcc, array $attachments = []): LocalMessage {
+		// Delete the IMAP draft
+		if($message->getUid() !== null) {
+			$this->eventDispatcher->dispatchTyped(new DraftMessageDeletedEvent($account, $message));
+			$message->setUid(null);
+		}
+
+		$toRecipients = self::convertToRecipient($to, Recipient::TYPE_TO);
+		$ccRecipients = self::convertToRecipient($cc, Recipient::TYPE_CC);
+		$bccRecipients = self::convertToRecipient($bcc, Recipient::TYPE_BCC);
+		$message = $this->mapper->updateWithRecipients($message, $toRecipients, $ccRecipients, $bccRecipients);
+
+		if(empty($attachments)) {
+			$message->setAttachments($this->attachmentService->updateLocalMessageAttachments($account->getUserId(), $message, $attachments));
+			return $message;
+		}
+
+		$client = $this->clientFactory->getClient($account);
+		try {
+			$attachmentIds = $this->attachmentService->handleAttachments($account, $attachments, $client);
+		} finally {
+			$client->logout();
+		}
+		$message->setAttachments($this->attachmentService->updateLocalMessageAttachments($account->getUserId(), $message, $attachmentIds));
+		return $message;
+	}
+}

--- a/lib/Service/OutboxService.php
+++ b/lib/Service/OutboxService.php
@@ -112,14 +112,14 @@ class OutboxService implements ILocalMailboxService {
 	 * @return LocalMessage[]
 	 */
 	public function getMessages(string $userId): array {
-		return $this->mapper->getAllForUser($userId);
+		return $this->mapper->getAllForUser($userId, LocalMessage::TYPE_OUTGOING);
 	}
 
 	/**
 	 * @throws DoesNotExistException
 	 */
 	public function getMessage(int $id, string $userId): LocalMessage {
-		return $this->mapper->findById($id, $userId);
+		return $this->mapper->findById($id, $userId, LocalMessage::TYPE_OUTGOING);
 	}
 
 	public function deleteMessage(string $userId, LocalMessage $message): void {

--- a/tests/Integration/Service/DraftsServiceIntegrationTest.php
+++ b/tests/Integration/Service/DraftsServiceIntegrationTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+/*
+ * *
+ *  * Mail App
+ *  *
+ *  * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *  *
+ *  * @author Anna Larch <anna.larch@gmx.net>
+ *  *
+ *  * This library is free software; you can redistribute it and/or
+ *  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ *  * License as published by the Free Software Foundation; either
+ *  * version 3 of the License, or any later version.
+ *  *
+ *  * This library is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *  *
+ *  * You should have received a copy of the GNU Affero General Public
+ *  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *  *
+ *
+ */
+
+namespace OCA\Mail\Tests\Integration\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestUser;
+use Horde_Imap_Client;
+use OC;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IAttachmentService;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Contracts\IMailTransmission;
+use OCA\Mail\Db\LocalAttachmentMapper;
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\LocalMessageMapper;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Attachment\AttachmentService;
+use OCA\Mail\Service\Attachment\AttachmentStorage;
+use OCA\Mail\Service\DraftsService;
+use OCA\Mail\Service\OutboxService;
+use OCA\Mail\Service\Sync\SyncService;
+use OCA\Mail\Tests\Integration\Framework\ImapTest;
+use OCA\Mail\Tests\Integration\Framework\ImapTestAccount;
+use OCA\Mail\Tests\Integration\TestCase;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Folder;
+use OCP\IServerContainer;
+use OCP\IUser;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class DraftsServiceIntegrationTest extends TestCase {
+	use ImapTest,
+		ImapTestAccount,
+		TestUser;
+
+	/** @var MailAccount */
+	private $account;
+
+	/** @var IUser */
+	private $user;
+
+	/** @var IAttachmentService */
+	private $attachmentService;
+
+	/** @var IMailTransmission */
+	private $transmission;
+
+	/** @var OutboxService */
+	private $draftsService;
+
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
+
+	/** @var IMAPClientFactory */
+	private $clientFactory;
+
+	/** @var LocalMessageMapper */
+	private $mapper;
+
+	/** @var Folder */
+	private $userFolder;
+
+	/** @var  */
+	private $accountService;
+
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->resetImapAccount();
+		$this->disconnectImapAccount();
+
+		$this->user = $this->createTestUser();
+		$this->account = $this->createTestAccount($this->user->getUID());
+		$c = OC::$server->get(ContainerInterface::class);
+		$userContainer = $c->get(IServerContainer::class);
+		$this->userFolder = $userContainer->getUserFolder($this->account->getUserId());
+		$mailManager = OC::$server->get(IMailManager::class);
+		$this->attachmentService = new AttachmentService(
+			$this->userFolder,
+			OC::$server->get(LocalAttachmentMapper::class),
+			OC::$server->get(AttachmentStorage::class),
+			$mailManager,
+			OC::$server->get(\OCA\Mail\IMAP\MessageMapper::class),
+			new NullLogger()
+		);
+		$this->client = $this->getClient($this->account);
+		$this->mapper = OC::$server->get(LocalMessageMapper::class);
+		$this->eventDispatcher = OC::$server->get(IEventDispatcher::class);
+		$this->clientFactory = OC::$server->get(IMAPClientFactory::class);
+		$this->accountService = OC::$server->get(AccountService::class);
+
+		$this->db = \OC::$server->getDatabaseConnection();
+		$qb = $this->db->getQueryBuilder();
+		$delete = $qb->delete($this->mapper->getTableName());
+		$delete->execute();
+
+		$this->draftsService = new DraftsService(
+			$this->mapper,
+			$this->attachmentService,
+			$this->clientFactory,
+			$this->eventDispatcher,
+			$this->createMock(LoggerInterface::class)
+		);
+	}
+
+	public function testSaveAndGetMessage(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$to = [[
+			'label' => 'Penny',
+			'email' => 'library@stardewvalley.com'
+		]];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, $to, [], []);
+		$this->assertNotEmpty($saved->getRecipients());
+		$this->assertEmpty($saved->getAttachments());
+
+		$retrieved = $this->draftsService->getMessage($message->getId(), $this->user->getUID());
+		$this->assertNotEmpty($retrieved->getRecipients());
+		$this->assertEmpty($retrieved->getAttachments());
+
+		self::assertCount(1, $retrieved->getRecipients());
+	}
+
+	public function testSaveAndGetMessages(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, [], [], []);
+		$this->assertEmpty($saved->getRecipients());
+		$this->assertEmpty($saved->getAttachments());
+
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, [], [], []);
+		$this->assertEmpty($saved->getRecipients());
+		$this->assertEmpty($saved->getAttachments());
+
+		$messages = $this->draftsService->getMessages($this->user->getUID());
+		$this->assertCount(2, $messages);
+	}
+
+	public function testSaveAndGetMessageWithMessageAttachment(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		/** @var \Horde_Imap_Client_Mailbox[] $mailBoxes */
+		$mailBoxes = $this->getMailboxes();
+		$inbox = null;
+		foreach ($mailBoxes as $mailBox) {
+			if ($mailBox->equals('INBOX')) {
+				$inbox = $mailBox;
+				break;
+			}
+		}
+		$imapMessage = $this->getMessageBuilder()
+			->from('buffington@domain.tld')
+			->to('user@domain.tld')
+			->finish();
+		$newUid = $this->saveMessage($inbox->__toString(), $imapMessage, $this->account);
+		/** @var MailboxMapper $mailBoxMapper */
+		$mailBoxMapper = OC::$server->query(MailboxMapper::class);
+		$dbInbox = $mailBoxMapper->find(new Account($this->account), $inbox->__toString());
+		/** @var SyncService $syncService */
+		$syncService = OC::$server->query(SyncService::class);
+		$syncService->syncMailbox(
+			new Account($this->account),
+			$dbInbox,
+			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			[],
+			false
+		);
+		/** @var MessageMapper $messageMapper */
+		$messageMapper = OC::$server->query(MessageMapper::class);
+		$dbMessages = $messageMapper->findByUids($dbInbox, [$newUid]);
+		$attachments = [
+			[
+				'type' => 'message',
+				'id' => $dbMessages[0]->getId(),
+				'fileName' => 'embedded.msg'
+			]
+		];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, [], [], [], $attachments);
+		$this->assertEmpty($saved->getRecipients());
+		$this->assertNotEmpty($saved->getAttachments());
+		$this->assertCount(1, $saved->getAttachments());
+
+		$messages = $this->draftsService->getMessages($this->user->getUID());
+		$result = $messages[0];
+		$attachments = $result->getAttachments();
+		$attachment = $attachments[0];
+
+		$this->assertCount(1, $messages);
+		$this->assertNotEmpty($message->getAttachments());
+		$this->assertCount(1, $attachments);
+		$this->assertEquals('embedded.msg', $attachment->getFileName());
+		$this->assertEquals($message->getId(), $attachment->getLocalMessageId());
+	}
+
+	public function testSaveAndGetMessageWithCloudAttachmentt(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+		$this->userFolder->newFile('/test.txt', file_get_contents(__DIR__ . '/../../data/test.txt'));
+		$attachments = [
+			[
+				'type' => 'cloud',
+				'fileName' => 'test.txt'
+			]
+		];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, [], [], [], $attachments);
+		$this->assertEmpty($saved->getRecipients());
+		$this->assertNotEmpty($saved->getAttachments());
+		$this->assertCount(1, $saved->getAttachments());
+
+		$messages = $this->draftsService->getMessages($this->user->getUID());
+		$result = $messages[0];
+		$attachments = $result->getAttachments();
+		$attachment = $attachments[0];
+
+		$this->assertCount(1, $messages);
+		$this->assertNotEmpty($message->getAttachments());
+		$this->assertCount(1, $attachments);
+		$this->assertEquals('test.txt', $attachment->getFileName());
+		$this->assertEquals($message->getId(), $attachment->getLocalMessageId());
+	}
+
+	public function testSaveAndDeleteMessage(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$to = [[
+			'label' => 'Penny',
+			'email' => 'library@stardewvalley.com'
+		]];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, $to, [], []);
+		$this->assertNotEmpty($message->getRecipients());
+		$this->assertEmpty($message->getAttachments());
+
+		$this->draftsService->deleteMessage($this->user->getUID(), $saved);
+
+		$this->expectException(DoesNotExistException::class);
+		$this->draftsService->getMessage($message->getId(), $this->user->getUID());
+	}
+
+	public function testSaveAndUpdateMessage(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$to = [[
+			'label' => 'Penny',
+			'email' => 'library@stardewvalley.com'
+		]];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, $to, [], []);
+		$this->assertNotEmpty($message->getRecipients());
+		$this->assertCount(1, $saved->getRecipients());
+		$this->assertEmpty($message->getAttachments());
+
+		$saved->setSubject('Your Trailer will be put up for sale');
+		$cc = [[
+			'label' => 'Pam',
+			'email' => 'buyMeABeer@stardewvalley.com'
+		]];
+		$updated = $this->draftsService->updateMessage(new Account($this->account), $saved, $to, $cc, []);
+
+		$this->assertNotEmpty($updated->getRecipients());
+		$this->assertEquals('Your Trailer will be put up for sale', $updated->getSubject());
+		$this->assertCount(2, $updated->getRecipients());
+	}
+
+	public function testSaveAndSendMessage(): void {
+		$message = new LocalMessage();
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setAccountId($this->account->getId());
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setHtml(true);
+
+		$to = [[
+			'label' => 'Penny',
+			'email' => 'library@stardewvalley.com'
+		]];
+
+		$saved = $this->draftsService->saveMessage(new Account($this->account), $message, $to, [], []);
+		$this->assertNotEmpty($message->getRecipients());
+		$this->assertCount(1, $saved->getRecipients());
+		$this->assertEmpty($message->getAttachments());
+
+		$this->draftsService->sendMessage($saved, new Account($this->account));
+
+		$this->expectException(DoesNotExistException::class);
+		$this->draftsService->getMessage($message->getId(), $this->user->getUID());
+	}
+}

--- a/tests/Unit/Controller/DraftsControllerTest.php
+++ b/tests/Unit/Controller/DraftsControllerTest.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * Mail
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Controller;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\AppFramework\Http;
+use OCA\Mail\Account;
+use OCA\Mail\Controller\DraftsController;
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Http\JsonResponse;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\DraftsService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\Exception;
+use OCP\IRequest;
+
+class DraftsControllerTest extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appName = 'mail';
+		$this->service = $this->createMock(DraftsService::class);
+		$this->userId = 'john';
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
+
+		$this->controller = new DraftsController(
+			$this->appName,
+			$this->userId,
+			$this->request,
+			$this->service,
+			$this->accountService
+		);
+	}
+
+	public function testIndex(): void {
+		$messages = [
+			new LocalMessage(),
+			new LocalMessage()
+		];
+		$this->service->expects(self::once())
+			->method('getMessages')
+			->with($this->userId)
+			->willReturn($messages);
+
+		$expected = JsonResponse::success(['messages' => $messages]);
+		$actual = $this->controller->index();
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testIndexNoMessages(): void {
+		$messages = [];
+
+		$this->service->expects(self::once())
+			->method('getMessages')
+			->with($this->userId)
+			->willReturn($messages);
+
+		$expected = JsonResponse::success(['messages' => $messages]);
+		$actual = $this->controller->index();
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testShow(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+
+		$expected = JsonResponse::success($message);
+		$actual = $this->controller->show($message->getId());
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testShowMessageNotFound(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willThrowException(new DoesNotExistException(''));
+		$this->accountService->expects(self::never())
+			->method('find');
+
+		$this->expectException(DoesNotExistException::class);
+		$this->controller->show($message->getId());
+	}
+
+	public function testSend(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$account = new Account(new MailAccount());
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+		$this->service->expects(self::once())
+			->method('sendMessage')
+			->with($message, $account);
+
+		$expected = JsonResponse::success('Message moved to Outbox', Http::STATUS_ACCEPTED);
+		$actual = $this->controller->send($message->getId());
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testSendNoMessage(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willThrowException(new DoesNotExistException(''));
+		$this->accountService->expects(self::never())
+			->method('find');
+		$this->service->expects(self::never())
+			->method('sendMessage');
+
+		$this->expectException(DoesNotExistException::class);
+		$expected = JsonResponse::fail('', Http::STATUS_NOT_FOUND);
+		$actual = $this->controller->send($message->getId());
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testSendClientException(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willThrowException(new ClientException());
+		$this->service->expects(self::never())
+			->method('sendMessage');
+
+		$this->expectException(ClientException::class);
+		$this->controller->send($message->getId());
+	}
+
+	public function testSendServiceException(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$account = new Account(new MailAccount());
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+		$this->service->expects(self::once())
+			->method('sendMessage')
+			->willThrowException(new ServiceException());
+
+		$this->expectException(ServiceException::class);
+		$this->controller->send($message->getId());
+	}
+
+	public function testDestroy(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$this->service->expects(self::once())
+			->method('deleteMessage')
+			->with($this->userId, $message);
+
+		$expected = JsonResponse::success('Message deleted', Http::STATUS_ACCEPTED);
+		$actual = $this->controller->destroy($message->getId());
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testDestroyNoMessage(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willThrowException(new DoesNotExistException(''));
+		$this->service->expects(self::never())
+			->method('deleteMessage');
+
+		$this->expectException(DoesNotExistException::class);
+		$expected = JsonResponse::fail('', Http::STATUS_NOT_FOUND);
+		$actual = $this->controller->destroy($message->getId());
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testCreate(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$account = new Account(new MailAccount());
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+		$this->service->expects(self::once())
+			->method('saveMessage')
+			->with($account, $message, $to, $cc, [], []);
+
+		$expected = JsonResponse::success($message, Http::STATUS_CREATED);
+		$actual = $this->controller->create(
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testCreateAccountNotFound(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willThrowException(new ClientException());
+		$this->service->expects(self::never())
+			->method('saveMessage');
+
+		$this->expectException(ClientException::class);
+		$actual = $this->controller->create(
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+	}
+
+	public function testCreateDbException(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_OUTGOING);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId());
+		$this->service->expects(self::once())
+			->method('saveMessage')
+			->willThrowException(new Exception());
+
+		$this->expectException(Exception::class);
+		$this->controller->create(
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+	}
+
+	public function testUpdate(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setFailed(false);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$account = new Account(new MailAccount());
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+		$this->service->expects(self::once())
+			->method('updateMessage')
+			->with($account, $message, $to, $cc, [], [])
+			->willReturn($message);
+
+		$expected = JsonResponse::success($message, Http::STATUS_ACCEPTED);
+		$actual = $this->controller->update(
+			$message->getId(),
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			false,
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testUpdateMessageNotFound(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setFailed(false);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willThrowException(new DoesNotExistException(''));
+		$this->service->expects(self::never())
+			->method('updateMessage');
+
+
+		$this->expectException(DoesNotExistException::class);
+		$expected = JsonResponse::fail('', Http::STATUS_NOT_FOUND);
+		$actual = $this->controller->update(
+			$message->getId(),
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			false,
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testUpdateDbException(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setFailed(false);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$account = new Account(new MailAccount());
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+		$this->service->expects(self::once())
+			->method('updateMessage')
+			->with($account, $message, $to, $cc, [], [])
+			->willThrowException(new Exception());
+
+		$this->expectException(Exception::class);
+		$this->controller->update(
+			$message->getId(),
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			false,
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId()
+		);
+	}
+}

--- a/tests/Unit/Service/DraftsServiceTest.php
+++ b/tests/Unit/Service/DraftsServiceTest.php
@@ -1,0 +1,593 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mail App
+ *
+ * @copyright 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\EventDispatcher\EventDispatcher;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\LocalAttachment;
+use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\LocalMessageMapper;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Recipient;
+use OCA\Mail\Events\DraftMessageDeletedEvent;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Attachment\AttachmentService;
+use OCA\Mail\Service\DraftsService;
+use OCA\Mail\Service\MailTransmission;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\DB\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class DraftsServiceTest extends TestCase {
+
+
+	/** @var MailTransmission|MockObject */
+	private $transmission;
+
+	/** @var LocalMessageMapper|MockObject */
+	private $mapper;
+
+	/** @var DraftsService */
+	private $draftsService;
+
+	/** @var string */
+	private $userId;
+
+	/** @var AttachmentService|MockObject */
+	private $attachmentService;
+
+	/** @var IMAPClientFactory|MockObject */
+	private $clientFactory;
+
+	/** @var EventDispatcher|EventDispatcher&MockObject|MockObject  */
+	private $eventDispatcher;
+
+	/** @var MockObject|LoggerInterface */
+	private $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->transmission = $this->createMock(MailTransmission::class);
+		$this->mapper = $this->createMock(LocalMessageMapper::class);
+		$this->attachmentService = $this->createMock(AttachmentService::class);
+		$this->clientFactory = $this->createMock(IMAPClientFactory::class);
+		$this->mailManager = $this->createMock(IMailManager::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->eventDispatcher = $this->createMock(EventDispatcher::class);
+		$this->draftsService = new DraftsService(
+			$this->mapper,
+			$this->attachmentService,
+			$this->clientFactory,
+			$this->eventDispatcher,
+			$this->logger
+		);
+		$this->userId = 'linus';
+	}
+
+	public function testGetMessages(): void {
+		$this->mapper->expects(self::once())
+			->method('getAllForUser')
+			->with($this->userId)
+			->willReturn([
+				[
+					'id' => 1,
+					'type' => 1,
+					'account_id' => 1,
+					'alias_id' => 2,
+					'send_at' => $this->time->getTime(),
+					'subject' => 'Test',
+					'body' => 'Test',
+					'html' => false,
+					'reply_to_id' => null,
+					'uid' => 99
+
+				],
+				[
+					'id' => 2,
+					'type' => 1,
+					'account_id' => 1,
+					'alias_id' => 2,
+					'send_at' => $this->time->getTime(),
+					'subject' => 'Second Test',
+					'body' => 'Second Test',
+					'html' => true,
+					'reply_to_id' => null,
+					'uid' => 10
+				]
+			]);
+
+		$this->draftsService->getMessages($this->userId);
+	}
+
+	public function testGetMessagesNoneFound(): void {
+		$this->mapper->expects(self::once())
+			->method('getAllForUser')
+			->with($this->userId)
+			->willThrowException(new Exception());
+
+		$this->expectException(Exception::class);
+		$this->draftsService->getMessages($this->userId);
+	}
+
+	public function testGetMessage(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+
+		$this->mapper->expects(self::once())
+			->method('findById')
+			->with(1, $this->userId)
+			->willReturn($message);
+
+		$this->draftsService->getMessage(1, $this->userId);
+	}
+
+	public function testNoMessage(): void {
+		$this->mapper->expects(self::once())
+			->method('findById')
+			->with(1, $this->userId)
+			->willThrowException(new DoesNotExistException('Could not fetch any messages'));
+
+		$this->expectException(DoesNotExistException::class);
+		$this->draftsService->getMessage(1, $this->userId);
+	}
+
+	public function testDeleteMessage(): void {
+		$message = new LocalMessage();
+		$message->setId(10);
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setUid(100);
+		$account = new Account(new MailAccount());
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped')
+			->with(new DraftMessageDeletedEvent($account, $message));
+		$this->attachmentService->expects(self::once())
+			->method('deleteLocalMessageAttachments')
+			->with($this->userId, $message->getId());
+		$this->mapper->expects(self::once())
+			->method('deleteWithRecipients')
+			->with($message);
+
+		$this->draftsService->deleteMessage($this->userId, $message, $account);
+	}
+
+	public function testDeleteMessageNoUid(): void {
+		$message = new LocalMessage();
+		$message->setId(10);
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$account = new Account(new MailAccount());
+
+		$this->eventDispatcher->expects(self::never())
+			->method('dispatchTyped');
+		$this->attachmentService->expects(self::once())
+			->method('deleteLocalMessageAttachments')
+			->with($this->userId, $message->getId());
+		$this->mapper->expects(self::once())
+			->method('deleteWithRecipients')
+			->with($message);
+
+		$this->draftsService->deleteMessage($this->userId, $message, $account);
+	}
+
+	public function testSaveMessage(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$message->setType(LocalMessage::TYPE_DRAFT);
+		$message->setUid(100);
+		$to = [
+			[
+				'label' => 'Lewis',
+				'email' => 'tent-living@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$cc = [];
+		$bcc = [];
+		$attachments = [[]];
+		$attachmentIds = [1];
+		$rTo = Recipient::fromParams([
+			'label' => 'Lewis',
+			'email' => 'tent-living@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message2 = $message;
+		$message2->setId(10);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+		$client = $this->createMock(\Horde_Imap_Client_Socket::class);
+
+		$this->mapper->expects(self::once())
+			->method('saveWithRecipients')
+			->with($message, [$rTo], $cc, $bcc)
+			->willReturn($message2);
+		$this->clientFactory->expects(self::once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$this->attachmentService->expects(self::once())
+			->method('handleAttachments')
+			->with($account, $attachments, $client)
+			->willReturn($attachmentIds);
+		$this->attachmentService->expects(self::once())
+			->method('saveLocalMessageAttachments')
+			->with($this->userId, 10, $attachmentIds);
+
+		$this->draftsService->saveMessage($account, $message, $to, $cc, $bcc, $attachments);
+	}
+
+	public function testUpdateMessage(): void {
+		$message = new LocalMessage();
+		$message->setId(10);
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$message->setUid(100);
+		$old = Recipient::fromParams([
+			'label' => 'Pam',
+			'email' => 'BuyMeAnAle@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message->setRecipients([$old]);
+		$to = [
+			[
+				'label' => 'Linus',
+				'email' => 'tent-living@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$cc = [];
+		$bcc = [];
+		$attachments = [['type' => '']];
+		$attachmentIds = [3];
+		$rTo = Recipient::fromParams([
+			'label' => 'Linus',
+			'email' => 'tent-living@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message2 = $message;
+		$message2->setRecipients([$rTo]);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+		$client = $this->createMock(\Horde_Imap_Client_Socket::class);
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped')
+			->with(new DraftMessageDeletedEvent($account, $message));
+		$this->mapper->expects(self::once())
+			->method('updateWithRecipients')
+			->with($message, [$rTo], $cc, $bcc)
+			->willReturn($message2);
+		$this->clientFactory->expects(self::once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$this->attachmentService->expects(self::once())
+			->method('handleAttachments')
+			->with($account, $attachments, $client)
+			->willReturn($attachmentIds);
+		$this->attachmentService->expects(self::once())
+			->method('updateLocalMessageAttachments')
+			->with($this->userId, $message2, $attachmentIds);
+
+		$this->draftsService->updateMessage($account, $message, $to, $cc, $bcc, $attachments);
+	}
+
+	public function testUpdateMessageNoAttachments(): void {
+		$message = new LocalMessage();
+		$message->setId(10);
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$message->setUid(100);
+		$old = Recipient::fromParams([
+			'label' => 'Pam',
+			'email' => 'BuyMeAnAle@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message->setRecipients([$old]);
+		$to = [
+			[
+				'label' => 'Linus',
+				'email' => 'tent-living@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$cc = [];
+		$bcc = [];
+		$attachments = [];
+		$rTo = Recipient::fromParams([
+			'label' => 'Linus',
+			'email' => 'tent-living@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message2 = $message;
+		$message2->setRecipients([$rTo]);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped')
+			->with(new DraftMessageDeletedEvent($account, $message));
+		$this->mapper->expects(self::once())
+			->method('updateWithRecipients')
+			->with($message, [$rTo], $cc, $bcc)
+			->willReturn($message2);
+		$this->attachmentService->expects(self::once())
+			->method('updateLocalMessageAttachments')
+			->with($this->userId, $message2, $attachments);
+		$this->clientFactory->expects(self::never())
+			->method('getClient');
+		$this->attachmentService->expects(self::never())
+			->method('handleAttachments');
+
+		$this->draftsService->updateMessage($account, $message, $to, $cc, $bcc, $attachments);
+	}
+
+	public function testUpdateMessageNoUid(): void {
+		$message = new LocalMessage();
+		$message->setId(10);
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$old = Recipient::fromParams([
+			'label' => 'Pam',
+			'email' => 'BuyMeAnAle@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message->setRecipients([$old]);
+		$to = [
+			[
+				'label' => 'Linus',
+				'email' => 'tent-living@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$cc = [];
+		$bcc = [];
+		$attachments = [['type' => '']];
+		$attachmentIds = [3];
+		$rTo = Recipient::fromParams([
+			'label' => 'Linus',
+			'email' => 'tent-living@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message2 = $message;
+		$message2->setRecipients([$rTo]);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+		$client = $this->createMock(\Horde_Imap_Client_Socket::class);
+
+		$this->eventDispatcher->expects(self::never())
+			->method('dispatchTyped');
+		$this->mapper->expects(self::once())
+			->method('updateWithRecipients')
+			->with($message, [$rTo], $cc, $bcc)
+			->willReturn($message2);
+		$this->clientFactory->expects(self::once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$this->attachmentService->expects(self::once())
+			->method('handleAttachments')
+			->with($account, $attachments, $client)
+			->willReturn($attachmentIds);
+		$this->attachmentService->expects(self::once())
+			->method('updateLocalMessageAttachments')
+			->with($this->userId, $message2, $attachmentIds);
+
+		$this->draftsService->updateMessage($account, $message, $to, $cc, $bcc, $attachments);
+	}
+
+	public function testSaveMessageNoAttachments(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('abcd');
+		$to = [
+			[
+				'label' => 'Pam',
+				'email' => 'BuyMeAnAle@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$cc = [];
+		$bcc = [];
+		$rTo = Recipient::fromParams([
+			'label' => 'Pam',
+			'email' => 'BuyMeAnAle@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$message2 = $message;
+		$message2->setId(10);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+
+		$this->mapper->expects(self::once())
+			->method('saveWithRecipients')
+			->with($message, [$rTo], $cc, $bcc)
+			->willReturn($message2);
+		$this->attachmentService->expects(self::never())
+			->method('saveLocalMessageAttachments');
+
+		$this->draftsService->saveMessage($account, $message, $to, $cc, $bcc);
+	}
+
+	public function testSaveMessageError(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setSendAt($this->time->getTime());
+		$message->setSubject('Test');
+		$message->setBody('Test Test Test');
+		$message->setHtml(true);
+		$message->setInReplyToMessageId('laskdjhsakjh33233928@startdewvalley.com');
+		$to = [
+			[
+				'label' => 'Gunther',
+				'email' => 'museum@startdewvalley.com',
+				'type' => Recipient::TYPE_TO,
+			]
+		];
+		$rTo = Recipient::fromParams([
+			'label' => 'Gunther',
+			'email' => 'museum@startdewvalley.com',
+			'type' => Recipient::TYPE_TO,
+		]);
+		$account = $this->createMock(Account::class);
+
+		$this->mapper->expects(self::once())
+			->method('saveWithRecipients')
+			->with($message, [$rTo], [], [])
+			->willThrowException(new Exception());
+		$this->attachmentService->expects(self::never())
+			->method('saveLocalMessageAttachments');
+		$this->expectException(Exception::class);
+
+		$this->draftsService->saveMessage($account, $message, $to, [], []);
+	}
+
+	public function testSendMessage(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setUid(100);
+		$recipient = new Recipient();
+		$recipient->setEmail('museum@startdewvalley.com');
+		$recipient->setLabel('Gunther');
+		$recipient->setType(Recipient::TYPE_TO);
+		$recipients = [$recipient];
+		$attachment = new LocalAttachment();
+		$attachment->setMimeType('image/png');
+		$attachment->setFileName('SlimesInTheMines.png');
+		$attachment->setCreatedAt($this->time->getTime());
+		$attachments = [$attachment];
+		$message->setRecipients($recipients);
+		$message->setAttachments($attachments);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+
+		$this->eventDispatcher->expects(self::once())
+			->method('dispatchTyped')
+			->with(new DraftMessageDeletedEvent($account, $message));
+		$this->mapper->expects(self::once())
+			->method('update')
+			->with($message);
+
+		$this->draftsService->sendMessage($message, $account);
+	}
+
+	public function testSendMessageNoUid(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$recipient = new Recipient();
+		$recipient->setEmail('museum@startdewvalley.com');
+		$recipient->setLabel('Gunther');
+		$recipient->setType(Recipient::TYPE_TO);
+		$recipients = [$recipient];
+		$attachment = new LocalAttachment();
+		$attachment->setMimeType('image/png');
+		$attachment->setFileName('SlimesInTheMines.png');
+		$attachment->setCreatedAt($this->time->getTime());
+		$attachments = [$attachment];
+		$message->setRecipients($recipients);
+		$message->setAttachments($attachments);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+
+		$this->eventDispatcher->expects(self::never())
+			->method('dispatchTyped');
+		$this->mapper->expects(self::once())
+			->method('update')
+			->with($message);
+
+		$this->draftsService->sendMessage($message, $account);
+	}
+
+	public function testSendMessageNoRecipients(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$recipients = [];
+		$message->setRecipients($recipients);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $this->userId
+		]);
+
+		$this->eventDispatcher->expects(self::never())
+			->method('dispatchTyped');
+		$this->mapper->expects(self::never())
+			->method('update');
+
+		$this->expectException(ClientException::class);
+		$this->draftsService->sendMessage($message, $account);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/7076

Move the draft handling from IMAP to our local messages mailbox.

To do:
- [ ] Provide API endpoints
- [ ] Tests
- [ ] Background Job that syncs drafts without UID to IMAP
- [ ] Background Job that syncs drafts from IMAP to the local mailbox

There was some discussion about whether the drafts box should be unified or not.

- [x] ~~Clarify whether we need to split messages on a per account basis (this should be possible to handle with a few changes)~~ Neither. Local drafts are not visible to the user ever but have an account ID assigned.
