### PR TITLE
Don't decode content for preview twice

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -726,22 +726,11 @@ class MessageMapper {
 			$part = $parts[$fetchData->getUid()];
 			$htmlBody = $part->getBodyPart($htmlBodyId);
 			if (!empty($htmlBody)) {
-				$mimeHeaders = $part->getMimeHeader($htmlBodyId, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
-				if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
-					$structure->setTransferEncoding($enc);
-				}
-				$structure->setContents($htmlBody);
-				$html = new Html2Text($structure->getContents());
+				$html = new Html2Text($htmlBody);
 				return new MessageStructureData($hasAttachments, trim($html->getText()), $isImipMessage);
 			}
 			$textBody = $part->getBodyPart($textBodyId);
 			if (!empty($textBody)) {
-				$mimeHeaders = $part->getMimeHeader($textBodyId, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
-				if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
-					$structure->setTransferEncoding($enc);
-					$structure->setContents($textBody);
-					return new MessageStructureData($hasAttachments, $structure->getContents(), $isImipMessage);
-				}
 				return new MessageStructureData($hasAttachments, $textBody, $isImipMessage);
 			}
 

--- a/lib/Migration/Version1140Date20221113205737.php
+++ b/lib/Migration/Version1140Date20221113205737.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCA\Mail\Db\MessageMapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+class Version1140Date20221113205737 extends SimpleMigrationStep {
+	private LoggerInterface $logger;
+	private MessageMapper $messageMapper;
+
+	public function __construct(
+		MessageMapper $messageMapper,
+		LoggerInterface $logger
+	) {
+		$this->logger = $logger;
+		$this->messageMapper = $messageMapper;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		if (!method_exists($this->messageMapper, 'resetPreviewDataFlag')) {
+			$this->logger->warning('Service method missing due to in process upgrade');
+			return;
+		}
+		$this->messageMapper->resetPreviewDataFlag();
+	}
+}


### PR DESCRIPTION
Follow-up for #7486 and #7497

Hi :wave: 

I'm unsure about this one. 

We got some reports (e.g., https://github.com/nextcloud/mail/issues/7497#issuecomment-1311073366) that the preview is still wrong. 

I can reproduce the behavior locally with base64 encoded text/plain messages. 
The message data is already decoded when our code to decode the data runs. 

How to test:

- Reset data `update oc_mail_messages set structure_analyzed = null and preview_text = null where 1;` 
- Reload mailbox and wait a sec

