### PR TITLE
Improve loading experience for message on thread

### DIFF
--- a/src/components/MessageEncryptedBody.vue
+++ b/src/components/MessageEncryptedBody.vue
@@ -46,8 +46,8 @@ export default {
 <style scoped>
 #mail-content {
 	height: 450px;
-	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
-opacity: 0;
+	animation: show 200ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+opacity: 0.3;
 transform: rotateX(-90deg);
 	transform-origin: top center;
 }

--- a/src/components/MessageEncryptedBody.vue
+++ b/src/components/MessageEncryptedBody.vue
@@ -46,7 +46,7 @@ export default {
 <style scoped>
 #mail-content {
 	height: 450px;
-	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
 opacity: 0;
 transform: rotateX(-90deg);
 	transform-origin: top center;

--- a/src/components/MessageEncryptedBody.vue
+++ b/src/components/MessageEncryptedBody.vue
@@ -46,5 +46,16 @@ export default {
 <style scoped>
 #mail-content {
 	height: 450px;
+	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+opacity: 0;
+transform: rotateX(-90deg);
+	transform-origin: top center;
 }
+@keyframes show {
+	100% {
+		opacity: 1;
+		transform: none;
+	}
+}
+
 </style>

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -43,7 +43,7 @@
 import { iframeResizer } from 'iframe-resizer'
 import PrintScout from 'printscout'
 import { trustSender } from '../service/TrustedSenderService'
-import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading } from '@nextcloud/vue'
+import { NcActionButton as ActionButton, NcActions as Actions } from '@nextcloud/vue'
 import IconImage from 'vue-material-design-icons/ImageSizeSelectActual'
 import IconMail from 'vue-material-design-icons/Email'
 import IconDomain from 'vue-material-design-icons/Domain'
@@ -61,7 +61,6 @@ export default {
 		IconImage,
 		IconMail,
 		IconDomain,
-		IconLoading,
 	},
 	props: {
 		url: {
@@ -190,6 +189,19 @@ export default {
 }
 .message-frame {
 	width: 100%;
+	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+
+	// Prestate
+	opacity: 0;
+	// remove transform for just a fade-in
+	transform: rotateX(-90deg);
+	transform-origin: top center;
+}
+@keyframes show {
+	100% {
+		opacity: 1;
+		transform: none;
+	}
 }
 :deep(.button-vue__icon) {
 	display: none !important;

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -189,12 +189,10 @@ export default {
 }
 .message-frame {
 	width: 100%;
-	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	animation: show 200ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
 
 	// Prestate
-	opacity: 0;
-	// remove transform for just a fade-in
-	transform: rotateX(-90deg);
+	opacity: 0.3;
 	transform-origin: top center;
 }
 @keyframes show {

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -27,6 +27,7 @@
 				</ActionButton>
 			</Actions>
 		</div>
+		<IconLoading v-if="loading" />
 		<div id="message-container" :class="{hidden: loading, scroll: !fullHeight}">
 			<iframe v-show="!hidden"
 				ref="iframe"
@@ -43,7 +44,7 @@
 import { iframeResizer } from 'iframe-resizer'
 import PrintScout from 'printscout'
 import { trustSender } from '../service/TrustedSenderService'
-import { NcActionButton as ActionButton, NcActions as Actions } from '@nextcloud/vue'
+import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading } from '@nextcloud/vue'
 import IconImage from 'vue-material-design-icons/ImageSizeSelectActual'
 import IconMail from 'vue-material-design-icons/Email'
 import IconDomain from 'vue-material-design-icons/Domain'
@@ -61,6 +62,7 @@ export default {
 		IconImage,
 		IconMail,
 		IconDomain,
+		IconLoading,
 	},
 	props: {
 		url: {

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -27,9 +27,9 @@
 				</ActionButton>
 			</Actions>
 		</div>
-		<IconLoading v-if="loading" />
 		<div id="message-container" :class="{hidden: loading, scroll: !fullHeight}">
-			<iframe ref="iframe"
+			<iframe v-show="!hidden"
+				ref="iframe"
 				class="message-frame"
 				:title="t('mail', 'Message frame')"
 				:src="url"
@@ -81,6 +81,7 @@ export default {
 	data() {
 		return {
 			loading: true,
+			hidden: true,
 			hasBlockedContent: false,
 			isSenderTrusted: this.message.isSenderTrusted,
 		}
@@ -109,6 +110,7 @@ export default {
 			return iframe.contentDocument || iframe.contentWindow.document
 		},
 		onMessageFrameLoad() {
+			this.hidden = false
 			const iframeDoc = this.getIframeDoc()
 			this.hasBlockedContent
 				= iframeDoc.querySelectorAll('[data-original-src]').length > 0

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -78,9 +78,8 @@ export default {
 <style lang="scss" scoped>
 .message-container {
 	white-space: pre-wrap;
-	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
-	opacity: 0;
-	transform: rotateX(-90deg);
+	animation: show 200ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	opacity: 0.3;
 	transform-origin: top center;
 }
 @keyframes show {

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -78,7 +78,7 @@ export default {
 <style lang="scss" scoped>
 .message-container {
 	white-space: pre-wrap;
-	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
 	opacity: 0;
 	transform: rotateX(-90deg);
 	transform-origin: top center;

--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -76,7 +76,19 @@ export default {
 }
 </style>
 <style lang="scss" scoped>
-.message-container,
+.message-container {
+	white-space: pre-wrap;
+	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	opacity: 0;
+	transform: rotateX(-90deg);
+	transform-origin: top center;
+}
+@keyframes show {
+	100% {
+		opacity: 1;
+		transform: none;
+	}
+}
 .mail-signature {
 	white-space: pre-wrap;
 }

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -36,6 +36,7 @@
 			<ThreadEnvelope v-for="env in thread"
 				:key="env.databaseId"
 				:envelope="env"
+				:class="{'closedThread': !expanded, 'openedThread': expanded}"
 				:mailbox-id="$route.params.mailboxId"
 				:expanded="expandedThreads.includes(env.databaseId)"
 				:full-height="thread.length === 1"
@@ -68,6 +69,13 @@ export default {
 		Popover,
 	},
 
+	props: {
+		expanded: {
+			required: false,
+			type: Boolean,
+			default: false,
+		},
+	},
 	data() {
 		return {
 			loading: true,
@@ -140,6 +148,13 @@ export default {
 			}
 			logger.debug('navigated to another thread', { to, from })
 			this.resetThread()
+		},
+		expanded(expanded) {
+			if (expanded) {
+				this.fetchThread()
+			} else {
+				this.threadId = undefined
+			}
 		},
 	},
 	created() {
@@ -422,5 +437,11 @@ export default {
 }
 .user-bubble__title {
 	cursor: pointer;
+}
+.closedThread {
+	min-height: 135px;
+}
+.openedThread {
+	min-height: 500px;
 }
 </style>

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -425,7 +425,7 @@ export default {
 	cursor: pointer;
 }
 .thread-animation {
-	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+	animation: show 1200ms 1000ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
 
 	// Prestate
 	opacity: 0;

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -35,6 +35,7 @@
 			</div>
 			<ThreadEnvelope v-for="env in thread"
 				:key="env.databaseId"
+				class="thread-animation"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
 				:expanded="expandedThreads.includes(env.databaseId)"
@@ -422,5 +423,20 @@ export default {
 }
 .user-bubble__title {
 	cursor: pointer;
+}
+.thread-animation {
+	animation: show 600ms 100ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+
+	// Prestate
+	opacity: 0;
+	// remove transform for just a fade-in
+	transform: rotateX(-90deg);
+	transform-origin: top center;
+}
+@keyframes show {
+	100% {
+		opacity: 1;
+		transform: none;
+	}
 }
 </style>

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -35,7 +35,6 @@
 			</div>
 			<ThreadEnvelope v-for="env in thread"
 				:key="env.databaseId"
-				class="thread-animation"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
 				:expanded="expandedThreads.includes(env.databaseId)"
@@ -423,20 +422,5 @@ export default {
 }
 .user-bubble__title {
 	cursor: pointer;
-}
-.thread-animation {
-	animation: show 1200ms 1000ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
-
-	// Prestate
-	opacity: 0;
-	// remove transform for just a fade-in
-	transform: rotateX(-90deg);
-	transform-origin: top center;
-}
-@keyframes show {
-	100% {
-		opacity: 1;
-		transform: none;
-	}
 }
 </style>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -233,6 +233,7 @@ export default {
 	data() {
 		return {
 			loading: false,
+			hidden: true,
 			error: undefined,
 			message: undefined,
 			importantSvg,
@@ -490,6 +491,7 @@ export default {
 		margin-right: 10px;
 		background-color: var(--color-main-background);
 		padding-bottom: 28px;
+		min-height: 150px;
 
 		& + .envelope {
 			margin-top: -28px;

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -145,6 +145,7 @@
 		</div>
 		<Loading v-if="loading" />
 		<Message v-else-if="message"
+			class="message-animation"
 			:envelope="envelope"
 			:message="message"
 			:full-height="fullHeight" />
@@ -233,7 +234,6 @@ export default {
 	data() {
 		return {
 			loading: false,
-			hidden: true,
 			error: undefined,
 			message: undefined,
 			importantSvg,
@@ -606,5 +606,14 @@ export default {
 	}
 	.junk-favorite-position {
 		margin-bottom: 36px !important;
+	}
+	.message-animation {
+		animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+
+		// Prestate
+		opacity: 0;
+		// remove transform for just a fade-in
+		transform: rotateX(-90deg);
+		transform-origin: top center;
 	}
 </style>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -608,12 +608,17 @@ export default {
 		margin-bottom: 36px !important;
 	}
 	.message-animation {
-		animation: show 400ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
+		animation: show 200ms 80ms cubic-bezier(0.38, 0.97, 0.56, 0.76) forwards;
 
 		// Prestate
-		opacity: 0;
+		opacity: 0.3;
 		// remove transform for just a fade-in
-		transform: rotateX(-90deg);
 		transform-origin: top center;
+	}
+	@keyframes show {
+		100% {
+			opacity: 1;
+			transform: none;
+		}
 	}
 </style>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -491,10 +491,9 @@ export default {
 		margin-right: 10px;
 		background-color: var(--color-main-background);
 		padding-bottom: 28px;
-		min-height: 150px;
 
 		& + .envelope {
-			margin-top: -28px;
+			margin-top: -60px;
 		}
 
 		&:last-of-type {


### PR DESCRIPTION
ref #6045 

 

- [x] Fix the message loading screen

Add minimum height to element so the spinner looks less broken. This should be less than an action message
After the loading finished, animate that the element grows to the actual message size (especially text messages)