### PR TITLE
perf(imap): Reduce number of STATUS commands for background mailbox sync

### DIFF
--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -151,7 +151,7 @@ class Mailbox extends Entity implements JsonSerializable {
 	 * @return MailboxStats
 	 */
 	public function getStats(): MailboxStats {
-		return new MailboxStats($this->getMessages(), $this->getUnseen(), $this->getMyAcls());
+		return new MailboxStats($this->getMessages(), $this->getUnseen());
 	}
 
 	#[ReturnTypeWillChange]

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -38,7 +38,7 @@ class Folder {
 	/** @var string */
 	private $delimiter;
 
-	/** @var array */
+	/** @var null|array */
 	private $status;
 
 	/** @var string[] */
@@ -50,7 +50,7 @@ class Folder {
 		Horde_Imap_Client_Mailbox $mailbox,
 		array $attributes,
 		?string $delimiter,
-		array $status) {
+		?array $status) {
 		$this->accountId = $accountId;
 		$this->mailbox = $mailbox;
 		$this->attributes = $attributes;
@@ -76,9 +76,9 @@ class Folder {
 	}
 
 	/**
-	 * @return array
+	 * @return null|array
 	 */
-	public function getStatus(): array {
+	public function getStatus(): ?array {
 		return $this->status;
 	}
 

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -59,28 +59,25 @@ class FolderMapper {
 			'delimiter' => true,
 			'attributes' => true,
 			'special_use' => true,
-			'status' => Horde_Imap_Client::STATUS_ALL,
 		]);
-
-		return array_filter(array_map(static function (array $mailbox) use ($account) {
+		$toPersist = array_filter($mailboxes, function (array $mailbox) {
 			$attributes = array_flip(array_map('strtolower', $mailbox['attributes']));
 			if (isset($attributes['\\nonexistent'])) {
 				// Ignore mailbox that does not exist, similar to \Horde_Imap_Client::MBOX_SUBSCRIBED_EXISTS mode
-				return null;
+				return false;
 			}
-			if (in_array($mailbox['mailbox']->utf8, self::DOVECOT_SIEVE_FOLDERS, true)) {
-				// This is a special folder that must not be shown
-				return null;
-			}
-
+			// This is a special folder that must not be shown
+			return !in_array($mailbox['mailbox']->utf8, self::DOVECOT_SIEVE_FOLDERS, true);
+		});
+		return array_map(static function (array $mailbox) use ($account) {
 			return new Folder(
 				$account->getId(),
 				$mailbox['mailbox'],
 				$mailbox['attributes'],
 				$mailbox['delimiter'],
-				$mailbox['status'],
+				null,
 			);
-		}, $mailboxes));
+		}, $toPersist);
 	}
 
 	public function createFolder(Horde_Imap_Client_Socket $client,
@@ -137,21 +134,20 @@ class FolderMapper {
 	 *
 	 * @throws Horde_Imap_Client_Exception
 	 *
-	 * @return MailboxStats
+	 * @return MailboxStats[]
 	 */
 	public function getFoldersStatusAsObject(Horde_Imap_Client_Socket $client,
-		string $mailbox): MailboxStats {
-		$status = $client->status($mailbox);
-		$acls = null;
-		if ($client->capability->query('ACL')) {
-			$acls = (string)$client->getMyACLRights($mailbox);
-		}
+		array $mailboxes): array {
+		$multiStatus = $client->status($mailboxes);
 
-		return new MailboxStats(
-			$status['messages'],
-			$status['unseen'],
-			$acls
-		);
+		$statuses = [];
+		foreach ($multiStatus as $mailbox => $status) {
+			$statuses[$mailbox] = new MailboxStats(
+				$status['messages'],
+				$status['unseen'],
+			);
+		}
+		return $statuses;
 	}
 
 	/**

--- a/lib/IMAP/MailboxStats.php
+++ b/lib/IMAP/MailboxStats.php
@@ -32,12 +32,10 @@ use ReturnTypeWillChange;
 class MailboxStats implements JsonSerializable {
 	private int $total;
 	private int $unread;
-	private ?string $myAcls;
 
-	public function __construct(int $total, int $unread, ?string $myAcls) {
+	public function __construct(int $total, int $unread) {
 		$this->total = $total;
 		$this->unread = $unread;
-		$this->myAcls = $myAcls;
 	}
 
 	public function getTotal(): int {
@@ -48,16 +46,11 @@ class MailboxStats implements JsonSerializable {
 		return $this->unread;
 	}
 
-	public function getMyAcls(): ?string {
-		return $this->myAcls;
-	}
-
 	#[ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [
 			'total' => $this->total,
 			'unread' => $this->unread,
-			'myAcls' => $this->myAcls,
 		];
 	}
 }

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -43,8 +43,11 @@ use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use function array_combine;
 use function array_map;
+use function array_reduce;
+use function array_slice;
 use function in_array;
 use function json_encode;
+use function shuffle;
 use function sprintf;
 use function str_starts_with;
 
@@ -103,14 +106,16 @@ class MailboxSync {
 				$namespaces = $client->getNamespaces([], [
 					'ob_return' => true,
 				]);
+				$personalNamespace = $this->getPersonalNamespace($namespaces);
 				$account->getMailAccount()->setPersonalNamespace(
-					$this->getPersonalNamespace($namespaces)
+					$personalNamespace
 				);
 			} catch (Horde_Imap_Client_Exception $e) {
 				$logger->debug('Getting namespaces for account ' . $account->getId() . ' failed: ' . $e->getMessage(), [
 					'exception' => $e,
 				]);
 				$namespaces = null;
+				$personalNamespace = null;
 			}
 
 			try {
@@ -125,7 +130,7 @@ class MailboxSync {
 			}
 			$this->folderMapper->detectFolderSpecialUse($folders);
 
-			$this->atomic(function () use ($account, $folders, $namespaces) {
+			$mailboxes = $this->atomic(function () use ($account, $folders, $namespaces) {
 				$old = $this->mailboxMapper->findAll($account);
 				$indexedOld = array_combine(
 					array_map(static function (Mailbox $mb) {
@@ -134,8 +139,10 @@ class MailboxSync {
 					$old
 				);
 
-				$this->persist($account, $folders, $indexedOld, $namespaces);
+				return $this->persist($account, $folders, $indexedOld, $namespaces);
 			}, $this->dbConnection);
+
+			$this->syncMailboxStatus($mailboxes, $personalNamespace, $client);
 
 			$this->dispatcher->dispatchTyped(
 				new MailboxesSynchronizedEvent($account)
@@ -156,7 +163,7 @@ class MailboxSync {
 	public function syncStats(Account $account, Mailbox $mailbox): void {
 		$client = $this->imapClientFactory->getClient($account);
 		try {
-			$stats = $this->folderMapper->getFoldersStatusAsObject($client, $mailbox->getName());
+			$stats = $this->folderMapper->getFoldersStatusAsObject($client, [$mailbox->getName()])[$mailbox->getName()];
 		} catch (Horde_Imap_Client_Exception $e) {
 			$id = $mailbox->getId();
 			throw new ServiceException(
@@ -173,19 +180,23 @@ class MailboxSync {
 		$this->mailboxMapper->update($mailbox);
 	}
 
+	/**
+	 * @return Mailbox[]
+	 */
 	private function persist(Account $account,
 		array $folders,
 		array $existing,
-		?Horde_Imap_Client_Namespace_List $namespaces): void {
+		?Horde_Imap_Client_Namespace_List $namespaces): array {
+		$mailboxes = [];
 		foreach ($folders as $folder) {
 			if (isset($existing[$folder->getMailbox()])) {
-				$this->updateMailboxFromFolder(
+				$mailboxes[] = $this->updateMailboxFromFolder(
 					$folder,
 					$existing[$folder->getMailbox()],
 					$namespaces,
 				);
 			} else {
-				$this->createMailboxFromFolder(
+				$mailboxes[] = $this->createMailboxFromFolder(
 					$account,
 					$folder,
 					$namespaces,
@@ -201,44 +212,49 @@ class MailboxSync {
 
 		$account->getMailAccount()->setLastMailboxSync($this->timeFactory->getTime());
 		$this->mailAccountMapper->update($account->getMailAccount());
+
+		return $mailboxes;
 	}
 
 	private function getPersonalNamespace(Horde_Imap_Client_Namespace_List $namespaces): ?string {
 		foreach ($namespaces as $namespace) {
 			/** @var Horde_Imap_Client_Data_Namespace $namespace */
 			if ($namespace->type === Horde_Imap_Client::NS_PERSONAL) {
-				return $namespace->name;
+				return $namespace->name !== "" ? $namespace->name : null;
 			}
-			$namespace->name;
 		}
 		return null;
 	}
 
-	private function updateMailboxFromFolder(Folder $folder, Mailbox $mailbox, ?Horde_Imap_Client_Namespace_List $namespaces): void {
+	private function updateMailboxFromFolder(Folder $folder, Mailbox $mailbox, ?Horde_Imap_Client_Namespace_List $namespaces): Mailbox {
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages($folder->getStatus()['messages'] ?? 0);
-		$mailbox->setUnseen($folder->getStatus()['unseen'] ?? 0);
+		$status = $folder->getStatus();
+		if ($status !== null) {
+			$mailbox->setMessages($status['messages'] ?? 0);
+			$mailbox->setUnseen($status['unseen'] ?? 0);
+		}
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$mailbox->setMyAcls($folder->getMyAcls());
 		$mailbox->setShared($this->isMailboxShared($namespaces, $mailbox));
-		$this->mailboxMapper->update($mailbox);
+		return $this->mailboxMapper->update($mailbox);
 	}
 
-	private function createMailboxFromFolder(Account $account, Folder $folder, ?Horde_Imap_Client_Namespace_List $namespaces): void {
+	private function createMailboxFromFolder(Account $account, Folder $folder, ?Horde_Imap_Client_Namespace_List $namespaces): Mailbox {
 		$mailbox = new Mailbox();
 		$mailbox->setName($folder->getMailbox());
 		$mailbox->setAccountId($account->getId());
 		$mailbox->setAttributes(json_encode($folder->getAttributes()));
 		$mailbox->setDelimiter($folder->getDelimiter());
-		$mailbox->setMessages($folder->getStatus()['messages'] ?? 0);
-		$mailbox->setUnseen($folder->getStatus()['unseen'] ?? 0);
+		$status = $folder->getStatus();
+		$mailbox->setMessages($status['messages'] ?? 0);
+		$mailbox->setUnseen($status['unseen'] ?? 0);
 		$mailbox->setSelectable(!in_array('\noselect', $folder->getAttributes()));
 		$mailbox->setSpecialUse(json_encode($folder->getSpecialUse()));
 		$mailbox->setMyAcls($folder->getMyAcls());
 		$mailbox->setShared($this->isMailboxShared($namespaces, $mailbox));
-		$this->mailboxMapper->insert($mailbox);
+		return $this->mailboxMapper->insert($mailbox);
 	}
 
 	private function isMailboxShared(?Horde_Imap_Client_Namespace_List $namespaces, Mailbox $mailbox): bool {
@@ -249,5 +265,42 @@ class MailboxSync {
 			}
 		}
 		return false;
+	}
+
+	private function syncMailboxStatus(mixed $mailboxes, ?string $personalNamespace, \Horde_Imap_Client_Socket $client): void {
+		/** @var array{0: Mailbox[], 1: Mailbox[]} */
+		[$sync, $doNotSync] = array_reduce($mailboxes, function (array $carry, Mailbox $mailbox) use ($personalNamespace): array {
+			/** @var array{0: Mailbox[], 1: Mailbox[]} $carry */
+			[$sync, $doNotSync] = $carry;
+			$inboxName = $personalNamespace === null ? "INBOX" : ($personalNamespace . $mailbox->getDelimiter() . "INBOX");
+			if ($inboxName === $mailbox->getName() || $mailbox->getSyncInBackground()) {
+				return [
+					array_merge($sync, [$mailbox]),
+					$doNotSync,
+				];
+			}
+			return [
+				$sync,
+				array_merge($doNotSync, [$mailbox]),
+			];
+		}, [[], []]);
+
+		// Synchronize the mailboxes selected for sync and keep the rest updated occasionally
+		shuffle($doNotSync);
+		/** @var Mailbox[] $syncStatus */
+		$syncStatus = [...$sync, ...array_slice($doNotSync, 0, 5)];
+		$statuses = $this->folderMapper->getFoldersStatusAsObject($client, array_map(function (Mailbox $mailbox) {
+			return $mailbox->getName();
+		}, $syncStatus));
+		foreach ($syncStatus as $mailbox) {
+			$status = $statuses[$mailbox->getName()];
+			$mailbox->setMessages($status->getTotal());
+			$mailbox->setUnseen($status->getUnread());
+		}
+		$this->atomic(function () use ($syncStatus) {
+			foreach ($syncStatus as $mailbox) {
+				$this->mailboxMapper->update($mailbox);
+			}
+		}, $this->dbConnection);
 	}
 }


### PR DESCRIPTION
Before this patch, the mailbox STATUS is fetched for *all* mailboxes. This is fine for accounts with a handful of mailboxes. Yet there are users who organize their email into hundreds of mailboxes and at some point this leads to excessive STATUS commands for every mailbox list sync.

This patch reduces the number of STATUS commands by only running them for the INBOX, mailboxes marked for background sync and 5 additional mailboxes.

If a user has hundreds of mailboxes and marks them all for background sync, we'll still have a performance problem. But otherwise the sync should be faster now, and mailboxes not marked for sync still get an occasional update about the unread/total messages stats.

This is a follow-up to https://github.com/nextcloud/mail/pull/8449

## How to test

0) Check out latest `main`
1) Add an account with at least 6 mailboxes
2) Comment out https://github.com/nextcloud/mail/blob/1115beaf2bf8b674fd0a6b50ee499605b7455dc6/lib/Command/SyncAccount.php#L104
3) Empty data/horde_imap.log
4) Run ``NC_debug=true php occ mail:account:sync <account id> --force``
5) Run ``cat data/horde_imap.log | wc -l`` and write down the number of lines reported
6) Check out ``perf/imap/reduce-mailbox-status-background-sync``
7) Empty data/horde_imap.log
8) Run ``NC_debug=true php occ mail:account:sync <account id> --force``
9) Run ``cat data/horde_imap.log | wc -l`` and write down the number of lines reported

For my test account I get 116 lines of IMAP communication on main and 67 lines with the patch.