### PR TITLE
Log into IMAP before reading capabilities

### DIFF
--- a/lib/Command/DiagnoseAccount.php
+++ b/lib/Command/DiagnoseAccount.php
@@ -109,6 +109,8 @@ class DiagnoseAccount extends Command {
 	private function printCapabilitiesStats(OutputInterface $output,
 											Horde_Imap_Client_Socket $imapClient): void {
 		$output->writeln("IMAP capabilities:");
+		// Once logged in more capabilities are advertised
+		$imapClient->login();
 		$capabilities = array_keys(
 			json_decode(
 				$imapClient->capability->serialize(),


### PR DESCRIPTION
``occ mail:account:diagnose`` printed a short list of capabilities because when capabilities were queried the connection was not logged in.

### Before

```
IMAP capabilities:
- AUTH
- ENABLE
- ID
- IDLE
- IMAP4REV1
- LITERAL+
- LOGIN-REFERRALS
- SASL-IR
```

### After
```
IMAP capabilities:
- BINARY
- CATENATE
- CHILDREN
- CONDSTORE
- CONTEXT
- ENABLE
- ESEARCH
- ESORT
- I18NLEVEL
- ID
- IDLE
- IMAP4REV1
- LIST-EXTENDED
- LIST-STATUS
- LITERAL+
- LOGIN-REFERRALS
- MOVE
- MULTIAPPEND
- NAMESPACE
- NOTIFY
- PREVIEW
- QRESYNC
- SASL-IR
- SEARCHRES
- SNIPPET
- SORT
- SPECIAL-USE
- THREAD
- UIDPLUS
- UNSELECT
- URL-PARTIAL
- WITHIN
```

