### PR TITLE
Fix saving provisioning and anti-spam settings

### DIFF
--- a/src/components/settings/AntiSpamSettings.vue
+++ b/src/components/settings/AntiSpamSettings.vue
@@ -52,8 +52,9 @@
 							type="email">
 						<br>
 						<Button
-							type="secondary submit"
+							type="secondary"
 							:disabled="loading"
+							native-type="submit"
 							class="config-button">
 							<template #icon>
 								<IconUpload :size="20" />

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -317,7 +317,7 @@
 						<Button
 							class="config-button save-config"
 							type="secondary"
-							:native-type="submit"
+							native-type="submit"
 							:disabled="loading">
 							<template #icon>
 								<IconUpload :size="20" />


### PR DESCRIPTION
Saving provisioning settings has been broken since e2472148b1f74bd256f2d6041e5782786ce89e80. This fixes the save button by making `native-type` a string instead of a method binding.

It also fixes the button for saving anti-spam settings by adding `native-type="submit"`.