### PR TITLE
Add skeleton loading thread messages

### DIFF
--- a/src/components/MessageLoadingSkeleton.vue
+++ b/src/components/MessageLoadingSkeleton.vue
@@ -1,0 +1,98 @@
+<template>
+	<div class="message-loading-skeleton">
+		<div class="message-loading-skeleton__body">
+			<div class="message-loading-skeleton__body__line-one">
+					&nbsp;
+			</div>
+			<div class="message-loading-skeleton__body__line-two">
+					&nbsp;
+			</div>
+			<div class="message-loading-skeleton__body__line-three">
+					&nbsp;
+			</div>
+			<div class="message-loading-skeleton__body__line-four">
+					&nbsp;
+			</div>
+			<div class="message-loading-skeleton__body__line-five">
+					&nbsp;
+			</div>
+			<div class="message-loading-skeleton__body__line-six">
+					&nbsp;
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+
+export default {
+	name: 'MessageLoadingSkeleton',
+}
+</script>
+
+<style lang="scss" scoped>
+
+/* skeleton */
+.message-loading-skeleton {
+	display: flex;
+	flex-grow: 1;
+	align-items: flex-start;
+	padding: 8px;
+	width: 100%;
+	&__body {
+		max-height: 500px;
+		max-width: 1200px;
+		flex: 1 1 100%;
+		display: flex;
+		flex-direction: column;
+		margin-left: 50px;
+		&__line-one,
+		&__line-two,
+		&__line-three,
+		&__line-four,
+		&__line-five,
+		&__line-six {
+			white-space: nowrap;
+			height: 13px;
+			background: linear-gradient(-45deg, #d3d3d3, #f5f5f5, #f2f3f4, #e5e4e2);
+			background-size: 400% 400%;
+			animation: gradient 3s ease-in infinite;
+		}
+		&__line-one {
+			width: 10%;
+			margin-bottom: 25px;
+		}
+		&__line-two {
+			width: 80%;
+			margin-bottom: 6px;
+		}
+		&__line-three {
+			width: 50%;
+			margin-bottom: 6px;
+		}
+		&__line-four {
+			width: 70%;
+			margin-bottom: 6px;
+		}
+		&__line-five {
+			width: 40%;
+			margin-bottom: 25px;
+		}
+		&__line-six {
+			width: 30%;
+		}
+	}
+	@keyframes gradient {
+		 0% {
+			 background-position: 0% 50%;
+		 }
+		 50% {
+			 background-position: 100% 50%;
+		 }
+		 100% {
+			 background-position: 0% 50%;
+		 }
+	 }
+}
+
+</style>

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -34,10 +34,7 @@
 					</div>
 				</div>
 			</div>
-			<!-- Show inner loading screen only if we have at least one message of the thread -->
-			<Loading v-if="loading && thread.length" :hint="t('mail', 'Loading messages')" />
 			<ThreadEnvelope v-for="env in thread"
-				v-else
 				:key="env.databaseId"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -143,7 +143,7 @@
 				</template>
 			</div>
 		</div>
-		<Loading v-if="loading !== LOADING_DONE" />
+		<MessageLoadingSkeleton v-if="loading !== LOADING_DONE" />
 		<Message v-if="message && loading !== LOADING_MESSAGE"
 			v-show="loading === LOADING_DONE"
 			:envelope="envelope"
@@ -164,7 +164,7 @@ import Error from './Error'
 import importantSvg from '../../img/important.svg'
 import IconFavorite from 'vue-material-design-icons/Star'
 import JunkIcon from './icons/JunkIcon'
-import Loading from './Loading'
+import MessageLoadingSkeleton from './MessageLoadingSkeleton'
 import logger from '../logger'
 import Message from './Message'
 import MenuEnvelope from './MenuEnvelope'
@@ -196,7 +196,7 @@ export default {
 		Error,
 		IconFavorite,
 		JunkIcon,
-		Loading,
+		MessageLoadingSkeleton,
 		MenuEnvelope,
 		Moment,
 		Message,
@@ -505,6 +505,15 @@ export default {
 		margin-right: 10px;
 		background-color: var(--color-main-background);
 		padding-bottom: 28px;
+		animation: show 200ms 90ms cubic-bezier(.17, .67, .83, .67) forwards;
+		opacity: 0.5;
+		transform-origin: top center;
+		@keyframes show {
+			100% {
+				opacity: 1;
+				transform: none;
+			}
+		}
 
 		& + .envelope {
 			margin-top: -28px;


### PR DESCRIPTION
contributes to #6045 

- [x] Add skeleton for message body
- [x] When there is a thread with more than one msg - one message container is shown(see Jans mockup below)  then the other threads show up.
- [x] Animate the whole container
- [x] Dont animate the text

We agreed with Jan that the skeleton lines to be square since we have it like that everywhere, but in future they should be round/pill style.

[Screencast from 17.11.2022 18:27:21.webm](https://user-images.githubusercontent.com/12728974/202516961-a508e332-5d1d-41a8-bcd9-f8983c90868b.webm)

  