### PR TITLE
[stable2.2] ci: Use server stable26 instead of master

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
           - name: Install dependencies
             run: composer i
           - name: Install OCP package
-            run: composer require --dev christophwurst/nextcloud:${{ matrix.ocp-version }} --ignore-platform-reqs
+            run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }} --ignore-platform-reqs
           - name: Run coding standards check
             run: composer run psalm
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              ocp-version: [ 'dev-master', 'dev-stable25' ]
+              ocp-version: [ 'dev-stable26', 'dev-stable25' ]
       name: Nextcloud ${{ matrix.ocp-version }}
       steps:
           - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.0', '8.1', '8.2']
-        nextcloud-versions: ['master']
+        nextcloud-versions: ['stable26']
         include:
           - php-versions: 7.4
             nextcloud-versions: stable25
@@ -65,17 +65,17 @@ jobs:
       strategy:
           matrix:
               php-versions: ['8.0']
-              nextcloud-versions: ['master']
+              nextcloud-versions: ['stable26']
               db: ['sqlite', 'mysql', 'pgsql']
               include:
                 - php-versions: 7.4
                   nextcloud-versions: stable25
                   db: 'mysql'
                 - php-versions: 8.1
-                  nextcloud-versions: master
+                  nextcloud-versions: stable26
                   db: 'pgsql'
                 - php-versions: 8.2
-                  nextcloud-versions: master
+                  nextcloud-versions: stable26
                   db: 'sqlite'
       name: php${{ matrix.php-versions }}-${{ matrix.db }} integration tests
       services:


### PR DESCRIPTION
Addresses failing CI seen in https://github.com/nextcloud/mail/pull/8277