### PR TITLE
fix(smime): set primary key in first migration

### DIFF
--- a/lib/Migration/Version2300Date20221216115727.php
+++ b/lib/Migration/Version2300Date20221216115727.php
@@ -65,6 +65,7 @@ class Version2300Date20221216115727 extends SimpleMigrationStep {
 			$table->addColumn('private_key', Types::TEXT, [
 				'notnull' => false,
 			]);
+			$table->setPrimaryKey(['id'], 'mail_smime_certs_id_idx');
 			$table->addIndex(['user_id'], 'mail_smime_certs_uid_idx');
 			$table->addIndex(['id', 'user_id'], 'mail_smime_certs_id_uid_idx');
 		}


### PR DESCRIPTION
Fixes #8564 

Ref https://github.com/nextcloud/mail/issues/8564#issuecomment-1596653096

The migration after that already adds a primary key. However, there will be a warning because the table exists without a PK for a brief moment which is not optimal.