### PR TITLE
fix(provisioning): Return database ID of new configs

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -64,14 +64,14 @@ class SettingsController extends Controller {
 
 	public function createProvisioning(array $data): JSONResponse {
 		try {
-			$this->provisioningManager->newProvisioning($data);
+			return new JSONResponse(
+				$this->provisioningManager->newProvisioning($data)
+			);
 		} catch (ValidationException $e) {
 			return HttpJsonResponse::fail([$e->getFields()]);
 		} catch (\Exception $e) {
 			return HttpJsonResponse::fail([$e->getMessage()]);
 		}
-
-		return new JSONResponse([]);
 	}
 
 	public function updateProvisioning(int $id, array $data): JSONResponse {

--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -252,9 +252,9 @@ class Manager {
 	 * @throws ValidationException
 	 * @throws \OCP\DB\Exception
 	 */
-	public function newProvisioning(array $data): void {
+	public function newProvisioning(array $data): Provisioning {
 		$provisioning = $this->provisioningMapper->validate($data);
-		$this->provisioningMapper->insert($provisioning);
+		return $this->provisioningMapper->insert($provisioning);
 	}
 
 	/**

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -332,8 +332,9 @@ export default {
 		},
 		async saveNewSettings(settings) {
 			try {
-				await createProvisioningSettings(settings)
-				this.configs.unshift(settings)
+				const config = await createProvisioningSettings(settings)
+				logger.info('new provisioning config saved', { config })
+				this.configs.unshift(config)
 				this.addNew = false
 				this.resetForm()
 				showSuccess(t('mail', 'Saved config for "{domain}"', { domain: settings.provisioningDomain }))

--- a/tests/Unit/Controller/SettingsControllerTest.php
+++ b/tests/Unit/Controller/SettingsControllerTest.php
@@ -56,6 +56,18 @@ class SettingsControllerTest extends TestCase {
 		$this->assertInstanceOf(JSONResponse::class, $response);
 	}
 
+	public function testCreateProvisioning(): void {
+		$provisioning = new Provisioning();
+		$this->mock->getParameter('provisioningManager')
+			->expects(self::once())
+			->method('newProvisioning')
+			->willReturn($provisioning);
+
+		$response = $this->controller->createProvisioning([]);
+
+		self::assertEquals(new JSONResponse($provisioning), $response);
+	}
+
 	public function testDeprovision() {
 		$provisioning = new Provisioning();
 		$this->mock->getParameter('provisioningManager')

--- a/tests/Unit/Service/Provisioning/ManagerTest.php
+++ b/tests/Unit/Service/Provisioning/ManagerTest.php
@@ -228,34 +228,18 @@ class ManagerTest extends TestCase {
 		$this->manager->updatePassword($user, '123456');
 	}
 
-	public function testNewProvisioning() {
-		$config = new Provisioning([
-			'active' => true,
-			'email' => '%USERID%@domain.com',
-			'imapUser' => '%USERID%@domain.com',
-			'imapHost' => 'mx.domain.com',
-			'imapPort' => 993,
-			'imapSslMode' => 'ssl',
-			'smtpUser' => '%USERID%@domain.com',
-			'smtpHost' => 'mx.domain.com',
-			'smtpPort' => 567,
-			'smtpSslMode' => 'tls',
-			'sieveEnabled' => false,
-			'sieveUser' => '',
-			'sieveHost' => '',
-			'sievePort' => 0,
-			'sieveSslMode' => 'tls'
-		]);
+	public function testNewProvisioning(): void {
+		$config = new Provisioning();
 		$this->mock->getParameter('provisioningMapper')
 			->expects($this->once())
 			->method('validate')
 			->willReturn($config);
-
 		$this->mock->getParameter('provisioningMapper')
 			->expects($this->once())
-			->method('insert');
+			->method('insert')
+			->willReturn($config);
 
-		$this->manager->newProvisioning([
+		$result = $this->manager->newProvisioning([
 			'active' => true,
 			'email' => '%USERID%@domain.com',
 			'imapUser' => '%USERID%@domain.com',
@@ -272,5 +256,7 @@ class ManagerTest extends TestCase {
 			'sievePort' => 0,
 			'sieveSslMode' => 'tls'
 		]);
+
+		self::assertInstanceOf(Provisioning::class, $result);
 	}
 }


### PR DESCRIPTION
https://github.com/nextcloud/mail/pull/4968 oversight.

## How to test

1) Open ``/settings/admin/groupware``
2) Click *+ Add new config*
3) Enter `aaa` as provisioning doman, `test` as email address template
4) Click *Save config*
5) Click *Unprovision & Delete config*

Main: config disappears visually, but request sends a `{id}` for the config ID.
Here: real database ID is sent for deletion. Config is removed from the DB as well.

Beware: even if the config is deleted from the DB you might still see it after a page reload: https://github.com/nextcloud/mail/pull/7992