### PR TITLE
Show only existing mailboxes, not all subscribed mailboxes

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -55,7 +55,7 @@ class FolderMapper {
 	 */
 	public function getFolders(Account $account, Horde_Imap_Client_Socket $client,
 							   string $pattern = '*'): array {
-		$mailboxes = $client->listMailboxes($pattern, Horde_Imap_Client::MBOX_ALL_SUBSCRIBED, [
+		$mailboxes = $client->listMailboxes($pattern, Horde_Imap_Client::MBOX_SUBSCRIBED_EXISTS, [
 			'delimiter' => true,
 			'attributes' => true,
 			'special_use' => true,

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -47,7 +47,7 @@ class FolderMapperTest extends TestCase {
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('listMailboxes')
-			->with($this->equalTo('*'), $this->equalTo(Horde_Imap_Client::MBOX_ALL_SUBSCRIBED),
+			->with($this->equalTo('*'), $this->equalTo(Horde_Imap_Client::MBOX_SUBSCRIBED_EXISTS),
 				$this->equalTo([
 					'delimiter' => true,
 					'attributes' => true,
@@ -66,7 +66,7 @@ class FolderMapperTest extends TestCase {
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('listMailboxes')
-			->with($this->equalTo('*'), $this->equalTo(Horde_Imap_Client::MBOX_ALL_SUBSCRIBED),
+			->with($this->equalTo('*'), $this->equalTo(Horde_Imap_Client::MBOX_SUBSCRIBED_EXISTS),
 				$this->equalTo([
 					'delimiter' => true,
 					'attributes' => true,


### PR DESCRIPTION
Discovered while testing #7430

Mailboxes with the flags / attributes "\NoSelect" or "\NonExistent" should not be shown even if they might be subscribed mailboxes. See [rfc5258](https://www.rfc-editor.org/rfc/rfc5258.html) for the deets.

Not sure if the folder mapper stats needs an update too to additionally filter for `\\noselect` and/or `\\nonexistent`. Let's see after this is merged and #7430 is rebased.