### PR TITLE
Fix deprecated constructor null message

### DIFF
--- a/tests/Unit/Http/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/ErrorMiddlewareTest.php
@@ -138,10 +138,10 @@ class ErrorMiddlewareTest extends TestCase {
 	public function temporaryExceptionsData(): array {
 		return [
 			[new ServiceException('not temporary'), false],
-			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception(null, Horde_Imap_Client_Exception::DISCONNECT)), true],
-			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception(null, Horde_Imap_Client_Exception::SERVER_CONNECT)), false],
-			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception(null, Horde_Imap_Client_Exception::SERVER_READERROR)), true],
-			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception(null, Horde_Imap_Client_Exception::SERVER_WRITEERROR)), true],
+			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception('', Horde_Imap_Client_Exception::DISCONNECT)), true],
+			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception('', Horde_Imap_Client_Exception::SERVER_CONNECT)), false],
+			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception('', Horde_Imap_Client_Exception::SERVER_READERROR)), true],
+			[new ServiceException('temporary', 0, new Horde_Imap_Client_Exception('', Horde_Imap_Client_Exception::SERVER_WRITEERROR)), true],
 		];
 	}
 


### PR DESCRIPTION
Fixes 

``` 
PHP Deprecated:  Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in nextcloud/apps/mail/vendor/bytestream/horde-exception/lib/Horde/Exception/Wrapped.php on line 54
PHP Deprecated:  Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in nextcloud/apps/mail/vendor/bytestream/horde-exception/lib/Horde/Exception/Wrapped.php on line 54
PHP Deprecated:  Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in nextcloud/apps/mail/vendor/bytestream/horde-exception/lib/Horde/Exception/Wrapped.php on line 54
PHP Deprecated:  Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated in nextcloud/apps/mail/vendor/bytestream/horde-exception/lib/Horde/Exception/Wrapped.php on line 54
``` 