### PR TITLE
feat: respect acl when moving threads and mailboxes

### DIFF
--- a/src/components/MailboxPicker.vue
+++ b/src/components/MailboxPicker.vue
@@ -71,6 +71,7 @@ import IconFolder from 'vue-material-design-icons/Folder'
 
 import { translate as t } from '@nextcloud/l10n'
 import { translate as translateMailboxName } from '../i18n/MailboxTranslator'
+import { mailboxHasRights } from '../util/acl'
 
 export default {
 	name: 'MailboxPicker',
@@ -135,9 +136,9 @@ export default {
 		},
 		filteredMailboxes() {
 			if (this.pickedMailbox) {
-				return this.mailboxes.filter(mailbox => mailbox.databaseId !== this.pickedMailbox.databaseId)
+				return this.mailboxes.filter(mailbox => mailbox.databaseId !== this.pickedMailbox.databaseId && mailboxHasRights(mailbox, 'k'))
 			}
-			return this.mailboxes
+			return this.mailboxes.filter(mailbox => mailboxHasRights(mailbox, 'i'))
 		},
 	},
 	methods: {

--- a/src/tests/unit/util/acl.spec.js
+++ b/src/tests/unit/util/acl.spec.js
@@ -1,0 +1,56 @@
+/**
+ * @copyright Copyright (c) 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {mailboxHasRights} from '../../../util/acl'
+
+describe('acl', () => {
+	describe('mailboxHasRights', () => {
+		it('allow as fallback', () => {
+			const mailbox = {}
+
+			const actual = mailboxHasRights(mailbox, 'l')
+
+			expect(actual).toBeTruthy
+
+		})
+
+		it('allow when right included', () => {
+			const mailbox = {
+				myAcls: 'lrwstipekxa'
+			}
+
+			const actual = mailboxHasRights(mailbox, 'l')
+
+			expect(actual).toBeTruthy
+		})
+
+		it('deny when right not included', () => {
+			const mailbox = {
+				myAcls: 'lrw'
+			}
+
+			const actual = mailboxHasRights(mailbox, 'iw')
+
+			expect(actual).toBeFalsy
+		})
+	})
+})

--- a/src/util/acl.js
+++ b/src/util/acl.js
@@ -1,0 +1,42 @@
+/**
+ * @copyright Copyright (c) 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * @param {object} mailbox object
+ * @param {string} rights list of rights to check
+ * @return {boolean}
+ */
+export function mailboxHasRights(mailbox, rights) {
+	if (!mailbox.myAcls) {
+		return true
+	}
+
+	const acls = [...mailbox.myAcls]
+
+	for (const right of [...rights]) {
+		if (!acls.includes(right)) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/7909

The check for `i` does not cover all cases. 
To move `\SEEN`, `\DELETED` and `other flags` we need `s`, `t` and `w`.


