### PR TITLE
refactor: replace deprecated IQueryBuilder::execute

### DIFF
--- a/lib/Db/AliasMapper.php
+++ b/lib/Db/AliasMapper.php
@@ -105,7 +105,7 @@ class AliasMapper extends QBMapper {
 			->delete($this->getTableName())
 			->where($qb->expr()->eq('account_id', $qb->createNamedParameter($accountId)));
 
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**
@@ -128,7 +128,7 @@ class AliasMapper extends QBMapper {
 				$qb->expr()->isNotNull('provisioning_id')
 			);
 
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	public function deleteOrphans(): void {
@@ -137,7 +137,7 @@ class AliasMapper extends QBMapper {
 			->from($this->getTableName(), 'a')
 			->leftJoin('a', 'mail_accounts', 'ac', $qb1->expr()->eq('a.account_id', 'ac.id'))
 			->where($qb1->expr()->isNull('ac.id'));
-		$result = $idsQuery->execute();
+		$result = $idsQuery->executeQuery();
 		$ids = array_map(static function (array $row) {
 			return (int)$row['id'];
 		}, $result->fetchAll());
@@ -150,7 +150,7 @@ class AliasMapper extends QBMapper {
 			);
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$qb2->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$qb2->execute();
+			$qb2->executeStatement();
 		}
 	}
 }

--- a/lib/Db/CollectedAddressMapper.php
+++ b/lib/Db/CollectedAddressMapper.php
@@ -80,7 +80,7 @@ class CollectedAddressMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select($qb->func()->count())
 			->from($this->getTableName());
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 
 		$count = (int)$result->fetchColumn();
 		$result->closeCursor();
@@ -115,7 +115,7 @@ class CollectedAddressMapper extends QBMapper {
 			->from($this->getTableName(), 'c')
 			->leftJoin('c', 'mail_accounts', 'a', $qb1->expr()->eq('c.user_id', 'a.user_id'))
 			->where($qb1->expr()->isNull('a.id'));
-		$result = $idsQuery->execute();
+		$result = $idsQuery->executeQuery();
 		$ids = array_map(static function (array $row) {
 			return (int)$row['id'];
 		}, $result->fetchAll());
@@ -127,7 +127,7 @@ class CollectedAddressMapper extends QBMapper {
 			->where($qb2->expr()->in('id', $qb2->createParameter('ids')));
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$query->execute();
+			$query->executeStatement();
 		}
 	}
 }

--- a/lib/Db/LocalAttachmentMapper.php
+++ b/lib/Db/LocalAttachmentMapper.php
@@ -97,7 +97,7 @@ class LocalAttachmentMapper extends QBMapper {
 			$qb->delete($this->getTableName())
 				->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)))
 				->andWhere($qb->expr()->eq('local_message_id', $qb->createNamedParameter($localMessageId), IQueryBuilder::PARAM_INT));
-			$qb->execute();
+			$qb->executeStatement();
 			$this->db->commit();
 		} catch (Throwable $e) {
 			$this->db->rollBack();
@@ -119,7 +119,7 @@ class LocalAttachmentMapper extends QBMapper {
 				->andWhere(
 					$qb->expr()->in('id', $qb->createNamedParameter($attachmentIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
 				);
-			$qb->execute();
+			$qb->executeStatement();
 			$this->db->commit();
 		} catch (Throwable $e) {
 			$this->db->rollBack();

--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -66,7 +66,7 @@ class LocalMessageMapper extends QBMapper {
 				$qb->expr()->eq('a.user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR),
 				$qb->expr()->eq('m.type', $qb->createNamedParameter($type, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
 			);
-		$rows = $qb->execute();
+		$rows = $qb->executeQuery();
 
 		$results = [];
 		$ids = [];

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -136,7 +136,7 @@ class MailAccountMapper extends QBMapper {
 		$delete = $qb->delete($this->getTableName())
 			->where($qb->expr()->eq('provisioning_id', $qb->createNamedParameter($provisioningId, IQueryBuilder::PARAM_INT)));
 
-		$delete->execute();
+		$delete->executeStatement();
 	}
 
 	public function deleteProvisionedAccountsByUid(string $uid): void {
@@ -148,7 +148,7 @@ class MailAccountMapper extends QBMapper {
 				$qb->expr()->isNotNull('provisioning_id')
 			);
 
-		$delete->execute();
+		$delete->executeStatement();
 	}
 
 	public function getAllAccounts(): array {

--- a/lib/Db/MailboxMapper.php
+++ b/lib/Db/MailboxMapper.php
@@ -74,7 +74,7 @@ class MailboxMapper extends QBMapper {
 		$qb->select('id')
 			->from($this->getTableName());
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		while ($row = $cursor->fetch()) {
 			yield (int)$row['id'];
 		}
@@ -193,7 +193,7 @@ class MailboxMapper extends QBMapper {
 				$query->expr()->eq('id', $query->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),
 				$this->eqOrNull($query, $attr, $lock, IQueryBuilder::PARAM_INT)
 			);
-		if ($query->execute() === 0) {
+		if ($query->executeStatement() === 0) {
 			// Another process just started syncing
 
 			throw MailboxLockedException::from($mailbox);
@@ -267,7 +267,7 @@ class MailboxMapper extends QBMapper {
 			->from($this->getTableName(), 'm')
 			->leftJoin('m', 'mail_accounts', 'a', $qb1->expr()->eq('m.account_id', 'a.id'))
 			->where($qb1->expr()->isNull('a.id'));
-		$result = $idsQuery->execute();
+		$result = $idsQuery->executeQuery();
 		$ids = array_map(static function (array $row) {
 			return (int)$row['id'];
 		}, $result->fetchAll());
@@ -278,7 +278,7 @@ class MailboxMapper extends QBMapper {
 			->where($qb2->expr()->in('id', $qb2->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY));
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$query = $qb2->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$query->execute();
+			$query->executeStatement();
 		}
 	}
 
@@ -296,7 +296,7 @@ class MailboxMapper extends QBMapper {
 					$qb->expr()->eq('flag_important', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
 				);
 
-		$cursor = $query->execute();
+		$cursor = $query->executeQuery();
 		$uids = array_map(static function (array $row) {
 			return (int)$row['uid'];
 		}, $cursor->fetchAll());

--- a/lib/Db/RecipientMapper.php
+++ b/lib/Db/RecipientMapper.php
@@ -77,7 +77,7 @@ class RecipientMapper extends QBMapper {
 			->where(
 				$qb->expr()->eq('local_message_id', $qb->createNamedParameter($localMessageId, IQueryBuilder::PARAM_INT))
 			);
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**

--- a/lib/Db/StatisticsDao.php
+++ b/lib/Db/StatisticsDao.php
@@ -60,7 +60,7 @@ class StatisticsDao {
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id'))
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;
@@ -75,7 +75,7 @@ class StatisticsDao {
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_TO), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)))
 			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;
@@ -95,7 +95,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
 			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
 			->groupBy('r.email');
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$rows = $result->fetchAll();
 		$data = $this->emailCountResultToIndexedArray($rows);
 		$result->closeCursor();
@@ -112,7 +112,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('m.flag_important', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;
@@ -127,7 +127,7 @@ class StatisticsDao {
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;
@@ -153,7 +153,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
 			->groupBy('r.email');
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$rows = $result->fetchAll();
 		$data = $this->emailCountResultToIndexedArray($rows);
 		$result->closeCursor();
@@ -170,7 +170,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('m.flag_seen', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;
@@ -198,7 +198,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->eq("m.flag_$flag", $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
 			->groupBy('r.email');
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$rows = $result->fetchAll();
 		$data = $this->emailCountResultToIndexedArray($rows);
 		$result->closeCursor();
@@ -215,7 +215,7 @@ class StatisticsDao {
 			->andWhere($qb->expr()->eq('m.mailbox_id', $qb->createNamedParameter($mb->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('m.flag_answered', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->eq('r.email', $qb->createNamedParameter($email)));
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$cnt = $result->fetchColumn();
 		$result->closeCursor();
 		return (int)$cnt;

--- a/lib/Db/TagMapper.php
+++ b/lib/Db/TagMapper.php
@@ -103,7 +103,7 @@ class TagMapper extends QBMapper {
 		$qb->insert('mail_message_tags')
 		   ->setValue('imap_message_id', $qb->createNamedParameter($messageId))
 		   ->setValue('tag_id', $qb->createNamedParameter($tag->getId(), IQueryBuilder::PARAM_INT));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -116,7 +116,7 @@ class TagMapper extends QBMapper {
 		$qb->delete('mail_message_tags')
 			->where($qb->expr()->eq('imap_message_id', $qb->createNamedParameter($messageId)))
 			->andWhere($qb->expr()->eq('tag_id', $qb->createNamedParameter($tag->getId())));
-		$qb->execute();
+		$qb->executeStatement();
 	}
 
 	/**
@@ -141,7 +141,7 @@ class TagMapper extends QBMapper {
 
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$tagsQuery->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
-			$queryResult = $tagsQuery->execute();
+			$queryResult = $tagsQuery->executeQuery();
 
 			while (($row = $queryResult->fetch()) !== false) {
 				$messageId = $row['imap_message_id'];
@@ -187,7 +187,7 @@ class TagMapper extends QBMapper {
 		$messageIds = [];
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$tagsQuery->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
-			$queryResult = $tagsQuery->execute();
+			$queryResult = $tagsQuery->executeQuery();
 
 			while (($row = $queryResult->fetch()) !== false) {
 				$messageIds[] = $row['imap_message_id'];
@@ -262,7 +262,7 @@ class TagMapper extends QBMapper {
 			$qb->expr()->eq('mt1.tag_id', 'mt2.tag_id')
 		)
 		);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		$ids = array_unique(array_map(static function ($row) {
@@ -274,7 +274,7 @@ class TagMapper extends QBMapper {
 			->where($deleteQB->expr()->in('id', $deleteQB->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY));
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$deleteQB->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$deleteQB->execute();
+			$deleteQB->executeStatement();
 		}
 	}
 
@@ -285,7 +285,7 @@ class TagMapper extends QBMapper {
 		->from('mail_message_tags', 'mt')
 		->leftJoin('mt', $this->getTableName(), 't', $qb->expr()->eq('t.id', 'mt.tag_id'))
 		->where($qb->expr()->isNull('t.id'));
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 
@@ -298,7 +298,7 @@ class TagMapper extends QBMapper {
 			->where($deleteQB->expr()->in('id', $deleteQB->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY));
 		foreach (array_chunk($ids, 1000) as $chunk) {
 			$deleteQB->setParameter('ids', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$deleteQB->execute();
+			$deleteQB->executeStatement();
 		}
 	}
 }

--- a/lib/Db/ThreadMapper.php
+++ b/lib/Db/ThreadMapper.php
@@ -59,7 +59,7 @@ class ThreadMapper extends QBMapper {
 			}
 		}
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = array_map(static function (array $row) {
 			return [
 				'messageUid' => (int)$row[0],

--- a/lib/Db/TrustedSenderMapper.php
+++ b/lib/Db/TrustedSenderMapper.php
@@ -73,7 +73,7 @@ class TrustedSenderMapper extends QBMapper {
 				'type' => $qb->createNamedParameter($type),
 			]);
 
-		$insert->execute();
+		$insert->executeStatement();
 	}
 
 	public function remove(string $uid, string $email, string $type): void {
@@ -86,7 +86,7 @@ class TrustedSenderMapper extends QBMapper {
 				$qb->expr()->eq('type', $qb->createNamedParameter($type))
 			);
 
-		$delete->execute();
+		$delete->executeStatement();
 	}
 
 	/**

--- a/lib/Migration/Version0110Date20180825201241.php
+++ b/lib/Migration/Version0110Date20180825201241.php
@@ -133,6 +133,6 @@ class Version0110Date20180825201241 extends SimpleMigrationStep {
 				$address->getEmail(),
 				$address->getDisplayName()
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/lib/Migration/Version0161Date20190902103701.php
+++ b/lib/Migration/Version0161Date20190902103701.php
@@ -105,6 +105,6 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('mail_accounts')
 			->set('last_mailbox_sync', $update->createNamedParameter(0));
-		$update->execute();
+		$update->executeStatement();
 	}
 }

--- a/lib/Migration/Version0161Date20190902114635.php
+++ b/lib/Migration/Version0161Date20190902114635.php
@@ -68,6 +68,6 @@ class Version0161Date20190902114635 extends SimpleMigrationStep {
 		$update->update('mail_accounts')
 			->set('last_mailbox_sync', $update->createNamedParameter(0));
 
-		$update->execute();
+		$update->executeStatement();
 	}
 }

--- a/lib/Migration/Version1030Date20200228105714.php
+++ b/lib/Migration/Version1030Date20200228105714.php
@@ -24,6 +24,6 @@ class Version1030Date20200228105714 extends SimpleMigrationStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('mail_accounts')
 			->set('last_mailbox_sync', $update->createNamedParameter(0));
-		$update->execute();
+		$update->executeStatement();
 	}
 }

--- a/lib/Migration/Version1040Date20200422130220.php
+++ b/lib/Migration/Version1040Date20200422130220.php
@@ -47,11 +47,11 @@ class Version1040Date20200422130220 extends SimpleMigrationStep {
 			->set('sync_changed_token', $qb1->createNamedParameter(null))
 			->set('sync_vanished_lock', $qb1->createNamedParameter(null))
 			->set('sync_vanished_token', $qb1->createNamedParameter(null));
-		$updateMailboxes->execute();
+		$updateMailboxes->executeStatement();
 
 		// Clean up some orphaned data
 		$qb2 = $this->connection->getQueryBuilder();
 		$deleteRecipients = $qb2->delete('mail_recipients');
-		$deleteRecipients->execute();
+		$deleteRecipients->executeStatement();
 	}
 }

--- a/lib/Migration/Version1060Date20201015084952.php
+++ b/lib/Migration/Version1060Date20201015084952.php
@@ -56,6 +56,6 @@ class Version1060Date20201015084952 extends SimpleMigrationStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('mail_accounts')
 			->set('last_mailbox_sync', $update->createNamedParameter(0));
-		$update->execute();
+		$update->executeStatement();
 	}
 }

--- a/lib/Migration/Version1100Date20210419080523.php
+++ b/lib/Migration/Version1100Date20210419080523.php
@@ -177,7 +177,7 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 		$insertQb->setValue('sieve_host', $insertQb->createNamedParameter($conf['sieveHost'] ?? ''));
 		$insertQb->setValue('sieve_port', $insertQb->createNamedParameter($conf['sievePort'] ?? 4190, IQueryBuilder::PARAM_INT));
 		$insertQb->setValue('sieve_ssl_mode', $insertQb->createNamedParameter($conf['sieveSslMode'] ?? ''));
-		$insertQb->execute();
+		$insertQb->executeStatement();
 		$id = $insertQb->getLastInsertId();
 
 		// set wildcard provisioning config for all provisioned accounts so we don't use state
@@ -185,7 +185,7 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 		$updateQb = $updateQb->update('mail_accounts')
 			->set('provisioning_id', $updateQb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
 			->where($updateQb->expr()->eq('provisioned', $updateQb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)));
-		$updateQb->execute();
+		$updateQb->executeStatement();
 
 		$this->config->deleteAppValue(
 			Application::APP_ID,

--- a/lib/Migration/Version1105Date20210922104324.php
+++ b/lib/Migration/Version1105Date20210922104324.php
@@ -30,7 +30,7 @@ class Version1105Date20210922104324 extends SimpleMigrationStep {
 			->andWhere($qb->expr()->isNull('provisionings.id'));
 
 		try {
-			$result = $qb->execute();
+			$result = $qb->executeQuery();
 		} catch (Exception $e) {
 			$this->logger->info('Migration to cleanup mail accounts without valid provisioning configuration failed', [
 				'exception' => $e
@@ -52,7 +52,7 @@ class Version1105Date20210922104324 extends SimpleMigrationStep {
 			->where($qb->expr()->in('id', $qb->createNamedParameter($accountIds, IQueryBuilder::PARAM_INT_ARRAY)));
 
 		try {
-			$qb->execute();
+			$qb->executeStatement();
 		} catch (Exception $e) {
 			$this->logger->info('Migration to cleanup mail accounts without valid provisioning configuration failed', [
 				'exception' => $e

--- a/lib/Migration/Version2010Date20221002201527.php
+++ b/lib/Migration/Version2010Date20221002201527.php
@@ -46,6 +46,6 @@ class Version2010Date20221002201527 extends SimpleMigrationStep {
 		$update = $this->connection->getQueryBuilder();
 		$update->update('mail_accounts')
 			->set('last_mailbox_sync', $update->createNamedParameter(0));
-		$update->execute();
+		$update->executeStatement();
 	}
 }

--- a/tests/Integration/Db/CollectedAddressMapperTest.php
+++ b/tests/Integration/Db/CollectedAddressMapperTest.php
@@ -80,7 +80,7 @@ class CollectedAddressMapperTest extends TestCase {
 		// Empty DB
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->mapper->getTableName());
-		$qb->execute();
+		$qb->executeStatement();
 
 		$stmt->execute([
 			$this->address1->getEmail(),

--- a/tests/Integration/Db/LocalAttachmentMapperTest.php
+++ b/tests/Integration/Db/LocalAttachmentMapperTest.php
@@ -74,7 +74,7 @@ class LocalAttachmentMapperTest extends TestCase {
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$qb = $this->db->getQueryBuilder();
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 
 		$attachment1 = LocalAttachment::fromParams([
 			'fileName' => 'slimes_in_the_mines.jpeg',

--- a/tests/Integration/Db/LocalMessageMapperTest.php
+++ b/tests/Integration/Db/LocalMessageMapperTest.php
@@ -71,7 +71,7 @@ class LocalMessageMapperTest extends TestCase {
 
 		$qb = $this->db->getQueryBuilder();
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 
 		$this->account = $this->createTestAccount();
 
@@ -140,7 +140,7 @@ class LocalMessageMapperTest extends TestCase {
 		// cleanup
 		$qb = $this->db->getQueryBuilder();
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 
 		$message = new LocalMessage();
 		$message->setType(LocalMessage::TYPE_OUTGOING);

--- a/tests/Integration/Db/MailboxMapperTest.php
+++ b/tests/Integration/Db/MailboxMapperTest.php
@@ -60,7 +60,7 @@ class MailboxMapperTest extends TestCase {
 		$qb = $this->db->getQueryBuilder();
 
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 	}
 
 	public function testFindAllNoData() {
@@ -89,7 +89,7 @@ class MailboxMapperTest extends TestCase {
 					'unseen' => $qb->createNamedParameter($i, IQueryBuilder::PARAM_INT),
 					'selectable' => $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL),
 				]);
-			$insert->execute();
+			$insert->executeStatement();
 		}
 
 		$result = $this->mapper->findAll($account);
@@ -123,7 +123,7 @@ class MailboxMapperTest extends TestCase {
 				'unseen' => $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 				'selectable' => $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL),
 			]);
-		$insert->execute();
+		$insert->executeStatement();
 
 		$result = $this->mapper->find($account, 'INBOX');
 

--- a/tests/Integration/Db/MessageMapperTest.php
+++ b/tests/Integration/Db/MessageMapperTest.php
@@ -62,7 +62,7 @@ class MessageMapperTest extends TestCase {
 		$qb = $this->db->getQueryBuilder();
 
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 	}
 
 	public function testResetInReplyTo() : void {
@@ -79,7 +79,7 @@ class MessageMapperTest extends TestCase {
 					'sent_at' => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
 					'in_reply_to' => $qb->createNamedParameter('<>')
 				]);
-			$insert->execute();
+			$insert->executeStatement();
 		}, range(1, 10));
 
 		array_map(function ($i) {
@@ -93,7 +93,7 @@ class MessageMapperTest extends TestCase {
 					'sent_at' => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
 					'in_reply_to' => $qb->createNamedParameter('<abc@dgf.com>')
 				]);
-			$insert->execute();
+			$insert->executeStatement();
 		}, range(11, 20));
 
 		$result = $this->mapper->resetInReplyTo();
@@ -107,7 +107,7 @@ class MessageMapperTest extends TestCase {
 				$qb2->expr()->like('in_reply_to', $qb2->createNamedParameter("<>", IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR)
 			);
 
-		$result = $select->execute();
+		$result = $select->executeQuery();
 		$rows = $result->fetchAll();
 
 		$this->assertEmpty($rows);
@@ -124,7 +124,7 @@ class MessageMapperTest extends TestCase {
 				'subject' => $qb->createNamedParameter('TEST'),
 				'sent_at' => $qb->createNamedParameter(time(), IQueryBuilder::PARAM_INT),
 			]);
-		$insert->execute();
+		$insert->executeStatement();
 
 		$this->mapper->resetPreviewDataFlag();
 

--- a/tests/Integration/Db/RecipientMapperTest.php
+++ b/tests/Integration/Db/RecipientMapperTest.php
@@ -73,11 +73,11 @@ class RecipientMapperTest extends TestCase {
 
 		$qb = $this->db->getQueryBuilder();
 		$delete = $qb->delete($this->mapper->getTableName());
-		$delete->execute();
+		$delete->executeStatement();
 
 		$qb2 = $this->db->getQueryBuilder();
 		$delete2 = $qb2->delete($this->localMessageMapper->getTableName());
-		$delete2->execute();
+		$delete2->executeStatement();
 
 		$this->account = $this->createTestAccount();
 

--- a/tests/Integration/Db/TrustedSenderMapperTest.php
+++ b/tests/Integration/Db/TrustedSenderMapperTest.php
@@ -70,7 +70,7 @@ class TrustedSenderMapperTest extends TestCase {
 				'user_id' => $qb->createNamedParameter($uid),
 				'email' => $qb->createNamedParameter('christoph@next.cloud'),
 			])
-			->execute();
+			->executeStatement();
 
 		$exists = $this->mapper->exists($uid, "christoph@next.cloud");
 
@@ -87,7 +87,7 @@ class TrustedSenderMapperTest extends TestCase {
 				'type' => $qb->createNamedParameter('domain'),
 
 			])
-			->execute();
+			->executeStatement();
 
 		$exists = $this->mapper->exists($uid, "christoph@next.cloud");
 
@@ -109,7 +109,7 @@ class TrustedSenderMapperTest extends TestCase {
 				$qb->expr()->eq('user_id', $qb->createNamedParameter($uid)),
 				$qb->expr()->eq('email', $qb->createNamedParameter("christoph@next.cloud"))
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		$this->assertCount(1, $rows);
@@ -124,14 +124,14 @@ class TrustedSenderMapperTest extends TestCase {
 				'email' => $qb->createNamedParameter('christoph@next.cloud'),
 				'type' => $qb->createNamedParameter('individual'),
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('mail_trusted_senders')
 			->values([
 				'user_id' => $qb->createNamedParameter($uid),
 				'email' => $qb->createNamedParameter('next.cloud'),
 				'type' => $qb->createNamedParameter('domain'),
 			])
-			->execute();
+			->executeStatement();
 
 		$this->mapper->remove(
 			$uid,
@@ -147,7 +147,7 @@ class TrustedSenderMapperTest extends TestCase {
 				$qb->expr()->eq('email', $qb->createNamedParameter("christoph@next.cloud")),
 				$qb->expr()->eq('type', $qb->createNamedParameter("individual"))
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		$this->assertEmpty($rows);
@@ -162,14 +162,14 @@ class TrustedSenderMapperTest extends TestCase {
 				'email' => $qb->createNamedParameter('christoph@next.cloud'),
 				'type' => $qb->createNamedParameter('individual'),
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('mail_trusted_senders')
 			->values([
 				'user_id' => $qb->createNamedParameter($uid),
 				'email' => $qb->createNamedParameter('next.cloud'),
 				'type' => $qb->createNamedParameter('domain'),
 			])
-			->execute();
+			->executeStatement();
 
 		$this->mapper->remove(
 			$uid,
@@ -185,7 +185,7 @@ class TrustedSenderMapperTest extends TestCase {
 				$qb->expr()->eq('email', $qb->createNamedParameter("next.cloud")),
 				$qb->expr()->eq('type', $qb->createNamedParameter("domain"))
 			);
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$rows = $result->fetchAll();
 		$result->closeCursor();
 		$this->assertEmpty($rows);


### PR DESCRIPTION
Fixes #6619 

Removed deprecated `IQueryBuilder::execute` and replaceed with `IQueryBuilder::executeQuery` and `IQueryBuilder::executeStatement`