### PR TITLE
chore(deps): Do not request review for automerge PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,31 @@
 	],
 	"packageRules": [
 		{
+			"description": "Request JavaScript reviews",
+			"matchManagers": ["npm"],
+			"reviewers": [
+				"@ChristophWurst",
+				"@GretaD"
+			]
+		},
+		{
+			"description": "Request PHP reviews",
+			"matchManagers": ["composer"],
+			"reviewers": [
+				"@ChristophWurst",
+				"@kesselb"
+			]
+		},
+		{
+			"description": "Bump Github actions monthly and request reviews",
+			"matchManagers": ["github-actions"],
+			"extends": ["schedule:monthly"],
+			"reviewers": [
+				"ChristophWurst",
+				"kesselb"
+			]
+		},
+		{
 			"matchUpdateTypes": ["minor", "patch"],
 			"matchCurrentVersion": "!/^0/",
 			"automerge": true,
@@ -52,15 +77,6 @@
 			"matchBaseBranches": ["main"],
 			"matchDepTypes": ["devDependencies"],
 			"extends": ["schedule:monthly"]
-		},
-		{
-			"description": "Bump Github actions monthly",
-			"matchManagers": ["github-actions"],
-			"extends": ["schedule:monthly"],
-			"reviewers": [
-				"ChristophWurst",
-				"kesselb"
-			]
 		},
 		{
 			"groupName": "CKEditor family",
@@ -84,22 +100,6 @@
 			],
 			"rangeStrategy": "pin",
 			"automerge": false
-		},
-		{
-			"description": "Request JavaScript reviews",
-			"matchManagers": ["npm"],
-			"reviewers": [
-				"@ChristophWurst",
-				"@GretaD"
-			]
-		},
-		{
-			"description": "Request PHP reviews",
-			"matchManagers": ["composer"],
-			"reviewers": [
-				"@ChristophWurst",
-				"@kesselb"
-			]
 		}
 	],
 	"vulnerabilityAlerts": {


### PR DESCRIPTION
Renovate processes packages rules top to bottom. The automerge group is supposed to set the reviewers to an empty array, so the npm/composer reviewers have to be listed first.

Ref https://docs.renovatebot.com/configuration-options/#packagerules

[skipci]