### PR TITLE
Do not show nonexistent or noselect mailboxes

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -67,6 +67,10 @@ class FolderMapper {
 				return null;
 			}
 
+			if (!empty(array_intersect($mailbox['attributes'], ['\noselect', '\nonexistent']))) {
+				return null;
+			}
+
 			try {
 				$client->status($mailbox["mailbox"]);
 			} catch (Horde_Imap_Client_Exception $e) {
@@ -120,7 +124,7 @@ class FolderMapper {
 		$mailboxes = array_map(function (Folder $folder) {
 			return $folder->getMailbox();
 		}, array_filter($folders, function (Folder $folder) {
-			return !in_array('\noselect', $folder->getAttributes());
+			return !in_array('\noselect', $folder->getAttributes()) && !in_array('\nonexistent', $folder->getAttributes());
 		}));
 
 		$status = $client->status($mailboxes);

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -85,6 +85,29 @@ class FolderMapperTest extends TestCase {
 					],
 					'delimiter' => '.',
 				],
+				[
+					'mailbox' => new Horde_Imap_Client_Mailbox('All'),
+					'attributes' => [
+						'\noselect',
+					],
+					'delimiter' => '.',
+				],
+				[
+					'mailbox' => new Horde_Imap_Client_Mailbox('Nonexistent'),
+					'attributes' => [
+						'\nonexistent',
+					],
+					'delimiter' => '.',
+				],
+				[
+					'mailbox' => new Horde_Imap_Client_Mailbox('Both'),
+					'attributes' => [
+						'\subscribed',
+						'\nonexistent',
+						'\noselect',
+					],
+					'delimiter' => '.',
+				],
 			]);
 		$expected = [
 			new Folder(27, new Horde_Imap_Client_Mailbox('INBOX'), [], '.'),
@@ -133,7 +156,7 @@ class FolderMapperTest extends TestCase {
 		$folders[0]->expects($this->any())
 			->method('getMailbox')
 			->willReturn('folder1');
-		$folders[0]->expects($this->once())
+		$folders[0]->expects($this->exactly(2))
 			->method('getAttributes')
 			->willReturn([]);
 		$client->expects($this->once())
@@ -158,7 +181,7 @@ class FolderMapperTest extends TestCase {
 		$folders[0]->expects($this->any())
 			->method('getMailbox')
 			->willReturn('folder1');
-		$folders[0]->expects($this->once())
+		$folders[0]->expects($this->exactly(2))
 			->method('getAttributes')
 			->willReturn([]);
 		$client->expects($this->once())
@@ -181,9 +204,30 @@ class FolderMapperTest extends TestCase {
 		$folders[0]->expects($this->any())
 			->method('getMailbox')
 			->willReturn('folder1');
-		$folders[0]->expects($this->once())
+		$folders[0]->expects($this->exactly(1))
 			->method('getAttributes')
 			->willReturn(['\\noselect']);
+		$client->expects($this->once())
+			->method('status')
+			->with($this->equalTo([]))
+			->willReturn([]);
+		$folders[0]->expects($this->never())
+			->method('setStatus');
+
+		$this->mapper->getFoldersStatus($folders, $client);
+	}
+
+	public function testGetFoldersStatusNonExistentMailbox() {
+		$folders = [
+			$this->createMock(Folder::class),
+		];
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$folders[0]->expects($this->any())
+			->method('getMailbox')
+			->willReturn('folder1');
+		$folders[0]->expects($this->exactly(2))
+			->method('getAttributes')
+			->willReturn(['\\nonexistent']);
 		$client->expects($this->once())
 			->method('status')
 			->with($this->equalTo([]))


### PR DESCRIPTION
This fix will filter out any mailboxes with attributes
`\nonexistent` or `\noselect`  as these should never be shown to the
user irrespective of subscription status.