### PR TITLE
chore(deps): Configure renovate commit titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
 		"dependencies",
 		"3. to review"
 	],
+	"commitMessageAction": "Bump",
+	"commitMessageTopic": "{{depName}}",
+	"commitMessageExtra": "from {{currentVersion}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
 	"rangeStrategy": "bump",
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,


### PR DESCRIPTION
* `Bump` instead of `update dependency`
* Include current version

Ref https://github.com/nextcloud/groupware/issues/63#issuecomment-1443055107