### PR TITLE
Fix server error accessing message routes anonymously

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -67,7 +67,7 @@ class MessagesController extends Controller {
 	private ItineraryService $itineraryService;
 	private ?string $currentUserId;
 	private LoggerInterface $logger;
-	private Folder $userFolder;
+	private ?Folder $userFolder;
 	private IMimeTypeDetector $mimeTypeDetector;
 	private IL10N $l10n;
 	private IURLGenerator $urlGenerator;


### PR DESCRIPTION
Found using https://github.com/nextcloud/mail/issues/5714

The user folder is null when there is no user. This happens rarely, but it happens. It's the same kind of error we get with `$UserId` if when the request is anonymous. Then the user id is `null`, not a string.

"Regression" of https://github.com/nextcloud/mail/pull/7362.

In theory we could now get a NPE but since methods are guarded by the auth checks this doesn't happen practically. Let's see what Psalm thinks.

## How to test

1) Log into Nextcloud
2) Open Mail
3) Open a second tab
4) Log out on the second tab
5) Load a message in the first tab

Expected: smooth HTTP401
Actual: ![Bildschirmfoto vom 2022-11-02 19-14-45](https://user-images.githubusercontent.com/1374172/199570047-3b37c360-8930-44d1-9e29-0fb13f775143.png)
