### PR TITLE
Fix clickable area partially covering timestamp

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -670,6 +670,7 @@ export default {
 		z-index: 1;
 		padding: 2em;
 		margin: -2em;
+		margin-right: 0;
 	}
 	.icon-important {
 		:deep(path) {


### PR DESCRIPTION
## Before

Timestamp is partially covered by clickable area
<img width="654" alt="Nextcloud Mail app - sender clickable area covering timestamp" src="https://user-images.githubusercontent.com/419086/227586842-789191bb-06b6-447a-a66c-d4ff6135f2d8.png">

## After

Timestamp can be hovered over
<img width="631" alt="Nextcloud Mail app - sender clickable area fixed" src="https://user-images.githubusercontent.com/419086/227586873-adc92a48-2b23-4570-aa91-57f3a49d0a34.png">
