### PR TITLE
Fix focus on *To* when the composer opens

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -781,7 +781,7 @@ export default {
 	},
 	mounted() {
 		if (!this.isReply) {
-			this.$refs.toLabel.$el.focus()
+			this.$nextTick(() => this.$refs.toLabel.$el.focus())
 		}
 
 		// Add attachments in case of forward


### PR DESCRIPTION
The focus was moved to the first element in the modal, the account multiselect, most likely by the focus trap lib.

Fixes https://github.com/nextcloud/mail/issues/7125