### PR TITLE
Fix scrolling for  long threads

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -258,6 +258,10 @@ export default {
 <style lang="scss">
 #mail-message {
 	flex-grow: 1;
+	max-height: calc(100vh - 50px);
+	margin-bottom: 30vh;
+	overflow: auto;
+
 }
 
 .mail-message-body {


### PR DESCRIPTION
its only on 1.14 so no backport

before
![Screenshot from 2022-11-10 14-44-58](https://user-images.githubusercontent.com/12728974/201107843-c379cf4d-def8-43f9-8088-271622138dea.png)


after
![Screenshot from 2022-11-10 14-43-18](https://user-images.githubusercontent.com/12728974/201107712-bc025dc5-39b6-4ab0-96b6-1e6e09e7e2b3.png)
