### PR TITLE
Bump league/flysystem from 2.0.8 to 2.5.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,8 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         coverage: none
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Lint
       run: composer run lint
 
@@ -46,6 +48,8 @@ jobs:
       with:
         php-version: '8.0'
         coverage: none
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install dependencies
       run: composer i
     - name: Run coding standards check

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,6 +35,8 @@ jobs:
           php-version: 7.4
           extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip
           coverage: none
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Krankerl
         run: |
           wget https://github.com/ChristophWurst/krankerl/releases/download/v0.13.0/krankerl_0.13.0_amd64.deb

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -25,6 +25,8 @@ jobs:
             with:
                 php-version: 7.4
                 coverage: none
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           - name: Install dependencies
             run: composer i
           - name: Install OCP package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
         php-version: ${{ matrix.php-versions }}
         extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip,gmp
         coverage: xdebug
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Checkout Nextcloud
       run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
     - name: Patch version check for nightly PHP
@@ -126,6 +128,8 @@ jobs:
                 php-version: ${{ matrix.php-versions }}
                 extensions: ctype,curl,dom,gd,iconv,intl,json,mbstring,openssl,posix,sqlite,xml,zip,gmp
                 coverage: xdebug
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           - name: Checkout Nextcloud
             run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
           - name: Patch version check for nightly PHP

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,10 @@
 			"type": "vcs",
 			"url": "https://github.com/kwi-dk/UrlLinker",
 			"branch": "bleeding"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/nextcloud-deps/RubixML"
 		}
 	],
 	"config": {
@@ -40,7 +44,7 @@
 		"nextcloud/horde-managesieve": "^1.0",
 		"nextcloud/horde-smtp": "^1.0",
 		"psr/log": "^1",
-		"rubix/ml": "0.4.2",
+		"rubix/ml": "dev-chore/bump-flysystem-v2.1.1",
 		"sabberworm/php-css-parser": "^8.3",
 		"youthweb/urllinker": "^1.3"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5de945d832ec41e1171c74f0152f99b8",
+    "content-hash": "f15fe7fe7e37d90502a43a12cb7a4eca",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1865,16 +1865,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "2.0.8",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "82ad1e9a11745dba58775de2e8f47600b0a3331d"
+                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/82ad1e9a11745dba58775de2e8f47600b0a3331d",
-                "reference": "82ad1e9a11745dba58775de2e8f47600b0a3331d",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
+                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
                 "shasum": ""
             },
             "require": {
@@ -1891,11 +1891,13 @@
                 "aws/aws-sdk-php": "^3.132.4",
                 "composer/semver": "^3.0",
                 "ext-fileinfo": "*",
-                "friendsofphp/php-cs-fixer": "^2.16",
+                "ext-ftp": "*",
+                "friendsofphp/php-cs-fixer": "^3.2",
                 "google/cloud-storage": "^1.23",
                 "phpseclib/phpseclib": "^2.0",
                 "phpstan/phpstan": "^0.12.26",
-                "phpunit/phpunit": "^8.5 || ^9.4"
+                "phpunit/phpunit": "^8.5 || ^9.4",
+                "sabre/dav": "^4.1"
             },
             "type": "library",
             "autoload": {
@@ -1927,9 +1929,13 @@
                 "sftp",
                 "storage"
             ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/2.5.0"
+            },
             "funding": [
                 {
-                    "url": "https://offset.earth/frankdejonge",
+                    "url": "https://ecologi.com/frankdejonge",
                     "type": "custom"
                 },
                 {
@@ -1941,7 +1947,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-15T19:53:59+00:00"
+            "time": "2022-09-17T21:02:32+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -1983,6 +1989,10 @@
                 }
             ],
             "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.11.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/frankdejonge",
@@ -2151,22 +2161,22 @@
         },
         {
             "name": "rubix/ml",
-            "version": "0.4.2",
+            "version": "dev-chore/bump-flysystem-v2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/RubixML/ML.git",
-                "reference": "51f6f02f3d719b8f1c8641ff10accd9339fe691e"
+                "url": "https://github.com/nextcloud-deps/RubixML.git",
+                "reference": "35ebe863bb0ecfefb0524d7b77495107e4c5aefb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RubixML/ML/zipball/51f6f02f3d719b8f1c8641ff10accd9339fe691e",
-                "reference": "51f6f02f3d719b8f1c8641ff10accd9339fe691e",
+                "url": "https://api.github.com/repos/nextcloud-deps/RubixML/zipball/35ebe863bb0ecfefb0524d7b77495107e4c5aefb",
+                "reference": "35ebe863bb0ecfefb0524d7b77495107e4c5aefb",
                 "shasum": ""
             },
             "require": {
                 "amphp/parallel": "^1.3",
                 "ext-json": "*",
-                "league/flysystem": "~2.0.2",
+                "league/flysystem": "^2.1.1",
                 "php": ">=7.2",
                 "psr/log": "^1.1",
                 "rubix/tensor": "^2.2",
@@ -2194,24 +2204,53 @@
             },
             "type": "library",
             "autoload": {
+                "psr-4": {
+                    "Rubix\\ML\\": "src/"
+                },
                 "files": [
                     "src/constants.php",
                     "src/functions.php"
-                ],
+                ]
+            },
+            "autoload-dev": {
                 "psr-4": {
-                    "Rubix\\ML\\": "src/"
+                    "Rubix\\ML\\Tests\\": "tests/",
+                    "Rubix\\ML\\Benchmarks\\": "benchmarks/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "build": [
+                    "@composer install",
+                    "@analyze",
+                    "@test",
+                    "@check"
+                ],
+                "analyze": [
+                    "phpstan analyse -c phpstan.neon"
+                ],
+                "benchmark": [
+                    "phpbench run --report=env --report=aggregate"
+                ],
+                "check": [
+                    "@putenv PHP_CS_FIXER_IGNORE_ENV=1",
+                    "php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no"
+                ],
+                "fix": [
+                    "php-cs-fixer fix --config=.php_cs.dist"
+                ],
+                "test": [
+                    "phpunit"
+                ]
+            },
             "license": [
                 "MIT"
             ],
             "authors": [
                 {
                     "name": "Andrew DalPino",
-                    "email": "support@andrewdalpino.com",
+                    "role": "Project Lead",
                     "homepage": "https://github.com/andrewdalpino",
-                    "role": "Project Lead"
+                    "email": "support@andrewdalpino.com"
                 },
                 {
                     "name": "Contributors",
@@ -2221,14 +2260,9 @@
             "description": "A high-level machine learning and deep learning library for the PHP language.",
             "homepage": "https://rubixml.com",
             "keywords": [
-                "Algorithm",
-                "Deep learning",
-                "Linear regression",
-                "Neural network",
-                "Rubix",
-                "TF-IDF",
                 "adaboost",
                 "ai",
+                "algorithm",
                 "analytics",
                 "anomaly detection",
                 "artificial intelligence",
@@ -2241,6 +2275,7 @@
                 "data science",
                 "dataset",
                 "dbscan",
+                "deep learning",
                 "dimensionality reduction",
                 "ensemble",
                 "estimator",
@@ -2261,6 +2296,7 @@
                 "k-nearest neighbors",
                 "kmeans",
                 "knn",
+                "linear regression",
                 "local outlier factor",
                 "loda",
                 "lof",
@@ -2274,6 +2310,7 @@
                 "naive bayes",
                 "natural language processing",
                 "nearest neighbors",
+                "neural network",
                 "nlp",
                 "outlier detection",
                 "php",
@@ -2288,6 +2325,7 @@
                 "regression",
                 "regressor",
                 "ridge",
+                "rubix",
                 "rubix ml",
                 "rubixml",
                 "softmax",
@@ -2297,16 +2335,24 @@
                 "t-sne",
                 "text mining",
                 "tf idf",
+                "tf-idf",
                 "tsne",
                 "unsupervised learning"
             ],
+            "support": {
+                "docs": "https://docs.rubixml.com",
+                "issues": "https://github.com/RubixML/ML/issues",
+                "source": "https://github.com/RubixML/ML",
+                "chat": "https://t.me/RubixML",
+                "email": "support@andrewdalpino.com"
+            },
             "funding": [
                 {
-                    "url": "https://github.com/sponsors/RubixML",
-                    "type": "github"
+                    "type": "github",
+                    "url": "https://github.com/sponsors/RubixML"
                 }
             ],
-            "time": "2022-02-12T00:57:06+00:00"
+            "time": "2022-10-06T11:26:57+00:00"
         },
         {
             "name": "rubix/tensor",
@@ -3193,6 +3239,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "rubix/ml": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
Rubix doesn't allow us to update the buggy Flysystem so we temporarily switch to a fork.