### PR TITLE
Fix auto config routes for non-admins

### DIFF
--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -69,6 +69,14 @@ class AutoConfigController extends Controller {
 		return JsonResponse::success($config)->cacheFor(5 * 60, false, true);
 	}
 
+	/**
+	 * @param string $email
+	 *
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @return JsonResponse
+	 */
 	public function queryMx(string $email): JsonResponse {
 		$rfc822Address = new Horde_Mail_Rfc822_Address($email);
 		if (!$rfc822Address->valid) {
@@ -80,6 +88,15 @@ class AutoConfigController extends Controller {
 		)->cacheFor(5 * 60, false, true);
 	}
 
+	/**
+	 * @param string $host
+	 * @param int $port
+	 *
+	 * @NoAdminRequired
+	 * @TrapError
+	 *
+	 * @return JsonResponse
+	 */
 	public function testConnectivity(string $host, int $port): JsonResponse {
 		if (!in_array($port, [143, 993, 465, 587])) {
 			return JsonResponse::fail('Port not allowed');


### PR DESCRIPTION
Only ISPDB discovery was accessible for non-admins. This means that email addresses of larger providers worked for non-admins during the auto discovery. More custom setup failed hard because the MX and port check routes were blocked.

## How to test

1) Log in as non-admin user
2) Open the Mail app
3) Open the account setup
4) Add an email account from a custom domain

---

Fixes https://github.com/nextcloud/mail/issues/7713