### PR TITLE
Drop right border from navigation header

### DIFF
--- a/src/components/NewMessageButtonHeader.vue
+++ b/src/components/NewMessageButtonHeader.vue
@@ -90,7 +90,6 @@ export default {
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
 	gap: 4px;
 	height: 61px;
-	border-right: 1px solid var(--color-border)
 }
 .refresh__button {
 	background-color: transparent;


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/35315 makes border colors more visible. There is a border for the header that we probably don't need.

| Before | After server PR | After
|---|---|---|
|![Bildschirmfoto vom 2022-11-23 16-42-51](https://user-images.githubusercontent.com/1374172/203588622-2370f452-b448-4f68-b085-066c3cb6e158.png) | ![Bildschirmfoto vom 2022-11-23 16-42-16](https://user-images.githubusercontent.com/1374172/203588679-7c77ac95-c852-479b-8da7-c2ef8c77c9e2.png) | ![Bildschirmfoto vom 2022-11-23 16-47-29](https://user-images.githubusercontent.com/1374172/203589612-e4a02513-9597-484c-84b8-ff4215c13edd.png) |
