### PR TITLE
chore(deps): Do not automerge @nextcloud/vue bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,19 @@
 			"reviewers": []
 		},
 		{
+			"description": "Do not merge @nextcloud/vue without human review",
+			"matchPackageNames": ["@nextcloud/vue"],
+			"automerge": false,
+			"labels": [
+				"dependencies",
+				"3. to review"
+			],
+			"reviewers": [
+				"@ChristophWurst",
+				"@GretaD"
+			]
+		},
+		{
 			"enabled": false,
 			"matchBaseBranches": "/^stable(.)+/"
 		},


### PR DESCRIPTION
They are not reliably recently. We should test every bump.

Prevents https://github.com/nextcloud/mail/pull/8188 in the future.