### PR TITLE
Display email address 

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -52,6 +52,7 @@
 				class="app-content-list-item-star junk-icon-style"
 				:data-starred="envelope.flags.$junk ? 'true' : 'false'"
 				@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
+
 			<router-link
 				:to="route"
 				event=""
@@ -60,6 +61,9 @@
 				@click.native.prevent="$emit('toggle-expand', $event)">
 				<div class="sender">
 					{{ envelope.from && envelope.from[0] ? envelope.from[0].label : '' }}
+					<p class="sender__email">
+						{{ envelope.from && envelope.from[0] ? envelope.from[0].email : '' }}
+					</p>
 				</div>
 				<div v-if="hasChangedSubject" class="subline">
 					{{ cleanSubject }}
@@ -582,6 +586,10 @@ export default {
 <style lang="scss" scoped>
 	.sender {
 		margin-left: 8px;
+
+		&__email{
+			color: var(--color-text-maxcontrast);
+		}
 	}
 
 	.right {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/40746210/234261164-778c70a0-4ca5-48b4-87bd-98bba4a05e7c.png)
After:
![image](https://user-images.githubusercontent.com/40746210/234260888-8dfb7cd1-00cf-4670-a4b1-a5c363cf6a4e.png)

Fixes https://github.com/nextcloud/mail/issues/8379