### PR TITLE
Fix new message button header transparency and position

### DIFF
--- a/src/components/NewMessageButtonHeader.vue
+++ b/src/components/NewMessageButtonHeader.vue
@@ -79,8 +79,10 @@ export default {
 
 <style lang="scss" scoped>
 .header {
-	display: flex;
+	display: absolute;
 	align-items: center;
+	position: inherit;
+	background-color: transparent;
 	padding: 8px 8px 8px 48px;
 	gap: 4px;
 	height: 61px;

--- a/src/components/NewMessageButtonHeader.vue
+++ b/src/components/NewMessageButtonHeader.vue
@@ -79,7 +79,7 @@ export default {
 
 <style lang="scss" scoped>
 .header {
-	display: absolute;
+	display: flex;
 	align-items: center;
 	position: inherit;
 	background-color: transparent;


### PR DESCRIPTION
Fixes transparency on new message button.

Current:
![image](https://user-images.githubusercontent.com/10717998/190439787-786c09c5-4097-4e0a-9fca-1f47ac532d69.png)


Changes:
![image](https://user-images.githubusercontent.com/10717998/190439688-cbf2725a-74e5-4a2e-8ca5-2846dda769b3.png)
