### PR TITLE
chore(static analysis): Ignore Symfony Command classes for Psalm

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,11 @@
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
 				<referencedClass name="Psr\Http\Client\ClientExceptionInterface" />
 				<referencedClass name="Symfony\Component\HttpFoundation\IpUtils" />
+				<referencedClass name="Symfony\Component\Console\Command\Command" />
+				<referencedClass name="Symfony\Component\Console\Input\InputArgument" />
+				<referencedClass name="Symfony\Component\Console\Input\InputInterface" />
+				<referencedClass name="Symfony\Component\Console\Input\InputOption" />
+				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>
@@ -42,6 +47,7 @@
 				<referencedClass name="Doctrine\DBAL\Schema\SchemaException" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
+				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 			</errorLevel>
 		</UndefinedDocblockClass>
 		<UndefinedFunction>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,65 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="dev-master@">
-  <file src="lib/Command/AddMissingTags.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/CleanUp.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/CreateAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/CreateTagMigrationJobEntry.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/DeleteAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/DiagnoseAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/ExportAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/ExportAccountThreads.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/SyncAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/Thread.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/TrainAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/Command/UpdateAccount.php">
-    <UndefinedClass occurrences="1">
-      <code>Command</code>
-    </UndefinedClass>
-  </file>
   <file src="lib/Db/MessageMapper.php">
     <InvalidReturnStatement occurrences="1">
       <code>$update-&gt;execute()</code>
@@ -84,24 +24,5 @@
       <code>$node-&gt;tagName</code>
       <code>$node-&gt;textContent</code>
     </UndefinedPropertyFetch>
-  </file>
-  <file src="lib/Support/ConsoleLoggerDecorator.php">
-    <UndefinedClass occurrences="2">
-      <code>OutputInterface</code>
-      <code>OutputInterface</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="11">
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>$this-&gt;consoleOutput</code>
-      <code>OutputInterface</code>
-    </UndefinedDocblockClass>
   </file>
 </files>


### PR DESCRIPTION
Static analysis fails in https://github.com/nextcloud/mail/pull/7805 due to the use of the Symfony Command class.

As long as there is no Nextcloud abstraction we are out of alternatives. Instead of updating the baseline for every new command we can also tell Psalm to not report this missing class.

:crossed_fingers: 