### PR TITLE
Fix warnings because of missing aria-label on NcActionButtons without text

### DIFF
--- a/src/components/ComposerSessionIndicator.vue
+++ b/src/components/ComposerSessionIndicator.vue
@@ -34,14 +34,19 @@
 
 		<div class="composer-session__actions">
 			<NcActions>
-				<NcActionButton :disabled="disabled" @click.stop="onShowComposer">
+				<NcActionButton
+					:aria-label="t('mail', 'Expand composer')"
+					:disabled="disabled"
+					@click.stop="onShowComposer">
 					<template #icon>
 						<ArrowExpandIcon :size="20" />
 					</template>
 				</NcActionButton>
 			</NcActions>
 			<NcActions>
-				<NcActionButton :disabled="disabled" @click.stop="onClose">
+				<NcActionButton :aria-label="t('mail', 'Close composer')"
+					:disabled="disabled"
+					@click.stop="onClose">
 					<template #icon>
 						<CloseIcon :size="20" />
 					</template>

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -46,7 +46,7 @@
 		</EmptyContent>
 		<template v-else>
 			<NcActions class="minimize-button">
-				<NcActionButton @click="onMinimize">
+				<NcActionButton :aria-label="t('mail', 'Minimize composer')" @click="onMinimize">
 					<template #icon>
 						<MinimizeIcon :size="20" />
 					</template>


### PR DESCRIPTION
Fix: #8247 