### PR TITLE
feat!(deps): Drop Nextcloud 25 support

### DIFF
--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -24,7 +24,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        ocp-version: [ 'dev-master', 'dev-stable25' ]
+        ocp-version: [ 'dev-master' ]
 
     name: Nextcloud ${{ matrix.ocp-version }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,6 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2']
         nextcloud-versions: ['master']
-        include:
-          - php-versions: 8.0
-            nextcloud-versions: stable25
     name: Nextcloud ${{ matrix.nextcloud-versions }} php${{ matrix.php-versions }} unit tests
     steps:
     - name: Set up Nextcloud env

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>2.3.0-alpha.5</version>
+	<version>3.0.0-alpha.0</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
@@ -30,7 +30,7 @@
 	<screenshot>https://user-images.githubusercontent.com/1374172/79554966-278e1600-809f-11ea-82ea-7a0d72a2704f.png</screenshot>
 	<dependencies>
 		<php min-version="8.0" max-version="8.2" />
-		<nextcloud min-version="25" max-version="26" />
+		<nextcloud min-version="26" max-version="26" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Mail\BackgroundJob\CleanupJob</job>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "2.3.0-alpha.4",
+  "version": "3.0.0-alpha0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "2.3.0-alpha.4",
+      "version": "3.0.0-alpha0",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "35.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "2.3.0-alpha.4",
+  "version": "3.0.0-alpha0",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,


### PR DESCRIPTION
Apps have to support the same PHP range as server. This means https://github.com/nextcloud/mail/pull/7865 is only legit if we cut off Nextcloud versions that need PHP7.4.

Mail 2.3.x will not exist. We will wipe all pre-releases from the app store.