### PR TITLE
Fix copy to clipboard

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<Popover trigger="click" class="contact-popover">
+	<Popover ref="popover" trigger="click" class="contact-popover">
 		<UserBubble slot="trigger"
 			:display-name="label"
 			:avatar-image="avatarUrlAbsolute"
@@ -204,7 +204,7 @@ export default {
 	},
 	methods: {
 		onClickCopyToClipboard() {
-			this.$copyText(this.email)
+			this.$copyText(this.email, this.$refs.popover.$refs.popover.$refs.popperContent.$el)
 		},
 		onClickReply() {
 			this.$router.push({


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/7169

To make clipboard.js work with modals, the fakeElement (to copy the data from) must be part of the modals DOM structure.