### PR TITLE
Fetch sieve script after enabling sieve

### DIFF
--- a/src/components/SieveAccountForm.vue
+++ b/src/components/SieveAccountForm.vue
@@ -182,6 +182,11 @@ export default {
 					account: this.account,
 					data: this.sieveConfig,
 				})
+				if (this.sieveConfig.sieveEnabled) {
+					await this.$store.dispatch('fetchActiveSieveScript', {
+						accountId: this.account.id,
+					})
+				}
 			} catch (error) {
 				this.errorMessage = error.message
 			}


### PR DESCRIPTION
Otherwise, the autoresponder won't render because it is waiting for the sieve script to be fetched.

## Before
[sieve-enable-responder-before.webm](https://user-images.githubusercontent.com/1479486/189895547-13e2cc38-3987-4a8a-943d-a2c0693dbbef.webm)

## After
[sieve-enable-responder-after.webm](https://user-images.githubusercontent.com/1479486/189895590-c0602d2c-aa28-473c-b976-401b1fb8db1c.webm)