### PR TITLE
feat(imap): Persist if mailbox is shared or not

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 - **🙈 We’re not reinventing the wheel!** Based on the great [Horde](https://horde.org) libraries.
 - **📬 Want to host your own mail server?** We do not have to reimplement this as you could set up [Mail-in-a-Box](https://mailinabox.email)!
 	]]></description>
-	<version>3.0.0-alpha.1</version>
+	<version>3.0.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -68,6 +68,8 @@ use function strtolower;
  * @method void setSyncInBackground(bool $sync)
  * @method string|null getMyAcls()
  * @method void setMyAcls(string|null $acls)
+ * @method bool|null isShared()
+ * @method void setShared(bool $shared)
  */
 class Mailbox extends Entity implements JsonSerializable {
 	protected $name;
@@ -86,6 +88,7 @@ class Mailbox extends Entity implements JsonSerializable {
 	protected $specialUse;
 	protected $syncInBackground;
 	protected $myAcls;
+	protected $shared;
 
 	/**
 	 * @var int
@@ -102,6 +105,7 @@ class Mailbox extends Entity implements JsonSerializable {
 		$this->addType('syncVanishedLock', 'integer');
 		$this->addType('selectable', 'boolean');
 		$this->addType('syncInBackground', 'boolean');
+		$this->addType('shared', 'boolean');
 	}
 
 	public function isInbox(): bool {
@@ -167,6 +171,7 @@ class Mailbox extends Entity implements JsonSerializable {
 			'syncInBackground' => ($this->getSyncInBackground() === true),
 			'unread' => $this->unseen,
 			'myAcls' => $this->myAcls,
+			'shared' => $this->shared === true,
 		];
 	}
 }

--- a/lib/Migration/Version3000Date20230301152454.php
+++ b/lib/Migration/Version3000Date20230301152454.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3000Date20230301152454 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$mailboxesTable = $schema->getTable('mail_mailboxes');
+		if (!$mailboxesTable->hasColumn('shared')) {
+			$mailboxesTable->addColumn('shared', 'boolean', [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -26,7 +26,9 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\IMAP;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Data_Namespace;
 use Horde_Imap_Client_Exception;
+use Horde_Imap_Client_Namespace_List;
 use Horde_Imap_Client_Socket;
 use OC\AppFramework\Utility\TimeFactory;
 use OCA\Mail\Account;
@@ -135,6 +137,59 @@ class MailboxSyncTest extends TestCase {
 			->expects($this->once())
 			->method('dispatchTyped')
 			->with($this->equalTo(new MailboxesSynchronizedEvent($account)));
+
+		$this->sync->sync($account, new NullLogger());
+	}
+
+	public function testSyncShared(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(0);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$personal = new Horde_Imap_Client_Data_Namespace();
+		$personal->name = '';
+		$personal->type = Horde_Imap_Client_Data_Namespace::NS_PERSONAL;
+		$shared = new Horde_Imap_Client_Data_Namespace();
+		$shared->name = 'Shared/';
+		$shared->type = Horde_Imap_Client_Data_Namespace::NS_OTHER;
+		$client->expects($this->once())
+			->method('getNamespaces')
+			->willReturn(new Horde_Imap_Client_Namespace_List([
+				$personal,
+				$shared,
+			]));
+		$folders = [
+			$this->createMock(Folder::class),
+			$this->createMock(Folder::class),
+		];
+		$status = [
+			'unseen' => 10,
+			'messages' => 42,
+		];
+		$folders[0]->method('getStatus')->willReturn($status);
+		$folders[1]->method('getStatus')->willReturn($status);
+		$folders[0]->method('getMailbox')->willReturn('INBOX');
+		$folders[1]->method('getMailbox')->willReturn('Shared/Foo');
+		$this->folderMapper->expects($this->once())
+			->method('getFolders')
+			->with($account, $client)
+			->willReturn($folders);
+		$inbox = new Mailbox();
+		$inbox->setId(101);
+		$inbox->setName('INBOX');
+		$sharedMailbox = new Mailbox();
+		$sharedMailbox->setId(102);
+		$sharedMailbox->setName('Shared/Foo');
+		$this->mailboxMapper->expects(self::once())
+			->method('findAll')
+			->with($account)
+			->willReturn([$inbox, $sharedMailbox]);
 
 		$this->sync->sync($account, new NullLogger());
 	}


### PR DESCRIPTION
Groundwork for https://github.com/nextcloud/mail/issues/8157

### How to test

1) Add an account that has ACL support and receives mailboxes
2) Inspect oc_mail_mailboxes for that account
3) All received mailboxes have shared=1