### PR TITLE
Update ::v-deep to :deep and fix style issue

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -547,18 +547,18 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .tabs-component-tabs {
+:deep(.tabs-component-tabs) {
 	display: flex;
 }
 
-::v-deep .tabs-component-tab {
+:deep(.tabs-component-tab) {
 	flex-grow: 1;
 	text-align: center;
 	color: var(--color-text-lighter);
 	margin-bottom: 10px;
 }
 
-::v-deep .tabs-component-tab.is-active {
+:deep(.tabs-component-tab.is-active) {
 	border-bottom: 1px solid black;
 	font-weight: bold;
 }

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -213,7 +213,7 @@ export default {
 	justify-content: space-between;
 }
 
-::v-deep .modal-container {
+:deep(.modal-container) {
 	display: block;
 	overflow: scroll;
 	transition: transform 300ms ease;

--- a/src/components/AliasSettings.vue
+++ b/src/components/AliasSettings.vue
@@ -145,7 +145,7 @@ export default {
 input {
 	width: 195px;
 }
-::v-deep.button-vue {
+.button-vue:deep() {
 	display: inline-block !important;
 	margin-top: 4px !important;
 }

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1269,7 +1269,7 @@ export default {
 		padding: 11px 20px 11px 0;
 	}
 
-	::v-deep(.multiselect--multiple .multiselect__tags) {
+	:deep(.multiselect--multiple .multiselect__tags) {
 		display: grid;
 		grid-template-columns: calc(100% - 18px) 18px 100%;
 
@@ -1279,7 +1279,7 @@ export default {
 		}
 	}
 
-	::v-deep(.multiselect__content-wrapper) {
+	:deep(.multiselect__content-wrapper) {
 		border-bottom: 1px solid var(--color-border);
 		margin-top: 0;
 
@@ -1288,18 +1288,18 @@ export default {
 		}
 	}
 
-	::v-deep(.multiselect__input) {
+	:deep(.multiselect__input) {
 		position: relative !important;
 		top: 0;
 		grid-column-start: 1;
 		grid-column-end: 3;
 	}
 
-	::v-deep(.multiselect--active input:focus-visible) {
+	:deep(.multiselect--active input:focus-visible) {
 		box-shadow: none;
 	}
 
-	::v-deep(.multiselect__tags) {
+	:deep(.multiselect__tags) {
 		box-sizing: border-box;
 		height: auto;
 	}
@@ -1450,13 +1450,13 @@ export default {
 	min-height: 100px;
 }
 
-::v-deep .multiselect .multiselect__tags, .subject {
+:deep(.multiselect .multiselect__tags), .subject {
 	border: none !important;
 }
-::v-deep [data-select="create"] .avatardiv--unknown {
+:deep([data-select="create"] .avatardiv--unknown) {
 	background: var(--color-text-maxcontrast) !important;
 }
-::v-deep .multiselect.opened .multiselect__tags .multiselect__tags-wrap {
+:deep(.multiselect.opened .multiselect__tags .multiselect__tags-wrap) {
 	flex-wrap: wrap;
 }
 

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -160,7 +160,7 @@ export default {
 	margin-top: 5vh;
 	margin-right: 5px;
 }
-.unread ::v-deep .item__details {
+.unread :deep(.item__details) {
 	font-weight: bold;
 }
 </style>

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -592,14 +592,14 @@ export default {
 }
 
 .icon-important {
-	::v-deep path {
+	:deep(path) {
 	fill: #ffcc00;
 	stroke: var(--color-main-background);
 	}
 	.list-item:hover &,
 	.list-item:focus &,
 	.list-item.active & {
-	::v-deep path {
+	:deep(path) {
 	stroke: var(--color-background-dark);
 	}
 	}
@@ -664,12 +664,12 @@ export default {
 	opacity: 0.25;
 }
 
-::v-deep .action--primary {
+:deep(.action--primary) {
 	.material-design-icon {
 		margin-bottom: -14px;
 	}
 }
-::v-deep .list-item__extra {
+:deep(.list-item__extra) {
 	margin-left: 41px !important;
 }
 .tag-group__label {
@@ -697,13 +697,13 @@ export default {
 	overflow: hidden;
 	left: 4px;
 }
-::v-deep.list-item__wrapper {
+.list-item__wrapper:deep() {
 	list-style: none;
 }
 .app-content-list-item-star.favorite-icon-style {
 	display: block;
 }
-::v-deep.icon-important.app-content-list-item-star {
+.icon-important.app-content-list-item-star:deep() {
 	position: absolute;
 	top: 14px;
 	z-index: 1;
@@ -721,7 +721,7 @@ export default {
 		opacity: .4;
 	}
 }
-::v-deep .svg svg{
+:deep(.svg svg) {
 	height: 16px;
 	width: 16px;
 }
@@ -731,10 +731,10 @@ export default {
 .attachment-icon-style {
 	opacity: .6;
 }
-::v-deep .list-item-content__wrapper {
+:deep(.list-item-content__wrapper) {
 	margin-top: 6px;
 }
-::v-deep .list-item__extra {
+:deep(.list-item__extra) {
 	margin-top: 9px;
 }
 </style>

--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -180,7 +180,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .modal-wrapper .modal-container {
+:deep(.modal-wrapper .modal-container) {
 	width: calc(100vw - 120px) !important;
 	height: calc(100vh - 120px) !important;
 	max-width: 490px !important;
@@ -192,14 +192,14 @@ export default {
 input {
 	width: 100%;
 }
-::v-deep input[type='text'].multiselect__input {
+:deep(input[type='text'].multiselect__input) {
 	padding: 0 !important;
 }
-::v-deep .multiselect__single {
+:deep(.multiselect__single) {
 	margin-left: -18px;
 	width: 100px;
 }
-::v-deep .multiselect__tags {
+:deep(.multiselect__tags) {
 	border: none !important;
 }
 .all-day {
@@ -214,7 +214,7 @@ input {
 	height: 44px !important;
 	float: right;
 }
-::v-deep .mx-datepicker {
+:deep(.mx-datepicker) {
 	width: 213px;
 }
 </style>

--- a/src/components/Imip.vue
+++ b/src/components/Imip.vue
@@ -543,7 +543,7 @@ export default {
 				&__multiselect {
 					width: 100%;
 
-					::v-deep .calendar-picker-option__label {
+					:deep(.calendar-picker-option__label) {
 						max-width: unset !important;
 					}
 				}

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -489,7 +489,7 @@ export default {
 <style lang="scss" scoped>
 // Fix vertical space between sections in priority inbox
 .nameimportant {
-	::v-deep #load-more-mail-messages {
+	:deep(#load-more-mail-messages) {
 		margin-top: 0;
 		margin-bottom: 8px;
 	}

--- a/src/components/MailboxPicker.vue
+++ b/src/components/MailboxPicker.vue
@@ -173,7 +173,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .modal-container {
+:deep(.modal-container) {
 	width: calc(100vw - 120px) !important;
 	height: calc(100vh - 120px) !important;
 	max-width: 600px !important;

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -261,7 +261,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.v-popover > .trigger > {
+.v-popover > .trigger > * {
 	z-index: 1;
 }
 
@@ -293,7 +293,7 @@ export default {
 #app-content-wrapper {
 	display: flex;
 }
-::v-deep .button-vue--vue-secondary {
+:deep(.button-vue--vue-secondary) {
 	box-shadow: none;
 }
 .envelope-list {

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -420,7 +420,7 @@ export default {
 </script>
 <style lang="scss" scoped>
 	.source-modal {
-		::v-deep .modal-container {
+		:deep(.modal-container) {
 			height: 800px;
 		}
 

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -179,7 +179,7 @@ export default {
 		overflow-y: auto;
 	}
 }
-::v-deep .button-vue__text {
+:deep(.button-vue__text) {
 	border: none !important;
 	font-weight: normal !important;
 	padding-left: 14px !important;
@@ -189,7 +189,7 @@ export default {
 .message-frame {
 	width: 100%;
 }
-::v-deep .button-vue__icon {
+:deep(.button-vue__icon) {
 	display: none !important;
 }
 </style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -180,7 +180,7 @@ export default {
 		animation: rotation 2s linear;
 	}
 }
-::v-deep .app-navigation-new button {
+:deep(.app-navigation-new button) {
 	width: 240px !important;
 	height: 44px;
 }
@@ -195,7 +195,7 @@ to {
 .app-navigation-spacer {
 	order: 0 !important;
 }
-::v-deep .settings-button {
+:deep(.settings-button) {
 	opacity: .7 !important;
 	font-weight: bold !important;
 }

--- a/src/components/NavigationAccountExpandCollapse.vue
+++ b/src/components/NavigationAccountExpandCollapse.vue
@@ -73,7 +73,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .app-navigation-entry__title {
+:deep(.app-navigation-entry__title) {
 	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/src/components/NavigationOutbox.vue
+++ b/src/components/NavigationOutbox.vue
@@ -64,7 +64,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .counter-bubble__counter {
+:deep(.counter-bubble__counter) {
 	margin-right: 43px;
 }
 .outbox-opacity-icon {

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -203,11 +203,11 @@ export default {
 
 <style lang="scss" scoped>
 @media only screen and (max-width: 600px) {
-	::v-deep .modal-container {
+	:deep(.modal-container) {
 		max-width: 80%;
 	}
 }
-::v-deep .modal-wrapper .modal-container {
+:deep(.modal-wrapper .modal-container) {
 	overflow-y: auto !important;
 	overflow-x: auto !important;
 	// from original Modal max-height

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -137,7 +137,7 @@ export default {
 	height: calc(100vh - var(--header-height));
 
 }
-::v-deep .button-vue--vue-secondary {
+:deep(.button-vue--vue-secondary) {
 	box-shadow: none;
 }
 </style>

--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -288,7 +288,7 @@ export default {
 .contact-existing {
 	font-size: small !important;
 }
-::v-deep .button-vue__text {
+:deep(.button-vue__text) {
 	font-weight: normal !important;
 }
 </style>

--- a/src/components/RecipientListItem.vue
+++ b/src/components/RecipientListItem.vue
@@ -75,7 +75,7 @@ export default {
 		background: var(--color-background-darker);
 	}
 }
-::v-deep .option {
+:deep(.option) {
 	margin-left: 10px;
 }
 </style>

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -225,7 +225,7 @@ export default {
 .ck-balloon-panel {
 	 z-index: 10000 !important;
  }
-::v-deep.button-vue {
+.button-vue:deep() {
 	display: inline-block !important;
 	margin-top: 4px !important;
 }

--- a/src/components/TagModal.vue
+++ b/src/components/TagModal.vue
@@ -256,12 +256,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .modal-content {
+:deep(.modal-content) {
 	padding: 0 20px 20px 20px;
 	max-height: calc(100vh - 210px);
 	overflow-y: auto;
 }
-::v-deep .modal-container {
+:deep(.modal-container) {
 	width: auto !important;
 }
 .tag-title {
@@ -330,7 +330,7 @@ export default {
 	list-style: none;
 }
 @media only screen and (max-width: 512px) {
-	::v-deep .modal-container {
+	:deep(.modal-container) {
 	top: 100px !important;
 	max-height: calc(100vh - 170px) !important
 	}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -210,10 +210,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep a {
+:deep(a) {
 	color: #07d;
 }
-::v-deep p {
+:deep(p) {
 	cursor: text;
 }
 </style>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -482,7 +482,7 @@ export default {
 		min-width: 0; /* https://css-tricks.com/flexbox-truncated-text/ */
 	}
 	.icon-important {
-		::v-deep path {
+		:deep(path) {
 			fill: #ffcc00;
 			stroke: var(--color-main-background);
 			cursor: pointer;

--- a/src/components/TrustedSenders.vue
+++ b/src/components/TrustedSenders.vue
@@ -100,7 +100,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep.button-vue {
+.button-vue:deep() {
 	display: inline-block !important;
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -128,7 +128,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .app-content-details {
+:deep(.app-content-details) {
 	margin: 0 auto;
 	max-width: 900px;
 	display: flex;
@@ -137,7 +137,7 @@ export default {
 	min-width: 70%;
 }
 // Align the appNavigation toggle with the apps header toolbar
-::v-deep button.app-navigation-toggle {
+:deep(button.app-navigation-toggle) {
 	top: 8px;
 }
 </style>

--- a/src/views/KeyboardShortcuts.vue
+++ b/src/views/KeyboardShortcuts.vue
@@ -62,7 +62,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-::v-deep .modal-wrapper .modal-container {
+:deep(.modal-wrapper .modal-container) {
 	display: block;
 	overflow: scroll;
 	transition: transform 300ms ease;


### PR DESCRIPTION
Fixes `[@vue/compiler-sfc] ::v-deep usage as a combinator has been deprecated. Use :deep(<inner-selector>) instead.`