### PR TITLE
fix: Check strict cookies for image proxy

### DIFF
--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -36,6 +36,7 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
+use function file_get_contents;
 
 class ProxyController extends Controller {
 	private IURLGenerator $urlGenerator;
@@ -104,6 +105,12 @@ class ProxyController extends Controller {
 	public function proxy(string $src): ProxyDownloadResponse {
 		// close the session to allow parallel downloads
 		$this->session->close();
+
+		// If strict cookies are set it means we come from the same domain so no open redirect
+		if (!$this->request->passesStrictCookieCheck()) {
+			$content = file_get_contents(__DIR__ . '/../../img/blocked-image.png');
+			return new ProxyDownloadResponse($content, $src, 'application/octet-stream');
+		}
 
 		$client = $this->clientService->newClient();
 		try {

--- a/tests/Unit/Controller/ProxyControllerTest.php
+++ b/tests/Unit/Controller/ProxyControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  *
@@ -156,11 +158,41 @@ class ProxyControllerTest extends TestCase {
 		$this->controller->redirect('ftps://example.com');
 	}
 
-	public function testProxy() {
+	public function testProxyWithoutCookies(): void {
+		$src = 'http://example.com';
+		$content = '🐵🐵🐵';
+		$this->session->expects($this->once())
+			->method('close');
+		$client = $this->getMockBuilder(IClient::class)->getMock();
+		$this->clientService->expects(self::never())
+			->method('newClient')
+			->willReturn($client);
+		$unexpected = new ProxyDownloadResponse(
+			$content,
+			$src,
+			'application/octet-stream'
+		);
+		$this->controller = new ProxyController(
+			$this->appName,
+			$this->request,
+			$this->urlGenerator,
+			$this->session,
+			$this->clientService,
+			$this->logger
+		);
+
+		$response = $this->controller->proxy($src);
+
+		$this->assertNotEquals($unexpected, $response);
+	}
+
+	public function testProxy(): void {
 		$src = 'http://example.com';
 		$httpResponse = $this->createMock(IResponse::class);
 		$content = '🐵🐵🐵';
-
+		$this->request->expects(self::once())
+			->method('passesStrictCookieCheck')
+			->willReturn(true);
 		$this->session->expects($this->once())
 			->method('close');
 		$client = $this->getMockBuilder(IClient::class)->getMock();


### PR DESCRIPTION
https://github.com/nextcloud/mail/pull/2153's little sibling. It makes sense to check for the cookie existence here too.

## How to test

1) Set up an account
2) Open a HTML message with external images
3) Click *Show images* and *Show images temporarily*

main: images show
here: images show