### PR TITLE
Fix: OAuth refreshed access token was saved in the wrong field

### DIFF
--- a/lib/Integration/GoogleIntegration.php
+++ b/lib/Integration/GoogleIntegration.php
@@ -175,8 +175,7 @@ class GoogleIntegration {
 
 		$data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
 		$encryptedAccessToken = $this->crypto->encrypt($data['access_token']);
-		$account->getMailAccount()->setInboundPassword($encryptedAccessToken);
-		$account->getMailAccount()->setOutboundPassword($encryptedAccessToken);
+		$account->getMailAccount()->setOauthAccessToken($encryptedAccessToken);
 		$account->getMailAccount()->setOauthTokenTtl($this->timeFactory->getTime() + $data['expires_in']);
 
 		return $account;


### PR DESCRIPTION
Google OAuth was saving the token in wrong field in `refresh` (previous commit fixed `finishConnect` only)