### PR TITLE
fix: archiving messages via shortcut

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -163,6 +163,7 @@
 				</ActionButton>
 				<ActionButton v-if="showArchiveButton && hasArchiveAcl"
 					:close-after-click="true"
+					:disabled="disableArchiveButton"
 					@click.prevent="onArchive">
 					<template #icon>
 						<ArchiveIcon
@@ -431,6 +432,10 @@ export default {
 		},
 		showArchiveButton() {
 			return this.account.archiveMailboxId !== null
+		},
+		disableArchiveButton() {
+			return this.account.archiveMailboxId !== null
+				&& this.account.archiveMailboxId === this.mailbox.databaseId
 		},
 		showFavoriteIconVariant() {
 			return this.data.flags.flagged

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -138,6 +138,7 @@
 					</ButtonVue>
 					<ButtonVue v-if="showArchiveButton && hasArchiveAcl"
 						:close-after-click="true"
+						:disabled="disableArchiveButton"
 						type="tertiary-no-background"
 						@click.prevent="onArchive">
 						<template #icon>
@@ -341,6 +342,10 @@ export default {
 		},
 		showArchiveButton() {
 			return this.account.archiveMailboxId !== null
+		},
+		disableArchiveButton() {
+			return this.account.archiveMailboxId !== null
+				&& this.account.archiveMailboxId === this.mailbox.databaseId
 		},
 		junkFavoritePosition() {
 			return this.showSubline && this.tags.length > 0


### PR DESCRIPTION
Fix #8047 

A couple of fixes for archiving via shortcut. 

#### Disable archive message and archive thread when the message is already in the archive mailbox

![Screenshot from 2023-03-03 12-06-13](https://user-images.githubusercontent.com/3902676/222705007-7023f162-7bda-4889-8336-79228e003843.png)
![Screenshot from 2023-03-03 12-06-20](https://user-images.githubusercontent.com/3902676/222705013-3ff5ca37-27de-48a6-add7-6e953c46e5af.png)


#### Show a warning when you press "a" but no archive mailbox is configured


![Screenshot from 2023-03-03 11-14-38](https://user-images.githubusercontent.com/3902676/222705190-c373804d-bfa9-47ac-9f49-cdb8160690db.png)

#### Show a warning when you press "a" but acl does not allow to insert/delete the message(s)

![Screenshot from 2023-03-03 12-08-11](https://user-images.githubusercontent.com/3902676/222705369-d8fc3a78-8d5f-4137-b639-1ec2bd09da98.png)

#### Fix TypeError: _this6.onArchive is not a function

Function onArchive does not exist. 
I'm reusing onDelete to update url and open the next message.  



