### PR TITLE
perf(autoloader): Use Composer's authoritative classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
 		"sort-packages": true,
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true
-		}
+		},
+		"optimize-autoloader": true,
+		"classmap-authoritative": true,
+		"autoloader-suffix": "Mail"
 	},
 	"require": {
 		"php": ">=8.0 <=8.1",
@@ -46,7 +49,10 @@
 	"autoload": {
 		"files": [
 			"lib/functions.php"
-		]
+		],
+		"psr-4": {
+			"OCA\\Mail\\": "lib/"
+		}
 	},
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",

--- a/composer/autoload.php
+++ b/composer/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
And stop server from doing the autoloading for us.

https://github.com/nextcloud/spreed/blob/c0f1bf940595b02ccc9120495667dcc1898e55eb/composer.json does too.

## Benchmarks

![Bildschirmfoto vom 2023-01-20 11-54-37](https://user-images.githubusercontent.com/1374172/213679293-bb3002ba-a9f1-4335-845d-673e8e04f0a5.png)

## Before optimizing all four Groupware apps

![Bildschirmfoto vom 2023-01-20 13-21-55](https://user-images.githubusercontent.com/1374172/213693980-e3112c33-568b-44c3-ba0c-71bfe8e52d90.png)

## After optimizing all four Groupware apps

![Bildschirmfoto vom 2023-01-20 13-22-06](https://user-images.githubusercontent.com/1374172/213693976-c15ddc30-1f20-4f65-859a-3da7603e270f.png)