### PR TITLE
Fix composer margin on rich text

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -212,11 +212,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+
 :deep(a) {
 	color: #07d;
 }
 :deep(p) {
 	cursor: text;
+	margin: 0 !important;
 }
 </style>
 


### PR DESCRIPTION
Steps to reproduce: 

1. Open composer
2. start typing an email 
3. Enable/disable formatting 

Main: text jumps up/down as formatting is enabled/disabled
Here: text stays consistent