### PR TITLE
chore(oauth): Remove branding from generic OAUTH settings

### DIFF
--- a/lib/Controller/GoogleIntegrationController.php
+++ b/lib/Controller/GoogleIntegrationController.php
@@ -103,7 +103,7 @@ class GoogleIntegrationController extends Controller {
 			// TODO: redirect to main nextcloud page
 			return new StandaloneTemplateResponse(
 				Application::APP_ID,
-				'google_oauth_done',
+				'oauth_done',
 				[],
 				'guest',
 			);
@@ -113,7 +113,7 @@ class GoogleIntegrationController extends Controller {
 			// TODO: handle error
 			return new StandaloneTemplateResponse(
 				Application::APP_ID,
-				'google_oauth_done',
+				'oauth_done',
 				[],
 				'guest',
 			);
@@ -125,7 +125,7 @@ class GoogleIntegrationController extends Controller {
 			// TODO: redirect to main nextcloud page
 			return new StandaloneTemplateResponse(
 				Application::APP_ID,
-				'google_oauth_done',
+				'oauth_done',
 				[],
 				'guest',
 			);
@@ -143,7 +143,7 @@ class GoogleIntegrationController extends Controller {
 			// TODO: redirect to main nextcloud page
 			return new StandaloneTemplateResponse(
 				Application::APP_ID,
-				'google_oauth_done',
+				'oauth_done',
 				[],
 				'guest',
 			);
@@ -157,7 +157,7 @@ class GoogleIntegrationController extends Controller {
 
 		return new StandaloneTemplateResponse(
 			Application::APP_ID,
-			'google_oauth_done',
+			'oauth_done',
 			[],
 			'guest',
 		);

--- a/src/main-oauth-popup.js
+++ b/src/main-oauth-popup.js
@@ -22,8 +22,9 @@
 import { getRequestToken } from '@nextcloud/auth'
 import { generateFilePath } from '@nextcloud/router'
 import Vue from 'vue'
+
+import OauthDone from './views/OauthDone'
 import Nextcloud from './mixins/Nextcloud'
-import GoogleOauthDone from './views/GoogleOauthDone'
 
 __webpack_nonce__ = btoa(getRequestToken())
 // eslint-disable-next-line camelcase
@@ -31,8 +32,8 @@ __webpack_public_path__ = generateFilePath('mail', '', 'js/')
 
 Vue.mixin(Nextcloud)
 
-const View = Vue.extend(GoogleOauthDone)
-new View({}).$mount('#mail-google-oauth-done')
+const View = Vue.extend(OauthDone)
+new View({}).$mount('#mail-oauth-done')
 
 if (window.opener) {
 	window.opener.postMessage('DONE')

--- a/src/views/OauthDone.vue
+++ b/src/views/OauthDone.vue
@@ -30,7 +30,7 @@
 import NcGuestContent from '@nextcloud/vue/dist/Components/NcGuestContent'
 
 export default {
-	name: 'GoogleOauthDone',
+	name: 'OauthDone',
 	components: {
 		NcGuestContent,
 	},

--- a/templates/oauth_done.php
+++ b/templates/oauth_done.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-script(\OCA\Mail\AppInfo\Application::APP_ID, 'googleoauthpopup');
+script(\OCA\Mail\AppInfo\Application::APP_ID, 'oauthpopup');
 
 ?>
 
-<div id="mail-google-oauth-done" />
+<div id="mail-oauth-done" />

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -25,7 +25,7 @@ module.exports = {
 		autoredirect: path.join(__dirname, 'src/autoredirect.js'),
 		dashboard: path.join(__dirname, 'src/main-dashboard.js'),
 		mail: path.join(__dirname, 'src/main.js'),
-		googleoauthpopup: path.join(__dirname, 'src/main-google-oauth-popup.js'),
+		oauthpopup: path.join(__dirname, 'src/main-oauth-popup.js'),
 		settings: path.join(__dirname, 'src/main-settings'),
 		htmlresponse: path.join(__dirname, 'src/html-response.js'),
 	},


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/mail/pull/7722.

Removes Google branding from all file names and component names that are not specific to Google.