### PR TITLE
Disable provisioned accounts if using passwordless authentication

### DIFF
--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -70,6 +70,11 @@ class ProvisioningMiddleware extends Middleware {
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);
 			$password = $this->credentialStore->getLoginCredentials()->getPassword();
+			// FIXME: Need to check for an empty string here too?
+			// The password is empty (and not null) when using WebAuthn passwordless login.
+			// Maybe research other providers as well.
+			// Ref \OCA\Mail\Controller\PageController::index()
+			//     -> inital state for password-is-unavailable
 			if ($password === null) {
 				// Nothing to update, might be passwordless signin
 				$this->logger->debug('No password set for ' . $user->getUID());

--- a/src/main.js
+++ b/src/main.js
@@ -91,6 +91,10 @@ store.commit('savePreference', {
 	key: 'allow-new-accounts',
 	value: loadState('mail', 'allow-new-accounts', true),
 })
+store.commit('savePreference', {
+	key: 'password-is-unavailable',
+	value: loadState('mail', 'password-is-unavailable', false),
+})
 
 const accountSettings = loadState('mail', 'account-settings')
 const accounts = loadState('mail', 'accounts', [])

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -660,10 +660,14 @@ export default {
 
 			const mailbox = getters.getMailbox(mailboxId)
 
+			// Skip superfluous requests if using passwordless authentication. They will fail anyway.
+			const passwordIsUnavailable = getters.getPreference('password-is-unavailable', false)
+			const isDisabled = (account) => passwordIsUnavailable && !!account.provisioningId
+
 			if (mailbox.isUnified) {
 				return Promise.all(
 					getters.accounts
-						.filter((account) => !account.isUnified)
+						.filter((account) => !account.isUnified && !isDisabled(account))
 						.map((account) =>
 							Promise.all(
 								getters
@@ -684,7 +688,7 @@ export default {
 					getPrioritySearchQueries().map((query) => {
 						return Promise.all(
 							getters.accounts
-								.filter((account) => !account.isUnified)
+								.filter((account) => !account.isUnified && !isDisabled(account))
 								.map((account) =>
 									Promise.all(
 										getters
@@ -774,10 +778,14 @@ export default {
 		})
 	},
 	async syncInboxes({ commit, getters, dispatch }) {
+		// Skip superfluous requests if using passwordless authentication. They will fail anyway.
+		const passwordIsUnavailable = getters.getPreference('password-is-unavailable', false)
+		const isDisabled = (account) => passwordIsUnavailable && !!account.provisioningId
+
 		return handleHttpAuthErrors(commit, async () => {
 			const results = await Promise.all(
 				getters.accounts
-					.filter((a) => !a.isUnified)
+					.filter((a) => !a.isUnified && !isDisabled(a))
 					.map((account) => {
 						return Promise.all(
 							getters.getMailboxes(account.id).map(async (mailbox) => {

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -51,6 +51,7 @@ describe('Vuex store actions', () => {
 				getMailboxes: jest.fn(),
 				getEnvelope: jest.fn(),
 				getEnvelopes: jest.fn(),
+				getPreference: jest.fn(),
 			},
 		}
 	})

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -37,6 +37,8 @@ use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Authentication\LoginCredentials\ICredentials;
+use OCP\Authentication\LoginCredentials\IStore as ICredentialStore;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -92,6 +94,9 @@ class PageControllerTest extends TestCase {
 	/** @var IEventDispatcher|MockObject */
 	private $eventDispatcher;
 
+	/** @var ICredentialStore|MockObject */
+	private $credentialStore;
+
 	/** @var PageController */
 	private $controller;
 
@@ -113,6 +118,7 @@ class PageControllerTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->outboxService = $this->createMock(OutboxService::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->credentialStore = $this->createMock(ICredentialStore::class);
 
 		$this->controller = new PageController(
 			$this->appName,
@@ -130,6 +136,7 @@ class PageControllerTest extends TestCase {
 			$this->logger,
 			$this->outboxService,
 			$this->eventDispatcher,
+			$this->credentialStore,
 		);
 	}
 
@@ -238,13 +245,23 @@ class PageControllerTest extends TestCase {
 			->with($this->equalTo('jane'), $this->equalTo('settings'),
 				$this->equalTo('email'), $this->equalTo(''))
 			->will($this->returnValue('jane@doe.cz'));
-		$this->initialState->expects($this->exactly(9))
+
+		$loginCredentials = $this->createMock(ICredentials::class);
+		$loginCredentials->expects($this->once())
+			->method('getPassword')
+			->willReturn(null);
+		$this->credentialStore->expects($this->once())
+			->method('getLoginCredentials')
+			->willReturn($loginCredentials);
+
+		$this->initialState->expects($this->exactly(10))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
 				['accounts', $accountsJson],
 				['account-settings', []],
 				['tags', []],
+				['password-is-unavailable', true],
 				['prefill_displayName', 'Jane Doe'],
 				['prefill_email', 'jane@doe.cz'],
 				['outbox-messages', []],


### PR DESCRIPTION
Fix #7520 

Best reviewed with hidden white space changes: https://github.com/nextcloud/mail/pull/7616/files?w=1

This bug can be reproduced by using WebAuthn passwordless authentication. You can set it up in `Personal Settings -> Security -> Passwordless Authentication`.

## Before

Endless spinner was showing when clicking on a mail. It can't be loaded because the provisioned account isn't able to access the password for the IMAP server.

## After

The account is disabled and a info message is shown to the user. It might be a little bit technical. Feel free to propose better phrasing.

![image](https://user-images.githubusercontent.com/1479486/202235314-e31a128a-c889-4547-82b1-8c36028c75e1.png)