### PR TITLE
[stable2.2] Fix CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2']
         nextcloud-versions: ['master']
         include:
+          - php-versions: 7.4
+            nextcloud-versions: stable25
           - php-versions: 8.0
             nextcloud-versions: stable25
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests

--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -65,7 +65,7 @@ class ProvisioningMiddleware extends Middleware {
 		}
 		$configs = $this->provisioningManager->getConfigs();
 		if (empty($configs)) {
-			return null;
+			return;
 		}
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);


### PR DESCRIPTION
PHP 7.4 is not supported by nc master anymore. Also incorporsates a backport of #7947.