### PR TITLE
Fix risky ConfigurationTest

### DIFF
--- a/tests/Unit/Service/Autoconfig/ConfigurationTest.php
+++ b/tests/Unit/Service/Autoconfig/ConfigurationTest.php
@@ -31,5 +31,7 @@ use OCA\Mail\Service\AutoConfig\Configuration;
 class ConfigurationTest extends TestCase {
 	public function testEmptyConfig(): void {
 		$cfg = new Configuration(null, null);
+
+		$this->addToAssertionCount(1);
 	}
 }


### PR DESCRIPTION
It causes `composer run test:unit:dev` to stop prematurely.