### PR TITLE
chore: Drop unnecessary var annotations

### DIFF
--- a/lib/BackgroundJob/MigrateImportantJob.php
+++ b/lib/BackgroundJob/MigrateImportantJob.php
@@ -29,7 +29,6 @@ namespace OCA\Mail\BackgroundJob;
 
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccountMapper;
-use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 
 use OCA\Mail\Exception\ServiceException;
@@ -74,7 +73,6 @@ class MigrateImportantJob extends QueuedJob {
 	public function run($argument) {
 		$mailboxId = (int)$argument['mailboxId'];
 		try {
-			/** @var Mailbox $mailbox*/
 			$mailbox = $this->mailboxMapper->findById($mailboxId);
 		} catch (DoesNotExistException $e) {
 			$this->logger->debug('Could not find mailbox <' . $mailboxId . '>');

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -330,9 +330,7 @@ class MessageMapper extends QBMapper {
 					Address::TYPE_BCC => $message->getBcc(),
 				];
 				foreach ($recipientTypes as $type => $recipients) {
-					/** @var AddressList $recipients */
 					foreach ($recipients->iterate() as $recipient) {
-						/** @var Address $recipient */
 						if ($recipient->getEmail() === null) {
 							// If for some reason the e-mail is not set we should ignore this entry
 							continue;

--- a/lib/Db/TrustedSenderMapper.php
+++ b/lib/Db/TrustedSenderMapper.php
@@ -57,7 +57,6 @@ class TrustedSenderMapper extends QBMapper {
 				$qb->expr()->eq('user_id', $qb->createNamedParameter($uid))
 			);
 
-		/** @var TrustedSender[] $rows */
 		$rows = $this->findEntities($select);
 
 		return $rows !== [];

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -133,11 +133,8 @@ class MessageMapper {
 			]
 		);
 		$perf->step('mailbox meta search');
-		/** @var int $min */
 		$min = (int) $metaResults['min'];
-		/** @var int $max */
 		$max = (int) $metaResults['max'];
-		/** @var int $total */
 		$total = (int) $metaResults['count'];
 
 		if ($total === 0) {
@@ -764,7 +761,6 @@ class MessageMapper {
 			if (!isset($result[$messageUid])) {
 				throw new DoesNotExistException('Unable to load the attachment.');
 			}
-			/** @var Horde_Imap_Client_Data_Fetch $fetch */
 			$fullTextResult = $result[$messageUid];
 
 			$decryptedText = $this->smimeService

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -105,7 +105,6 @@ class PreviewEnhancer {
 				return $message;
 			}
 
-			/** @var MessageStructureData $structureData */
 			$structureData = $data[$message->getUid()];
 			$message->setFlagAttachments($structureData->hasAttachments());
 			$message->setPreviewText($structureData->getPreviewText());

--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -84,7 +84,6 @@ class ThreadBuilder {
 		$idTable = [];
 
 		foreach ($messages as $message) {
-			/** @var Message $message */
 			// Step 1.A
 			$container = $idTable[$message->getId()] ?? null;
 			if ($container !== null && !$container->hasMessage()) {

--- a/lib/Listener/InteractionListener.php
+++ b/lib/Listener/InteractionListener.php
@@ -25,7 +25,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Listener;
 
-use OCA\Mail\Address;
 use OCA\Mail\Events\MessageSentEvent;
 use OCP\Contacts\Events\ContactInteractedWithEvent;
 use OCP\EventDispatcher\Event;
@@ -75,7 +74,6 @@ class InteractionListener implements IEventListener {
 			->merge($event->getMessage()->getCC())
 			->merge($event->getMessage()->getBCC());
 		foreach ($recipients->iterate() as $recipient) {
-			/** @var Address $recipient */
 			$interactionEvent = new ContactInteractedWithEvent($user);
 			$email = $recipient->getEmail();
 			if ($email === null) {

--- a/lib/Migration/Version0110Date20180825201241.php
+++ b/lib/Migration/Version0110Date20180825201241.php
@@ -56,7 +56,6 @@ class Version0110Date20180825201241 extends SimpleMigrationStep {
 			return;
 		}
 
-		/** @var IDBConnection $connection */
 		$connection = $this->connection;
 
 		// add method to overwrite tableName / entityClass

--- a/lib/Migration/Version1101Date20210616141806.php
+++ b/lib/Migration/Version1101Date20210616141806.php
@@ -16,7 +16,6 @@ class Version1101Date20210616141806 extends SimpleMigrationStep {
 	 * @throws SchemaException
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		$provisioningTable = $schema->getTable('mail_provisionings');

--- a/lib/Migration/Version3000Date20230301152454.php
+++ b/lib/Migration/Version3000Date20230301152454.php
@@ -38,7 +38,6 @@ class Version3000Date20230301152454 extends SimpleMigrationStep {
 	 * @return null|ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		$mailboxesTable = $schema->getTable('mail_mailboxes');

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -70,7 +70,6 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	 */
 	public function filter(&$uri, $config, $context) {
 		/** @var \HTMLPurifier_Context $context */
-		/** @var \HTMLPurifier_Config $config */
 
 		if ($uri->scheme === null) {
 			$uri->scheme = 'https';

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -768,7 +768,6 @@ class MailManager implements IMailManager {
 
 	public function createTag(string $displayName, string $color, string $userId): Tag {
 		$imapLabel = str_replace(' ', '_', $displayName);
-		/** @var string|false $imapLabel */
 		$imapLabel = mb_convert_encoding($imapLabel, 'UTF7-IMAP', 'UTF-8');
 		if ($imapLabel === false) {
 			throw new ClientException('Error converting display name to UTF7-IMAP ', 0);

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -27,7 +27,6 @@ namespace OCA\Mail\Service;
 use Horde_Exception;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Data_Fetch;
-use Horde_Imap_Client_DateTime;
 use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Ids;
 use Horde_Mail_Transport_Null;
@@ -722,7 +721,6 @@ class MailTransmission implements IMailTransmission {
 			throw new ServiceException('Message "' .$message->getId() . '" not found.');
 		}
 
-		/** @var Horde_Imap_Client_DateTime $imapDate */
 		$imapDate = $fetchResults[0]->getImapDate();
 		/** @var Horde_Mime_Headers $headers */
 		$mdnHeaders = $fetchResults[0]->getHeaderText('0', Horde_Imap_Client_Data_Fetch::HEADER_PARSE);

--- a/lib/Service/SmimeService.php
+++ b/lib/Service/SmimeService.php
@@ -280,7 +280,6 @@ class SmimeService {
 		$emailAddresses = [];
 
 		foreach ($addressList->iterate() as $address) {
-			/** @var Address $address */
 			try {
 				$emailAddress = $address->getEmail();
 			} catch (\Exception $e) {
@@ -588,7 +587,6 @@ class SmimeService {
 	 */
 	public function encryptMimePart(Horde_Mime_Part  $part, array $certificates): Horde_Mime_Part {
 		try {
-			/** @var string[] $decryptedCertificates */
 			$decryptedCertificates = array_map(function (SmimeCertificate $certificate) {
 				return $this->crypto->decrypt($certificate->getCertificate());
 			}, $certificates);


### PR DESCRIPTION
Automated changed done by Psalm in preparation for v6.

> Warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
