### PR TITLE
Fix high memory usage during thread building

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -204,7 +204,13 @@ class MessageMapper extends QBMapper {
 		$messagesQuery->select('id', 'subject', 'message_id', 'in_reply_to', 'references', 'thread_root_id')
 			->from($this->getTableName())
 			->where($messagesQuery->expr()->in('mailbox_id', $messagesQuery->createFunction($mailboxesQuery->getSQL()), IQueryBuilder::PARAM_INT_ARRAY))
-			->andWhere($messagesQuery->expr()->isNotNull('message_id'));
+			->andWhere(
+				$messagesQuery->expr()->isNotNull('message_id'),
+				$messagesQuery->expr()->orX(
+					$messagesQuery->expr()->isNotNull('in_reply_to'),
+					$messagesQuery->expr()->neq('references', $messagesQuery->createNamedParameter('[]'))
+				),
+			);
 
 		$result = $messagesQuery->execute();
 		$messages = [];

--- a/lib/IMAP/Threading/Container.php
+++ b/lib/IMAP/Threading/Container.php
@@ -25,11 +25,12 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP\Threading;
 
+use JsonSerializable;
 use RuntimeException;
 use function array_key_exists;
 use function spl_object_id;
 
-class Container {
+class Container implements JsonSerializable {
 	/** @var Message|null */
 	private $message;
 
@@ -146,5 +147,14 @@ class Container {
 	 */
 	public function getChildren(): array {
 		return $this->children;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'message' => $this->message,
+			'id' => $this->id,
+			'root' => $this->root,
+			'children' => $this->children,
+		];
 	}
 }

--- a/lib/IMAP/Threading/Container.php
+++ b/lib/IMAP/Threading/Container.php
@@ -33,6 +33,9 @@ class Container {
 	/** @var Message|null */
 	private $message;
 
+	/** @var string|null */
+	private $id;
+
 	/** @var bool */
 	private $root;
 
@@ -43,21 +46,25 @@ class Container {
 	private $children = [];
 
 	private function __construct(?Message $message,
+								 ?string $id = null,
 								 bool $root = false) {
 		$this->message = $message;
+		$this->id = $id;
 		$this->root = $root;
 	}
 
 	public static function root(): self {
 		return new self(
 			null,
+			null,
 			true
 		);
 	}
 
-	public static function empty(): self {
+	public static function empty(?string $id = null): self {
 		return new self(
-			null
+			null,
+			$id,
 		);
 	}
 
@@ -77,6 +84,10 @@ class Container {
 
 	public function getMessage(): ?Message {
 		return $this->message;
+	}
+
+	public function getId(): ?string {
+		return $this->id;
 	}
 
 	public function isRoot(): bool {

--- a/lib/IMAP/Threading/DatabaseMessage.php
+++ b/lib/IMAP/Threading/DatabaseMessage.php
@@ -110,6 +110,7 @@ class DatabaseMessage extends Message implements JsonSerializable {
 			parent::jsonSerialize(),
 			[
 				'databaseId' => $this->databaseId,
+				'threadRootId' => $this->getThreadRootId(),
 			]
 		);
 	}

--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -98,7 +98,7 @@ class ThreadBuilder {
 			foreach ($message->getReferences() as $reference) {
 				$refContainer = $idTable[$reference] ?? null;
 				if ($refContainer === null) {
-					$refContainer = $idTable[$reference] = Container::empty();
+					$refContainer = $idTable[$reference] = Container::empty($reference);
 				}
 				if (!$refContainer->hasParent()
 					&& !($parent !== null && !$parent->hasAncestor($refContainer))
@@ -149,7 +149,7 @@ class ThreadBuilder {
 
 			// Step 4.B
 			if (!$container->hasMessage() && $container->hasChildren()) {
-				if (!$container->getParent()->isRoot() && count($container->getChildren()) > 1) {
+				if (!$container->getParent()->isRoot() && count($container->getChildren()) > 0) {
 					// Do not promote
 					continue;
 				}

--- a/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
+++ b/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
@@ -68,7 +68,7 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 		$accountId = $event->getAccount()->getId();
 		$logger->debug("Building threads for account $accountId");
 		$messages = $this->mapper->findThreadingData($event->getAccount());
-		$logger->debug("Account $accountId has " . count($messages) . " messages for threading");
+		$logger->debug("Account $accountId has " . count($messages) . " messages with threading information");
 		$threads = $this->builder->build($messages, $logger);
 		$logger->debug("Account $accountId has " . count($threads) . " threads");
 		/** @var DatabaseMessage[] $flattened */
@@ -105,7 +105,7 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 
 			yield from $this->flattenThreads(
 				$thread->getChildren(),
-				$threadId ?? ($message === null ? null : $message->getId())
+				$threadId ?? ($message === null ? $thread->getId() : $message->getId())
 			);
 		}
 	}

--- a/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
+++ b/tests/Unit/IMAP/Threading/ThreadBuilderTest.php
@@ -475,6 +475,29 @@ class ThreadBuilderTest extends TestCase {
 		);
 	}
 
+	public function testWithVirtualParent(): void {
+		$messages = [
+			new Message('AW: s1', 'id2', ['id1']),
+		];
+
+		$result = $this->builder->build($messages, $this->logger);
+
+		$this->assertEquals(
+			[
+				[
+					'id' => null,
+					'children' => [
+						[
+							'id' => 'id2',
+							'children' => [],
+						],
+					],
+				],
+			],
+			$this->abstract($result)
+		);
+	}
+
 	/**
 	 * This is a test case from real-world data, compared to how Evolution renders the thread
 	 *


### PR DESCRIPTION
## Problem

Threading is done across all messages of one account. With the number of messages the amount of input data for the threading algorithm increases. As some point, the available memory size of a PHP process is reached.

A testing account with 600k dummy emails could be sync'ed into the database case, but at threading the process always ran out of memory.

## Solution

If only messages with threading info are loaded we can significantly reduce the amount of memory consumed to build threads. This is because many messages are not part of a thread. And if they are, the references and in-reply-to headers are enough information to know that there was a previous message. So we build the threads out of existence of the thread roots. As long as the threading result is the same, this doesn't matter.

### Example 1: we have message X and Y. Y points to X as parent message.

Previously we loaded them both. Then found out the are related and save X's ID as *thread root id*.
Now we only load Y, because X doesn't point to any other message. We still know that Y is part of a thread with X's id. So we save X's id as Y's *thread root id*. X is not changed, but keeps its default self-reference for the thread root. Both messages therefore belong to X's id.

### Example 2: we have message Y that points to unknown message X

Previously and now we only load message Y. But previously we discarded the empty tree node for X by replacing it with Y. Therefore Y referenced itself as thread root. If we ever found X, the algorithm would stop replacing the now not empty node and Y's thread root updates to X. The thread is built explicitly.
Now we already save Y's id as X's thread root. We don't care if the parent exists or not. If Y appears, it doesn't have any influence on the threading algorithm. The thread is therefore built implicitly because X and Y have the same thread root ids.

### Example 3: we have a message that points to no other

Previously this message was loaded for threading. If no other message pointed to it it was a useless node in the tree that did not get any database update.
Now we don't even load the message. It doesn't have any effect on the algorithm output.

## Todo

- [x] Make it work
- [x] Make it work *exactly* like the previous algorithm. ~~Right now there are very few messages/threads where the new algorithm causes different results than the old.~~ Different thread root IDs because we keep references of (yet) unknown messages. But the resulting threads are identical.
- [ ] What about subject threading?!

Fixes https://github.com/nextcloud/mail/issues/6887

---

> There are two types of people in the world: Those who can extrapolate from incomplete data.

Unknown.