### PR TITLE
GH-7414: Fix schema definition for QuotePlugin

### DIFF
--- a/src/ckeditor/quote/QuotePlugin.js
+++ b/src/ckeditor/quote/QuotePlugin.js
@@ -32,7 +32,7 @@ export default class Quote extends Plugin {
 		const schema = this.editor.model.schema
 
 		schema.register('quote', {
-			inheritAllFrom: '$block',
+			inheritAllFrom: '$container',
 		})
 	}
 

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -46,7 +46,7 @@
 			:placeholder="t('mail', 'Signature …')"
 			:bus="bus" />
 		<p v-if="isLargeSignature" class="warning-large-signature">
-			{{ t('mail', 'Your signature is larger than 2 MB. This may affect the performance of your editor.')}}
+			{{ t('mail', 'Your signature is larger than 2 MB. This may affect the performance of your editor.') }}
 		</p>
 		<ButtonVue
 			type="primary"
@@ -120,7 +120,7 @@ export default {
 		},
 		isLargeSignature() {
 			return (new Blob([this.signature])).size > 2 * 1024 * 1024
-		}
+		},
 	},
 	watch: {
 		async signatureAboveQuote(val, oldVal) {

--- a/src/tests/unit/components/QuotePlugin.spec.js
+++ b/src/tests/unit/components/QuotePlugin.spec.js
@@ -1,0 +1,78 @@
+/*
+ * @copyright 2022 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author 2022 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import VirtualTestEditor from '../../virtualtesteditor'
+import ParagraphPlugin from '@ckeditor/ckeditor5-paragraph/src/paragraph'
+import QuotePlugin from '../../../ckeditor/quote/QuotePlugin'
+
+describe('QuotePlugin', () => {
+
+	it('Keep quote wrapper with QuotePlugin', async() => {
+		const text = '<div class="quote"><p>bonjour bonjour</p></div>'
+		const expected = '<div class=\"quote\"><p>bonjour bonjour</p></div>'
+
+		const editor = await VirtualTestEditor.create({
+			initialData: text,
+			plugins: [ParagraphPlugin, QuotePlugin],
+		})
+
+		expect(editor.getData()).toEqual(expected)
+	})
+
+	it('Remove quote wrapper without QuotePlugin', async() => {
+		const text = '<div class="quote"><p>bonjour bonjour</p></div>'
+		const expected = '<p>bonjour bonjour</p>'
+
+		const editor = await VirtualTestEditor.create({
+			initialData: text,
+			plugins: [ParagraphPlugin],
+		})
+
+		expect(editor.getData()).toEqual(expected)
+	})
+
+
+	it('Editor contains a <quote> element', async() => {
+		const text = '<div class="quote"><p>bonjour bonjour</p></div>'
+
+		const editor = await VirtualTestEditor.create({
+			initialData: text,
+			plugins: [ParagraphPlugin, QuotePlugin],
+		})
+
+		const range = editor.model.createRangeIn(
+			editor.model.document.getRoot()
+		)
+
+		let hasQuoteElement = false;
+
+		for (const value of range.getWalker({ shallow: true })) {
+			if (value.item.is('element')) {
+				if (value.item.name === 'quote') {
+					hasQuoteElement = true;
+				}
+			}
+		}
+
+		expect(hasQuoteElement).toBeTruthy()
+	})
+
+})


### PR DESCRIPTION
Groundwork for #7414.

To wrap a `<blockQuote>` element in our `<quote>` element it must inherit from $container.

| Before | After |
| --- | --- |
| ![Screenshot from 2022-10-12 22-23-13](https://user-images.githubusercontent.com/3902676/195440503-600e133f-e120-4ed5-9b42-85a70504b8e3.png) | ![Screenshot from 2022-10-12 21-56-16](https://user-images.githubusercontent.com/3902676/195440239-2136bdf9-68da-49a9-8edf-d0f58da0e662.png) |



