### PR TITLE
[stable1.14] Fix lost modifications of preview text

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -499,6 +499,8 @@ class MessageMapper extends QBMapper {
 				$previewText = $message->getPreviewText();
 				if ($previewText !== null) {
 					$previewText = mb_strcut(mb_convert_encoding($previewText, 'UTF-8', 'UTF-8'), 0, 255);
+					// Make sure modifications are visible when these objects are used right away
+					$message->setPreviewText($previewText);
 				}
 				$query->setParameter(
 					'preview_text',


### PR DESCRIPTION
Messages are processed one, on demand. The processing result is stored to the database. In that process we strip invalid characters from the preview text and cut it to database column width.
If a message is processed and converted into response JSON, the stripping and cutting didn't have an effect for the in memory objects. Only messages loaded from the database cache had a stripped and cut json representation.

Backport of https://github.com/nextcloud/mail/pull/7264.