### PR TITLE
chore(autoloading): Only use authoritative classmaps for production

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
 			"bamarni/composer-bin-plugin": true
 		},
 		"optimize-autoloader": true,
-		"classmap-authoritative": true,
 		"autoloader-suffix": "Mail"
 	},
 	"require": {

--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,6 +1,6 @@
 [package]
 before_cmds = [
-	"composer install --no-dev -o",
+	"composer install --no-dev -a",
 	"npm install --deps",
 	"npm run build",
 ]


### PR DESCRIPTION
## How to test

1) Run `composer i`
2) Check `vendor/composer/autoload_real.php`

Main: you find a `$loader->setClassMapAuthoritative(true);` and switching between branches could potentially trigger missing classes if you don't run `composer i` or `composer dump-autoload` to update the class map
Here: class map is still optimized on dev but tries to look up missing classes. On production we use the authoritative classmaps nevertheless.