### PR TITLE
ci: Only run integration tests if unit tests pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
         fail_ci_if_error: true
 
   integration-tests:
+      needs: unit-tests
       runs-on: ubuntu-latest
       strategy:
           matrix:

--- a/tests/Unit/Service/AccountServiceTest.php
+++ b/tests/Unit/Service/AccountServiceTest.php
@@ -73,10 +73,6 @@ class AccountServiceTest extends TestCase {
 		$this->account2 = $this->createMock(MailAccount::class);
 	}
 
-	public function testFails(): void {
-		self::assertTrue(false);
-	}
-
 	public function testFindByUserId() {
 		$this->mapper->expects($this->once())
 			->method('findByUserId')

--- a/tests/Unit/Service/AccountServiceTest.php
+++ b/tests/Unit/Service/AccountServiceTest.php
@@ -73,6 +73,10 @@ class AccountServiceTest extends TestCase {
 		$this->account2 = $this->createMock(MailAccount::class);
 	}
 
+	public function testFails(): void {
+		self::assertTrue(false);
+	}
+
 	public function testFindByUserId() {
 		$this->mapper->expects($this->once())
 			->method('findByUserId')


### PR DESCRIPTION
Unit tests are fast. Integration tests are heavy. We can align the two to stop PRs that won't get merged anyway.

Caveat: serializes test execution.

Ref https://docs.github.com/en/actions/using-workflows/about-workflows#creating-dependent-jobs