### PR TITLE
Fix mailbox cache sync scope of current mailbox

### DIFF
--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -162,7 +162,7 @@ class SyncService {
 			$newUids = $this->messageMapper->findUidsForIds($mailbox, $newIds);
 			$newIds = $this->messageMapper->findIdsByQuery($mailbox, $query, null, $newUids);
 		}
-		$new = $this->messageMapper->findByIds($account->getUserId(), $newIds);
+		$new = $this->messageMapper->findByMailboxAndIds($mailbox, $account->getUserId(), $newIds);
 
 		// TODO: $changed = $this->messageMapper->findChanged($account, $mailbox, $uids);
 		if ($query !== null) {
@@ -171,7 +171,7 @@ class SyncService {
 		} else {
 			$changedIds = $knownIds;
 		}
-		$changed = $this->messageMapper->findByIds($account->getUserId(), $changedIds);
+		$changed = $this->messageMapper->findByMailboxAndIds($mailbox, $account->getUserId(), $changedIds);
 
 		$stillKnownIds = array_map(static function (Message $msg) {
 			return $msg->getId();


### PR DESCRIPTION
During IMAP->DB sync we only process one mailbox at a time. Therefore we can scope queries to a database.