### PR TITLE
Fine-tune padding of composer elements

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1334,13 +1334,27 @@ export default {
 	.multiselect {
 		margin-right: 12px;
 	}
-}
 
-.subject {
-	font-size: 20px;
-	font-weight: bold;
-	margin: 0;
-	padding: 24px 20px;
+	.subject {
+		font-weight: bold;
+		margin: 3px 0 !important;
+		padding: 0 12px !important;
+	}
+
+	.message-body {
+		height: 100%;
+		width: 100%;
+		margin: 0;
+		border: none !important;
+		outline: none !important;
+		box-shadow: none !important;
+		padding: 12px;
+
+		// Fix contenteditable not becoming focused upon clichint within it's
+		// boundaries in safari
+		-webkit-user-select: text;
+		user-select: text;
+	}
 }
 
 .warning-box {
@@ -1352,23 +1366,6 @@ export default {
 .message-editor {
 	flex: 1 1 100%;
 	min-height: 0;
-}
-
-.message-body {
-	height: 100%;
-	width: 100%;
-	margin: 0;
-	border: none !important;
-	outline: none !important;
-	box-shadow: none !important;
-	padding-top: 12px;
-	padding-bottom: 12px;
-	padding-left: 20px;
-
-	// Fix contenteditable not becoming focused upon clichint within it's
-	// boundaries in safari
-	-webkit-user-select: text;
-	user-select: text;
 }
 
 .draft-status {
@@ -1468,7 +1465,7 @@ export default {
 .composer-actions--secondary-actions {
 	display: flex;
 	flex-direction: row;
-	padding: 5px;
+	padding: 12px;
 }
 .composer-actions--primary-actions .button {
 	padding: 2px;


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Bildschirmfoto vom 2022-09-08 18-38-12](https://user-images.githubusercontent.com/1374172/189178054-8c0ab833-9186-4cb8-833c-a5803a2365d2.png) | ![Bildschirmfoto vom 2022-09-08 18-37-22](https://user-images.githubusercontent.com/1374172/189178065-09ab5dba-02d8-4206-a126-1db1dc883209.png) |
| ![Bildschirmfoto vom 2022-09-08 18-38-21](https://user-images.githubusercontent.com/1374172/189178053-51b13e06-6b30-4118-881e-e67347547f05.png) | ![Bildschirmfoto vom 2022-09-08 18-37-31](https://user-images.githubusercontent.com/1374172/189178060-f6829dea-de7b-409d-b49a-dfa9c703d8b3.png) |
| ![Bildschirmfoto vom 2022-09-08 18-38-31](https://user-images.githubusercontent.com/1374172/189178050-94cfbeb3-da7a-4c70-a253-438fa6cbd5ea.png) | ![Bildschirmfoto vom 2022-09-08 18-37-50](https://user-images.githubusercontent.com/1374172/189178057-f1c0188b-9e29-49bd-b80c-218e25b5945a.png) |

There is still a bit of room for improvements. Consider this the first step.