### PR TITLE
Use NcRichText component from `@nextcloud/vue`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@nextcloud/router": "^2.0.1",
         "@nextcloud/vue": "~7.8.0",
         "@nextcloud/vue-dashboard": "^2",
-        "@nextcloud/vue-richtext": "^2.1.0-beta.5",
         "@riophae/vue-treeselect": "^0.4.0",
         "@vue/babel-preset-app": "^5.0.8",
         "buffer": "^6.0.3",
@@ -3862,70 +3861,6 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
-    },
-    "node_modules/@nextcloud/vue-richtext": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-      "integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
-      "dependencies": {
-        "@nextcloud/axios": "^2.0.0",
-        "@nextcloud/event-bus": "^3.0.2",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue": "^7.5.0",
-        "clone": "^2.1.2",
-        "vue": "^2.7.8",
-        "vue-material-design-icons": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^2.7.8"
-      }
-    },
-    "node_modules/@nextcloud/vue-richtext/node_modules/@nextcloud/event-bus": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
-      "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
-      "dependencies": {
-        "semver": "^7.3.7"
-      },
-      "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@nextcloud/vue-richtext/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-richtext/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@nextcloud/vue-richtext/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@nextcloud/vue-select": {
       "version": "3.22.2",
@@ -20521,52 +20456,6 @@
             "loader-utils": "^2.0.0",
             "schema-utils": "^3.0.0"
           }
-        }
-      }
-    },
-    "@nextcloud/vue-richtext": {
-      "version": "2.1.0-beta.5",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue-richtext/-/vue-richtext-2.1.0-beta.5.tgz",
-      "integrity": "sha512-ivvP5AfjyQyhvqfFjJGkjwWFHtur3YaRHwatTYu0BWL3wDKoX9S1I6tb/GQphXB5jabMCTmdi7sPywAs9rwH4Q==",
-      "requires": {
-        "@nextcloud/axios": "^2.0.0",
-        "@nextcloud/event-bus": "^3.0.2",
-        "@nextcloud/initial-state": "^2.0.0",
-        "@nextcloud/router": "^2.0.0",
-        "@nextcloud/vue": "^7.5.0",
-        "clone": "^2.1.2",
-        "vue": "^2.7.8",
-        "vue-material-design-icons": "^5.1.2"
-      },
-      "dependencies": {
-        "@nextcloud/event-bus": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.0.2.tgz",
-          "integrity": "sha512-svXCZa4UkoZKsBiGzTi0cVcbPFUOhCm7pMKjGumRwBvHywX+8by478IQ8Grw75PFHxajMJZ0KrOTTM8WnzzEAw==",
-          "requires": {
-            "semver": "^7.3.7"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@nextcloud/router": "^2.0.1",
     "@nextcloud/vue": "~7.8.0",
     "@nextcloud/vue-dashboard": "^2",
-    "@nextcloud/vue-richtext": "^2.1.0-beta.5",
     "@riophae/vue-treeselect": "^0.4.0",
     "@vue/babel-preset-app": "^5.0.8",
     "buffer": "^6.0.3",

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="message-composer">
-		<ReferencePickerModal v-if="isPickerAvailable && isPickerOpen" @submit="onPicked" @cancel="closePicker" />
+		<NcReferencePickerModal v-if="isPickerAvailable && isPickerOpen" @submit="onPicked" @cancel="closePicker" />
 		<div class="composer-fields composer-fields__from mail-account">
 			<label class="from-label" for="from">
 				{{ t('mail', 'From') }}
@@ -442,8 +442,7 @@ import MailvelopeEditor from './MailvelopeEditor'
 import { getMailvelope } from '../crypto/mailvelope'
 import { isPgpgMessage } from '../crypto/pgp'
 
-import '@nextcloud/vue-richtext/dist/style.css'
-import { ReferencePickerModal } from '@nextcloud/vue-richtext'
+import { NcReferencePickerModal } from '@nextcloud/vue/dist/Components/NcRichText.js'
 
 import Send from 'vue-material-design-icons/Send'
 import SendClock from 'vue-material-design-icons/SendClock'
@@ -485,7 +484,7 @@ export default {
 		UnfoldLessHorizontal,
 		IconHtml,
 		IconClose,
-		ReferencePickerModal,
+		NcReferencePickerModal,
 	},
 	props: {
 		fromAccount: {


### PR DESCRIPTION
Circular dependency is definitely going down with the next `@nextcloud/vue` release which will include `NcRichText` and everything needed for the link picker and the reference widgets.

refs https://github.com/nextcloud/nextcloud-vue/pull/3841 https://github.com/nextcloud/nextcloud-vue/issues/3812

I'll update `@nextcloud/vue` and set this to "ready for review" once the new release is out.