### PR TITLE
feat: implement trash retention

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Positive:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>3.4.0-alpha.1</version>
+	<version>3.4.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
@@ -47,6 +47,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<job>OCA\Mail\BackgroundJob\OutboxWorkerJob</job>
 		<job>OCA\Mail\BackgroundJob\IMipMessageJob</job>
 		<job>OCA\Mail\BackgroundJob\DraftsJob</job>
+		<job>OCA\Mail\BackgroundJob\TrashRetentionJob</job>
 	</background-jobs>
 	<repair-steps>
 		<post-migration>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -59,6 +59,7 @@ use OCA\Mail\Listener\HamReportListener;
 use OCA\Mail\Listener\InteractionListener;
 use OCA\Mail\Listener\MailboxesSynchronizedSpecialMailboxesUpdater;
 use OCA\Mail\Listener\MessageCacheUpdaterListener;
+use OCA\Mail\Listener\MessageKnownSinceListener;
 use OCA\Mail\Listener\NewMessageClassificationListener;
 use OCA\Mail\Listener\OauthTokenRefreshListener;
 use OCA\Mail\Listener\SaveSentMessageListener;
@@ -128,6 +129,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(MessageSentEvent::class, InteractionListener::class);
 		$context->registerEventListener(MessageSentEvent::class, SaveSentMessageListener::class);
 		$context->registerEventListener(NewMessagesSynchronized::class, NewMessageClassificationListener::class);
+		$context->registerEventListener(NewMessagesSynchronized::class, MessageKnownSinceListener::class);
 		$context->registerEventListener(SynchronizationEvent::class, AccountSynchronizedThreadUpdaterListener::class);
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 

--- a/lib/BackgroundJob/TrashRetentionJob.php
+++ b/lib/BackgroundJob/TrashRetentionJob.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\BackgroundJob;
+
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Db\MessageRetentionMapper;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+class TrashRetentionJob extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private LoggerInterface $logger,
+		private IMAPClientFactory $clientFactory,
+		private MessageMapper $messageMapper,
+		private MessageRetentionMapper $messageRetentionMapper,
+		private MailAccountMapper $accountMapper,
+		private MailboxMapper $mailboxMapper,
+		private IMailManager $mailManager,
+	) {
+		parent::__construct($time);
+
+		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function run($argument) {
+		$accounts = $this->accountMapper->getAllAccounts();
+		foreach ($accounts as $account) {
+			$account = new Account($account);
+
+			$retentionDays = $account->getMailAccount()->getTrashRetentionDays();
+			if ($retentionDays === null || $retentionDays <= 0) {
+				continue;
+			}
+
+			$retentionSeconds = $retentionDays * 24 * 3600;
+
+			try {
+				$this->cleanTrash($account, $retentionSeconds);
+			} catch (ServiceException|ClientException $e) {
+				$this->logger->error('Could not clean trash mailbox', [
+					'exception' => $e,
+					'userId' => $account->getUserId(),
+					'accountId' => $account->getId(),
+					'trashMailboxId' => $account->getMailAccount()->getTrashMailboxId(),
+				]);
+			}
+		}
+
+	}
+
+	/**
+	 * @throws ClientException
+	 * @throws ServiceException
+	 */
+	private function cleanTrash(Account $account, int $retentionSeconds): void {
+		$trashMailboxId = $account->getMailAccount()->getTrashMailboxId();
+		if ($trashMailboxId === null) {
+			return;
+		}
+
+		try {
+			$trashMailbox = $this->mailboxMapper->findById($trashMailboxId);
+		} catch (DoesNotExistException $e) {
+			return;
+		}
+
+		$now = $this->time->getTime();
+		$messages = $this->messageMapper->findMessagesKnownSinceBefore(
+			$trashMailboxId,
+			$now - $retentionSeconds,
+		);
+
+		if (count($messages) === 0) {
+			return;
+		}
+
+		$processedMessageIds = [];
+		$client = $this->clientFactory->getClient($account);
+		try {
+			foreach ($messages as $message) {
+				$this->mailManager->deleteMessageWithClient(
+					$account,
+					$trashMailbox,
+					$message->getUid(),
+					$client,
+				);
+
+				$messageId = $message->getMessageId();
+				if ($messageId !== null) {
+					$processedMessageIds[] = $messageId;
+				}
+			}
+		} finally {
+			$client->logout();
+		}
+
+		$this->messageRetentionMapper->deleteByMessageIds($processedMessageIds);
+	}
+}

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -32,6 +32,7 @@ use OCA\Mail\Db\Message;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Exception\TrashMailboxNotSetException;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\Quota;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -142,12 +143,29 @@ interface IMailManager {
 	/**
 	 * @param Account $account
 	 * @param string $mailboxId
-	 * @param int $messageId
+	 * @param int $messageUid
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function deleteMessage(Account $account, string $mailboxId, int $messageId): void;
+	public function deleteMessage(Account $account, string $mailboxId, int $messageUid): void;
+
+	/**
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 * @param int $messageUid
+	 * @param Horde_Imap_Client_Socket $client The caller is responsible to close the client.
+	 *
+	 * @throws ServiceException
+	 * @throws ClientException
+	 * @throws TrashMailboxNotSetException If no trash folder is configured for the given account.
+	 */
+	public function deleteMessageWithClient(
+		Account $account,
+		Mailbox $mailbox,
+		int $messageUid,
+		Horde_Imap_Client_Socket $client,
+	): void;
 
 	/**
 	 * Mark all messages of a folder as read

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -241,7 +241,8 @@ class AccountsController extends Controller {
 		int $sentMailboxId = null,
 		int $trashMailboxId = null,
 		int $archiveMailboxId = null,
-		bool $signatureAboveQuote = null): JSONResponse {
+		bool $signatureAboveQuote = null,
+		int $trashRetentionDays = null): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $id);
 
 		$dbAccount = $account->getMailAccount();
@@ -273,6 +274,10 @@ class AccountsController extends Controller {
 		}
 		if ($signatureAboveQuote !== null) {
 			$dbAccount->setSignatureAboveQuote($signatureAboveQuote);
+		}
+		if ($trashRetentionDays !== null) {
+			// Passing 0 (or lower) disables retention
+			$dbAccount->setTrashRetentionDays($trashRetentionDays <= 0 ? null : $trashRetentionDays);
 		}
 		return new JSONResponse(
 			$this->accountService->save($dbAccount)

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -108,6 +108,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSmimeCertificateId(int|null $smimeCertificateId)
  * @method int|null getQuotaPercentage()
  * @method void setQuotaPercentage(int $quota);
+ * @method int|null getTrashRetentionDays()
+ * @method void setTrashRetentionDays(int|null $trashRetentionDays)
  */
 class MailAccount extends Entity {
 	public const SIGNATURE_MODE_PLAIN = 0;
@@ -176,6 +178,9 @@ class MailAccount extends Entity {
 	/** @var int|null */
 	protected $quotaPercentage;
 
+	/** @var int|null */
+	protected $trashRetentionDays;
+
 	/**
 	 * @param array $params
 	 */
@@ -227,6 +232,9 @@ class MailAccount extends Entity {
 		if (isset($params['signatureAboveQuote'])) {
 			$this->setSignatureAboveQuote($params['signatureAboveQuote']);
 		}
+		if (isset($params['trashRetentionDays'])) {
+			$this->setTrashRetentionDays($params['trashRetentionDays']);
+		}
 
 		$this->addType('inboundPort', 'integer');
 		$this->addType('outboundPort', 'integer');
@@ -245,6 +253,7 @@ class MailAccount extends Entity {
 		$this->addType('signatureMode', 'int');
 		$this->addType('smimeCertificateId', 'integer');
 		$this->addType('quotaPercentage', 'integer');
+		$this->addType('trashRetentionDays', 'integer');
 	}
 
 	/**
@@ -275,6 +284,7 @@ class MailAccount extends Entity {
 			'signatureMode' => $this->getSignatureMode(),
 			'smimeCertificateId' => $this->getSmimeCertificateId(),
 			'quotaPercentage' => $this->getQuotaPercentage(),
+			'trashRetentionDays' => $this->getTrashRetentionDays(),
 		];
 
 		if (!is_null($this->getOutboundHost())) {

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -151,6 +151,9 @@ class MailAccountMapper extends QBMapper {
 		$delete->executeStatement();
 	}
 
+	/**
+	 * @return MailAccount[]
+	 */
 	public function getAllAccounts(): array {
 		$qb = $this->db->getQueryBuilder();
 		$query = $qb

--- a/lib/Db/MessageRetention.php
+++ b/lib/Db/MessageRetention.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setMessageId(string $messageId)
+ * @method string getMessageId()
+ * @method void setKnownSince(int $knownSince)
+ * @method int getKnownSince()
+ */
+class MessageRetention extends Entity {
+
+	/** @var string */
+	protected $messageId;
+
+	/** @var int */
+	protected $knownSince;
+
+	public function __construct() {
+		$this->addType('messageId', 'string');
+		$this->addType('knownSince', 'integer');
+	}
+}

--- a/lib/Db/MessageRetentionMapper.php
+++ b/lib/Db/MessageRetentionMapper.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<MessageRetention>
+ */
+class MessageRetentionMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'mail_messages_retention', MessageRetention::class);
+	}
+
+	/**
+	 * @param string[] $messageIds
+	 *
+	 * @return void
+	 */
+	public function deleteByMessageIds(array $messageIds): void {
+		$qb = $this->db->getQueryBuilder();
+
+		$delete = $qb->delete($this->getTableName())
+			->where($qb->expr()->in(
+				'message_id',
+				$qb->createParameter('message_ids'),
+				IQueryBuilder::PARAM_STR_ARRAY,
+			));
+
+		foreach (array_chunk($messageIds, 500) as $messageIdChunk) {
+			$delete->setParameter(
+				'message_ids',
+				$messageIdChunk,
+				IQueryBuilder::PARAM_STR_ARRAY,
+			);
+			$delete->executeStatement();
+		}
+	}
+
+	/**
+	 * Delete all orphaned extra entries that have no matching message anymore.
+	 */
+	public function deleteOrphans(): void {
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete($this->getTableName())
+			->where('id', $deleteQb->expr()->in(
+				'id',
+				$deleteQb->createParameter('ids'),
+				IQueryBuilder::PARAM_INT_ARRAY,
+			));
+
+		$selectQb = $this->db->getQueryBuilder();
+		$selectQb->select('mr.id')
+			->from($this->getTableName(), 'mr')
+			->leftJoin('mr', 'mail_messages', 'm', $selectQb->expr()->eq(
+				'm.message_id',
+				'mr.message_id',
+				IQueryBuilder::PARAM_STR,
+			))
+			->where($selectQb->expr()->isNull('m.id'));
+		$cursor = $selectQb->executeQuery();
+		$ids = [];
+		while ($row = $cursor->fetch()) {
+			$ids[] = (int)$row['id'];
+		}
+		$cursor->closeCursor();
+
+		foreach (array_chunk($ids, 500) as $idChunk) {
+			$deleteQb->setParameter('ids', $idChunk, IQueryBuilder::PARAM_INT_ARRAY);
+			$deleteQb->executeStatement();
+		}
+	}
+}

--- a/lib/Listener/MessageKnownSinceListener.php
+++ b/lib/Listener/MessageKnownSinceListener.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Listener;
+
+use OCA\Mail\Db\MessageRetention;
+use OCA\Mail\Db\MessageRetentionMapper;
+use OCA\Mail\Events\NewMessagesSynchronized;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<Event|NewMessagesSynchronized>
+ */
+class MessageKnownSinceListener implements IEventListener {
+
+	public function __construct(
+		private MessageRetentionMapper $messageRetentionMapper,
+		private ITimeFactory $timeFactory,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof NewMessagesSynchronized)) {
+			return;
+		}
+
+		$trashRetention = $event->getAccount()->getMailAccount()->getTrashRetentionDays();
+		if ($trashRetention === null) {
+			return;
+		}
+
+		$trashMailboxId = $event->getAccount()->getMailAccount()->getTrashMailboxId();
+		if ($trashMailboxId === null) {
+			return;
+		}
+
+		$now = $this->timeFactory->getTime();
+		foreach ($event->getMessages() as $message) {
+			if ($message->getMailboxId() !== $trashMailboxId) {
+				continue;
+			}
+
+			$retention = new MessageRetention();
+			$retention->setMessageId($message->getMessageId());
+			$retention->setKnownSince($now);
+			$this->messageRetentionMapper->insert($retention);
+		}
+	}
+}

--- a/lib/Migration/Version3300Date20230801124717.php
+++ b/lib/Migration/Version3300Date20230801124717.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3300Date20230801124717 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		if (!$accountsTable->hasColumn('trash_retention_days')) {
+			$accountsTable->addColumn('trash_retention_days', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		if (!$schema->hasTable('mail_messages_retention')) {
+			$messagesRetentionTable = $schema->createTable('mail_messages_retention');
+			$messagesRetentionTable->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 4,
+			]);
+			$messagesRetentionTable->addColumn('message_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 1024,
+			]);
+			$messagesRetentionTable->addColumn('known_since', Types::INTEGER, [
+				'notnull' => true,
+				'length' => 4,
+			]);
+			$messagesRetentionTable->setPrimaryKey(['id'], 'mail_msg_retention_id_idx');
+			$messagesRetentionTable->addIndex(['message_id'], 'mail_msg_retention_msgid_idx');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -176,7 +176,7 @@ class AccountService {
 	}
 
 	/**
-	 * @return Account[]
+	 * @return MailAccount[]
 	 */
 	public function getAllAcounts(): array {
 		return $this->mapper->getAllAccounts();

--- a/lib/Service/CleanupService.php
+++ b/lib/Service/CleanupService.php
@@ -29,6 +29,7 @@ use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\CollectedAddressMapper;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Db\MessageRetentionMapper;
 use OCA\Mail\Db\TagMapper;
 
 class CleanupService {
@@ -47,16 +48,20 @@ class CleanupService {
 	/** @var TagMapper */
 	private $tagMapper;
 
+	private MessageRetentionMapper $messageRetentionMapper;
+
 	public function __construct(AliasMapper $aliasMapper,
 		MailboxMapper $mailboxMapper,
 		MessageMapper $messageMapper,
 		CollectedAddressMapper $collectedAddressMapper,
-		TagMapper $tagMapper) {
+		TagMapper $tagMapper,
+		MessageRetentionMapper $messageRetentionMapper) {
 		$this->aliasMapper = $aliasMapper;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->collectedAddressMapper = $collectedAddressMapper;
 		$this->tagMapper = $tagMapper;
+		$this->messageRetentionMapper = $messageRetentionMapper;
 	}
 
 	public function cleanUp(): void {
@@ -66,5 +71,6 @@ class CleanupService {
 		$this->collectedAddressMapper->deleteOrphans();
 		$this->tagMapper->deleteOrphans();
 		$this->tagMapper->deleteDuplicates();
+		$this->messageRetentionMapper->deleteOrphans();
 	}
 }

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -121,8 +121,12 @@ class ImapToDbSynchronizer {
 		bool $force = false,
 		int $criteria = Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS): void {
 		$rebuildThreads = false;
+		$trashMailboxId = $account->getMailAccount()->getTrashMailboxId();
+		$trashRetentionDays = $account->getMailAccount()->getTrashRetentionDays();
 		foreach ($this->mailboxMapper->findAll($account) as $mailbox) {
-			if (!$mailbox->isInbox() && !$mailbox->getSyncInBackground()) {
+			$syncTrash = $trashMailboxId === $mailbox->getId() && $trashRetentionDays !== null;
+
+			if (!$syncTrash && !$mailbox->isInbox() && !$mailbox->getSyncInBackground()) {
 				$logger->debug("Skipping mailbox sync for " . $mailbox->getId());
 				continue;
 			}

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -59,6 +59,12 @@
 			</p>
 			<AccountDefaultsSettings :account="account" />
 		</AppSettingsSection>
+		<AppSettingsSection id="trash-retention" :title=" t('mail', 'Automatic trash deletion')">
+			<p class="settings-hint">
+				{{ t('mail', 'Days after which messages in Trash will automatically be deleted:') }}
+			</p>
+			<TrashRetentionSettings :account="account" />
+		</AppSettingsSection>
 		<AppSettingsSection
 			v-if="account"
 			id="out-of-office-replies"
@@ -121,6 +127,7 @@ import SieveAccountForm from './SieveAccountForm'
 import SieveFilterForm from './SieveFilterForm'
 import OutOfOfficeForm from './OutOfOfficeForm'
 import CertificateSettings from './CertificateSettings'
+import TrashRetentionSettings from './TrashRetentionSettings'
 
 export default {
 	name: 'AccountSettings',
@@ -137,6 +144,7 @@ export default {
 		AccountDefaultsSettings,
 		OutOfOfficeForm,
 		CertificateSettings,
+		TrashRetentionSettings,
 	},
 	props: {
 		account: {

--- a/src/components/TrashRetentionSettings.vue
+++ b/src/components/TrashRetentionSettings.vue
@@ -1,0 +1,67 @@
+<!--
+  - @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU General Public License as published by
+  - the Free Software Foundation, either version 3 of the License, or
+  - (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU General Public License for more details.
+  -
+  - You should have received a copy of the GNU General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div>
+		<input v-model="trashRetentionDays"
+			type="number"
+			min="0"
+			@input="debouncedSave()">
+		<p>
+			{{ t('mail', 'Disable trash retention by leaving the field empty or setting it to 0. Only mails deleted after enabling trash retention will be processed.') }}
+		</p>
+	</div>
+</template>
+
+<script>
+import debounce from 'lodash/fp/debounce'
+
+export default {
+	name: 'TrashRetentionSettings',
+	props: {
+		account: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			trashRetentionDays: this.account.trashRetentionDays,
+			debouncedSave: debounce(1000, this.save),
+		}
+	},
+	methods: {
+		async save() {
+			let trashRetentionDays = parseInt(this.trashRetentionDays)
+			if (isNaN(trashRetentionDays)) {
+				// NaN probably means an empty input field, so we disable retention
+				trashRetentionDays = 0
+			}
+
+			await this.$store.dispatch('patchAccount', {
+				account: this.account,
+				data: { trashRetentionDays },
+			})
+		},
+	},
+}
+</script>

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -47,6 +47,7 @@ class MailAccountTest extends TestCase {
 		$a->setProvisioningId(null);
 		$a->setOrder(13);
 		$a->setQuotaPercentage(10);
+		$a->setTrashRetentionDays(60);
 
 		$this->assertEquals([
 			'id' => 12345,
@@ -76,6 +77,7 @@ class MailAccountTest extends TestCase {
 			'signatureMode' => null,
 			'smimeCertificateId' => null,
 			'quotaPercentage' => 10,
+			'trashRetentionDays' => 60,
 		], $a->toJson());
 	}
 
@@ -108,6 +110,7 @@ class MailAccountTest extends TestCase {
 			'signatureMode' => null,
 			'smimeCertificateId' => null,
 			'quotaPercentage' => null,
+			'trashRetentionDays' => 60,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency

--- a/tests/Unit/Job/TrashRetentionJobTest.php
+++ b/tests/Unit/Job/TrashRetentionJobTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Job;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Socket;
+use OCA\Mail\Account;
+use OCA\Mail\BackgroundJob\TrashRetentionJob;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Db\MessageRetentionMapper;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Service\Sync\SyncService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class TrashRetentionJobTest extends TestCase {
+
+	private const ARGUMENT = null;
+
+	/** @var ITimeFactory|MockObject */
+	private $timeFactory;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	/** @var IMAPClientFactory|MockObject */
+	private $clientFactory;
+
+	/** @var MessageMapper|MockObject */
+	private $messageMapper;
+
+	/** @var MessageRetentionMapper|MockObject */
+	private $messageRetentionMapper;
+
+	/** @var MailAccountMapper|MockObject */
+	private $accountMapper;
+
+	/** @var MailboxMapper|MockObject */
+	private $mailboxMapper;
+
+	/** @var IMailManager|MockObject */
+	private $mailManager;
+
+	/** @var SyncService|MockObject */
+	private $syncService;
+
+	private TrashRetentionJob $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->clientFactory = $this->createMock(IMAPClientFactory::class);
+		$this->messageMapper = $this->createMock(MessageMapper::class);
+		$this->messageRetentionMapper = $this->createMock(MessageRetentionMapper::class);
+		$this->accountMapper = $this->createMock(MailAccountMapper::class);
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->mailManager = $this->createMock(IMailManager::class);
+		$this->syncService = $this->createMock(SyncService::class);
+
+		$this->job = new TrashRetentionJob(
+			$this->timeFactory,
+			$this->logger,
+			$this->clientFactory,
+			$this->messageMapper,
+			$this->messageRetentionMapper,
+			$this->accountMapper,
+			$this->mailboxMapper,
+			$this->mailManager,
+			$this->syncService,
+		);
+	}
+
+	public function testRun() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(60);
+		$dbAccount->setTrashMailboxId(42);
+		$dbAccount->setUserId('user');
+		$account = new Account($dbAccount);
+		$trash = new Mailbox();
+		$message = new Message();
+		$message->setUid(420);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->mailboxMapper->expects($this->once())
+			->method('findById')
+			->with(42)
+			->willReturn($trash);
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(1000000);
+		$this->messageMapper->expects($this->once())
+			->method('findMessagesKnownSinceBefore')
+			->with(42, 1000000 - 24 * 60 * 3600)
+			->willReturn([$message]);
+		$this->clientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$this->mailManager->expects($this->once())
+			->method('deleteMessageWithClient')
+			->with($account, $trash, 420, $client);
+		$client->expects($this->once())
+			->method('logout');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunWithoutRetention() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(null);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->mailManager->expects($this->never())
+			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunWith0DaysRetention() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(0);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->mailManager->expects($this->never())
+			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunWithNegativeRetention() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(-1);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->mailManager->expects($this->never())
+			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunWithoutTrash() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(60);
+		$dbAccount->setTrashMailboxId(null);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->mailboxMapper->expects($this->never())
+			->method('findById');
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->mailManager->expects($this->never())
+			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunWithNonExistingTrash() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(60);
+		$dbAccount->setTrashMailboxId(42);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->mailboxMapper->expects($this->once())
+			->method('findById')
+			->with(42)
+			->willThrowException(new DoesNotExistException('Mailbox 42 does not exist'));
+		$this->syncService->expects($this->never())
+			->method('syncMailbox');
+		$this->mailManager->expects($this->never())
+			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+}

--- a/tests/Unit/Listener/MessageKnownSinceListenerTest.php
+++ b/tests/Unit/Listener/MessageKnownSinceListenerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageRetention;
+use OCA\Mail\Db\MessageRetentionMapper;
+use OCA\Mail\Events\NewMessagesSynchronized;
+use OCA\Mail\Listener\MessageKnownSinceListener;
+use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MessageKnownSinceListenerTest extends TestCase {
+
+	/** @var MessageRetentionMapper|MockObject */
+	private $messageRetentionMapper;
+
+	/** @var ITimeFactory|MockObject */
+	private $timeFactory;
+
+	private MessageKnownSinceListener $messageKnownSinceListener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->messageRetentionMapper = $this->createMock(MessageRetentionMapper::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+
+		$this->messageKnownSinceListener = new MessageKnownSinceListener(
+			$this->messageRetentionMapper,
+			$this->timeFactory,
+		);
+	}
+
+	public function testHandle() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(60);
+		$dbAccount->setTrashMailboxId(420);
+		$account = new Account($dbAccount);
+		$mailbox = $this->createMock(Mailbox::class);
+		$message1 = new Message();
+		$message1->setMessageId('<foobar@local.host>');
+		$message1->setMailboxId(420);
+		$message2 = new Message();
+		$message2->setMessageId('<foobar2@local.host>');
+		$message2->setMailboxId(1);
+		$messages = [$message1, $message2];
+		$event = new NewMessagesSynchronized($account, $mailbox, $messages);
+
+		$messageRetention = new MessageRetention();
+		$messageRetention->setMessageId('<foobar@local.host>');
+		$messageRetention->setKnownSince(1000);
+
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(1000);
+		$this->messageRetentionMapper->expects($this->once())
+			->method('insert')
+			->with($messageRetention);
+
+		$this->messageKnownSinceListener->handle($event);
+	}
+
+	public function testHandleWithoutRetention() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(null);
+		$dbAccount->setTrashMailboxId(420);
+		$account = new Account($dbAccount);
+		$mailbox = $this->createMock(Mailbox::class);
+		$message1 = new Message();
+		$message1->setMessageId('<foobar@local.host>');
+		$message1->setMailboxId(420);
+		$message2 = new Message();
+		$message2->setMessageId('<foobar2@local.host>');
+		$message2->setMailboxId(1);
+		$messages = [$message1, $message2];
+		$event = new NewMessagesSynchronized($account, $mailbox, $messages);
+
+		$this->timeFactory->expects($this->never())
+			->method('getTime');
+		$this->messageRetentionMapper->expects($this->never())
+			->method('insert');
+
+		$this->messageKnownSinceListener->handle($event);
+	}
+}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -36,7 +36,6 @@ use OCA\Mail\Db\MessageMapper as DbMessageMapper;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Db\ThreadMapper;
-use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Folder;
@@ -163,12 +162,8 @@ class MailManagerTest extends TestCase {
 	public function testDeleteMessageSourceFolderNotFound(): void {
 		/** @var Account|MockObject $account */
 		$account = $this->createMock(Account::class);
-		$this->eventDispatcher->expects($this->once())
-			->method('dispatch')
-			->with(
-				$this->equalTo(BeforeMessageDeletedEvent::class),
-				$this->anything()
-			);
+		$this->eventDispatcher->expects($this->never())
+			->method('dispatchTyped');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
@@ -187,17 +182,15 @@ class MailManagerTest extends TestCase {
 		$account = $this->createMock(Account::class);
 		$mailAccount = new MailAccount();
 		$mailAccount->setTrashMailboxId(123);
+		$mailbox = new Mailbox();
+		$mailbox->setName('INBOX');
 		$account->method('getMailAccount')->willReturn($mailAccount);
 		$this->eventDispatcher->expects($this->once())
-			->method('dispatch')
-			->with(
-				$this->equalTo(BeforeMessageDeletedEvent::class),
-				$this->anything()
-			);
+			->method('dispatchTyped');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
-			->willReturn($this->createMock(Mailbox::class));
+			->willReturn($mailbox);
 		$this->mailboxMapper->expects($this->once())
 			->method('findById')
 			->with(123)
@@ -222,7 +215,7 @@ class MailManagerTest extends TestCase {
 		$trash = new Mailbox();
 		$trash->setName('Trash');
 		$this->eventDispatcher->expects($this->exactly(2))
-			->method('dispatch');
+			->method('dispatchTyped');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
@@ -262,7 +255,7 @@ class MailManagerTest extends TestCase {
 		$trash = new Mailbox();
 		$trash->setName('Trash');
 		$this->eventDispatcher->expects($this->exactly(2))
-			->method('dispatch');
+			->method('dispatchTyped');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'Trash')
@@ -759,7 +752,7 @@ class MailManagerTest extends TestCase {
 			->method('move');
 		$this->eventDispatcher
 			->expects(self::exactly(4))
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$this->manager->deleteThread(
 			$account,
@@ -802,7 +795,7 @@ class MailManagerTest extends TestCase {
 			->method('expunge');
 		$this->eventDispatcher
 			->expects(self::exactly(4))
-			->method('dispatch');
+			->method('dispatchTyped');
 
 		$this->manager->deleteThread(
 			$account,


### PR DESCRIPTION
Fix #5746 

Unfortunately, we have to rely on the imap date attribute which will be the initial reception date of a mail. The [RFC](https://datatracker.ietf.org/doc/html/rfc3501#section-2.3.3) recommends that servers _should_ preserve this date even when an envelope is copied to another mailbox. Moving (as in deleting) is translated to a copy followed by a delete of the original envelope.

It is likely that most or all imap servers follow the recommendation, so we should assume that the imap always corresponds to the date of reception.

## Section in the account settings modal

![grafik](https://github.com/nextcloud/mail/assets/1479486/e7faa46e-d062-4722-90ca-8cd94893da49)