### PR TITLE
Make the composer component stateless

### DIFF
--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -259,15 +259,7 @@ export default {
 							})
 						})
 						.then(({ file, id }) => {
-							logger.info('uploaded')
-							this.attachments.some((attachment, i) => {
-								if (attachment.displayName === file.name) {
-									this.attachments[i].id = id
-									this.attachments[i].finished = true
-									return true
-								}
-								return false
-							})
+							logger.info('local attachment uploaded', { file, id })
 
 							this.emitNewAttachments([{
 								fileName: file.name,

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -61,8 +61,6 @@ describe('Composer', () => {
 		const view = shallowMount(Composer, {
 			propsData: {
 				inReplyToMessageId: 'abc123',
-				draft: jest.fn(),
-				send: jest.fn(),
 			},
 			store,
 			localVue,
@@ -71,6 +69,37 @@ describe('Composer', () => {
 		const composerData = view.vm.getMessageData()
 
 		expect(composerData.inReplyToMessageId).toEqual('abc123')
+	})
+
+	it('disabled the send button', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				inReplyToMessageId: 'abc123',
+			},
+			store,
+			localVue,
+		})
+
+		const canSend = view.vm.canSend
+
+		expect(canSend).toEqual(false)
+	})
+
+	it('enables the send button if data is entered', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				inReplyToMessageId: 'abc123',
+				to: [
+					{ label: 'test', email: 'test@domain.tld' },
+				]
+			},
+			store,
+			localVue,
+		})
+
+		const canSend = view.vm.canSend
+
+		expect(canSend).toEqual(true)
 	})
 
 })


### PR DESCRIPTION
This moves state (drafts, final message) out of the composer component and up to the message modal. This makes it possible to save a draft when the modal closes in https://github.com/nextcloud/mail/pull/7648. Right we'd need an indirection hack to invoke that from the parent. If we move the logic up a level everything is at the level where we need it.

What I've tested so far
1) Auto-saving a draft
2) Auto-saving another draft revision
3) Draft error handling + retry
4) Sending a message
5) Attach local files

I'll see if we can unit-test a few more critical paths in those two components.