### PR TITLE
Fix enable last day checkbox not being parsed correctly

### DIFF
--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -200,6 +200,7 @@ export default {
 				this.enabled = !!state.enabled ?? false
 				this.firstDay = state.start ?? new Date()
 				this.lastDay = state.end ?? null
+				this.enableLastDay = !!this.lastDay
 				this.subject = state.subject ?? ''
 				this.message = toHtml(plain(state.message)).value ?? ''
 			},


### PR DESCRIPTION
The checkbox was always disabled when parsing an enabled auto responder. Now it is properly enabled if there is a last day. 