### PR TITLE
feat: Easy unsubscribe from lists with mailto unsubscribe header

### DIFF
--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -70,6 +70,7 @@ class ImapMessageFetcher {
 	private string $rawReferences = '';
 	private string $dispositionNotificationTo = '';
 	private ?string $unsubscribeUrl = null;
+	private ?string $unsubscribeMailto = null;
 
 	public function __construct(int $uid,
 		string $mailbox,
@@ -250,6 +251,7 @@ class ImapMessageFetcher {
 			$this->rawReferences,
 			$this->dispositionNotificationTo,
 			$this->unsubscribeUrl,
+			$this->unsubscribeMailto,
 			$envelope->in_reply_to,
 			$isEncrypted,
 			$isSigned,
@@ -518,6 +520,10 @@ class ImapMessageFetcher {
 			foreach ($headers as $header) {
 				if (str_starts_with($header->url, 'http')) {
 					$this->unsubscribeUrl = $header->url;
+					break;
+				}
+				if (str_starts_with($header->url, 'mailto')) {
+					$this->unsubscribeMailto = $header->url;
 					break;
 				}
 			}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -77,6 +77,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	private string $rawReferences;
 	private string $dispositionNotificationTo;
 	private ?string $unsubscribeUrl;
+	private ?string $unsubscribeMailto;
 	private string $rawInReplyTo;
 	private bool $isEncrypted;
 	private bool $isSigned;
@@ -102,6 +103,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		string $rawReferences,
 		string $dispositionNotificationTo,
 		?string $unsubscribeUrl,
+		?string $unsubscribeMailto,
 		string $rawInReplyTo,
 		bool $isEncrypted,
 		bool $isSigned,
@@ -127,6 +129,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$this->rawReferences = $rawReferences;
 		$this->dispositionNotificationTo = $dispositionNotificationTo;
 		$this->unsubscribeUrl = $unsubscribeUrl;
+		$this->unsubscribeMailto = $unsubscribeMailto;
 		$this->rawInReplyTo = $rawInReplyTo;
 		$this->isEncrypted = $isEncrypted;
 		$this->isSigned = $isSigned;
@@ -309,6 +312,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'hasHtmlBody' => $this->hasHtmlMessage,
 			'dispositionNotificationTo' => $this->getDispositionNotificationTo(),
 			'unsubscribeUrl' => $this->unsubscribeUrl,
+			'unsubscribeMailto' => $this->unsubscribeMailto,
 			'scheduling' => $this->scheduling,
 		];
 	}

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -23,8 +23,8 @@
   -->
 
 <template>
-	<AppSettingsDialog :open="true"
-		id="app-settings-dialog"
+	<AppSettingsDialog id="app-settings-dialog"
+		:open="true"
 		:show-navigation="true">
 		<AppSettingsSection
 			id="account-settings"

--- a/src/components/ConfirmationModal.vue
+++ b/src/components/ConfirmationModal.vue
@@ -25,12 +25,13 @@
 			<h2>{{ title }}</h2>
 			<slot />
 			<div class="confirm-modal__buttons">
-				<NcButton type="tertiary" @click="cancel">
+				<NcButton type="tertiary" :disabled="disabled" @click="cancel">
 					{{ t('mail', 'Cancel') }}
 				</NcButton>
 				<NcButton :href="confirmUrl"
 					:rel="confirmUrl ? 'noopener noreferrer' : false"
 					:target="confirmUrl ? '_blank' : false"
+					:disabled="disabled"
 					type="primary"
 					@click="confirm">
 					{{ confirmText }}
@@ -63,6 +64,10 @@ export default {
 		confirmUrl: {
 			type: String,
 			default: undefined,
+		},
+		disabled: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	methods: {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -217,6 +217,10 @@ export default {
 		})
 	},
 	convertComposerMessageToOutbox(state, { message }) {
+		if (!state.newMessage) {
+			// If the message is dispatched in the background there is no newMessage data in state
+			return
+		}
 		Vue.set(state.newMessage, 'type', 'outbox')
 		Vue.set(state.newMessage.data, 'id', message.id)
 	},

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
@@ -85,6 +87,7 @@ class IMAPMessageTest extends TestCase {
 			'',
 			'disposition',
 			null,
+			null,
 			'',
 			false,
 			false,
@@ -123,6 +126,7 @@ class IMAPMessageTest extends TestCase {
 			'',
 			'disposition',
 			null,
+			null,
 			'',
 			false,
 			false,
@@ -153,6 +157,7 @@ class IMAPMessageTest extends TestCase {
 				'important' => true,
 			],
 			'unsubscribeUrl' => null,
+			'unsubscribeMailto' => null,
 			'hasHtmlBody' => true,
 			'dispositionNotificationTo' => 'disposition',
 			'scheduling' => [],


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/5387

Sibling of https://github.com/nextcloud/mail/pull/8395. Now lists that only send a `mailto` link are supported too. If both HTTP and mailto are sent we take the HTTP.

Ref https://github.com/nextcloud/mail/issues/5387

| Default | Confirmation | While unsubscribing |
|--------|--------|--------|
| ![Bildschirmfoto vom 2023-05-02 11-45-06](https://user-images.githubusercontent.com/1374172/235635199-49cb1a08-1e9d-4eea-963d-be95b4a50459.png) | ![Bildschirmfoto vom 2023-05-02 11-45-17](https://user-images.githubusercontent.com/1374172/235635254-2d9a9e8d-df8a-4acc-97ea-a9ed6c964379.png) | ![Bildschirmfoto vom 2023-05-02 11-48-45](https://user-images.githubusercontent.com/1374172/235635300-429c42bd-d16b-4dab-8d65-5e2ec0fb5d57.png) | 

## How to test

1) Open a message with a mailto unsubscribe header (e.g. Linkedin message)
2) See and click the *Unsubscribe* button
3) Click *Send unsubscribe email*
4) Wait a moment
5) See message in *Sent* mailbox