### PR TITLE
feat(smime): encrypt messages

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>3.0.0-alpha.0</version>
+	<version>3.0.0-alpha.1</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -58,6 +58,8 @@ use function array_filter;
  * @method setSmimeSign(bool $smimeSign)
  * @method int|null getSmimeCertificateId()
  * @method setSmimeCertificateId(?int $smimeCertificateId)
+ * @method bool|null getSmimeEncrypt()
+ * @method setSmimeEncrypt (bool $smimeEncryt)
  */
 class LocalMessage extends Entity implements JsonSerializable {
 	public const TYPE_OUTGOING = 0;
@@ -111,6 +113,9 @@ class LocalMessage extends Entity implements JsonSerializable {
 	/** @var int|null */
 	protected $smimeCertificateId;
 
+	/** @var bool|null */
+	protected $smimeEncrypt;
+
 	public function __construct() {
 		$this->addType('type', 'integer');
 		$this->addType('accountId', 'integer');
@@ -121,6 +126,7 @@ class LocalMessage extends Entity implements JsonSerializable {
 		$this->addType('updatedAt', 'integer');
 		$this->addType('smimeSign', 'boolean');
 		$this->addType('smimeCertificateId', 'integer');
+		$this->addType('smimeEncrypt', 'boolean');
 	}
 
 	#[ReturnTypeWillChange]
@@ -161,6 +167,7 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'failed' => $this->isFailed() === true,
 			'smimeCertificateId' => $this->getSmimeCertificateId(),
 			'smimeSign' => $this->getSmimeSign() === true,
+			'smimeEncrypt' => $this->getSmimeEncrypt() === true,
 		];
 	}
 

--- a/lib/Db/SmimeCertificateMapper.php
+++ b/lib/Db/SmimeCertificateMapper.php
@@ -100,4 +100,25 @@ class SmimeCertificateMapper extends QBMapper {
 
 		return $this->findEntities($qb);
 	}
+
+	/**
+	 * Find all S/MIME certificates by email addresses
+	 *
+	 * @param string $userId
+	 * @param string[] $emailAddresses
+	 * @return SmimeCertificate[]
+	 *
+	 * @throws \OCP\DB\Exception
+	 */
+	public function findAllByEmailAddresses(string $userId, array $emailAddresses): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('user_id', $qb->createNamedParameter($userId)),
+				$qb->expr()->in('email_address', $qb->createNamedParameter($emailAddresses, IQueryBuilder::PARAM_STR_ARRAY)),
+			);
+
+		return $this->findEntities($qb);
+	}
 }

--- a/lib/Exception/SmimeEncryptException.php
+++ b/lib/Exception/SmimeEncryptException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Mail\Exception;
+
+use Exception;
+
+class SmimeEncryptException extends Exception {
+}

--- a/lib/Migration/Version2300Date20230221170502.php
+++ b/lib/Migration/Version2300Date20230221170502.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version2300Date20230221170502 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$outboxTable = $schema->getTable('mail_local_messages');
+		if (!$outboxTable->hasColumn('smime_encrypt')) {
+			$outboxTable->addColumn('smime_encrypt', 'boolean', [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -35,6 +35,7 @@ use OCA\Mail\AddressList;
 class NewMessageData {
 	private ?int $smimeCertificateId;
 	private bool $smimeSign;
+	private bool $smimeEncrypt;
 
 	/** @var Account */
 	private $account;
@@ -86,7 +87,8 @@ class NewMessageData {
 								bool $isHtml = true,
 								bool $isMdnRequested = false,
 								?int $smimeCertificateId = null,
-								bool $smimeSign = false) {
+								bool $smimeSign = false,
+								bool $smimeEncrypt = false) {
 		$this->account = $account;
 		$this->to = $to;
 		$this->cc = $cc;
@@ -98,6 +100,7 @@ class NewMessageData {
 		$this->isMdnRequested = $isMdnRequested;
 		$this->smimeCertificateId = $smimeCertificateId;
 		$this->smimeSign = $smimeSign;
+		$this->smimeEncrypt = $smimeEncrypt;
 	}
 
 	/**
@@ -124,7 +127,8 @@ class NewMessageData {
 									   bool $isHtml = true,
 									   bool $requestMdn = false,
 									   ?int $smimeCertificateId = null,
-									   bool $smimeSign = false): NewMessageData {
+									   bool $smimeSign = false,
+									   bool $smimeEncrypt = false): NewMessageData {
 		$toList = AddressList::parse($to ?: '');
 		$ccList = AddressList::parse($cc ?: '');
 		$bccList = AddressList::parse($bcc ?: '');
@@ -141,6 +145,7 @@ class NewMessageData {
 			$requestMdn,
 			$smimeCertificateId,
 			$smimeSign,
+			$smimeEncrypt,
 		);
 	}
 
@@ -207,5 +212,9 @@ class NewMessageData {
 
 	public function getSmimeCertificateId(): ?int {
 		return $this->smimeCertificateId;
+	}
+
+	public function getSmimeEncrypt(): bool {
+		return $this->smimeEncrypt;
 	}
 }

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -49,6 +49,8 @@
 			:can-save-draft="canSaveDraft"
 			:saving-draft="savingDraft"
 			:draft-saved="draftSaved"
+			:smime-sign="composerData.smimeSign"
+			:smime-encrypt="composerData.smimeEncrypt"
 			@draft="onDraft"
 			@discard-draft="discardDraft"
 			@upload-attachment="onAttachmentUploading"

--- a/src/service/AliasService.js
+++ b/src/service/AliasService.js
@@ -2,12 +2,13 @@ import { generateUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 
 /**
- * @typedef {object} Alias
+ * @typedef Alias
  * @property {number} id the id
  * @property {string} alias alias address
  * @property {string} name alias display name
  * @property {string} signature alias signature
  * @property {boolean} provisioned whether the alias comes from LDAP
+ * @property {number|null} smimeCertificateId smime certificate id
  */
 
 /**

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -129,5 +129,6 @@ export const getters = {
 	}),
 	getSmimeCertificates: (state) => state.smimeCertificates,
 	getSmimeCertificate: (state) => (id) => state.smimeCertificates.find((cert) => cert.id === id),
+	getSmimeCertificateByEmail: (state) => (email) => state.smimeCertificates.find((cert) => cert.emailAddress === email),
 	getNcVersion: (state) => state.preferences?.ncVersion,
 }

--- a/tests/Unit/Controller/OutboxControllerTest.php
+++ b/tests/Unit/Controller/OutboxControllerTest.php
@@ -37,11 +37,30 @@ use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Http\JsonResponse;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\OutboxService;
+use OCA\Mail\Service\SmimeService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\DB\Exception;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class OutboxControllerTest extends TestCase {
+	private string $appName;
+
+	/** @var OutboxService&MockObject */
+	private $service;
+
+	private string $userId;
+
+	/** @var IRequest&MockObject */
+	private $request;
+
+	/** @var AccountService&MockObject */
+	private $accountService;
+
+	/** @var SmimeService&MockObject  */
+	private $smimeService;
+
+	private OutboxController $controller;
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -50,13 +69,15 @@ class OutboxControllerTest extends TestCase {
 		$this->userId = 'john';
 		$this->request = $this->createMock(IRequest::class);
 		$this->accountService = $this->createMock(AccountService::class);
+		$this->smimeService = $this->createMock(SmimeService::class);
 
 		$this->controller = new OutboxController(
 			$this->appName,
 			$this->userId,
 			$this->request,
 			$this->service,
-			$this->accountService
+			$this->accountService,
+			$this->smimeService,
 		);
 	}
 
@@ -254,6 +275,7 @@ class OutboxControllerTest extends TestCase {
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
@@ -276,6 +298,7 @@ class OutboxControllerTest extends TestCase {
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			$to,
 			$cc,
 			[],
@@ -297,6 +320,7 @@ class OutboxControllerTest extends TestCase {
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
@@ -317,6 +341,7 @@ class OutboxControllerTest extends TestCase {
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			$to,
 			$cc,
 			[],
@@ -336,6 +361,7 @@ class OutboxControllerTest extends TestCase {
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
@@ -356,6 +382,7 @@ class OutboxControllerTest extends TestCase {
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			$to,
 			$cc,
 			[],
@@ -375,6 +402,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setBody('message');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
+		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setFailed(false);
@@ -403,6 +432,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getBody(),
 			'<p>message</p>',
 			$message->isHtml(),
+			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			false,
 			$to,
 			$cc,
@@ -424,6 +455,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setBody('message');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
+		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setFailed(false);
@@ -447,6 +480,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getBody(),
 			'<p>message</p>',
 			$message->isHtml(),
+			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			false,
 			$to,
 			$cc,
@@ -468,6 +503,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setBody('message');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
+		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setFailed(false);
@@ -496,6 +533,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getBody(),
 			'<p>message</p>',
 			$message->isHtml(),
+			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
 			false,
 			$to,
 			$cc,
@@ -503,6 +542,103 @@ class OutboxControllerTest extends TestCase {
 			[],
 			$message->getAliasId(),
 			$message->getInReplyToMessageId()
+		);
+	}
+
+	public function testCreateValidateCertificateId(): void {
+		$message = new LocalMessage();
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_OUTGOING);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+
+		$this->smimeService
+			->method('findCertificate')
+			->willThrowException(new DoesNotExistException('No such certificate'));
+		$account = new Account(new MailAccount());
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+
+		$this->expectException(DoesNotExistException::class);
+		$this->controller->create(
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
+			$to,
+			$cc,
+			[],
+			[],
+			null,
+			$message->getAliasId(),
+			$message->getInReplyToMessageId(),
+			100
+		);
+	}
+
+	public function testUpdateValidateCertificateId(): void {
+		$message = new LocalMessage();
+		$message->setId(1);
+		$message->setAccountId(1);
+		$message->setAliasId(2);
+		$message->setSubject('subject');
+		$message->setBody('message');
+		$message->setEditorBody('<p>message</p>');
+		$message->setHtml(true);
+		$message->setSmimeSign(false);
+		$message->setSmimeEncrypt(false);
+		$message->setInReplyToMessageId('abc');
+		$message->setType(LocalMessage::TYPE_OUTGOING);
+		$message->setFailed(false);
+		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
+		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
+
+
+		$this->smimeService
+			->method('findCertificate')
+			->willThrowException(new DoesNotExistException('No such certificate'));
+		$this->service->expects(self::once())
+			->method('getMessage')
+			->with($message->getId(), $this->userId)
+			->willReturn($message);
+		$account = new Account(new MailAccount());
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $message->getAccountId())
+			->willReturn($account);
+
+		$this->expectException(DoesNotExistException::class);
+		$this->controller->update(
+			$message->getId(),
+			$message->getAccountId(),
+			$message->getSubject(),
+			$message->getBody(),
+			'<p>message</p>',
+			$message->isHtml(),
+			$message->getSmimeSign(),
+			$message->getSmimeEncrypt(),
+			false,
+			$to,
+			$cc,
+			[],
+			[],
+			$message->getAliasId(),
+			$message->getInReplyToMessageId(),
+			100
 		);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/7668

## Todo

- [x]  Write test for submitButtonTitle
- [x] Restore state for sign/encrypt for messages in outbox
- [x] Reset wantsSmimeSign, wantsSmimeEncrypt on alias change
- [x] Add smimeCertificateForCurrentAlias to canSend