### PR TITLE
Bump version to v2.2.0 Alpha 0

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>2.1.0-rc.1</version>
+	<version>2.2.0-alpha.0</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "2.1.0-rc.1",
+  "version": "2.2.0-alpha0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "2.1.0-rc.1",
+      "version": "2.2.0-alpha0",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "~35.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "2.1.0-rc.1",
+  "version": "2.2.0-alpha0",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,


### PR DESCRIPTION
Makes it clearer that 2.1 has been branched off into `stable2.1`.