### PR TITLE
feat(acl): check delete acl for move operation

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -128,7 +128,7 @@
 				</template>
 				{{ t('mail', 'Saving') }}
 			</ActionText>
-			<ActionButton v-if="!account.isUnified && hasDelimiter && !mailbox.specialRole && !hasSubMailboxes"
+			<ActionButton v-if="!account.isUnified && hasDelimiter && !mailbox.specialRole && !hasSubMailboxes && hasDeleteAcl"
 				:id="genId(mailbox)"
 				:close-after-click="true"
 				@click.prevent="onOpenMoveModal">
@@ -136,7 +136,7 @@
 					<IconExternal
 						:size="20" />
 				</template>
-				{{ t('mail', 'Move') }}
+				{{ t('mail', 'Move mailbox') }}
 			</ActionButton>
 			<ActionButton
 				v-if="debug && !account.isUnified && mailbox.specialRole !== 'flagged'"


### PR DESCRIPTION
Rename mailbox needs x (delete mailbox) for the source mailbox. 
Hide the button if we cannot.

Renamed the label from Move to Move mailbox like the other operations (e.g. Clear mailbox, Delete mailbox).