### PR TITLE
Fix error message regarding parsedState.message being undefined

### DIFF
--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -201,7 +201,7 @@ export default {
 				this.firstDay = state.start ?? new Date()
 				this.lastDay = state.end ?? null
 				this.subject = state.subject ?? ''
-				this.message = toHtml(plain(state.message)).value ?? ''
+				this.message = toHtml(plain(state.message ?? '')).value
 			},
 		},
 		enableLastDay(enableLastDay) {


### PR DESCRIPTION
Followup to #7269

This is a purely cosmetic change as nothing is broken. I moved the `??` operator inside the parens as a fallback. The value of `state.message` might be undefined on page load.