### PR TITLE
fix: missing important icon in envelope list

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -26,8 +26,8 @@
 				v-if="isImportant"
 				class="app-content-list-item-star svg icon-important"
 				:data-starred="isImportant ? 'true' : 'false'"
-				@click.prevent="onToggleImportant"
-				v-html="hasWriteAcl ? false : importantSvg" />
+				@click.prevent="hasWriteAcl ? false : onToggleImportant"
+				v-html="importantSvg" />
 			<JunkIcon
 				v-if="data.flags.$junk"
 				:size="18"


### PR DESCRIPTION
The icon should be shown but not clickable if the required ACL is missing.

| Before | After | 
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/214605915-7c319354-de37-4123-97f4-4a7328c5edb3.png) | ![grafik](https://user-images.githubusercontent.com/1479486/214605825-be74f509-dfa5-45d6-b90a-b1d8514e215b.png) |

Backports are not required as ACLs are unreleased.