### PR TITLE
fix: use api to read input value

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -75,7 +75,10 @@
 					</template>
 					{{ t('mail', 'Add mailbox') }}
 				</ActionButton>
-				<ActionInput v-if="editing" @submit.prevent.stop="createMailbox">
+				<ActionInput
+					v-if="editing"
+					:value.sync="createMailboxName"
+					@submit.prevent.stop="createMailbox">
 					<template #icon>
 						<IconFolderAdd
 							:size="20" />
@@ -187,6 +190,7 @@ export default {
 			editing: false,
 			showSaving: false,
 			showSettings: false,
+			createMailboxName: '',
 		}
 	},
 	computed: {
@@ -228,7 +232,7 @@ export default {
 	methods: {
 		createMailbox(e) {
 			this.editing = true
-			const name = e.target.elements[1].value
+			const name = this.createMailboxName
 			logger.info('creating mailbox ' + name)
 			this.menuOpen = false
 			this.$store

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -93,7 +93,10 @@
 				</template>
 				{{ t('mail', 'Add submailbox') }}
 			</ActionButton>
-			<ActionInput v-if="editing" @submit.prevent.stop="createMailbox">
+			<ActionInput
+				v-if="editing"
+				:value.sync="createMailboxName"
+				@submit.prevent.stop="createMailbox">
 				<template #icon>
 					<IconFolderAdd
 						:size="20" />
@@ -298,6 +301,7 @@ export default {
 			showMoveModal: false,
 			hasDelimiter: !!this.mailbox.delimiter,
 			UNIFIED_INBOX_ID,
+			createMailboxName: '',
 		}
 	},
 	computed: {
@@ -479,7 +483,7 @@ export default {
 
 		async createMailbox(e) {
 			this.editing = true
-			const name = e.target.elements[1].value
+			const name = this.createMailboxName
 			const withPrefix = this.mailbox.name + this.mailbox.delimiter + name
 			logger.info(`creating mailbox ${withPrefix} as submailbox of ${this.mailbox.databaseId}`)
 			this.menuOpen = false


### PR DESCRIPTION
> The internal dom structure was changed by https://github.com/nextcloud/nextcloud-vue/pull/3517

stable2.2 uses nextcloud/vue 7.1 => no backport

Test Case 1:

- Open menu for account in navigation
- Click "Add mailbox"
- Add a mailbox

Test Case 2:

- Open menu for mailbox in navigation
- Click "Add submailbox" 
- Add a sub mailbox

It does not work on main because the internal dom strucure was changed.