### PR TITLE
Fix handling of account update API response

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -245,7 +245,7 @@ class AccountsController extends Controller {
 			$dbAccount->setSignatureAboveQuote($signatureAboveQuote);
 		}
 		return new JSONResponse(
-			$this->accountService->save($dbAccount)->toJson()
+			$this->accountService->save($dbAccount)
 		);
 	}
 

--- a/src/service/AccountService.js
+++ b/src/service/AccountService.js
@@ -42,7 +42,7 @@ export const update = (data) => {
 
 	return axios
 		.put(url, data)
-		.then((resp) => resp.data)
+		.then((resp) => resp.data.data)
 		.then(fixAccountId)
 		.catch((e) => {
 			if (e.response && e.response.status === 400) {


### PR DESCRIPTION
Axios gives us the response contents inside `data`, but our response also has a key `data`. So we need `.data.data`.

Found in #7430 