### PR TITLE
Add draft id to composer

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -156,7 +156,10 @@ export default {
 						this.$store.commit('removeMessage', { id: data.draftId })
 
 						// Fetch new draft envelope
-						await this.$store.dispatch('fetchEnvelope', id)
+						await this.$store.dispatch('fetchEnvelope', {
+							accountId: data.account,
+							id,
+						})
 
 						return id
 					}
@@ -179,6 +182,11 @@ export default {
 				to: serializeRecipients ? data.to.map(this.recipientToRfc822).join(', ') : data.to,
 				cc: serializeRecipients ? data.cc.map(this.recipientToRfc822).join(', ') : data.cc,
 				bcc: serializeRecipients ? data.bcc.map(this.recipientToRfc822).join(', ') : data.bcc,
+				attachments: data.attachments,
+				aliasId: data.aliasId,
+				inReplyToMessageId: data.inReplyToMessageId,
+				sendAt: data.sendAt,
+				draftId: data.draftId,
 			}
 		},
 		onAttachmentUploading(done, data) {

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -11,7 +11,7 @@ const amendEnvelopeWithIds = curry((accountId, envelope) => ({
 	...envelope,
 }))
 
-export function fetchEnvelope(id) {
+export function fetchEnvelope(accountId, id) {
 	const url = generateUrl('/apps/mail/api/messages/{id}', {
 		id,
 	})
@@ -19,6 +19,7 @@ export function fetchEnvelope(id) {
 	return axios
 		.get(url)
 		.then((resp) => resp.data)
+		.then(amendEnvelopeWithIds(accountId))
 		.catch((error) => {
 			if (error.response && error.response.status === 404) {
 				return undefined

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -467,7 +467,7 @@ export default {
 			commit('hideMessageComposer')
 		})
 	},
-	async fetchEnvelope({ commit, getters }, id) {
+	async fetchEnvelope({ commit, getters }, { accountId, id }) {
 		return handleHttpAuthErrors(commit, async () => {
 			const cached = getters.getEnvelope(id)
 			if (cached) {
@@ -475,7 +475,7 @@ export default {
 				return cached
 			}
 
-			const envelope = await fetchEnvelope(id)
+			const envelope = await fetchEnvelope(accountId, id)
 			// Only commit if not undefined (not found)
 			if (envelope) {
 				commit('addEnvelope', {


### PR DESCRIPTION
This fixes never sending the draft id to the backend.

- [x] The old draft envelope disappears but the successive draft enelope isn't shown in the envelope list after editing.