### PR TITLE
Fix lost modifications of preview text

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -499,6 +499,8 @@ class MessageMapper extends QBMapper {
 				$previewText = null;
 				if ($message->getPreviewText() !== null) {
 					$previewText = mb_strcut(mb_convert_encoding($message->getPreviewText(), 'UTF-8', 'UTF-8'), 0, 255);
+					// Make sure modifications are visible when these objects are used right away
+					$message->setPreviewText($previewText);
 				}
 				$query->setParameter(
 					'preview_text',


### PR DESCRIPTION
Messages are processed one, on demand. The processing result is stored to the database. In that process we strip invalid characters from the preview text and cut it to database column width.
If a message is processed and converted into response JSON, the stripping and cutting didn't have an effect for the in memory objects. Only messages loaded from the database cache had a stripped and cut json representation.

Fixes

```
{"reqId":"9LagtRSWLlG1xSDPba8j","level":3,"time":"2022-09-12T09:08:22+00:00","remoteAddr":"…","user":"m…","app":"index","method":"GET","url":"/apps/mail/api/messages?mailboxId=2402&limit=20&cursor=1662365013","message":"Could not json_encode due to invalid non UTF-8 characters in the array: array (\n  0 => \n  OCA\\Mail\\Db\\Message::__set_state(
``` 