### PR TITLE
feat: parse mailto addresses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@nextcloud/vue-dashboard": "^2.0.1",
         "@riophae/vue-treeselect": "^0.4.0",
         "@vue/babel-preset-app": "^5.0.8",
+        "address-rfc2822": "^2.1.0",
         "buffer": "^6.0.3",
         "color-convert": "^2.0.1",
         "core-js": "^3.31.0",
@@ -5759,6 +5760,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/address-rfc2822": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/address-rfc2822/-/address-rfc2822-2.1.0.tgz",
+      "integrity": "sha512-TwoTmJcYzS+CLw/h+AO3zOzRFGSMNowmp/tlOXcYPygkr2vMAWLs0pDajJiJK/dtVPpFx1utw/CzzLfmmtkagw==",
+      "dependencies": {
+        "email-addresses": "^4.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -7948,6 +7957,11 @@
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
+    "node_modules/email-addresses": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-4.0.0.tgz",
+      "integrity": "sha512-Nas3sSSiD5lSIoqBos0FMjB9h4clHxXuAahHKGJ5doRWavEB7pBHzOxnI7R5f1MuGNrrSnsZFJ81HCBv0DZmnw=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -22120,6 +22134,14 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
+    "address-rfc2822": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/address-rfc2822/-/address-rfc2822-2.1.0.tgz",
+      "integrity": "sha512-TwoTmJcYzS+CLw/h+AO3zOzRFGSMNowmp/tlOXcYPygkr2vMAWLs0pDajJiJK/dtVPpFx1utw/CzzLfmmtkagw==",
+      "requires": {
+        "email-addresses": "^4.0.0"
+      }
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -23778,6 +23800,11 @@
           "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
+    },
+    "email-addresses": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-4.0.0.tgz",
+      "integrity": "sha512-Nas3sSSiD5lSIoqBos0FMjB9h4clHxXuAahHKGJ5doRWavEB7pBHzOxnI7R5f1MuGNrrSnsZFJ81HCBv0DZmnw=="
     },
     "emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@nextcloud/vue-dashboard": "^2.0.1",
     "@riophae/vue-treeselect": "^0.4.0",
     "@vue/babel-preset-app": "^5.0.8",
+    "address-rfc2822": "^2.1.0",
     "buffer": "^6.0.3",
     "color-convert": "^2.0.1",
     "core-js": "^3.31.0",

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -75,6 +75,7 @@ import { NcAppContent as AppContent, NcAppContentList as AppContentList, NcButto
 import isMobile from '@nextcloud/vue/dist/Mixins/isMobile'
 import SectionTitle from './SectionTitle'
 import Vue from 'vue'
+import addressParser from 'address-rfc2822'
 
 import infiniteScroll from '../directives/infinite-scroll'
 import IconInfo from 'vue-material-design-icons/Information'
@@ -266,12 +267,25 @@ export default {
 				return []
 			}
 
-			return [
-				{
-					label: str,
-					email: str,
-				},
-			]
+			let addresses = []
+			try {
+				addresses = addressParser.parse(str)
+			} catch (error) {
+				logger.debug('could not parse string into email addresses', { str, error })
+			}
+
+			return addresses.map(address => {
+				const result = {
+					label: address.name(),
+					email: address.address,
+				}
+
+				if (result.label === '') {
+					result.label = result.email
+				}
+
+				return result
+			})
 		},
 		onUpdateSearchQuery(query) {
 			this.searchQuery = query


### PR DESCRIPTION
To improve compatibility with contacts send email feature.

Send email will compose a mailto link with all email addresses from the contact group. A mailto link with multiple email addresses needs some preprocessing in mail.

**How to test:**

- Mail: Enable "Register as application for mail links" 
- Contacts: Create a contact group. Add some contacts. Make sure the contacts have an email address.
- Contacts: Click "Send email" for the contact group.
- Mail: See all email addresses in the To field ;)

**Side note:**

The mailto link generated by contacts (https://github.com/nextcloud/contacts/blob/a72b5849337354bac60db24fd56c7e062cf3135d/src/components/AppNavigation/GroupNavigationItem.vue#L177) does not comply with https://datatracker.ietf.org/doc/html/rfc6068. 

However, most clients seem to throw the mailto link into a parser and are not too strict about the format. 
