### PR TITLE
Fix dragover indicator being inherited to children

### DIFF
--- a/src/directives/drag-and-drop/styles/droppable-mailbox.scss
+++ b/src/directives/drag-and-drop/styles/droppable-mailbox.scss
@@ -41,7 +41,7 @@
 	opacity: .3;
 }
 [droppable-mailbox="dragover"] {
-	a {
+	> div > a {
 		&:before {
 			content: '';
 			position: absolute;


### PR DESCRIPTION
## Before
[dragover-before.webm](https://user-images.githubusercontent.com/1479486/205621956-e682a86e-c499-47d2-bfc5-6e0b40232c89.webm)

## After
[dragover-after.webm](https://user-images.githubusercontent.com/1479486/205621953-a5005802-205c-4b5d-845a-04bc0890027f.webm)

