### PR TITLE
Fix date formatting for sieve autoresponder

### DIFF
--- a/src/tests/unit/util/outOfOffice.spec.js
+++ b/src/tests/unit/util/outOfOffice.spec.js
@@ -152,8 +152,8 @@ describe('outOfOffice', () => {
 	})
 
 	describe('formatDateForSieve', () => {
-		it('should format js dates according to YYYY-MM-DD', () => {
-			const date = new Date('2022-09-02T08:58:01+0000')
+		it('should format a JS date instance according to YYYY-MM-DD', () => {
+			const date = new Date('2022-09-02')
 			const expected = '2022-09-02'
 			const actual = formatDateForSieve(date)
 			expect(actual).toEqual(expected)

--- a/src/util/outOfOffice.js
+++ b/src/util/outOfOffice.js
@@ -174,7 +174,10 @@ export function buildOutOfOfficeSieveScript(sieveScript, {
  * @return {string} YYYY-MM-DD
  */
 export function formatDateForSieve(date) {
-	return date.toISOString().slice(0, 10)
+	const year = date.getFullYear().toString().padStart(4, '0')
+	const month = (date.getMonth() + 1).toString().padStart(2, '0')
+	const day = date.getDate().toString().padStart(2, '0')
+	return `${year}-${month}-${day}`
 }
 
 /**


### PR DESCRIPTION
Fix #7184

A date like `Sun Aug 28 2022 00:00:00 GMT+0200` from the picker was converted to `2022-09-27` because `Date.toISOString()` always outputs a date in UTC (e.g. `2022-08-27T22:00:00.000Z`).

~I added a new test case to catch this bug.~

**EDIT:** JavaScript dates are weird.