### PR TITLE
Fix disabling the add account button

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -176,7 +176,7 @@ class PageController extends Controller {
 		);
 
 		$this->initialStateService->provideInitialState(
-			'allow_new_mail_accounts',
+			'allow-new-accounts',
 			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
 		);
 

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -145,7 +145,7 @@ export default {
 			return this.$store.getters.getPreference('tag-classified-messages', 'true') === 'true'
 		},
 		allowNewMailAccounts() {
-			return this.$store.getters.getPreference('allow-new-accounts', 'true') === 'true'
+			return this.$store.getters.getPreference('allow-new-accounts', true)
 		},
 	},
 	methods: {

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -47,7 +47,7 @@ export default {
 		return {
 			displayName: loadState('mail', 'prefill_displayName'),
 			email: loadState('mail', 'prefill_email'),
-			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts'),
+			allowNewMailAccounts: loadState('mail', 'allow-new-accounts', true),
 			error: null,
 		}
 	},

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -249,7 +249,7 @@ class PageControllerTest extends TestCase {
 				['prefill_email', 'jane@doe.cz'],
 				['outbox-messages', []],
 				['disable-scheduled-send', false],
-				['allow_new_mail_accounts', true]
+				['allow-new-accounts', true]
 			);
 
 		$expected = new TemplateResponse($this->appName, 'index',


### PR DESCRIPTION
Followup to #7358

The button was always enabled because the fallback to `true` was always triggered.