### PR TITLE
fix(imap): Chunk UIDs by string length

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -25,6 +25,30 @@ declare(strict_types=1);
 
 namespace OCA\Mail;
 
+use Horde_Imap_Client_Ids;
+use function array_slice;
+use function array_splice;
+use function max;
+use function strlen;
+
 function array_flat_map(callable $map, array $data): array {
 	return array_merge([], ...array_map($map, $data));
+}
+
+/**
+ * @param int[] $uids
+ * @return Horde_Imap_Client_Ids[]
+ */
+function chunk_uid_sequence(array $uids, int $bytes): array {
+	$chunks = [];
+	while (!empty($uids)) {
+		$take = count($uids);
+		while (strlen((new Horde_Imap_Client_Ids(array_slice($uids, 0, $take)))->tostring) >= $bytes) {
+			$take = (int)($take * 0.75);
+		}
+		$chunks[] = new Horde_Imap_Client_Ids(
+			array_splice($uids, 0, max($take, 1))
+		);
+	}
+	return $chunks;
 }

--- a/tests/Unit/IMAP/Sync/SynchronizerTest.php
+++ b/tests/Unit/IMAP/Sync/SynchronizerTest.php
@@ -103,7 +103,7 @@ class SynchronizerTest extends TestCase {
 		$request->method('getToken')
 			->willReturn('123456');
 		$request->method('getUids')
-			->willReturn(range(1, 30000, 1));
+			->willReturn(range(1, 8000, 2)); // 19444 bytes
 		$capabilities = $this->createMock(Horde_Imap_Client_Data_Capability::class);
 		$imapClient->expects(self::once())
 			->method('__get')


### PR DESCRIPTION
IMAP sync requires an IMAP FETCH command that fetches specific messages. If the full mailbox has to be sync'ed, that can be a long list of UIDs.

The synchronizer had already broken UIDs into chunks by a maximum chunk size. Yet the chunk size does not correlate with the resulting IMAP FETCH command length.

An advanced chunk function calculates the UID range string and decreases the chunk size until the UIDs produce a string that fits the given byte size.

Fixes https://github.com/nextcloud/mail/issues/6038