### PR TITLE
chore(deps): Group ckeditor family for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,28 @@
 			"matchBaseBranches": ["main"],
 			"matchDepTypes": ["devDependencies"],
 			"extends": ["schedule:monthly"]
+		},
+		{
+			"description": "CKEditor family",
+			"matchPackageNames": [
+				"@ckeditor/ckeditor5-alignment",
+				"@ckeditor/ckeditor5-basic-styles",
+				"@ckeditor/ckeditor5-block-quote",
+				"@ckeditor/ckeditor5-build-balloon",
+				"@ckeditor/ckeditor5-core",
+				"@ckeditor/ckeditor5-editor-balloon",
+				"@ckeditor/ckeditor5-essentials",
+				"@ckeditor/ckeditor5-font",
+				"@ckeditor/ckeditor5-heading",
+				"@ckeditor/ckeditor5-image",
+				"@ckeditor/ckeditor5-link",
+				"@ckeditor/ckeditor5-list",
+				"@ckeditor/ckeditor5-paragraph",
+				"@ckeditor/ckeditor5-remove-format",
+				"@ckeditor/ckeditor5-theme-lark",
+				"@ckeditor/ckeditor5-upload"
+			],
+			"rangeStrategy": "pin"
 		}
 	],
 	"vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -62,7 +62,8 @@
 				"@ckeditor/ckeditor5-theme-lark",
 				"@ckeditor/ckeditor5-upload"
 			],
-			"rangeStrategy": "pin"
+			"rangeStrategy": "pin",
+			"automerge": false
 		}
 	],
 	"vulnerabilityAlerts": {


### PR DESCRIPTION
Renovate turns out to not detect these packages as monorepo.

* Group packages that need to be kept in sync
* Pin their versions to avoid partial updates
* Do not automerge because our CI does not catch typical ckeditor issues

Ref https://github.com/nextcloud/mail/issues/7948