### PR TITLE
fix(drafts): delete old draft when saving new version

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -44,7 +44,6 @@
 			:in-reply-to-message-id="composerData.inReplyToMessageId"
 			:reply-to="composerData.replyTo"
 			:forward-from="composerData.forwardFrom"
-			:draft-id="composerData.draftId"
 			:send-at="composerData.sendAt * 1000"
 			:forwarded-messages="forwardedMessages"
 			:can-save-draft="canSaveDraft"
@@ -91,7 +90,7 @@ export default {
 		return {
 			toolbarElements: undefined,
 			original: undefined,
-			draftsPromise: Promise.resolve(this.composerData?.draftId),
+			draftsPromise: Promise.resolve(),
 			attachmentsPromise: Promise.resolve(),
 			canSaveDraft: true,
 			savingDraft: false,
@@ -100,6 +99,12 @@ export default {
 			sending: false,
 			error: undefined,
 			warning: undefined,
+		}
+	},
+	created() {
+		const draftId = this.composerData?.draftId
+		if (draftId) {
+			this.draftsPromise = Promise.resolve(draftId)
 		}
 	},
 	computed: {


### PR DESCRIPTION
The computed prop `this.composerData?.draftId` is not available in `data()` so it needs to be initialized in `created()`.

1. Have at least one draft in your drafts folder.
3. Edit some draft by clicking on it.
4. Wait until the next draft is saved (takes a while).
5. Close the modal.
6. Check the drafts mailbox.

### Without this PR

Two drafts (old and new) are present. The old one is not deleted.

### With this PR

The old draft is replaced with the new one.