### PR TITLE
fix: saving preferences not extracting the returned value properly

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -135,7 +135,7 @@ export default {
 			const newValue = await savePreference(key, value)
 			commit('savePreference', {
 				key,
-				value: newValue,
+				value: newValue.value,
 			})
 		})
 	},


### PR DESCRIPTION
The controller returns an object but the action expected a plain value (e.g. a bool).

```json
{ "value": true }
```

## Before

Saving a preference worked but the change wasn't reflected in the UI when going from false -> true. The checkbox only changed its state when going from true -> false.

The correct state is shown after a page reload, as the initial state parser handles the data correctly.

## After

The checkbox of a preference is correctly toggled after clicking on it and persisting the preference.