### PR TITLE
fix: Allow dynamic autoloading for classes added during upgrade

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,6 +1,6 @@
 [package]
 before_cmds = [
-	"composer install --no-dev -a",
+	"composer install --no-dev -o",
 	"npm install --deps",
 	"npm run build",
 ]


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/8146

Partly reverts https://github.com/nextcloud/mail/pull/8020

Authoritative class maps do not get refreshed at upgrade, when new app code is added. This means any classes that didn't exist in the previous version are not loaded.