### PR TITLE
Fix deprecated constructor null code

### DIFF
--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -113,7 +113,7 @@ class MailboxSyncTest extends TestCase {
 			->willReturn($client);
 		$client->expects($this->once())
 			->method('getNamespaces')
-			->willThrowException(new Horde_Imap_Client_Exception());
+			->willThrowException(new Horde_Imap_Client_Exception('', 0));
 		$folders = [
 			$this->createMock(Folder::class),
 			$this->createMock(Folder::class),

--- a/tests/Unit/Listener/SaveSentMessageListenerTest.php
+++ b/tests/Unit/Listener/SaveSentMessageListenerTest.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Listener;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Exception;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
@@ -181,7 +182,7 @@ class SaveSentMessageListenerTest extends TestCase {
 				$mailbox,
 				$mail
 			)
-			->willThrowException(new \Horde_Imap_Client_Exception());
+			->willThrowException(new Horde_Imap_Client_Exception('', 0));
 		$this->expectException(ServiceException::class);
 
 		$this->listener->handle($event);

--- a/tests/Unit/Migration/MigrateImportantFromImapAndDbTest.php
+++ b/tests/Unit/Migration/MigrateImportantFromImapAndDbTest.php
@@ -106,7 +106,7 @@ class MigrateImportantFromImapAndDbTest extends TestCase {
 	public function testMigrateImportantOnImapExceptionGetFlagged() {
 		$account = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
-		$e = new Horde_Imap_Client_Exception('');
+		$e = new Horde_Imap_Client_Exception('', 0);
 
 		$this->messageMapper->expects($this->once())
 			->method('getFlagged')
@@ -125,7 +125,7 @@ class MigrateImportantFromImapAndDbTest extends TestCase {
 		$account = $this->createMock(Account::class);
 		$mailbox = new Mailbox();
 		$mailbox->setName('INBOX');
-		$e = new Horde_Imap_Client_Exception('');
+		$e = new Horde_Imap_Client_Exception('', 0);
 		$uids = [1,2,3];
 
 		$this->messageMapper->expects($this->once())
@@ -186,7 +186,7 @@ class MigrateImportantFromImapAndDbTest extends TestCase {
 		$mailbox = new Mailbox();
 		$mailbox->setId(1);
 		$mailbox->setName('INBOX');
-		$e = new Horde_Imap_Client_Exception('');
+		$e = new Horde_Imap_Client_Exception('', 0);
 		$uids = [1,2,3];
 
 		$this->mailboxMapper->expects($this->once())


### PR DESCRIPTION
Fixes

```
PHP Deprecated:  Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated in /nextcloud/apps/mail/vendor/bytestream/horde-exception/lib/Horde/Exception/Wrapped.php on line 5
```