### PR TITLE
fix: Merge overlapping recipient popovers

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -25,9 +25,9 @@
 			:display-name="label"
 			:avatar-image="avatarUrlAbsolute"
 			@click="onClickOpenContactDialog">
-			<span class="user-bubble-email">{{ email }}</span>
 		</UserBubble>
 		<div class="contact-wrapper">
+			<p class="contact-popover__email">{{ email }}</p>
 			<ButtonVue
 				v-if="contactsWithEmail && contactsWithEmail.length > 0"
 				type="tertiary-no-background"
@@ -280,9 +280,6 @@ export default {
 .user-bubble__title {
 	max-width: 30vw;
 }
-.user-bubble-email {
-	margin: 10px;
-}
 
 .contact-menu {
 	display: flex;
@@ -290,6 +287,10 @@ export default {
 }
 .contact-popover {
 	display: inline-block;
+
+	&__email {
+		text-align: center;
+	}
 }
 .contact-wrapper {
 	padding:10px;


### PR DESCRIPTION
1) Popover for the recipient email
2) Popover for Contacts integration

Now the contents are merged into one popover.

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2023-04-11 08-29-42](https://user-images.githubusercontent.com/1374172/231075616-5015003d-a3cc-47ec-b531-0be1a575d45f.png) | ![Bildschirmfoto vom 2023-04-11 08-30-33](https://user-images.githubusercontent.com/1374172/231075705-5352c751-bb76-45eb-8173-f12c3207ad80.png) |
| ![Bildschirmfoto vom 2023-04-11 08-30-12](https://user-images.githubusercontent.com/1374172/231075658-1c663e22-f24e-4d4a-9695-35ff519da53b.png) |  | 

@rollanders @goulvench @dbielz @BroCanDo for review

Fixes https://github.com/nextcloud/mail/issues/7884