### PR TITLE
fix(sync): mailboxes not being synced due to short circuiting

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -127,7 +127,7 @@ class ImapToDbSynchronizer {
 				continue;
 			}
 			$logger->debug("Syncing " . $mailbox->getId());
-			$rebuildThreads = $rebuildThreads || $this->sync(
+			if ($this->sync(
 				$account,
 				$mailbox,
 				$logger,
@@ -135,7 +135,9 @@ class ImapToDbSynchronizer {
 				null,
 				$force,
 				true
-			);
+			)) {
+				$rebuildThreads = true;
+			}
 		}
 		$this->dispatcher->dispatchTyped(
 			new SynchronizationEvent(


### PR DESCRIPTION
Fix #8223

If a mailbox causes threads to be rebuilt during background sync, all succeeding mailboxes will be skipped due to a short circuit evaluation of the logical or operator.

Consider this piece of code: https://3v4l.org/kK4Dc