### PR TITLE
GH-7143: Show warning for large signatures

### DIFF
--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -45,6 +45,9 @@
 			:html="true"
 			:placeholder="t('mail', 'Signature …')"
 			:bus="bus" />
+		<p v-if="isLargeSignature" class="warning-large-signature">
+			{{ t('mail', 'Your signature is larger than 2 MB. This may affect the performance of your editor.')}}
+		</p>
 		<ButtonVue
 			type="primary"
 			:disabled="loading"
@@ -115,6 +118,9 @@ export default {
 
 			return identities
 		},
+		isLargeSignature() {
+			return (new Blob([this.signature])).size > 2 * 1024 * 1024
+		}
 	},
 	watch: {
 		async signatureAboveQuote(val, oldVal) {
@@ -222,5 +228,8 @@ export default {
 ::v-deep.button-vue {
 	display: inline-block !important;
 	margin-top: 4px !important;
+}
+.warning-large-signature {
+	color: darkorange;
 }
 </style>

--- a/src/tests/unit/components/SignatureSettings.vue.spec.js
+++ b/src/tests/unit/components/SignatureSettings.vue.spec.js
@@ -1,0 +1,48 @@
+/*
+ * @copyright 2022 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author 2022 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {createLocalVue, shallowMount} from '@vue/test-utils'
+import Vuex from 'vuex'
+import Nextcloud from '../../../mixins/Nextcloud'
+import SignatureSettings from '../../../components/SignatureSettings'
+
+const localVue = createLocalVue()
+
+localVue.use(Vuex)
+localVue.mixin(Nextcloud)
+
+describe('SignatureSettings', () => {
+
+	it('Show warning for large signatures', () => {
+		const wrapper = shallowMount(SignatureSettings, {
+			localVue,
+			propsData: {
+				account: {
+					aliases: [],
+					signature: String('<p>Lorem ipsum</p>').repeat(120000),
+				},
+			},
+		})
+
+		expect(wrapper.vm.isLargeSignature).toBeTruthy()
+	})
+
+})


### PR DESCRIPTION
Fix #7143 

A large signature can affect the editor performance.

![image](https://user-images.githubusercontent.com/3902676/191309157-49deb750-90c3-468d-9d90-3a564ad570b7.png)
