### PR TITLE
fix(db): Run read-write-update of mailboxes in transaction

### DIFF
--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -44,6 +44,7 @@ use OCA\Mail\IMAP\MailboxStats;
 use OCA\Mail\IMAP\MailboxSync;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 
@@ -68,6 +69,8 @@ class MailboxSyncTest extends TestCase {
 
 	/** @var IEventDispatcher|MockObject */
 	private $dispatcher;
+	/** @var IDBConnection|(IDBConnection&MockObject)|MockObject */
+	private IDBConnection|MockObject $dbConnection;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -78,6 +81,7 @@ class MailboxSyncTest extends TestCase {
 		$this->imapClientFactory = $this->createMock(IMAPClientFactory::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->dbConnection = $this->createMock(IDBConnection::class);
 
 		$this->sync = new MailboxSync(
 			$this->mailboxMapper,
@@ -85,7 +89,8 @@ class MailboxSyncTest extends TestCase {
 			$this->mailAccountMapper,
 			$this->imapClientFactory,
 			$this->timeFactory,
-			$this->dispatcher
+			$this->dispatcher,
+			$this->dbConnection,
 		);
 	}
 


### PR DESCRIPTION
New mailboxes are INSERTed, existing ones are UPDATEd. Two sync processes at the same time could try to INSERT the same mailbox. A transaction prevents that.

This is only an issue on clustered databases.