### PR TITLE
Add skeleton for loading state

### DIFF
--- a/src/components/LoadingSkeleton.vue
+++ b/src/components/LoadingSkeleton.vue
@@ -1,0 +1,99 @@
+<template>
+	<div>
+		<div v-for="i in numberOfLines" :key="i" class="item-list__entry">
+			<div
+				class="item-avatar" />
+			<div class="item__details">
+				<h3>&nbsp;</h3>
+				<p class="message">
+					&nbsp;
+				</p>
+				<p class="message-preview">
+					&nbsp;
+				</p>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'LoadingSkeleton',
+	props: {
+		numberOfLines: {
+			type: Number,
+			default: 10,
+		},
+		withAvatar: {
+			type: Boolean,
+			default: true,
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+
+/* skeleton */
+.item-list__entry {
+	display: flex;
+	align-items: flex-start;
+	padding: 8px;
+	.item-avatar {
+		position: relative;
+		top: 4px;
+		border-radius: 50px;
+		width: 44px;
+		height: 44px;
+		animation: loadingskeleton 2s ease infinite alternate,
+		nudge 3s linear infinite alternate;
+	}
+	.item__details {
+		padding-left: 8px;
+		max-height: 70px;
+		flex-grow: 1;
+		display: flex;
+		flex-direction: column;
+		h3,
+		.message.message-preview {
+			white-space: nowrap;
+			background-color: var(--color-background-hover);
+		}
+		h3 {
+			font-size: 100%;
+			margin: 0;
+			animation: loadingskeleton 2s ease infinite alternate,
+			nudge 3s linear infinite alternate;
+			width: 40%;
+			height: 15px;
+		}
+		.message-preview {
+			width: 100%;
+			height: 15px;
+			margin-top: 5px;
+			animation: loadingskeleton 2s ease infinite alternate,
+			nudge 3s linear infinite alternate;
+		}
+		.message {
+			width: 70%;
+			height: 15px;
+			margin-top: 5px;
+			animation: loadingskeleton 2s ease infinite alternate,
+			nudge 3s linear infinite alternate;
+		}
+	}
+	@keyframes loadingskeleton {
+		0%   {background-color: var(--color-border);}
+		25%  {background-color: var(--color-background-hover);}
+		40%  {background-color: var(--color-placeholder-light);}
+		50% {background-color: var(--color-loading-light);}
+		65%  {background-color: var(--color-background-hover);}
+		75%  {background-color: var(--color-placeholder-light);}
+		80% {background-color: var(--color-loading-light);}
+		90% {background-color: var(--color-placeholder-light);}
+		100% {background-color: var(--color-placeholder-light);}
+	}
+}
+
+</style>

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -24,7 +24,7 @@
 		:error="t('mail', 'Could not open mailbox')"
 		message=""
 		role="alert" />
-	<Loading v-else-if="loadingEnvelopes" :hint="t('mail', 'Loading messages …')" role="alert" />
+	<LoadingSkeleton v-else-if="loadingEnvelopes" :number-of-lines="20" />
 	<Loading
 		v-else-if="loadingCacheInitialization"
 		:hint="t('mail', 'Loading messages …')"
@@ -47,6 +47,7 @@
 <script>
 import EmptyMailbox from './EmptyMailbox'
 import EnvelopeList from './EnvelopeList'
+import LoadingSkeleton from './LoadingSkeleton'
 import Error from './Error'
 import { findIndex, propEq } from 'ramda'
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
@@ -69,6 +70,7 @@ export default {
 		EnvelopeList,
 		Error,
 		Loading,
+		LoadingSkeleton,
 	},
 	mixins: [isMobile],
 	props: {

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -36,9 +36,8 @@
 					:error="t('mail', 'Could not open outbox')"
 					message=""
 					role="alert" />
-				<Loading
-					v-else-if="loading"
-					:hint="t('mail', 'Loading messages …')" />
+				<LoadingSkeleton
+					v-else-if="loading" />
 				<EmptyMailbox v-else-if="messages.length === 0" />
 				<OutboxMessageListItem
 					v-for="message in messages"
@@ -52,7 +51,7 @@
 
 <script>
 import { NcAppContent as AppContent, NcAppContentList as AppContentList } from '@nextcloud/vue'
-import Loading from './Loading'
+import LoadingSkeleton from './LoadingSkeleton'
 import Error from './Error'
 import EmptyMailbox from './EmptyMailbox'
 import OutboxMessageContent from './OutboxMessageContent'
@@ -66,7 +65,7 @@ export default {
 		AppContent,
 		AppContentList,
 		Error,
-		Loading,
+		LoadingSkeleton,
 		EmptyMailbox,
 		OutboxMessageListItem,
 		OutboxMessageContent,


### PR DESCRIPTION
A skeleton will be shown when we initialize the mailbox.
The skeleton will not be shown when the page is loaded in the background or when we click refresh button. 
The reason for that is that after the list is already shown, when the automatic refreshing kicks in, the list will be transformed into skeleton seconds after it is shown. So, having the loading icon for that, should be fine.

Also, the skeleton doesnt replace the loadingCacheInitialization, there we should have the loading message, because it takes a while to populate the inbox/mailbox and the user should know what is happening, instead of having to look at a skeleton for a bit.