### PR TITLE
fix: regressions from ACL pulls

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -21,19 +21,19 @@
 				:size="18"
 				class="app-content-list-item-star favorite-icon-style"
 				:data-starred="data.flags.flagged ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? false : onToggleFlagged" />
+				@click.prevent="hasWriteAcl ? onToggleFlagged() : false" />
 			<div
 				v-if="isImportant"
 				class="app-content-list-item-star svg icon-important"
 				:data-starred="isImportant ? 'true' : 'false'"
-				@click.prevent="onToggleImportant"
-				v-html="hasWriteAcl ? false : importantSvg" />
+				@click.prevent="hasWriteAcl ? onToggleImportant() : false"
+				v-html="importantSvg" />
 			<JunkIcon
 				v-if="data.flags.$junk"
 				:size="18"
 				class="app-content-list-item-star junk-icon-style"
 				:data-starred="data.flags.$junk ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? false : onToggleJunk" />
+				@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
 			<div class="app-content-list-item-icon">
 				<Avatar :display-name="addresses" :email="avatarEmail" />
 				<p v-if="selectMode" class="app-content-list-item-select-checkbox">

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -251,10 +251,9 @@ export default {
 			required: true,
 		},
 		mailbox: {
-			// It is just used to get the accountId when envelope doesn't have it
+			// Required for checking ACLs
 			type: Object,
-			required: false,
-			default: undefined,
+			required: true,
 		},
 		isSelected: {
 			// Indicates if the envelope is currently selected

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -34,7 +34,7 @@
 				v-if="isImportant"
 				class="app-content-list-item-star icon-important"
 				:data-starred="isImportant ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? false : onToggleImportant"
+				@click.prevent="hasWriteAcl ? onToggleImportant() : false"
 				v-html="importantSvg" />
 			<IconFavorite
 				v-if="envelope.flags.flagged"
@@ -43,14 +43,14 @@
 				:class="{ 'junk-favorite-position': junkFavoritePosition, 'junk-favorite-position-with-tag-subline': junkFavoritePositionWithTagSubline }"
 				class="app-content-list-item-star favorite-icon-style"
 				:data-starred="envelope.flags.flagged ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? false : onToggleFlagged" />
+				@click.prevent="hasWriteAcl ? onToggleFlagged() : false" />
 			<JunkIcon
 				v-if="envelope.flags.$junk"
 				:size="18"
 				:class="{ 'junk-favorite-position': junkFavoritePosition, 'junk-favorite-position-with-tag-subline': junkFavoritePositionWithTagSubline }"
 				class="app-content-list-item-star junk-icon-style"
 				:data-starred="envelope.flags.$junk ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? false : onToggleJunk" />
+				@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
 			<router-link
 				:to="route"
 				event=""
@@ -151,6 +151,7 @@
 					</ButtonVue>
 					<MenuEnvelope class="app-content-list-item-menu"
 						:envelope="envelope"
+						:mailbox="mailbox"
 						:with-reply="false"
 						:with-select="false"
 						:with-show-source="true"


### PR DESCRIPTION
Followup to https://github.com/nextcloud/mail/pull/7920

## Fixes multiple bugs

### 1. The icon should be shown but not clickable if the required ACL is missing.

| Before | After | 
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/214605915-7c319354-de37-4123-97f4-4a7328c5edb3.png) | ![grafik](https://user-images.githubusercontent.com/1479486/214605825-be74f509-dfa5-45d6-b90a-b1d8514e215b.png) |

### 2. Generally makes all conditional click handlers work again. Their ternary operators were inverted.

### 3. Brings back the actions menu on the thread header.

| Before | After | 
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/214848022-8055b9bc-bee8-4ec3-b95c-1d5979bf6a56.png) | ![grafik](https://user-images.githubusercontent.com/1479486/214847940-52fceef1-c0df-42d3-91eb-76a01d29fc84.png) |

---

Backports are not required as ACLs are unreleased.