### PR TITLE
Redirect to setup page if no accounts are configured

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,19 @@ import MailboxLockedError from './errors/MailboxLockedError'
 
 export default {
 	name: 'App',
+	computed: {
+		hasMailAccounts() {
+			return !!this.$store.getters.accounts.find((account) => !account.isUnified)
+		},
+	},
 	async mounted() {
+		// Redirect to setup page if no accounts are configured
+		if (!this.hasMailAccounts) {
+			this.$router.replace({
+				name: 'setup',
+			})
+		}
+
 		this.sync()
 		await this.$store.dispatch('fetchCurrentUserPrincipal')
 		await this.$store.dispatch('loadCollections')


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/pull/7358#pullrequestreview-1127544493

Navigate to some mailbox (e. g. `/apps/mail/box/priority`) on a user with no imap account to test/reproduce the issue.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/193420768-09f89273-30cf-4782-b8f2-8092a0b5b02d.png) | ![Screenshot 2022-10-01 at 22-46-28 Mail - Nextcloud](https://user-images.githubusercontent.com/1479486/193427736-661c0008-31d2-4069-8436-af56628da47f.png) |
