### PR TITLE
feat: Allow a configurable background sync interval

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -42,6 +42,14 @@ Depending on your mail host, it may be necessary to increase your IMAP and/or SM
 'app.mail.sieve.timeout' => 2
 ```
 
+### Background sync interval
+
+Configure how often Mail keeps users' mailboxes updated in the background in seconds. Defaults to 3600.
+
+```php
+'app.mail.background-sync-interval' => 7200,
+```
+
 ### Use php-mail for sending mail
 You can use the php-mail function to send mails. This is needed for some webhosters (1&1 (1und1)):
 ```php

--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -35,9 +35,11 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
+use function max;
 use function sprintf;
 
 class SyncJob extends TimedJob {
@@ -54,7 +56,8 @@ class SyncJob extends TimedJob {
 								MailboxSync $mailboxSync,
 								ImapToDbSynchronizer $syncService,
 								LoggerInterface $logger,
-								IJobList $jobList) {
+								IJobList $jobList,
+								IConfig $config) {
 		parent::__construct($time);
 
 		$this->userManager = $userManager;
@@ -64,7 +67,12 @@ class SyncJob extends TimedJob {
 		$this->logger = $logger;
 		$this->jobList = $jobList;
 
-		$this->setInterval(3600);
+		$this->setInterval(
+			max(
+				5 * 60,
+				$config->getSystemValueInt('app.mail.background-sync-interval', 3600)
+			),
+		);
 		$this->setTimeSensitivity(self::TIME_SENSITIVE);
 	}
 


### PR DESCRIPTION
Admins of instances with accounts that are provisioned but rarely used may wish to reduce the number of background syncs.