### PR TITLE
Move OAuth access token into a dedicated column

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>2.3.0-alpha.1</version>
+	<version>2.3.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -97,6 +97,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setAuthMethod(string $method)
  * @method int getSignatureMode()
  * @method void setSignatureMode(int $signatureMode)
+ * @method string getOauthAccessToken()
+ * @method void setOauthAccessToken(string $token)
  * @method string getOauthRefreshToken()
  * @method void setOauthRefreshToken(string $token)
  * @method int|null getOauthTokenTtl()
@@ -126,6 +128,7 @@ class MailAccount extends Entity {
 	protected $showSubscribedOnly;
 	protected $personalNamespace;
 	protected $authMethod;
+	protected $oauthAccessToken;
 	protected $oauthRefreshToken;
 	protected $oauthTokenTtl;
 

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -79,7 +79,10 @@ class IMAPClientFactory {
 		);
 		$host = $account->getMailAccount()->getInboundHost();
 		$user = $account->getMailAccount()->getInboundUser();
-		$decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
+		$decryptedPassword = null;
+		if ($account->getMailAccount()->getInboundPassword() !== null) {
+			$decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
+		}
 		$port = $account->getMailAccount()->getInboundPort();
 		$sslMode = $account->getMailAccount()->getInboundSslMode();
 		if ($sslMode === 'none') {
@@ -101,9 +104,12 @@ class IMAPClientFactory {
 			],
 		];
 		if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
+			$decryptedAccessToken = $this->crypto->decrypt($account->getMailAccount()->getOauthAccessToken());
+
+			$params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
 			$params['xoauth2_token'] = new Horde_Imap_Client_Password_Xoauth2(
 				$account->getEmail(),
-				$decryptedPassword,
+				$decryptedAccessToken,
 			);
 		}
 		if ($useCache && $this->cacheFactory->isAvailable()) {

--- a/lib/Integration/GoogleIntegration.php
+++ b/lib/Integration/GoogleIntegration.php
@@ -129,8 +129,7 @@ class GoogleIntegration {
 		$encryptedRefreshToken = $this->crypto->encrypt($data['refresh_token']);
 		$account->getMailAccount()->setOauthRefreshToken($encryptedRefreshToken);
 		$encryptedAccessToken = $this->crypto->encrypt($data['access_token']);
-		$account->getMailAccount()->setInboundPassword($encryptedAccessToken);
-		$account->getMailAccount()->setOutboundPassword($encryptedAccessToken);
+		$account->getMailAccount()->setOauthAccessToken($encryptedAccessToken);
 		$account->getMailAccount()->setOauthTokenTtl($this->timeFactory->getTime() + $data['expires_in']);
 		return $account;
 	}

--- a/lib/Migration/Version2300Date20221215143450.php
+++ b/lib/Migration/Version2300Date20221215143450.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\AppFramework\Db\TTransactional;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version2300Date20221215143450 extends SimpleMigrationStep {
+	private IDBConnection $connection;
+
+	use TTransactional;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+
+		// Widen refresh token
+		$refreshTokenColumn = $accountsTable->getColumn('oauth_refresh_token');
+		$refreshTokenColumn->setLength(3000); // Fits Microsoft and Google tokens even after encryption
+
+		// Add dedicated access token column
+		if (!$accountsTable->hasColumn('oauth_access_token')) {
+			$accountsTable->addColumn('oauth_access_token', Types::TEXT, [
+				'notnull' => false,
+			]);
+		}
+
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$this->atomic(function () {
+			// Migrate old data to the new column
+			$qb1 = $this->connection->getQueryBuilder();
+			$qb1->update('mail_accounts')
+				->set('oauth_access_token', 'inbound_password')
+				->where(
+					$qb1->expr()->eq('auth_method', $qb1->createNamedParameter('xoauth2')),
+					$qb1->expr()->isNotNull('inbound_password')
+				);
+			$qb1->executeStatement();
+
+			// Delete previous data
+			$qb2 = $this->connection->getQueryBuilder();
+			$qb2->update('mail_accounts')
+				->set('inbound_password', $qb2->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+				->set('outbound_password', $qb2->createNamedParameter(null, IQueryBuilder::PARAM_NULL))
+				->where(
+					$qb2->expr()->eq('auth_method', $qb2->createNamedParameter('xoauth2')),
+					$qb2->expr()->isNotNull('oauth_access_token')
+				);
+			$qb2->executeStatement();
+		}, $this->connection);
+	}
+}

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -65,7 +65,10 @@ class SmtpClientFactory {
 			return new Horde_Mail_Transport_Mail();
 		}
 
-		$decryptedPassword = $this->crypto->decrypt($mailAccount->getOutboundPassword());
+		$decryptedPassword = null;
+		if ($mailAccount->getOutboundPassword() !== null) {
+			$decryptedPassword = $this->crypto->decrypt($mailAccount->getOutboundPassword());
+		}
 		$security = $mailAccount->getOutboundSslMode();
 		$params = [
 			'localhost' => $this->hostNameFactory->getHostName(),
@@ -83,9 +86,12 @@ class SmtpClientFactory {
 			],
 		];
 		if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
+			$decryptedAccessToken = $this->crypto->decrypt($account->getMailAccount()->getOauthAccessToken());
+
+			$params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
 			$params['xoauth2_token'] = new Horde_Smtp_Password_Xoauth2(
 				$account->getEmail(),
-				$decryptedPassword,
+				$decryptedAccessToken,
 			);
 		}
 		if ($this->config->getSystemValue('debug', false)) {


### PR DESCRIPTION
Depending on the vendor access tokens can be very long and the encrypted value exceeds 4000 chars allowed for our inbound_password column.

Required for https://github.com/nextcloud/mail/issues/6591.

## Todo

- [x] Adjust automated tests
- [x] Manual testing