### PR TITLE
Add the option to disable the new account button

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -305,6 +305,11 @@ return [
 			'verb' => 'DELETE'
 		],
 		[
+			'name' => 'settings#setAllowNewMailAccounts',
+			'url' => '/api/settings/allownewaccounts',
+			'verb' => 'POST'
+		],
+		[
 			'name' => 'trusted_senders#setTrusted',
 			'url' => '/api/trustedsenders/{email}',
 			'verb' => 'PUT'

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -175,6 +175,11 @@ class PageController extends Controller {
 			$cronMode === 'ajax',
 		);
 
+		$this->initialStateService->provideInitialState(
+			'allow_new_mail_accounts',
+			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
+		);
+
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$response->setContentSecurityPolicy($csp);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -32,6 +32,7 @@ use OCA\Mail\Service\AntiSpamService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 use OCP\IRequest;
 use function array_merge;
 
@@ -39,12 +40,16 @@ class SettingsController extends Controller {
 	private ProvisioningManager $provisioningManager;
 	private AntiSpamService $antiSpamService;
 
+	private IConfig $config;
+
 	public function __construct(IRequest $request,
 								ProvisioningManager $provisioningManager,
-								AntiSpamService $antiSpamService) {
+								AntiSpamService $antiSpamService,
+								IConfig $config) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->provisioningManager = $provisioningManager;
 		$this->antiSpamService = $antiSpamService;
+		$this->config = $config;
 	}
 
 	public function index(): JSONResponse {
@@ -109,5 +114,9 @@ class SettingsController extends Controller {
 	public function deleteAntiSpamEmail(): JSONResponse {
 		$this->antiSpamService->deleteConfig();
 		return new JSONResponse([]);
+	}
+
+	public function setAllowNewMailAccounts(bool $allowed) {
+		$this->config->setAppValue('mail', 'allow_new_mail_accounts', $allowed ? 'yes' : 'no');
 	}
 }

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -29,6 +29,7 @@ use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Service\AntiSpamService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\LDAP\ILDAPProvider;
 use OCP\Settings\ISettings;
@@ -43,12 +44,16 @@ class AdminSettings implements ISettings {
 	/** @var AntiSpamService */
 	private $antiSpamService;
 
+	private IConfig $config;
+
 	public function __construct(IInitialStateService $initialStateService,
 								ProvisioningManager $provisioningManager,
-								AntiSpamService $antiSpamService) {
+								AntiSpamService $antiSpamService,
+								IConfig $config) {
 		$this->initialStateService = $initialStateService;
 		$this->provisioningManager = $provisioningManager;
 		$this->antiSpamService = $antiSpamService;
+		$this->config = $config;
 	}
 
 	public function getForm() {
@@ -67,6 +72,11 @@ class AdminSettings implements ISettings {
 			]
 		);
 
+		$this->initialStateService->provideInitialState(
+			Application::APP_ID,
+			'allow_new_mail_accounts',
+			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
+		);
 
 		$this->initialStateService->provideLazyInitialState(
 			Application::APP_ID,

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<router-link to="/setup" class="app-settings-button button primary new-button">
+		<router-link v-if="allowNewMailAccounts" to="/setup" class="app-settings-button button primary new-button">
 			<IconAdd :size="20" />
 			{{ t('mail', 'Add mail account') }}
 		</router-link>
@@ -143,6 +143,9 @@ export default {
 		},
 		useAutoTagging() {
 			return this.$store.getters.getPreference('tag-classified-messages', 'true') === 'true'
+		},
+		allowNewMailAccounts() {
+			return this.$store.getters.getPreference('allow-new-accounts', 'true') === 'true'
 		},
 	},
 	methods: {

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -132,6 +132,19 @@
 				:disable="deleteProvisioning" />
 		</p>
 		<div class="app-description">
+			<h3>{{ t('mail', 'Allow additional mail accounts') }}</h3>
+			<article>
+				<p>
+					<NcCheckboxRadioSwitch
+						:checked.sync="allowNewMailAccounts"
+						type="switch"
+						@update:checked="updateAllowNewMailAccounts">
+						{{ t('mail','Allow additional Mail accounts from User Settings') }}
+					</NcCheckboxRadioSwitch>
+				</p>
+			</article>
+		</div>
+		<div class="app-description">
 			<h3>
 				{{
 					t(
@@ -166,16 +179,19 @@
 import Button from '@nextcloud/vue/dist/Components/NcButton'
 import logger from '../../logger'
 import { showError, showSuccess } from '@nextcloud/dialogs'
+import { loadState } from '@nextcloud/initial-state'
 import ProvisioningSettings from './ProvisioningSettings'
 import AntiSpamSettings from './AntiSpamSettings'
 import IconAdd from 'vue-material-design-icons/Plus'
 import IconSettings from 'vue-material-design-icons/Cog'
 import SettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch'
 import {
 	disableProvisioning,
 	createProvisioningSettings,
 	updateProvisioningSettings,
 	provisionAll,
+	updateAllowNewMailAccounts,
 
 } from '../../service/SettingsService'
 export default {
@@ -187,6 +203,7 @@ export default {
 		Button,
 		IconAdd,
 		IconSettings,
+		NcCheckboxRadioSwitch,
 	},
 	props: {
 		provisioningSettings: {
@@ -220,6 +237,7 @@ export default {
 				},
 				loading: false,
 			},
+			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts', true),
 		}
 	},
 	methods: {
@@ -243,7 +261,6 @@ export default {
 				showError(t('mail', 'Could not save provisioning setting'))
 				logger.error('Could not save provisioning setting', { error })
 			}
-
 		},
 		resetForm() {
 			this.formKey = Math.random()
@@ -269,6 +286,9 @@ export default {
 				showError(t('mail', 'Error when deleting and deprovisioning accounts for "{domain}"', { domain: deleted.provisioningDomain }))
 				logger.error('Could not delete provisioning config', { error })
 			}
+		},
+		async updateAllowNewMailAccounts(checked) {
+			await updateAllowNewMailAccounts(checked)
 		},
 	},
 }

--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,10 @@ store.commit('savePreference', {
 	key: 'tag-classified-messages',
 	value: getPreferenceFromPage('tag-classified-messages'),
 })
+store.commit('savePreference', {
+	key: 'allow-new-accounts',
+	value: loadState('mail', 'allow-new-accounts', true),
+})
 
 const accountSettings = loadState('mail', 'account-settings')
 const accounts = loadState('mail', 'accounts', [])

--- a/src/service/SettingsService.js
+++ b/src/service/SettingsService.js
@@ -68,3 +68,11 @@ export const deleteAntiSpamEmail = () => {
 	return axios.delete(generateUrl('/apps/mail/api/settings/antispam'))
 		.then((resp) => resp.data)
 }
+
+export const updateAllowNewMailAccounts = (allowed) => {
+	const url = generateUrl('/apps/mail/api/settings/allownewaccounts')
+	const data = {
+		allowed,
+	}
+	return axios.post(url, data).then((resp) => resp.data)
+}

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -3,7 +3,7 @@
 		<Navigation v-if="hasAccounts" />
 		<AppContent>
 			<div class="mail-empty-content">
-				<EmptyContent :title="t('mail', 'Connect your mail account')">
+				<EmptyContent v-if="allowNewMailAccounts" :title="t('mail', 'Connect your mail account')">
 					<template #icon>
 						<IconMail :size="65" />
 					</template>
@@ -12,6 +12,11 @@
 							:email="email"
 							:error.sync="error"
 							@account-created="onAccountCreated" />
+					</template>
+				</EmptyContent>
+				<EmptyContent v-else :title="t('mail', 'To add a mail account, please contact your administrator.')">
+					<template #icon>
+						<IconMail :size="65" />
 					</template>
 				</EmptyContent>
 			</div>
@@ -42,6 +47,7 @@ export default {
 		return {
 			displayName: loadState('mail', 'prefill_displayName'),
 			email: loadState('mail', 'prefill_email'),
+			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts'),
 			error: null,
 		}
 	},

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -38,6 +38,7 @@ use OCA\Mail\Service\Sync\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -100,6 +101,7 @@ class AccountsControllerTest extends TestCase {
 		$this->setupService = $this->createMock(SetupService::class);
 		$this->mailManager = $this->createMock(IMailManager::class);
 		$this->syncService = $this->createMock(SyncService::class);
+		$this->config = $this->createMock(IConfig::class);
 
 		$this->controller = new AccountsController(
 			$this->appName,
@@ -112,7 +114,8 @@ class AccountsControllerTest extends TestCase {
 			$this->transmission,
 			$this->setupService,
 			$this->mailManager,
-			$this->syncService
+			$this->syncService,
+			$this->config
 		);
 		$this->account = $this->createMock(Account::class);
 		$this->accountId = 123;
@@ -213,6 +216,9 @@ class AccountsControllerTest extends TestCase {
 	}
 
 	public function testCreateManualSuccess(): void {
+		$this->config->expects(self::once())
+			->method('getAppValue')
+			->willReturn('yes');
 		$autoDetect = false;
 		$email = 'user@domain.tld';
 		$accountName = 'Mail';
@@ -238,6 +244,35 @@ class AccountsControllerTest extends TestCase {
 
 		self::assertEquals($expectedResponse, $response);
 	}
+
+	public function testCreateManualNotAllowed(): void {
+		$autoDetect = false;
+		$email = 'user@domain.tld';
+		$accountName = 'Mail';
+		$imapHost = 'localhost';
+		$imapPort = 993;
+		$imapSslMode = 'ssl';
+		$imapUser = 'user@domain.tld';
+		$imapPassword = 'mypassword';
+		$smtpHost = 'localhost';
+		$smtpPort = 465;
+		$smtpSslMode = 'none';
+		$smtpUser = 'user@domain.tld';
+		$smtpPassword = 'mypassword';
+		$this->config->expects(self::once())
+			->method('getAppValue')
+			->willReturn('no');
+		$this->logger->expects(self::once())
+			->method('info');
+		$this->setupService->expects(self::never())
+			->method('createNewAccount');
+
+		$expectedResponse = \OCA\Mail\Http\JsonResponse::error('Could not create account');
+		$response = $this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $autoDetect);
+
+		self::assertEquals($expectedResponse, $response);
+	}
+
 
 	public function testCreateManualFailure(): void {
 		$autoDetect = false;

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -217,14 +217,16 @@ class PageControllerTest extends TestCase {
 				['debug', false, true],
 				['app.mail.attachment-size-limit', 0, 123],
 			]);
-		$this->config->expects($this->exactly(2))
+		$this->config->expects($this->exactly(3))
 			->method('getAppValue')
 			->withConsecutive(
 				[ 'mail', 'installed_version' ],
-				['core', 'backgroundjobs_mode', 'ajax' ]
+				['core', 'backgroundjobs_mode', 'ajax' ],
+				['mail', 'allow_new_mail_accounts', 'yes']
 			)->willReturnOnConsecutiveCalls(
 				$this->returnValue('1.2.3'),
-				$this->returnValue('cron')
+				$this->returnValue('cron'),
+				$this->returnValue('yes')
 			);
 		$user->expects($this->once())
 			->method('getDisplayName')
@@ -236,7 +238,7 @@ class PageControllerTest extends TestCase {
 			->with($this->equalTo('jane'), $this->equalTo('settings'),
 				$this->equalTo('email'), $this->equalTo(''))
 			->will($this->returnValue('jane@doe.cz'));
-		$this->initialState->expects($this->exactly(8))
+		$this->initialState->expects($this->exactly(9))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
@@ -246,7 +248,8 @@ class PageControllerTest extends TestCase {
 				['prefill_displayName', 'Jane Doe'],
 				['prefill_email', 'jane@doe.cz'],
 				['outbox-messages', []],
-				['disable-scheduled-send', false]
+				['disable-scheduled-send', false],
+				['allow_new_mail_accounts', true]
 			);
 
 		$expected = new TemplateResponse($this->appName, 'index',

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -53,7 +53,7 @@ class AdminSettingsTest extends TestCase {
 	}
 
 	public function testGetForm() {
-		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(2))
+		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(3))
 			->method('provideInitialState')
 			->withConsecutive(
 				[
@@ -65,7 +65,12 @@ class AdminSettingsTest extends TestCase {
 					Application::APP_ID,
 					'antispam_setting',
 					$this->anything()
-				]
+				],
+				[
+					Application::APP_ID,
+					'allow_new_mail_accounts',
+					$this->anything()
+				],
 			);
 		$expected = new TemplateResponse(Application::APP_ID, 'settings-admin');
 


### PR DESCRIPTION
Add the option for the admins to disable the "Add Mail Account" button in the Mail frontend.

This is expecially useful if you are using an account provisioning configuration.