### PR TITLE
Annotate that AddressList::count return type will change

### DIFF
--- a/lib/AddressList.php
+++ b/lib/AddressList.php
@@ -105,6 +105,7 @@ class AddressList implements Countable, JsonSerializable {
 	/**
 	 * @return int
 	 */
+	#[ReturnTypeWillChange]
 	public function count() {
 		return count($this->addresses);
 	}


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Return type of OCA\Mail\AddressList::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in apps/mail/lib/AddressList.php on line 108```