### PR TITLE
fix(XOAUTH2): Defer OAUTH account detection

### DIFF
--- a/src/tests/unit/components/AccountForm.vue.spec.js
+++ b/src/tests/unit/components/AccountForm.vue.spec.js
@@ -21,23 +21,33 @@
 
 import { testConnectivity, queryIspdb, queryMx } from '../../../service/AutoConfigService'
 import {createLocalVue, shallowMount} from '@vue/test-utils'
+import Vuex from 'vuex'
 
 import AccountForm from '../../../components/AccountForm'
 import Nextcloud from '../../../mixins/Nextcloud'
 
 const localVue = createLocalVue()
 
+localVue.use(Vuex)
 localVue.mixin(Nextcloud)
 
 jest.mock('../../../service/AutoConfigService')
 
 describe('AccountForm', () => {
 
-	let view
 	let save
+	let getters
+	let store
+	let view
 
 	beforeEach(() => {
 		save = jest.fn()
+		getters = {
+			googleOauthUrl: () => () => 'https://google.oauth',
+		}
+		store = new Vuex.Store({
+			getters,
+		})
 		view = shallowMount(AccountForm, {
 			propsData: {
 				displayName: 'Tom Turbo',
@@ -45,6 +55,7 @@ describe('AccountForm', () => {
 				save,
 			},
 			localVue,
+			store,
 		})
 	})
 


### PR DESCRIPTION
Defer the detection of OAUTH until auto config is done. Only if the IMAP and SMTP servers are from Google and we have OAUTH credentials then we try OAUTH. This makes it possible to use Gmail OAUTh with domains other than `@gmail.com`.

As a side effect we will no longer require a password unless Google integration is not set up.

Ref https://github.com/nextcloud/mail/pull/7722#issuecomment-1378412116

## How to test

0) Set up Gmail in the admin settings
1) Open the account setup
2) Enter a dummy email `test@hotmail.com`
3) Leave the password empty

-> Auto detection succeeds but you get the feedback *Password required*

4) Fill in a password

-> Auto detection succeeds but you get the feedback that username or password is wrong.

5) Enter a valid gmail account (can end with `@gmail.com` but no longer has to)

-> You get the popup window to configure it