### PR TITLE
Force the icon-collapse to align left

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -695,4 +695,8 @@ export default {
 .counter-bubble__counter {
 	max-width: initial;
 }
+// TODO: upsteream collapse icon position fix
+  :deep(.icon-collapse) {
+	  position: absolute !important;
+  }
 </style>


### PR DESCRIPTION
fixes: #7095

This is an old bug. Most probably this should be fixed on nc/vue but i dont see which change caused this error there. This error can be caused also from some server css, but so far i failed to find the right change, so pushing this pr till we figured it out.
before
![Screenshot from 2023-01-02 18-09-13](https://user-images.githubusercontent.com/12728974/210261824-4d98b267-fd2d-4c49-96da-d58ecedf34f3.png)
after
![Screenshot from 2023-01-02 18-08-52](https://user-images.githubusercontent.com/12728974/210261825-fbe03838-87df-4b1d-95e4-5834c6a51985.png)
