### PR TITLE
Fix open composer actions after changing encryption mode

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -232,7 +232,8 @@
 				</ButtonVue>
 			</div>
 			<div class="composer-actions--secondary-actions">
-				<Actions @close="isMoreActionsOpen = false">
+				<Actions :open.sync="isActionsOpen"
+					@close="isMoreActionsOpen = false">
 					<template v-if="!isMoreActionsOpen">
 						<ActionButton @click="onAddLocalAttachment">
 							<template #icon>
@@ -308,6 +309,7 @@
 						<ActionCheckbox
 							v-if="mailvelope.available"
 							:checked="encrypt"
+							@change="isActionsOpen = false"
 							@check="encrypt = true"
 							@uncheck="encrypt = false">
 							{{ t('mail', 'Encrypt message with Mailvelope') }}
@@ -584,6 +586,7 @@ export default {
 			loadingIndicatorTo: false,
 			loadingIndicatorCc: false,
 			loadingIndicatorBcc: false,
+			isActionsOpen: false,
 			isMoreActionsOpen: false,
 			selectedDate,
 			sendAtVal: this.sendAt,


### PR DESCRIPTION
If the email encryption is turned on or off, the menu should close. NcActionCheckbox does not come with a closeAfterClick like ActionButton, we need to keep track of the menu state ourselves and close manually.

## How to test

1) Set up https://mailvelope.com/en/ for your test email account
2) Configure the account in Mail
3) Open the message composer
4) Turn on encryption

Main: the menu stays open.
This banch: the menu closes.

![Bildschirmfoto vom 2022-11-07 10-27-57](https://user-images.githubusercontent.com/1374172/200275208-fe62e7d4-d668-49c8-a37a-5ea7e8dd18cf.png)
