### PR TITLE
fix: update interface to match implementation

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Contracts;
 
-use Horde_Imap_Client;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Attachment;
@@ -44,7 +43,7 @@ interface IMailManager {
 	 *
 	 * @return Mailbox
 	 *
-	 * @throws DoesNotExistException
+	 * @throws ClientException
 	 */
 	public function getMailbox(string $uid, int $id): Mailbox;
 


### PR DESCRIPTION
Found while working on https://github.com/nextcloud/mail/issues/4101

https://github.com/nextcloud/mail/blob/df221035fb5f2e7585cffc755a29d90152b90aab/lib/Service/MailManager.php#L127-L133

The implementation will not throw a DoesNotExistException.

Almost every method in IMailManager throws ClientException or ServiceException, 
and therefore I hope it's the correct change ;)