### PR TITLE
fix(imap): Only fetch mailbox STATUS once

### DIFF
--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -46,12 +46,16 @@ class Folder {
 
 	private ?string $myAcls;
 
-	public function __construct(int $accountId, Horde_Imap_Client_Mailbox $mailbox, array $attributes, ?string $delimiter) {
+	public function __construct(int $accountId,
+		Horde_Imap_Client_Mailbox $mailbox,
+		array $attributes,
+		?string $delimiter,
+		array $status) {
 		$this->accountId = $accountId;
 		$this->mailbox = $mailbox;
 		$this->attributes = $attributes;
 		$this->delimiter = $delimiter;
-		$this->status = [];
+		$this->status = $status;
 		$this->specialUse = [];
 		$this->myAcls = null;
 	}

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -115,7 +115,7 @@ class MailboxSync {
 
 			try {
 				$folders = $this->folderMapper->getFolders($account, $client);
-				$this->folderMapper->getFoldersStatus($folders, $client);
+				$this->folderMapper->fetchFolderAcls($folders, $client);
 			} catch (Horde_Imap_Client_Exception $e) {
 				throw new ServiceException(
 					sprintf("IMAP error synchronizing account %d: %s", $account->getId(), $e->getMessage()),

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -155,7 +155,7 @@ class MailManager implements IMailManager {
 		$client = $this->imapClientFactory->getClient($account);
 		try {
 			$folder = $this->folderMapper->createFolder($client, $account, $name);
-			$this->folderMapper->getFoldersStatus([$folder], $client);
+			$this->folderMapper->fetchFolderAcls([$folder], $client);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				"Could not get mailbox status: " . $e->getMessage(),

--- a/tests/FolderTest.php
+++ b/tests/FolderTest.php
@@ -40,7 +40,7 @@ class FolderTest extends TestCase {
 		$this->accountId = 15;
 		$this->mailbox = $this->createMock(Horde_Imap_Client_Mailbox::class);
 
-		$this->folder = new Folder($this->accountId, $this->mailbox, $attributes, $delimiter);
+		$this->folder = new Folder($this->accountId, $this->mailbox, $attributes, $delimiter, []);
 	}
 
 	public function testGetMailbox() {

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -144,7 +144,7 @@ class MailManagerTest extends TestCase {
 			->with($this->equalTo($client), $this->equalTo($account), $this->equalTo('new'))
 			->willReturn($folder);
 		$this->folderMapper->expects($this->once())
-			->method('getFoldersStatus')
+			->method('fetchFolderAcls')
 			->with($this->equalTo([$folder]));
 		$this->folderMapper->expects($this->once())
 			->method('detectFolderSpecialUse')


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/8445

## How to test
0) Add an account, look up its `id`
1) Run `UPDATE oc_mail_accounts SET last_mailbox_sync=0 WHERE id=<id>`
2) Run `echo "" > data/horde_imap.log` to clear the IMAP log
3) Run `NC_debug=true php occ mail:account:sync <id>`
4) Run `grep "STATUS Drafts" data/horde_imap.log`

### `main`

```
C: 11 STATUS Drafts (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Drafts (MESSAGES 9 RECENT 0 UIDNEXT 57 UIDVALIDITY 1393528617 UNSEEN 1)
C: 53 STATUS Drafts (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Drafts (MESSAGES 9 RECENT 0 UIDNEXT 57 UIDVALIDITY 1393528617 UNSEEN 1)
```

horde_imap.log is 2492B.
The client sent 112 commands.

### `fix/imap/only-fetch-mailbox-status-once`

```
C: 11 STATUS Drafts (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Drafts (MESSAGES 9 RECENT 0 UIDNEXT 57 UIDVALIDITY 1393528617 UNSEEN 1)
```

horde_imap.log is 2484B.
The client sent 70 commands.