### PR TITLE
test(unit): Fix tests without assertions

### DIFF
--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -153,6 +153,7 @@ class FolderMapperTest extends TestCase {
 			->with('capability')
 			->willReturn($capability);
 		$capability
+			->expects(self::once())
 			->method('query')
 			->with('ACL')
 			->willReturn(false);

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -554,16 +554,10 @@ class MailTransmissionTest extends TestCase {
 			'type' => Recipient::TYPE_TO
 		]);
 		$message->setRecipients([$to]);
-
-		$alias = Alias::fromParams([
-			'id' => 1,
-			'accountId' => 10,
-			'name' => 'Emily',
-			'alias' => 'Emmerlie'
-		]);
-
 		$replyMessage = new DbMessage();
 		$replyMessage->setMessageId('abc');
+		$this->messageMapper->expects(self::once())
+			->method('save');
 
 		$this->transmission->saveLocalDraft(new Account($mailAccount), $message);
 	}


### PR DESCRIPTION
Allows tests to pass again locally in dev mode where they stop at the first warning or error.

## How to test

1) `composer i`
2) `composer run test:unit:dev`

main: execution stops at warning
here: all tests pass