### PR TITLE
Show thread subject while loading thread messages

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -1,13 +1,14 @@
 <template>
 	<AppContentDetails id="mail-message">
-		<Loading v-if="loading" :hint="t('mail', 'Loading thread')" />
+		<!-- Show outer loading screen only if we have no data about the thread -->
+		<Loading v-if="loading && thread.length === 0" :hint="t('mail', 'Loading thread')" />
 		<template v-else>
 			<div id="mail-thread-header">
 				<div id="mail-thread-header-fields">
 					<h2 :title="threadSubject">
 						{{ threadSubject }}
 					</h2>
-					<div ref="avatarHeader" class="avatar-header">
+					<div v-if="thread.length" ref="avatarHeader" class="avatar-header">
 						<!-- Participants that can fit in the parent div -->
 						<RecipientBubble v-for="participant in threadParticipants.slice(0, participantsToDisplay)"
 							:key="participant.email"
@@ -33,7 +34,10 @@
 					</div>
 				</div>
 			</div>
-			<ThreadEnvelope v-for="env in thread"
+			<!-- Show inner loading screen only if we have at least one message of the thread -->
+			<Loading v-if="loading && thread.length" :hint="t('mail', 'Loading messages')" />
+			<ThreadEnvelope v-else
+				v-for="env in thread"
 				:key="env.databaseId"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/mail/issues/6045#issuecomment-1308609308

This removes the empty content *Loading thread* for the case that we know at least one message of the thread. Then we already show the subject on the top of the page and an inner loader (to be replaced by a skeleton view).

![Bildschirmfoto vom 2022-11-16 10-42-49](https://user-images.githubusercontent.com/1374172/202145902-13554221-2104-47e2-a12d-9016facec0fc.png)

In the case of a thread with no known message, e.g. at a page load or of a thread with an unknown ID, we will still need a loading screen for the whole thread. That is why the earlier empty content has to stay as fallback.

![Bildschirmfoto vom 2022-11-16 10-43-01](https://user-images.githubusercontent.com/1374172/202145934-6f3f81e4-c8cc-4fbf-830b-f43ca3af95f6.png)
