### PR TITLE
Do not emit TextEditor input event if nothing changed

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -189,8 +189,10 @@ export default {
 			this.$emit('ready', editor)
 		},
 		onEditorInput(text) {
-			logger.debug(`TextEditor input changed to <${text}>`)
-			this.$emit('input', text)
+			if (text !== this.value) {
+				logger.debug(`TextEditor input changed to <${text}>`)
+				this.$emit('input', text)
+			}
 		},
 		appendToBodyAtCursor(toAppend) {
 			// https://ckeditor.com/docs/ckeditor5/latest/builds/guides/faq.html#where-are-the-editorinserthtml-and-editorinserttext-methods-how-to-insert-some-content


### PR DESCRIPTION
Noticed working on use case 4 of https://github.com/nextcloud/mail/issues/4768 where we don't want to save any changes until the user makes any.

Without this patch the freshly initialized text editor emits an input event. But the value is identical to the prop value.