### PR TITLE
fix(imap): Ignore non existent mailboxes / no select for MYRIGHTS

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -63,6 +63,11 @@ class FolderMapper {
 		]);
 
 		return array_filter(array_map(static function (array $mailbox) use ($account) {
+			$attributes = array_flip(array_map('strtolower', $mailbox['attributes']));
+			if (isset($attributes['\\nonexistent'])) {
+				// Ignore mailbox that does not exist, similar to \Horde_Imap_Client::MBOX_SUBSCRIBED_EXISTS mode
+				return null;
+			}
 			if (in_array($mailbox['mailbox']->utf8, self::DOVECOT_SIEVE_FOLDERS, true)) {
 				// This is a special folder that must not be shown
 				return null;

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -123,7 +123,7 @@ class FolderMapper {
 
 		foreach ($folders as $folder) {
 			$acls = null;
-			if ($hasAcls) {
+			if ($hasAcls && !in_array('\\noselect', array_map('strtolower', $folder->getAttributes()), true)) {
 				$acls = (string)$client->getMyACLRights($folder->getMailbox());
 			}
 

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -181,6 +181,30 @@ class FolderMapperTest extends TestCase {
 		$this->assertEquals($expected, $created);
 	}
 
+	public function testFetchFoldersAclsNoSelect(): void {
+		$folders = [
+			$this->createMock(Folder::class),
+		];
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$folders[0]->expects($this->any())
+			->method('getAttributes')
+			->willReturn(['\\NoSelect']);
+		$capability = $this->createMock(Horde_Imap_Client_Data_Capability::class);
+		$client
+			->method('__get')
+			->with('capability')
+			->willReturn($capability);
+		$capability
+			->expects(self::once())
+			->method('query')
+			->with('ACL')
+			->willReturn(true);
+		$client->expects(self::never())
+			->method('getMyACLRights');
+
+		$this->mapper->fetchFolderAcls($folders, $client);
+	}
+
 	public function testFetchFoldersAcls(): void {
 		$folders = [
 			$this->createMock(Folder::class),
@@ -199,6 +223,8 @@ class FolderMapperTest extends TestCase {
 			->method('query')
 			->with('ACL')
 			->willReturn(false);
+		$client->expects(self::never())
+			->method('getMyACLRights');
 
 		$this->mapper->fetchFolderAcls($folders, $client);
 	}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/8534

Regression of https://github.com/nextcloud/mail/pull/8449. The code https://github.com/nextcloud/mail/blob/5055ba884ed12ae820a9816d12175ae9a9bb9bc7/lib/IMAP/FolderMapper.php#L70-L80 was dropped, which previously caught access to invalid mailboxes and silently ignored the mailbox.

Mailbox synchronization fails if a nonexistent mailbox is access during the `MYRIGHTS` command, if the server supports ACLs.

```
C: 4 LIST () "" (*) RETURN (SUBSCRIBED SPECIAL-USE)
S: * LIST (\Subscribed \Archive) "/" Archives
S: * LIST (\Subscribed \Drafts) "/" Drafts
S: * LIST (\Subscribed \Sent) "/" Sent
S: * LIST (\Subscribed \Trash) "/" Trash
S: * LIST (\NonExistent) "/" shared
S: * LIST (\Subscribed) "/" shared/otheruser@domain.tld
S: * LIST (\Subscribed) "/" INBOX
```

but then

```
C: 11 MYRIGHTS shared
>> ERROR: read/timeout error.
>> ERROR: Server closed the connection.
```