### PR TITLE
chore(deps): Fix ckeditor package group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,7 @@
 			]
 		},
 		{
-			"description": "CKEditor family",
+			"groupName": "CKEditor family",
 			"matchPackageNames": [
 				"@ckeditor/ckeditor5-alignment",
 				"@ckeditor/ckeditor5-basic-styles",


### PR DESCRIPTION
> To enable grouping, you configure the groupName field to something non-null.

https://docs.renovatebot.com/configuration-options/#groupname

Only 17 more PRs and we'll have a workable Renovate bot config :crossed_fingers: 