### PR TITLE
[stable2.0] Bump @nextcloud/vue to v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nextcloud/moment": "^1.2.1",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue": "^7.0.1",
+        "@nextcloud/vue": "^7.0.0",
         "@nextcloud/vue-dashboard": "^2",
         "@riophae/vue-treeselect": "^0.4.0",
         "@vue/babel-preset-app": "^5.0.8",
@@ -3506,18 +3506,6 @@
         "core-js": "^3.6.4"
       }
     },
-    "node_modules/@nextcloud/focus-trap": {
-      "version": "0.1.0-beta",
-      "resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
-      "integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
-      "dependencies": {
-        "focus-trap": "^7.0.0"
-      },
-      "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
     "node_modules/@nextcloud/initial-state": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -3592,9 +3580,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
-      "integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+      "integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",
@@ -3603,7 +3591,6 @@
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
         "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/focus-trap": "^0.1.0-beta",
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
@@ -3612,6 +3599,7 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
+        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
@@ -17564,14 +17552,6 @@
         "core-js": "^3.6.4"
       }
     },
-    "@nextcloud/focus-trap": {
-      "version": "0.1.0-beta",
-      "resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
-      "integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
-      "requires": {
-        "focus-trap": "^7.0.0"
-      }
-    },
     "@nextcloud/initial-state": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -17644,9 +17624,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
-      "integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+      "integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
       "requires": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",
@@ -17655,7 +17635,6 @@
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
         "@nextcloud/event-bus": "^3.0.0",
-        "@nextcloud/focus-trap": "^0.1.0-beta",
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
@@ -17664,6 +17643,7 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
+        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@nextcloud/moment": "^1.2.1",
         "@nextcloud/paths": "^2.1.0",
         "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue": "^7.0.0-beta.5",
+        "@nextcloud/vue": "^7.0.1",
         "@nextcloud/vue-dashboard": "^2",
         "@riophae/vue-treeselect": "^0.4.0",
         "@vue/babel-preset-app": "^5.0.8",
@@ -3506,6 +3506,18 @@
         "core-js": "^3.6.4"
       }
     },
+    "node_modules/@nextcloud/focus-trap": {
+      "version": "0.1.0-beta",
+      "resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
+      "integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
+      "dependencies": {
+        "focus-trap": "^7.0.0"
+      },
+      "engines": {
+        "node": "^16.0.0",
+        "npm": "^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@nextcloud/initial-state": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -3580,9 +3592,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "7.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.5.tgz",
-      "integrity": "sha512-qHHVSdMWdggjYvJUWg73UZeW6+QbP4NXFKN+h3upamGEizIGyoOtjVKhrftY/lKV1t80B75T/4u6drXFyrJLjA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
+      "integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
       "dependencies": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",
@@ -3591,6 +3603,7 @@
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
         "@nextcloud/event-bus": "^3.0.0",
+        "@nextcloud/focus-trap": "^0.1.0-beta",
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
@@ -3599,7 +3612,6 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
-        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",
@@ -17552,6 +17564,14 @@
         "core-js": "^3.6.4"
       }
     },
+    "@nextcloud/focus-trap": {
+      "version": "0.1.0-beta",
+      "resolved": "https://registry.npmjs.org/@nextcloud/focus-trap/-/focus-trap-0.1.0-beta.tgz",
+      "integrity": "sha512-c6mrUrvDGRVkYfUGAJl7o2lxA/iIMF46XgBdCGCnCJFISFqHoWYGQoG6adc6w2IL7uhGka+lzy38szz+WUYpkA==",
+      "requires": {
+        "focus-trap": "^7.0.0"
+      }
+    },
     "@nextcloud/initial-state": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.0.0.tgz",
@@ -17624,9 +17644,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "7.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0-beta.5.tgz",
-      "integrity": "sha512-qHHVSdMWdggjYvJUWg73UZeW6+QbP4NXFKN+h3upamGEizIGyoOtjVKhrftY/lKV1t80B75T/4u6drXFyrJLjA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.1.tgz",
+      "integrity": "sha512-VwukKyu2ytFLYVrLHKN+waC4xuZaaFdns5+bKX8PzYfqjhjMDbjaZubCb4VkCISsaNqfcnJiE6Rkxtw4mwI8Pw==",
       "requires": {
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.0.0",
@@ -17635,6 +17655,7 @@
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^3.1.4",
         "@nextcloud/event-bus": "^3.0.0",
+        "@nextcloud/focus-trap": "^0.1.0-beta",
         "@nextcloud/initial-state": "^2.0.0",
         "@nextcloud/l10n": "^1.6.0",
         "@nextcloud/logger": "^2.2.1",
@@ -17643,7 +17664,6 @@
         "emoji-mart-vue-fast": "^11.1.1",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.18",
-        "focus-trap": "^7.0.0",
         "hammerjs": "^2.0.8",
         "linkify-string": "^4.0.0",
         "md5": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nextcloud/moment": "^1.2.1",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue": "^7.0.0-beta.5",
+    "@nextcloud/vue": "^7.0.1",
     "@nextcloud/vue-dashboard": "^2",
     "@riophae/vue-treeselect": "^0.4.0",
     "@vue/babel-preset-app": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@nextcloud/moment": "^1.2.1",
     "@nextcloud/paths": "^2.1.0",
     "@nextcloud/router": "^2.0.0",
-    "@nextcloud/vue": "^7.0.1",
+    "@nextcloud/vue": "^7.0.0",
     "@nextcloud/vue-dashboard": "^2",
     "@riophae/vue-treeselect": "^0.4.0",
     "@vue/babel-preset-app": "^5.0.8",


### PR DESCRIPTION
Backport of https://github.com/nextcloud/mail/pull/7419

Refined version of https://github.com/nextcloud/mail/pull/7440 because .1 has a regression, .0 works.