### PR TITLE
fix(mailvelope): hide the missing pgp key warning when mailevelope is…

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -171,7 +171,7 @@
 		<div v-if="noReply" class="warning noreply-warning">
 			{{ t('mail', 'This message came from a noreply address so your reply will probably not be read.') }}
 		</div>
-		<div v-if="mailvelope.keysMissing.length" class="warning noreply-warning">
+		<div v-if="encrypt && mailvelope.keysMissing.length" class="warning noreply-warning">
 			{{
 				t('mail', 'The following recipients do not have a PGP key: {recipients}.', {
 					recipients: mailvelope.keysMissing.join(', '),


### PR DESCRIPTION
… disabled again

How to reproduce

- Compose new message
- Enter recipient without gpg key
- Toggle encrypt with mailevelope
- See warning
- Turn off mailevelope again
- Warning still there


| Before | After |
| --- | --- |
| [Screencast from 2023-02-21 16-42-47.webm](https://user-images.githubusercontent.com/3902676/220392919-2cb2d7d0-911e-47da-b19d-829fc301ec4e.webm) | [Screencast from 2023-02-21 16-44-11.webm](https://user-images.githubusercontent.com/3902676/220392940-f1312c5f-77e3-498c-80fe-579c5940cfa8.webm) |
