### PR TITLE
chore(renovate): add dedicated group for jest packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -119,6 +119,17 @@
 			],
 			"rangeStrategy": "pin",
 			"automerge": false
+		},
+		{
+			"groupName": "Jest family",
+			"matchPackageNames": [
+				"jest",
+				"jest-environment-jsdom",
+				"babel-jest",
+				"@vue/vue2-jest",
+				"@types/jest"
+			],
+			"automerge": true
 		}
 	],
 	"vulnerabilityAlerts": {


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/pull/8143#issuecomment-1444150460

Automatic detection of the jest group does not work properly.