### PR TITLE
chore: use attachment dto instead of assoc array

### DIFF
--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -28,21 +28,53 @@ namespace OCA\Mail;
 use Horde_Mime_Part;
 
 class Attachment {
-	private Horde_Mime_Part $mimePart;
+	private ?string $id;
+	private ?string $name;
+	private string $type;
+	private string $content;
+	private int $size;
 
-	public function __construct(Horde_Mime_Part $mimePart) {
-		$this->mimePart = $mimePart;
+	public function __construct(
+		?string $id,
+		?string $name,
+		string $type,
+		string $content,
+		int $size,
+	) {
+		$this->id = $id;
+		$this->name = $name;
+		$this->type = $type;
+		$this->content = $content;
+		$this->size = $size;
 	}
 
-	public function getContents(): string {
-		return $this->mimePart->getContents();
+	public static function fromMimePart(Horde_Mime_Part $mimePart): self {
+		return new Attachment(
+			$mimePart->getMimeId(),
+			$mimePart->getName(),
+			$mimePart->getType(),
+			$mimePart->getContents(),
+			(int)$mimePart->getBytes(),
+		);
+	}
+
+	public function getId(): ?string {
+		return $this->id;
 	}
 
 	public function getName(): ?string {
-		return $this->mimePart->getName();
+		return $this->name;
 	}
 
 	public function getType(): string {
-		return $this->mimePart->getType();
+		return $this->type;
+	}
+
+	public function getContent(): string {
+		return $this->content;
+	}
+
+	public function getSize(): int {
+		return $this->size;
 	}
 }

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -246,7 +246,7 @@ interface IMailManager {
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param Message $message
-	 * @return array
+	 * @return Attachment[]
 	 */
 	public function getMailAttachments(Account $account, Mailbox $mailbox, Message $message) : array;
 

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Controller;
 
+use OCA\Mail\Attachment;
 use OCA\Mail\Http\TrapError;
 use Exception;
 use Horde_Mime_Exception;
@@ -591,7 +592,7 @@ class MessagesController extends Controller {
 		// Body party and embedded messages do not have a name
 		if ($attachment->getName() === null) {
 			return new AttachmentDownloadResponse(
-				$attachment->getContents(),
+				$attachment->getContent(),
 				$this->l10n->t('Embedded message %s', [
 					$attachmentId,
 				]) . '.eml',
@@ -599,7 +600,7 @@ class MessagesController extends Controller {
 			);
 		}
 		return new AttachmentDownloadResponse(
-			$attachment->getContents(),
+			$attachment->getContent(),
 			$attachment->getName(),
 			$attachment->getType()
 		);
@@ -632,10 +633,10 @@ class MessagesController extends Controller {
 		$zip = new ZipResponse($this->request, 'attachments');
 
 		foreach ($attachments as $attachment) {
-			$fileName = $attachment['name'];
+			$fileName = $attachment->getName();
 			$fh = fopen("php://temp", 'r+');
-			fputs($fh, $attachment['content']);
-			$size = (int)$attachment['size'];
+			fputs($fh, $attachment->getContent());
+			$size = $attachment->getSize();
 			rewind($fh);
 			$zip->addResource($fh, $fileName, $size);
 		}
@@ -710,7 +711,7 @@ class MessagesController extends Controller {
 			}
 
 			$newFile = $this->userFolder->newFile($fullPath);
-			$newFile->putContent($attachment->getContents());
+			$newFile->putContent($attachment->getContent());
 		}
 		return new JSONResponse();
 	}

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -665,7 +665,7 @@ class MailManager implements IMailManager {
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param Message $message
-	 * @return array[]
+	 * @return Attachment[]
 	 */
 	public function getMailAttachments(Account $account, Mailbox $mailbox, Message $message): array {
 		$client = $this->imapClientFactory->getClient($account);

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -302,7 +302,7 @@ class MessagesControllerTest extends TestCase {
 			->with($this->equalTo($this->userId), $this->equalTo($accountId))
 			->will($this->returnValue($this->account));
 		$this->attachment->expects($this->once())
-			->method('getContents')
+			->method('getContent')
 			->will($this->returnValue($contents));
 		$this->attachment->expects($this->any())
 			->method('getName')
@@ -368,7 +368,7 @@ class MessagesControllerTest extends TestCase {
 			->method('putContent')
 			->with('abcdefg');
 		$this->attachment->expects($this->once())
-			->method('getContents')
+			->method('getContent')
 			->will($this->returnValue('abcdefg'));
 
 		$expected = new JSONResponse();
@@ -444,7 +444,7 @@ class MessagesControllerTest extends TestCase {
 			->method('putContent')
 			->with('abcdefg');
 		$this->attachment->expects($this->once())
-			->method('getContents')
+			->method('getContent')
 			->will($this->returnValue('abcdefg'));
 
 		$expected = new JSONResponse();
@@ -469,11 +469,13 @@ class MessagesControllerTest extends TestCase {
 		$mailbox->setName('INBOX');
 		$mailbox->setAccountId($accountId);
 		$attachments = [
-			[
-				'content' => 'abcdefg',
-				'name' => 'cat.png',
-				'size' => ''
-			]
+			new Attachment(
+				null,
+				'cat.png',
+				'image/png',
+				'abcdefg',
+				7,
+			),
 		];
 
 		$this->mailManager->expects($this->once())
@@ -503,10 +505,10 @@ class MessagesControllerTest extends TestCase {
 
 		$zip = new ZipResponse($this->request, 'attachments');
 		foreach ($attachments as $attachment) {
-			$fileName = $attachment['name'];
+			$fileName = $attachment->getName();
 			$fh = fopen("php://temp", 'r+');
-			fputs($fh, $attachment['content']);
-			$size = (int)$attachment['size'];
+			fputs($fh, $attachment->getContent());
+			$size = $attachment->getSize();
 			rewind($fh);
 			$zip->addResource($fh, $fileName, $size);
 		}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Tests\Unit\Service;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
+use OCA\Mail\Attachment;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
@@ -522,11 +523,13 @@ class MailManagerTest extends TestCase {
 			->method('getUserId')
 			->willReturn('user');
 		$attachments = [
-			[
-				'content' => 'abcdefg',
-				'name' => 'cat.png',
-				'size' => ''
-			]
+			new Attachment(
+				null,
+				'cat.png',
+				'image/png',
+				'abcdefg',
+				7
+			),
 		];
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = new Mailbox();


### PR DESCRIPTION
Enables further improvements. The attachment DTO is now a proper one instead of just a proxy for a Horde mime part object.