### PR TITLE
Toggle priority inbox

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -153,6 +153,7 @@ class PageController extends Controller {
 				'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
 				'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
 				'tag-classified-messages' => $this->preferences->getPreference($this->currentUserId, 'tag-classified-messages', 'true'),
+				'show-priority-inbox' => $this->preferences->getPreference($this->currentUserId, 'show-priority-inbox', 'true'),
 			]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -33,6 +33,20 @@
 			<label for="auto-tagging-toggle">{{ autoTaggingText }}</label>
 		</p>
 
+		<p v-if="togglePriorityInbox" class="app-settings">
+			<IconLoading :size="20" />
+			{{ usePriorityInboxText }}
+		</p>
+		<p v-else class="app-settings">
+			<input
+				id="priority-inbox-toggle"
+				class="checkbox"
+				type="checkbox"
+				:checked="usePriorityInbox"
+				@change="onTogglePriorityInbox">
+			<label for="priority-inbox-toggle">{{ usePriorityInboxText }}</label>
+		</p>
+
 		<p v-if="loadingAvatarSettings" class="app-settings avatar-settings">
 			<IconLoading :size="20" />
 			{{ t('mail', 'Use Gravatar and favicon avatars') }}
@@ -129,6 +143,9 @@ export default {
 			// eslint-disable-next-line
 			autoTaggingText: t('mail', 'Automatically classify importance of new email'),
 			toggleAutoTagging: false,
+			// eslint-disable-next-line
+			usePriorityInboxText: t('mail', 'Show the priority inbox'),
+			togglePriorityInbox: false,
 		}
 	},
 	computed: {
@@ -146,6 +163,9 @@ export default {
 		},
 		allowNewMailAccounts() {
 			return this.$store.getters.getPreference('allow-new-accounts', true)
+		},
+		usePriorityInbox() {
+			return this.$store.getters.getPreference('show-priority-inbox', 'true') === 'true'
 		},
 	},
 	methods: {
@@ -203,6 +223,23 @@ export default {
 				showError(t('mail', 'Could not update preference'))
 			} finally {
 				this.toggleAutoTagging = false
+			}
+		},
+		async onTogglePriorityInbox(e) {
+			this.togglePriorityInbox = true
+
+			try {
+				await this.$store
+					.dispatch('savePreference', {
+						key: 'show-priority-inbox',
+						value: e.target.checked ? 'true' : 'false',
+					})
+			} catch (error) {
+				Logger.error('could not save preferences', { error })
+
+				showError(t('mail', 'Could not update preference'))
+			} finally {
+				this.togglePriorityInbox = false
 			}
 		},
 		registerProtocolHandler() {

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -28,7 +28,7 @@
 				:key="'mailbox-' + mailbox.databaseId"
 				:account="unifiedAccount"
 				:mailbox="mailbox" />
-			<NavigationOutbox />
+			<NavigationOutbox v-if="showOutbox" />
 			<AppNavigationSpacer />
 
 			<!-- All other mailboxes grouped by their account -->
@@ -128,6 +128,9 @@ export default {
 		},
 		unifiedMailboxes() {
 			return this.$store.getters.getMailboxes(UNIFIED_ACCOUNT_ID)
+		},
+		showOutbox() {
+			return this.$store.getters['outbox/getAllMessages'].length !== 0
 		},
 	},
 	methods: {

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -308,9 +308,12 @@ export default {
 	},
 	computed: {
 		visible() {
+			const showPriorityInbox = this.$store.getters.getPreference('show-priority-inbox', 'true') === 'true';
 			return (
 				(this.account.showSubscribedOnly === false
-				|| (this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed'))) && this.isUnifiedButOnlyInbox
+				|| (this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed')))
+				&& (!this.mailbox.isPriorityInbox || showPriorityInbox)
+				&& (this.isUnifiedButOnlyInbox || !showPriorityInbox)
 			)
 		},
 		notInbox() {

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -308,7 +308,7 @@ export default {
 	},
 	computed: {
 		visible() {
-			const showPriorityInbox = this.$store.getters.getPreference('show-priority-inbox', 'true') === 'true';
+			const showPriorityInbox = this.$store.getters.getPreference('show-priority-inbox', 'true') === 'true'
 			return (
 				(this.account.showSubscribedOnly === false
 				|| (this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed')))

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,10 @@ store.commit('savePreference', {
 	key: 'allow-new-accounts',
 	value: loadState('mail', 'allow-new-accounts', true),
 })
+store.commit('savePreference', {
+	key: 'show-priority-inbox',
+	value: getPreferenceFromPage('show-priority-inbox'),
+})
 
 const accountSettings = loadState('mail', 'account-settings')
 const accounts = loadState('mail', 'accounts', [])

--- a/templates/index.php
+++ b/templates/index.php
@@ -32,3 +32,4 @@ script('mail', 'mail');
 <input type="hidden" id="collect-data" value="<?php p($_['collect-data']); ?>">
 <input type="hidden" id="start-mailbox-id" value="<?php p($_['start-mailbox-id']); ?>">
 <input type="hidden" id="tag-classified-messages" value="<?php p($_['tag-classified-messages']); ?>">
+<input type="hidden" id="show-priority-inbox" value="<?php p($_['show-priority-inbox']); ?>">

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -146,6 +146,7 @@ class PageControllerTest extends TestCase {
 				[$this->userId, 'collect-data', 'true', 'true'],
 				[$this->userId, 'start-mailbox-id', null, '123'],
 				[$this->userId, 'tag-classified-messages', 'true', 'true'],
+				[$this->userId, 'show-priority-inbox', 'true', 'true'],
 			]);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
@@ -261,6 +262,7 @@ class PageControllerTest extends TestCase {
 				'collect-data' => 'true',
 				'start-mailbox-id' => '123',
 				'tag-classified-messages' => 'true',
+				'show-priority-inbox' => 'true',
 			]);
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');


### PR DESCRIPTION
Did some work on this, as I read that it's basically a front-end only issue. I think it does everything it should do (it hides the priority inbox based on a setting and organizes the "special" mailboxes accordingly). However, I do not seem to get the startMailbox set to 'unified' instead of 'priority', how to fix this?

Fixes #3265