### PR TITLE
fix(php): Fix ProvisioningMiddleware method return type

### DIFF
--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -65,7 +65,7 @@ class ProvisioningMiddleware extends Middleware {
 		}
 		$configs = $this->provisioningManager->getConfigs();
 		if (empty($configs)) {
-			return null;
+			return;
 		}
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);


### PR DESCRIPTION
The base method declares void as return type. We must not return a value therefore.

This new Psalm report is caused by https://github.com/nextcloud/server/pull/36341.