### PR TITLE
refactor: replace literals with constants in column definition

### DIFF
--- a/lib/Migration/Version0100Date20180825194217.php
+++ b/lib/Migration/Version0100Date20180825194217.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Migration;
 
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -45,66 +46,66 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_accounts')) {
 			$table = $schema->createTable('mail_accounts');
-			$table->addColumn('id', 'integer', [
+			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$table->addColumn('user_id', 'string', [
+			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$table->addColumn('name', 'string', [
+			$table->addColumn('name', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);
-			$table->addColumn('email', 'string', [
+			$table->addColumn('email', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 				'default' => '',
 			]);
-			$table->addColumn('inbound_host', 'string', [
+			$table->addColumn('inbound_host', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->addColumn('inbound_port', 'string', [
+			$table->addColumn('inbound_port', Types::STRING, [
 				'notnull' => true,
 				'length' => 6,
 				'default' => '',
 			]);
-			$table->addColumn('inbound_ssl_mode', 'string', [
+			$table->addColumn('inbound_ssl_mode', Types::STRING, [
 				'notnull' => true,
 				'length' => 10,
 				'default' => '',
 			]);
-			$table->addColumn('inbound_user', 'string', [
+			$table->addColumn('inbound_user', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->addColumn('inbound_password', 'string', [
+			$table->addColumn('inbound_password', Types::STRING, [
 				'notnull' => true,
 				'length' => 2048,
 				'default' => '',
 			]);
-			$table->addColumn('outbound_host', 'string', [
+			$table->addColumn('outbound_host', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);
-			$table->addColumn('outbound_port', 'string', [
+			$table->addColumn('outbound_port', Types::STRING, [
 				'notnull' => false,
 				'length' => 6,
 			]);
-			$table->addColumn('outbound_ssl_mode', 'string', [
+			$table->addColumn('outbound_ssl_mode', Types::STRING, [
 				'notnull' => false,
 				'length' => 10,
 			]);
-			$table->addColumn('outbound_user', 'string', [
+			$table->addColumn('outbound_user', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);
-			$table->addColumn('outbound_password', 'string', [
+			$table->addColumn('outbound_password', Types::STRING, [
 				'notnull' => false,
 				'length' => 2048,
 			]);
@@ -114,21 +115,21 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_coll_addresses')) {
 			$table = $schema->createTable('mail_coll_addresses');
-			$table->addColumn('id', 'integer', [
+			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$table->addColumn('user_id', 'string', [
+			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->addColumn('email', 'string', [
+			$table->addColumn('email', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 			]);
-			$table->addColumn('display_name', 'string', [
+			$table->addColumn('display_name', Types::STRING, [
 				'notnull' => false,
 				'length' => 255,
 			]);
@@ -139,21 +140,21 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_aliases')) {
 			$table = $schema->createTable('mail_aliases');
-			$table->addColumn('id', 'integer', [
+			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$table->addColumn('account_id', 'integer', [
+			$table->addColumn('account_id', Types::INTEGER, [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,
 			]);
-			$table->addColumn('name', 'string', [
+			$table->addColumn('name', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);
-			$table->addColumn('alias', 'string', [
+			$table->addColumn('alias', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 			]);
@@ -162,22 +163,22 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_attachments')) {
 			$table = $schema->createTable('mail_attachments');
-			$table->addColumn('id', 'integer', [
+			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$table->addColumn('user_id', 'string', [
+			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$table->addColumn('file_name', 'string', [
+			$table->addColumn('file_name', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 				'default' => '',
 			]);
-			$table->addColumn('created_at', 'integer', [
+			$table->addColumn('created_at', Types::INTEGER, [
 				'notnull' => true,
 				'length' => 4,
 				'default' => 0,

--- a/lib/Migration/Version0130Date20190408134101.php
+++ b/lib/Migration/Version0130Date20190408134101.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -42,7 +43,7 @@ class Version0130Date20190408134101 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('signature', 'text', [
+		$accountsTable->addColumn('signature', Types::TEXT, [
 			'notnull' => false,
 			'length' => 1024,
 			'default' => '',

--- a/lib/Migration/Version0156Date20190828140357.php
+++ b/lib/Migration/Version0156Date20190828140357.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -42,40 +43,40 @@ class Version0156Date20190828140357 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('last_mailbox_sync', 'integer', [
+		$accountsTable->addColumn('last_mailbox_sync', Types::INTEGER, [
 			'default' => 0,
 		]);
 
 		$mailboxTable = $schema->createTable('mail_mailboxes');
-		$mailboxTable->addColumn('id', 'string', [
+		$mailboxTable->addColumn('id', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('account_id', 'integer', [
+		$mailboxTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('sync_token', 'string', [
+		$mailboxTable->addColumn('sync_token', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('attributes', 'string', [
+		$mailboxTable->addColumn('attributes', Types::STRING, [
 			'length' => 255,
 			'default' => '[]',
 		]);
-		$mailboxTable->addColumn('delimiter', 'string', [
+		$mailboxTable->addColumn('delimiter', Types::STRING, [
 			'notnull' => true,
 			'length' => 1,
 		]);
-		$mailboxTable->addColumn('messages', 'integer', [
+		$mailboxTable->addColumn('messages', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('unseen', 'integer', [
+		$mailboxTable->addColumn('unseen', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('selectable', 'boolean', [
+		$mailboxTable->addColumn('selectable', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => true,
 		]);

--- a/lib/Migration/Version0161Date20190902103701.php
+++ b/lib/Migration/Version0161Date20190902103701.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -50,40 +51,40 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$mailboxTable = $schema->createTable('mail_mailboxes');
-		$mailboxTable->addColumn('id', 'integer', [
+		$mailboxTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$mailboxTable->addColumn('name', 'string', [
+		$mailboxTable->addColumn('name', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('account_id', 'integer', [
+		$mailboxTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('sync_token', 'string', [
+		$mailboxTable->addColumn('sync_token', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('attributes', 'string', [
+		$mailboxTable->addColumn('attributes', Types::STRING, [
 			'length' => 255,
 			'default' => '[]',
 		]);
-		$mailboxTable->addColumn('delimiter', 'string', [
+		$mailboxTable->addColumn('delimiter', Types::STRING, [
 			'notnull' => true,
 			'length' => 1,
 		]);
-		$mailboxTable->addColumn('messages', 'integer', [
+		$mailboxTable->addColumn('messages', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('unseen', 'integer', [
+		$mailboxTable->addColumn('unseen', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('selectable', 'boolean', [
+		$mailboxTable->addColumn('selectable', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => true,
 		]);

--- a/lib/Migration/Version0161Date20190902114635.php
+++ b/lib/Migration/Version0161Date20190902114635.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -51,7 +52,7 @@ class Version0161Date20190902114635 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$mailboxTable = $schema->getTable('mail_mailboxes');
-		$mailboxTable->addColumn('special_use', 'string', [
+		$mailboxTable->addColumn('special_use', Types::STRING, [
 			'length' => 255,
 			'default' => '[]',
 		]);

--- a/lib/Migration/Version0180Date20190927124207.php
+++ b/lib/Migration/Version0180Date20190927124207.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -43,7 +44,7 @@ class Version0180Date20190927124207 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('editor_mode', 'string', [
+		$accountsTable->addColumn('editor_mode', Types::STRING, [
 			'notnull' => true,
 			'length' => 64,
 			'default' => 'plaintext',

--- a/lib/Migration/Version0190Date20191118160843.php
+++ b/lib/Migration/Version0190Date20191118160843.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -43,7 +44,7 @@ class Version0190Date20191118160843 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('provisioned', 'boolean', [
+		$accountsTable->addColumn('provisioned', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);

--- a/lib/Migration/Version0210Date20191212144925.php
+++ b/lib/Migration/Version0210Date20191212144925.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -42,7 +43,7 @@ class Version0210Date20191212144925 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('order', 'integer', [
+		$accountsTable->addColumn('order', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 			'default' => 1,

--- a/lib/Migration/Version1020Date20191002091035.php
+++ b/lib/Migration/Version1020Date20191002091035.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\IDBConnection;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
@@ -30,65 +31,65 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$messagesTable = $schema->createTable('mail_messages');
-		$messagesTable->addColumn('id', 'integer', [
+		$messagesTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$messagesTable->addColumn('uid', 'integer', [
+		$messagesTable->addColumn('uid', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$messagesTable->addColumn('message_id', 'string', [
+		$messagesTable->addColumn('message_id', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$messagesTable->addColumn('mailbox_id', 'string', [
+		$messagesTable->addColumn('mailbox_id', Types::STRING, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$messagesTable->addColumn('subject', 'string', [
+		$messagesTable->addColumn('subject', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 			'default' => '',
 		]);
-		$messagesTable->addColumn('sent_at', 'integer', [
+		$messagesTable->addColumn('sent_at', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$messagesTable->addColumn('flag_answered', 'boolean', [
+		$messagesTable->addColumn('flag_answered', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_deleted', 'boolean', [
+		$messagesTable->addColumn('flag_deleted', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_draft', 'boolean', [
+		$messagesTable->addColumn('flag_draft', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_flagged', 'boolean', [
+		$messagesTable->addColumn('flag_flagged', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_seen', 'boolean', [
+		$messagesTable->addColumn('flag_seen', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_forwarded', 'boolean', [
+		$messagesTable->addColumn('flag_forwarded', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_junk', 'boolean', [
+		$messagesTable->addColumn('flag_junk', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_notjunk', 'boolean', [
+		$messagesTable->addColumn('flag_notjunk', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('updated_at', 'integer', [
+		$messagesTable->addColumn('updated_at', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
@@ -101,24 +102,24 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$messagesTable->addIndex(['sent_at'], 'mail_message_sent_idx');
 
 		$recipientsTable = $schema->createTable('mail_recipients');
-		$recipientsTable->addColumn('id', 'integer', [
+		$recipientsTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$recipientsTable->addColumn('message_id', 'integer', [
+		$recipientsTable->addColumn('message_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$recipientsTable->addColumn('type', 'integer', [
+		$recipientsTable->addColumn('type', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 2,
 		]);
-		$recipientsTable->addColumn('label', 'string', [
+		$recipientsTable->addColumn('label', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$recipientsTable->addColumn('email', 'string', [
+		$recipientsTable->addColumn('email', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
@@ -127,27 +128,27 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$recipientsTable->addIndex(['email'], 'mail_recipient_email_idx');
 
 		$mailboxTable = $schema->getTable('mail_mailboxes');
-		$mailboxTable->addColumn('sync_new_lock', 'integer', [
+		$mailboxTable->addColumn('sync_new_lock', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('sync_changed_lock', 'integer', [
+		$mailboxTable->addColumn('sync_changed_lock', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('sync_vanished_lock', 'integer', [
+		$mailboxTable->addColumn('sync_vanished_lock', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
-		$mailboxTable->addColumn('sync_new_token', 'string', [
+		$mailboxTable->addColumn('sync_new_token', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('sync_changed_token', 'string', [
+		$mailboxTable->addColumn('sync_changed_token', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$mailboxTable->addColumn('sync_vanished_token', 'string', [
+		$mailboxTable->addColumn('sync_vanished_token', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);

--- a/lib/Migration/Version1020Date20200206134751.php
+++ b/lib/Migration/Version1020Date20200206134751.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -22,14 +23,14 @@ class Version1020Date20200206134751 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$messagesTable = $schema->getTable('mail_messages');
-		$messagesTable->addColumn('structure_analyzed', 'boolean', [
+		$messagesTable->addColumn('structure_analyzed', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_attachments', 'boolean', [
+		$messagesTable->addColumn('flag_attachments', Types::BOOLEAN, [
 			'notnull' => false,
 		]);
-		$messagesTable->addColumn('preview_text', 'string', [
+		$messagesTable->addColumn('preview_text', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);

--- a/lib/Migration/Version1040Date20200422142920.php
+++ b/lib/Migration/Version1040Date20200422142920.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -22,81 +23,81 @@ class Version1040Date20200422142920 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$messagesTable = $schema->createTable('mail_messages');
-		$messagesTable->addColumn('id', 'integer', [
+		$messagesTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$messagesTable->addColumn('uid', 'integer', [
+		$messagesTable->addColumn('uid', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$messagesTable->addColumn('message_id', 'string', [
+		$messagesTable->addColumn('message_id', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$messagesTable->addColumn('mailbox_id', 'integer', [
+		$messagesTable->addColumn('mailbox_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$messagesTable->addColumn('subject', 'string', [
+		$messagesTable->addColumn('subject', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 			'default' => '',
 		]);
-		$messagesTable->addColumn('sent_at', 'integer', [
+		$messagesTable->addColumn('sent_at', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$messagesTable->addColumn('flag_answered', 'boolean', [
+		$messagesTable->addColumn('flag_answered', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_deleted', 'boolean', [
+		$messagesTable->addColumn('flag_deleted', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_draft', 'boolean', [
+		$messagesTable->addColumn('flag_draft', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_flagged', 'boolean', [
+		$messagesTable->addColumn('flag_flagged', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_seen', 'boolean', [
+		$messagesTable->addColumn('flag_seen', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_forwarded', 'boolean', [
+		$messagesTable->addColumn('flag_forwarded', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_junk', 'boolean', [
+		$messagesTable->addColumn('flag_junk', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_notjunk', 'boolean', [
+		$messagesTable->addColumn('flag_notjunk', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_attachments', 'boolean', [
+		$messagesTable->addColumn('flag_attachments', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('flag_important', 'boolean', [
+		$messagesTable->addColumn('flag_important', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('structure_analyzed', 'boolean', [
+		$messagesTable->addColumn('structure_analyzed', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$messagesTable->addColumn('preview_text', 'string', [
+		$messagesTable->addColumn('preview_text', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 		]);
-		$messagesTable->addColumn('updated_at', 'integer', [
+		$messagesTable->addColumn('updated_at', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);

--- a/lib/Migration/Version1040Date20200506111214.php
+++ b/lib/Migration/Version1040Date20200506111214.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -22,59 +23,59 @@ class Version1040Date20200506111214 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->createTable('mail_classifiers');
-		$table->addColumn('id', 'integer', [
+		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$table->addColumn('account_id', 'integer', [
+		$table->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 20,
 		]);
-		$table->addColumn('type', 'string', [
+		$table->addColumn('type', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$table->addColumn('estimator', 'string', [
+		$table->addColumn('estimator', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$table->addColumn('app_version', 'string', [
+		$table->addColumn('app_version', Types::STRING, [
 			'notnull' => true,
 			'length' => 31,
 		]);
-		$table->addColumn('training_set_size', 'integer', [
+		$table->addColumn('training_set_size', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$table->addColumn('validation_set_size', 'integer', [
+		$table->addColumn('validation_set_size', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$table->addColumn('recall_important', 'decimal', [
+		$table->addColumn('recall_important', Types::DECIMAL, [
 			'notnull' => true,
 			'precision' => 10,
 			'scale' => 5,
 		]);
-		$table->addColumn('precision_important', 'decimal', [
+		$table->addColumn('precision_important', Types::DECIMAL, [
 			'notnull' => true,
 			'precision' => 10,
 			'scale' => 5,
 		]);
-		$table->addColumn('f1_score_important', 'decimal', [
+		$table->addColumn('f1_score_important', Types::DECIMAL, [
 			'notnull' => true,
 			'precision' => 10,
 			'scale' => 5,
 		]);
-		$table->addColumn('duration', 'integer', [
+		$table->addColumn('duration', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$table->addColumn('active', 'boolean', [
+		$table->addColumn('active', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$table->addColumn('created_at', 'integer', [
+		$table->addColumn('created_at', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);

--- a/lib/Migration/Version1040Date20200515080614.php
+++ b/lib/Migration/Version1040Date20200515080614.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -23,7 +24,7 @@ class Version1040Date20200515080614 extends SimpleMigrationStep {
 
 		$accountsTable = $schema->getTable('mail_accounts');
 
-		$accountsTable->addColumn('show_subscribed_only', 'boolean', [
+		$accountsTable->addColumn('show_subscribed_only', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);

--- a/lib/Migration/Version1050Date20200624101359.php
+++ b/lib/Migration/Version1050Date20200624101359.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
@@ -22,14 +23,14 @@ class Version1050Date20200624101359 extends SimpleMigrationStep {
 
 		$messagesTable = $schema->getTable('mail_messages');
 		$messagesTable->getColumn('message_id')->setLength(1023);
-		$messagesTable->addColumn('references', 'text', [
+		$messagesTable->addColumn('references', Types::TEXT, [
 			'notnull' => false,
 		]);
-		$messagesTable->addColumn('in_reply_to', 'string', [
+		$messagesTable->addColumn('in_reply_to', Types::STRING, [
 			'notnull' => false,
 			'length' => 1023,
 		]);
-		$messagesTable->addColumn('thread_root_id', 'string', [
+		$messagesTable->addColumn('thread_root_id', Types::STRING, [
 			'notnull' => false,
 			'length' => 1023,
 		]);

--- a/lib/Migration/Version1050Date20200831124954.php
+++ b/lib/Migration/Version1050Date20200831124954.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,7 +22,7 @@ class Version1050Date20200831124954 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('personal_namespace', 'string', [
+		$accountsTable->addColumn('personal_namespace', Types::STRING, [
 			'notnull' => false,
 		]);
 

--- a/lib/Migration/Version1050Date20200921141700.php
+++ b/lib/Migration/Version1050Date20200921141700.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,7 +22,7 @@ class Version1050Date20200921141700 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_attachments');
-		$accountsTable->addColumn('mime_type', 'string', [
+		$accountsTable->addColumn('mime_type', Types::STRING, [
 			'notnull' => false,
 			'length' => 255, // RFC 4288 defines max size
 		]);

--- a/lib/Migration/Version1050Date20200923180030.php
+++ b/lib/Migration/Version1050Date20200923180030.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -22,7 +23,7 @@ class Version1050Date20200923180030 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_mailboxes');
-		$accountsTable->addColumn('sync_in_background', 'boolean', [
+		$accountsTable->addColumn('sync_in_background', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);

--- a/lib/Migration/Version1060Date20201015084952.php
+++ b/lib/Migration/Version1060Date20201015084952.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -29,17 +30,17 @@ class Version1060Date20201015084952 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('drafts_mailbox_id', 'integer', [
+		$accountsTable->addColumn('drafts_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
 			'length' => 20,
 		]);
-		$accountsTable->addColumn('sent_mailbox_id', 'integer', [
+		$accountsTable->addColumn('sent_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
 			'length' => 20,
 		]);
-		$accountsTable->addColumn('trash_mailbox_id', 'integer', [
+		$accountsTable->addColumn('trash_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
 			'length' => 20,

--- a/lib/Migration/Version1080Date20201119084820.php
+++ b/lib/Migration/Version1080Date20201119084820.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,16 +22,16 @@ class Version1080Date20201119084820 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->createTable('mail_trusted_senders');
-		$table->addColumn('id', 'integer', [
+		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$table->addColumn('email', 'string', [
+		$table->addColumn('email', Types::STRING, [
 			'notnull' => true,
 			'length' => 255,
 		]);
-		$table->addColumn('user_id', 'string', [
+		$table->addColumn('user_id', Types::STRING, [
 			'notnull' => true,
 			'length' => 64,
 		]);

--- a/lib/Migration/Version1080Date20210108093802.php
+++ b/lib/Migration/Version1080Date20210108093802.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,7 +22,7 @@ class Version1080Date20210108093802 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$messagesTable = $schema->getTable('mail_messages');
-		$messagesTable->addColumn('flag_mdnsent', 'boolean', [
+		$messagesTable->addColumn('flag_mdnsent', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);

--- a/lib/Migration/Version1090Date20210127160127.php
+++ b/lib/Migration/Version1090Date20210127160127.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,31 +22,31 @@ class Version1090Date20210127160127 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('mail_accounts');
-		$table->addColumn('sieve_enabled', 'boolean', [
+		$table->addColumn('sieve_enabled', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$table->addColumn('sieve_host', 'string', [
+		$table->addColumn('sieve_host', Types::STRING, [
 			'notnull' => false,
 			'length' => 64,
 			'default' => null,
 		]);
-		$table->addColumn('sieve_port', 'string', [
+		$table->addColumn('sieve_port', Types::STRING, [
 			'notnull' => false,
 			'length' => 6,
 			'default' => null,
 		]);
-		$table->addColumn('sieve_ssl_mode', 'string', [
+		$table->addColumn('sieve_ssl_mode', Types::STRING, [
 			'notnull' => false,
 			'length' => 10,
 			'default' => null,
 		]);
-		$table->addColumn('sieve_user', 'string', [
+		$table->addColumn('sieve_user', Types::STRING, [
 			'notnull' => false,
 			'length' => 64,
 			'default' => null,
 		]);
-		$table->addColumn('sieve_password', 'string', [
+		$table->addColumn('sieve_password', Types::STRING, [
 			'notnull' => false,
 			'length' => 2048,
 			'default' => null,

--- a/lib/Migration/Version1090Date20210216154409.php
+++ b/lib/Migration/Version1090Date20210216154409.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,7 +22,7 @@ class Version1090Date20210216154409 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('mail_trusted_senders');
-		$table->addColumn('type', 'string', [
+		$table->addColumn('type', Types::STRING, [
 			'notnull' => true,
 			'default' => 'individual',
 		]);

--- a/lib/Migration/Version1100Date20210304143008.php
+++ b/lib/Migration/Version1100Date20210304143008.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -24,29 +25,29 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_tags')) {
 			$tagsTable = $schema->createTable('mail_tags');
-			$tagsTable->addColumn('id', 'integer', [
+			$tagsTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$tagsTable->addColumn('user_id', 'string', [
+			$tagsTable->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$tagsTable->addColumn('imap_label', 'string', [
+			$tagsTable->addColumn('imap_label', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 			]);
-			$tagsTable->addColumn('display_name', 'string', [
+			$tagsTable->addColumn('display_name', Types::STRING, [
 				'notnull' => true,
 				'length' => 128,
 			]);
-			$tagsTable->addColumn('color', 'string', [
+			$tagsTable->addColumn('color', Types::STRING, [
 				'notnull' => false,
 				'length' => 9,
 				'default' => "#fff"
 			]);
-			$tagsTable->addColumn('is_default_tag', 'boolean', [
+			$tagsTable->addColumn('is_default_tag', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false
 			]);
@@ -63,16 +64,16 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_message_tags')) {
 			$tagsMessageTable = $schema->createTable('mail_message_tags');
-			$tagsMessageTable->addColumn('id', 'integer', [
+			$tagsMessageTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$tagsMessageTable->addColumn('imap_message_id', 'string', [
+			$tagsMessageTable->addColumn('imap_message_id', Types::STRING, [
 				'notnull' => true,
 				'length' => 1023,
 			]);
-			$tagsMessageTable->addColumn('tag_id', 'integer', [
+			$tagsMessageTable->addColumn('tag_id', Types::INTEGER, [
 				'notnull' => true,
 				'length' => 4,
 			]);

--- a/lib/Migration/Version1100Date20210317164707.php
+++ b/lib/Migration/Version1100Date20210317164707.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -21,7 +22,7 @@ class Version1100Date20210317164707 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$table = $schema->getTable('mail_aliases');
-		$table->addColumn('signature', 'text', [
+		$table->addColumn('signature', Types::TEXT, [
 			'notnull' => false,
 			'length' => 1024,
 			'default' => '',

--- a/lib/Migration/Version1100Date20210419080523.php
+++ b/lib/Migration/Version1100Date20210419080523.php
@@ -9,6 +9,7 @@ use JsonException;
 use OCA\Mail\AppInfo\Application;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
@@ -42,76 +43,76 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_provisionings')) {
 			$provisioningTable = $schema->createTable('mail_provisionings');
-			$provisioningTable->addColumn('id', 'integer', [
+			$provisioningTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
 				'length' => 4,
 			]);
-			$provisioningTable->addColumn('provisioning_domain', 'string', [
+			$provisioningTable->addColumn('provisioning_domain', Types::STRING, [
 				'notnull' => true,
 				'length' => 63,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('email_template', 'string', [
+			$provisioningTable->addColumn('email_template', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('imap_user', 'string', [
+			$provisioningTable->addColumn('imap_user', Types::STRING, [
 				'notnull' => true,
 				'length' => 128,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('imap_host', 'string', [
+			$provisioningTable->addColumn('imap_host', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('imap_port', 'smallint', [
+			$provisioningTable->addColumn('imap_port', Types::SMALLINT, [
 				'notnull' => true,
 				'unsigned' => true,
 			]);
-			$provisioningTable->addColumn('imap_ssl_mode', 'string', [
+			$provisioningTable->addColumn('imap_ssl_mode', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('smtp_user', 'string', [
+			$provisioningTable->addColumn('smtp_user', Types::STRING, [
 				'notnull' => true,
 				'length' => 128,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('smtp_host', 'string', [
+			$provisioningTable->addColumn('smtp_host', Types::STRING, [
 				'notnull' => true,
 				'length' => 255,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('smtp_port', 'smallint', [
+			$provisioningTable->addColumn('smtp_port', Types::SMALLINT, [
 				'notnull' => true,
 				'unsigned' => true,
 			]);
-			$provisioningTable->addColumn('smtp_ssl_mode', 'string', [
+			$provisioningTable->addColumn('smtp_ssl_mode', Types::STRING, [
 				'notnull' => true,
 				'length' => 64,
 				'default' => '',
 			]);
-			$provisioningTable->addColumn('sieve_enabled', 'boolean', [
+			$provisioningTable->addColumn('sieve_enabled', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);
-			$provisioningTable->addColumn('sieve_user', 'string', [
+			$provisioningTable->addColumn('sieve_user', Types::STRING, [
 				'notnull' => false,
 				'length' => 128,
 			]);
-			$provisioningTable->addColumn('sieve_host', 'string', [
+			$provisioningTable->addColumn('sieve_host', Types::STRING, [
 				'notnull' => false,
 				'length' => 128,
 			]);
-			$provisioningTable->addColumn('sieve_port', 'smallint', [
+			$provisioningTable->addColumn('sieve_port', Types::SMALLINT, [
 				'notnull' => false,
 				'unsigned' => true,
 			]);
-			$provisioningTable->addColumn('sieve_ssl_mode', 'string', [
+			$provisioningTable->addColumn('sieve_ssl_mode', Types::STRING, [
 				'notnull' => false,
 				'length' => 64,
 			]);
@@ -125,7 +126,7 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 		}
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('provisioning_id', 'integer', [
+		$accountsTable->addColumn('provisioning_id', Types::INTEGER, [
 			'length' => 4,
 			'notnull' => false,
 		]);

--- a/lib/Migration/Version1100Date20210421113423.php
+++ b/lib/Migration/Version1100Date20210421113423.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,7 +45,7 @@ class Version1100Date20210421113423 extends SimpleMigrationStep {
 
 		$accountsTable = $schema->getTable('mail_accounts');
 
-		$accountsTable->addColumn('signature_above_quote', 'boolean', [
+		$accountsTable->addColumn('signature_above_quote', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);

--- a/lib/Migration/Version1101Date20210616141806.php
+++ b/lib/Migration/Version1101Date20210616141806.php
@@ -7,6 +7,7 @@ namespace OCA\Mail\Migration;
 use Closure;
 use Doctrine\DBAL\Schema\SchemaException;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -19,11 +20,11 @@ class Version1101Date20210616141806 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$provisioningTable = $schema->getTable('mail_provisionings');
-		$provisioningTable->addColumn('ldap_aliases_provisioning', 'boolean', [
+		$provisioningTable->addColumn('ldap_aliases_provisioning', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false
 		]);
-		$provisioningTable->addColumn('ldap_aliases_attribute', 'string', [
+		$provisioningTable->addColumn('ldap_aliases_attribute', Types::STRING, [
 			'notnull' => false,
 			'length' => 255,
 			'default' => '',

--- a/lib/Migration/Version1120Date20220223094709.php
+++ b/lib/Migration/Version1120Date20220223094709.php
@@ -29,6 +29,7 @@ namespace OCA\Mail\Migration;
 use Closure;
 use Doctrine\DBAL\Schema\Table;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -43,40 +44,40 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$localMessageTable = $schema->createTable('mail_local_messages');
-		$localMessageTable->addColumn('id', 'integer', [
+		$localMessageTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$localMessageTable->addColumn('type', 'integer', [
+		$localMessageTable->addColumn('type', Types::INTEGER, [
 			'notnull' => true,
 			'unsigned' => true,
 			'length' => 1,
 		]);
-		$localMessageTable->addColumn('account_id', 'integer', [
+		$localMessageTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
 			'length' => 4,
 		]);
-		$localMessageTable->addColumn('alias_id', 'integer', [
+		$localMessageTable->addColumn('alias_id', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
-		$localMessageTable->addColumn('send_at', 'integer', [
+		$localMessageTable->addColumn('send_at', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4
 		]);
-		$localMessageTable->addColumn('subject', 'text', [
+		$localMessageTable->addColumn('subject', Types::TEXT, [
 			'notnull' => true,
 			'length' => 255
 		]);
-		$localMessageTable->addColumn('body', 'text', [
+		$localMessageTable->addColumn('body', Types::TEXT, [
 			'notnull' => true
 		]);
-		$localMessageTable->addColumn('html', 'boolean', [
+		$localMessageTable->addColumn('html', Types::BOOLEAN, [
 			'notnull' => false,
 			'default' => false,
 		]);
-		$localMessageTable->addColumn('in_reply_to_message_id', 'text', [
+		$localMessageTable->addColumn('in_reply_to_message_id', Types::TEXT, [
 			'notnull' => false,
 			'length' => 1023,
 		]);
@@ -84,7 +85,7 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 
 		/** @var Table $recipientsTable */
 		$recipientsTable = $schema->getTable('mail_recipients');
-		$recipientsTable->addColumn('local_message_id', 'integer', [
+		$recipientsTable->addColumn('local_message_id', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);
@@ -94,7 +95,7 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 		$recipientsTable->addForeignKeyConstraint($localMessageTable, ['local_message_id'], ['id'], ['onDelete' => 'CASCADE']);
 
 		$attachmentsTable = $schema->getTable('mail_attachments');
-		$attachmentsTable->addColumn('local_message_id', 'integer', [
+		$attachmentsTable->addColumn('local_message_id', Types::INTEGER, [
 			'notnull' => false,
 			'length' => 4,
 		]);

--- a/lib/Migration/Version1124Date20220531094751.php
+++ b/lib/Migration/Version1124Date20220531094751.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -42,7 +43,7 @@ class Version1124Date20220531094751 extends SimpleMigrationStep {
 
 		$localMessageTable = $schema->getTable('mail_local_messages');
 		if (!$localMessageTable->hasColumn('failed')) {
-			$localMessageTable->addColumn('failed', 'boolean', [
+			$localMessageTable->addColumn('failed', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);

--- a/lib/Migration/Version1124Date20220601084530.php
+++ b/lib/Migration/Version1124Date20220601084530.php
@@ -25,6 +25,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -41,7 +42,7 @@ class Version1124Date20220601084530 extends SimpleMigrationStep {
 
 		$localMessageTable = $schema->getTable('mail_local_messages');
 		if (!$localMessageTable->hasColumn('editor_body')) {
-			$localMessageTable->addColumn('editor_body', 'text', [
+			$localMessageTable->addColumn('editor_body', Types::TEXT, [
 				'notnull' => false,
 			]);
 		}

--- a/lib/Migration/Version2000Date20220908130842.php
+++ b/lib/Migration/Version2000Date20220908130842.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,19 +45,19 @@ class Version2000Date20220908130842 extends SimpleMigrationStep {
 
 		$messagesTable = $schema->getTable('mail_messages');
 		if (!$messagesTable->hasColumn('imip_message')) {
-			$messagesTable->addColumn('imip_message', 'boolean', [
+			$messagesTable->addColumn('imip_message', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);
 		}
 		if (!$messagesTable->hasColumn('imip_processed')) {
-			$messagesTable->addColumn('imip_processed', 'boolean', [
+			$messagesTable->addColumn('imip_processed', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);
 		}
 		if (!$messagesTable->hasColumn('imip_error')) {
-			$messagesTable->addColumn('imip_error', 'boolean', [
+			$messagesTable->addColumn('imip_error', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);

--- a/lib/Migration/Version2010Date20221002201527.php
+++ b/lib/Migration/Version2010Date20221002201527.php
@@ -6,6 +6,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -29,7 +30,7 @@ class Version2010Date20221002201527 extends SimpleMigrationStep {
 		$schema = $schemaClosure();
 
 		$accountsTable = $schema->getTable('mail_accounts');
-		$accountsTable->addColumn('archive_mailbox_id', 'integer', [
+		$accountsTable->addColumn('archive_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
 			'length' => 20,

--- a/lib/Migration/Version2300Date20230127093733.php
+++ b/lib/Migration/Version2300Date20230127093733.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,13 +45,13 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 
 		$outboxTable = $schema->getTable('mail_local_messages');
 		if (!$outboxTable->hasColumn('smime_sign')) {
-			$outboxTable->addColumn('smime_sign', 'boolean', [
+			$outboxTable->addColumn('smime_sign', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);
 		}
 		if (!$outboxTable->hasColumn('smime_certificate_id')) {
-			$outboxTable->addColumn('smime_certificate_id', 'integer', [
+			$outboxTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
 				'length' => 4,
 			]);
@@ -58,7 +59,7 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 
 		$accountsTable = $schema->getTable('mail_accounts');
 		if (!$accountsTable->hasColumn('smime_certificate_id')) {
-			$accountsTable->addColumn('smime_certificate_id', 'integer', [
+			$accountsTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
 				'length' => 4,
 			]);
@@ -66,7 +67,7 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 
 		$aliasesTable = $schema->getTable('mail_aliases');
 		if (!$aliasesTable->hasColumn('smime_certificate_id')) {
-			$aliasesTable->addColumn('smime_certificate_id', 'integer', [
+			$aliasesTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
 				'length' => 4,
 			]);

--- a/lib/Migration/Version2300Date20230214104736.php
+++ b/lib/Migration/Version2300Date20230214104736.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,7 +45,7 @@ class Version2300Date20230214104736 extends SimpleMigrationStep {
 
 		$messageTable = $schema->getTable('mail_messages');
 		if (!$messageTable->hasColumn('encrypted')) {
-			$messageTable->addColumn('encrypted', 'boolean', [
+			$messageTable->addColumn('encrypted', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);

--- a/lib/Migration/Version2300Date20230221170502.php
+++ b/lib/Migration/Version2300Date20230221170502.php
@@ -28,6 +28,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -44,7 +45,7 @@ class Version2300Date20230221170502 extends SimpleMigrationStep {
 
 		$outboxTable = $schema->getTable('mail_local_messages');
 		if (!$outboxTable->hasColumn('smime_encrypt')) {
-			$outboxTable->addColumn('smime_encrypt', 'boolean', [
+			$outboxTable->addColumn('smime_encrypt', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);

--- a/lib/Migration/Version3000Date20230301152454.php
+++ b/lib/Migration/Version3000Date20230301152454.php
@@ -26,6 +26,7 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -42,7 +43,7 @@ class Version3000Date20230301152454 extends SimpleMigrationStep {
 
 		$mailboxesTable = $schema->getTable('mail_mailboxes');
 		if (!$mailboxesTable->hasColumn('shared')) {
-			$mailboxesTable->addColumn('shared', 'boolean', [
+			$mailboxesTable->addColumn('shared', Types::BOOLEAN, [
 				'notnull' => false,
 				'default' => false,
 			]);


### PR DESCRIPTION
Fixes: #6620

Replaced literals with constants, e.g. `\OCP\DB\Types::STRING` instead of `'string'` in migrations