### PR TITLE
Make HTML body loading a single step experience

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -36,7 +36,8 @@
 		<MessageHTMLBody v-if="message.hasHtmlBody"
 			:url="htmlUrl"
 			:message="message"
-			:full-height="fullHeight" />
+			:full-height="fullHeight"
+			@load="$emit('load', $event)" />
 		<MessageEncryptedBody v-else-if="isEncrypted"
 			:body="message.body"
 			:from="from"

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -27,8 +27,7 @@
 				</ActionButton>
 			</Actions>
 		</div>
-		<IconLoading v-if="loading" />
-		<div id="message-container" :class="{hidden: loading, scroll: !fullHeight}">
+		<div id="message-container" :class="{scroll: !fullHeight}">
 			<iframe ref="iframe"
 				class="message-frame"
 				:title="t('mail', 'Message frame')"
@@ -43,7 +42,7 @@
 import { iframeResizer } from 'iframe-resizer'
 import PrintScout from 'printscout'
 import { trustSender } from '../service/TrustedSenderService'
-import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading } from '@nextcloud/vue'
+import { NcActionButton as ActionButton, NcActions as Actions } from '@nextcloud/vue'
 import IconImage from 'vue-material-design-icons/ImageSizeSelectActual'
 import IconMail from 'vue-material-design-icons/Email'
 import IconDomain from 'vue-material-design-icons/Domain'
@@ -61,7 +60,6 @@ export default {
 		IconImage,
 		IconMail,
 		IconDomain,
-		IconLoading,
 	},
 	props: {
 		url: {
@@ -80,7 +78,6 @@ export default {
 	},
 	data() {
 		return {
-			loading: true,
 			hasBlockedContent: false,
 			isSenderTrusted: this.message.isSenderTrusted,
 		}
@@ -115,7 +112,7 @@ export default {
 				|| iframeDoc.querySelectorAll('[data-original-style]').length > 0
 				|| iframeDoc.querySelectorAll('style[data-original-content]').length > 0
 
-			this.loading = false
+			this.$emit('load')
 			if (this.isSenderTrusted) {
 				this.displayIframe()
 			}


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/mail/issues/6045

We have to fetch the message and then wait for the HTML body iframe to load. Those are two steps. We can't change that.

So we fake the experience by only showing one spinner that vanishes when the message and its body have loaded.