### PR TITLE
Show empty content when opening drafts

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -19,7 +19,8 @@
 					:account="account"
 					:mailbox="mailbox"
 					:search-query="query"
-					:bus="bus" />
+					:bus="bus"
+					:open-first="mailbox.specialRole !== 'drafts'" />
 				<template v-else>
 					<div class="app-content-list-item">
 						<SectionTitle class="important" :name="t('mail', 'Important')" />


### PR DESCRIPTION
Fix #7333 

Navigating to a drafts folder should not load the first envelope because drafts are handled differently (through the composer).

[drafts.webm](https://user-images.githubusercontent.com/1479486/193090762-3a7e2b06-5c1f-43a6-b621-45bbfa6e9e31.webm)
