### PR TITLE
Add lean sync for servers without CONDSTORE

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -411,9 +411,10 @@ class MessageMapper {
 	 */
 	public function getFlagged(Horde_Imap_Client_Socket $client,
 							   Mailbox $mailbox,
-							   string $flag): array {
+							   string $flag,
+							   bool $set = true): array {
 		$query = new Horde_Imap_Client_Search_Query();
-		$query->flag($flag, true);
+		$query->flag($flag, $set);
 		$messages = $client->search($mailbox->getName(), $query);
 		return $messages['match']->ids ?? [];
 	}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6341

This updates flags in 20+ queries. Bigger mailboxes require more queries. But still, if you  have 150k messages the sync ran 150k updates before, now it runs 20k. If we say that only read/unread and important flags are relevant we can cut it to 600 queries.

It aint much, but it it's an honest optimization.

## Todo
- [ ] Doing
- [ ] Testing