### PR TITLE
feat(acl): Use shared folder icon for shared mailboxes

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -56,6 +56,8 @@
 					:size="20" />
 				<IconDelete v-else-if="mailbox.databaseId === account.trashMailboxId"
 					:size="20" />
+				<IconFolderShared v-else-if="mailbox.shared"
+					:size="20" />
 				<IconFolder v-else
 					:size="20" />
 			</div>
@@ -212,6 +214,7 @@ import { NcAppNavigationItem as AppNavigationItem, NcCounterBubble as CounterBub
 import IconEmailCheck from 'vue-material-design-icons/EmailCheck'
 import IconExternal from 'vue-material-design-icons/OpenInNew'
 import IconFolder from 'vue-material-design-icons/Folder'
+import IconFolderShared from 'vue-material-design-icons/FolderAccount'
 import IconFolderAdd from 'vue-material-design-icons/FolderMultiple'
 import IconFavorite from 'vue-material-design-icons/Star'
 import IconFolderRename from 'vue-material-design-icons/FolderEdit'
@@ -257,6 +260,7 @@ export default {
 		IconAllInboxes,
 		IconFavorite,
 		IconFolder,
+		IconFolderShared,
 		IconDraft,
 		IconArchive,
 		IconInbox,


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/8157

- [x] Requires https://github.com/nextcloud/mail/pull/8171

![Bildschirmfoto vom 2023-03-02 07-40-29](https://user-images.githubusercontent.com/1374172/222352379-1eab94ec-49e8-4d3b-bb53-17cad1a5423b.png)
