### PR TITLE
Prevent trim'ing and strpos'ing null in integration tests

### DIFF
--- a/tests/Integration/Framework/ImapTest.php
+++ b/tests/Integration/Framework/ImapTest.php
@@ -138,10 +138,16 @@ trait ImapTest {
 		$headers = [
 			'From' => new Horde_Mail_Rfc822_Address($message->getFrom()),
 			'To' => new Horde_Mail_Rfc822_Address($message->getTo()),
-			'Cc' => $message->getCc() === null ?: new Horde_Mail_Rfc822_Address($message->getCc()),
-			'Bcc' => $message->getBcc() === null ?: new Horde_Mail_Rfc822_Address($message->getBcc()),
-			'Subject' => $message->getSubject(),
 		];
+		if ($message->getCc() !== null) {
+			$headers['Cc'] = new Horde_Mail_Rfc822_Address($message->getCc());
+		}
+		if ($message->getBcc() !== null) {
+			$headers['Bcc'] = new Horde_Mail_Rfc822_Address($message->getBcc());
+		}
+		if ($message->getSubject() !== null) {
+			$headers['Subject'] = $message->getSubject();
+		}
 
 		$mail = new Horde_Mime_Mail();
 		$mail->addHeaders($headers);

--- a/tests/Integration/Framework/ImapTest.php
+++ b/tests/Integration/Framework/ImapTest.php
@@ -138,8 +138,8 @@ trait ImapTest {
 		$headers = [
 			'From' => new Horde_Mail_Rfc822_Address($message->getFrom()),
 			'To' => new Horde_Mail_Rfc822_Address($message->getTo()),
-			'Cc' => new Horde_Mail_Rfc822_Address($message->getCc()),
-			'Bcc' => new Horde_Mail_Rfc822_Address($message->getBcc()),
+			'Cc' => $message->getCc() === null ?: new Horde_Mail_Rfc822_Address($message->getCc()),
+			'Bcc' => $message->getBcc() === null ?: new Horde_Mail_Rfc822_Address($message->getBcc()),
 			'Subject' => $message->getSubject(),
 		];
 

--- a/tests/Integration/Framework/MessageBuilder.php
+++ b/tests/Integration/Framework/MessageBuilder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -28,13 +30,13 @@ class MessageBuilder {
 	/** @var string */
 	private $to;
 
-	/** @var string */
+	/** @var string|null */
 	private $cc;
 
-	/** @var string */
+	/** @var string|null */
 	private $bcc;
 
-	/** @var string */
+	/** @var string|null */
 	private $date;
 
 	/** @var string */
@@ -54,7 +56,7 @@ class MessageBuilder {
 	 * @param string $from
 	 * @return MessageBuilder
 	 */
-	public function from($from) {
+	public function from(string $from) {
 		$this->from = $from;
 		return $this;
 	}
@@ -63,7 +65,7 @@ class MessageBuilder {
 	 * @param string $to
 	 * @return MessageBuilder
 	 */
-	public function to($to) {
+	public function to(string $to) {
 		$this->to = $to;
 		return $this;
 	}
@@ -72,7 +74,7 @@ class MessageBuilder {
 	 * @param string $cc
 	 * @return MessageBuilder
 	 */
-	public function cc($cc) {
+	public function cc(string $cc) {
 		$this->cc = $cc;
 		return $this;
 	}
@@ -81,7 +83,7 @@ class MessageBuilder {
 	 * @param string $bcc
 	 * @return MessageBuilder
 	 */
-	public function bcc($bcc) {
+	public function bcc(string $bcc) {
 		$this->bcc = $bcc;
 		return $this;
 	}

--- a/tests/Integration/Framework/SimpleMessage.php
+++ b/tests/Integration/Framework/SimpleMessage.php
@@ -28,31 +28,37 @@ class SimpleMessage {
 	/** @var string */
 	private $to;
 
-	/** @var string */
+	/** @var string|null */
 	private $cc;
 
-	/** @var string */
+	/** @var string|null */
 	private $bcc;
 
-	/** @var string */
+	/** @var string|null */
 	private $date;
 
-	/** @var string */
+	/** @var string|null */
 	private $subject;
 
-	/** @var string */
+	/** @var string|null */
 	private $body;
 
 	/**
 	 * @param string $from
 	 * @param string $to
-	 * @param string $cc
-	 * @param string $bcc
+	 * @param string|null $cc
+	 * @param string|null $bcc
 	 * @param string $date
 	 * @param string $subject
 	 * @param string $body
 	 */
-	public function __construct($from, $to, $cc, $bcc, $date, $subject, $body) {
+	public function __construct(string $from,
+		string $to,
+		?string $cc,
+		?string $bcc,
+		?string $date,
+		?string $subject,
+		?string $body) {
 		$this->from = $from;
 		$this->to = $to;
 		$this->cc = $cc;
@@ -62,52 +68,31 @@ class SimpleMessage {
 		$this->body = $body;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getFrom() {
+	public function getFrom(): string {
 		return $this->from;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getTo() {
+	public function getTo(): string {
 		return $this->to;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getCc() {
+	public function getCc(): ?string {
 		return $this->cc;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getBcc() {
+	public function getBcc(): ?string {
 		return $this->bcc;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getDate() {
+	public function getDate(): ?string {
 		return $this->date;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getSubject() {
+	public function getSubject(): ?string {
 		return $this->subject;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getBody() {
+	public function getBody(): ?string {
 		return $this->body;
 	}
 }


### PR DESCRIPTION
Fixes a flock of 
```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/christoph/workspace/nextcloud/apps/mail/vendor/bytestream/horde-mail/lib/Horde/Mail/Rfc822.php on line 224
```
and
```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /home/christoph/workspace/nextcloud/apps/mail/vendor/bytestream/horde-mime/lib/Horde/Mime.php on line 217
``` 

that pollute the text output.