### PR TITLE
Fix sending PGP messages as HTML

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -887,7 +887,7 @@ export default {
 				body: this.encrypt ? plain(this.bodyVal) : html(this.bodyVal),
 				attachments: this.attachments,
 				inReplyToMessageId: this.inReplyToMessageId ?? (this.replyTo ? this.replyTo.messageId : undefined),
-				isHtml: !this.editorPlainText,
+				isHtml: !this.encrypt && !this.editorPlainText,
 				requestMdn: this.requestMdn,
 				sendAt: this.sendAtVal ? Math.floor(this.sendAtVal / 1000) : undefined,
 			}


### PR DESCRIPTION
They are always plain text messages. Otherwise the PGP ciphertext is not recognized on the receiving end.

Fixes https://github.com/nextcloud/mail/issues/7344

## How to test

0. Set up Mailvelope
1. Open the app
2. Start a new message
3. Turn on formatting if it's not alreay on because of the account default
4. Turn on encryption
5. Send the message

Here: messages is sent as text/plain
Main: message is sent as text/html