### PR TITLE
chore: dynamic property creation is deprecated

### DIFF
--- a/tests/Unit/Controller/DraftsControllerTest.php
+++ b/tests/Unit/Controller/DraftsControllerTest.php
@@ -42,6 +42,14 @@ use OCP\DB\Exception;
 use OCP\IRequest;
 
 class DraftsControllerTest extends TestCase {
+	private string $appName;
+	private DraftsService $service;
+	private string $userId;
+	private IRequest $request;
+	private ITimeFactory $timeFactory;
+	private AccountService $accountService;
+	private DraftsController $controller;
+
 	protected function setUp(): void {
 		parent::setUp();
 

--- a/tests/Unit/Job/PreviewEnhancementProcessingJobTest.php
+++ b/tests/Unit/Job/PreviewEnhancementProcessingJobTest.php
@@ -57,6 +57,7 @@ class PreviewEnhancementProcessingJobTest extends TestCase {
 
 	/** @var IJobList|IJobList&MockObject|MockObject  */
 	private $jobList;
+	private PreviewEnhancementProcessingJob $job;
 
 	/** @var int[]  */
 	private static $argument;

--- a/tests/Unit/Service/DraftsServiceTest.php
+++ b/tests/Unit/Service/DraftsServiceTest.php
@@ -47,6 +47,7 @@ use OCA\Mail\Service\OutboxService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\Exception;
+use OCP\EventDispatcher\IEventDispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -74,7 +75,7 @@ class DraftsServiceTest extends TestCase {
 
 	/** @var IMailManager|MockObject */
 	private $mailManager;
-
+	private IEventDispatcher $eventDispatcher;
 	/** @var AccountService|MockObject */
 	private $accountService;
 

--- a/tests/Unit/Service/IMipServiceTest.php
+++ b/tests/Unit/Service/IMipServiceTest.php
@@ -75,6 +75,7 @@ class IMipServiceTest extends TestCase {
 
 	/** @var AccountService|MockObject */
 	private $accountService;
+	private IManager $calendarManager;
 
 	/** @var MailManager|MockObject  */
 	private $mailManager;


### PR DESCRIPTION
Fix a couple of deprecation warnings when running composer run test:unit:dev

```
PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Unit\Controller\DraftsControllerTest::$userId is deprecated in /var/www/html/apps-extra/mail/tests/Unit/Controller/DraftsControllerTest.php on line 55
PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Unit\Controller\DraftsControllerTest::$appName is deprecated in /var/www/html/apps-extra/mail/tests/Unit/Controller/DraftsControllerTest.php on line 53
PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Unit\Controller\DraftsControllerTest::$userId is deprecated in /var/www/html/apps-extra/mail/tests/Unit/Controller/DraftsControllerTest.php on line 55

```