### PR TITLE
Update @nextcloud/vue-richtext to fix circular dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@nextcloud/router": "^2.0.1",
         "@nextcloud/vue": "^7.7.1",
         "@nextcloud/vue-dashboard": "^2",
-        "@nextcloud/vue-richtext": "^2.1.0-beta.5",
+        "@nextcloud/vue-richtext": "^2.1.0-beta.6",
         "@riophae/vue-treeselect": "^0.4.0",
         "@vue/babel-preset-app": "^5.0.8",
         "buffer": "^6.0.3",
@@ -3823,9 +3823,9 @@
       }
     },
     "node_modules/@nextcloud/vue-richtext": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-      "integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.6.tgz",
+      "integrity": "sha512-LIhBCpFEfimUCHlPuhRADwTDXwOf4SASaQLYowofwvFfqTBjYi/TZdQfP4UBPaVFP2aKssOxuZ3HT83Z77ROAw==",
       "dependencies": {
         "@nextcloud/axios": "^2.0.0",
         "@nextcloud/event-bus": "^3.0.2",
@@ -19460,9 +19460,9 @@
       }
     },
     "@nextcloud/vue-richtext": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-      "integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
+      "version": "2.1.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.6.tgz",
+      "integrity": "sha512-LIhBCpFEfimUCHlPuhRADwTDXwOf4SASaQLYowofwvFfqTBjYi/TZdQfP4UBPaVFP2aKssOxuZ3HT83Z77ROAw==",
       "requires": {
         "@nextcloud/axios": "^2.0.0",
         "@nextcloud/event-bus": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nextcloud/router": "^2.0.1",
     "@nextcloud/vue": "^7.7.1",
     "@nextcloud/vue-dashboard": "^2",
-    "@nextcloud/vue-richtext": "^2.1.0-beta.5",
+    "@nextcloud/vue-richtext": "^2.1.0-beta.6",
     "@riophae/vue-treeselect": "^0.4.0",
     "@vue/babel-preset-app": "^5.0.8",
     "buffer": "^6.0.3",


### PR DESCRIPTION
refs https://github.com/nextcloud/vue-richtext/pull/920

This brings the link picker back.