### PR TITLE
chore: Ignore HTTP response class templates

### DIFF
--- a/lib/Http/AttachmentDownloadResponse.php
+++ b/lib/Http/AttachmentDownloadResponse.php
@@ -26,6 +26,10 @@ namespace OCA\Mail\Http;
 
 use OCP\AppFramework\Http\DownloadResponse;
 
+/**
+ * @psalm-suppress MissingTemplateParam
+ * @todo spec template with 28+
+ */
 class AttachmentDownloadResponse extends DownloadResponse {
 	/** @var string */
 	private $content;

--- a/lib/Http/AvatarDownloadResponse.php
+++ b/lib/Http/AvatarDownloadResponse.php
@@ -25,6 +25,10 @@ namespace OCA\Mail\Http;
 
 use OCP\AppFramework\Http\DownloadResponse;
 
+/**
+ * @psalm-suppress MissingTemplateParam
+ * @todo spec template with 28+
+ */
 class AvatarDownloadResponse extends DownloadResponse {
 	/** @var string */
 	private $content;

--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -27,6 +27,10 @@ namespace OCA\Mail\Http;
 
 use OCP\AppFramework\Http\Response;
 
+/**
+ * @psalm-suppress MissingTemplateParam
+ * @todo spec template with 28+
+ */
 class HtmlResponse extends Response {
 	/** @var string */
 	private $content;

--- a/lib/Http/JsonResponse.php
+++ b/lib/Http/JsonResponse.php
@@ -38,6 +38,8 @@ use function get_class;
 
 /**
  * @see https://github.com/omniti-labs/jsend
+ * @psalm-suppress MissingTemplateParam
+ * @todo spec template with 28+
  */
 class JsonResponse extends Base {
 	public function __construct($data = [],

--- a/lib/Http/ProxyDownloadResponse.php
+++ b/lib/Http/ProxyDownloadResponse.php
@@ -27,6 +27,10 @@ namespace OCA\Mail\Http;
 use DateTime;
 use OCP\AppFramework\Http\DownloadResponse;
 
+/**
+ * @psalm-suppress MissingTemplateParam
+ * @todo spec template with 28+
+ */
 class ProxyDownloadResponse extends DownloadResponse {
 	/** @var string */
 	private $content;


### PR DESCRIPTION
They are new in 28 and missing for 27 and older.

Ref https://github.com/nextcloud/server/pull/38802