### PR TITLE
feat(search): Use case-independent wildcard matches and match labels

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -746,7 +746,10 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->orX(
 					...array_map(function (string $email) use ($qb) {
 						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
-					}, $query->getFrom())
+					}, $query->getFrom()),
+					...array_map(function (string $label) use ($qb) {
+						return $qb->expr()->iLike('r0.label', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($label) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getFrom()),
 				)
 			);
 		}
@@ -755,7 +758,10 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->orX(
 					...array_map(function (string $email) use ($qb) {
 						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
-					}, $query->getTo())
+					}, $query->getTo()),
+					...array_map(function (string $label) use ($qb) {
+						return $qb->expr()->iLike('r0.label', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($label) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getTo()),
 				)
 			);
 		}
@@ -764,7 +770,10 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->orX(
 					...array_map(function (string $email) use ($qb) {
 						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
-					}, $query->getCc())
+					}, $query->getCc()),
+					...array_map(function (string $label) use ($qb) {
+						return $qb->expr()->iLike('r0.label', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($label) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getCc()),
 				)
 			);
 		}
@@ -773,7 +782,10 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->orX(
 					...array_map(function (string $email) use ($qb) {
 						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
-					}, $query->getBcc())
+					}, $query->getBcc()),
+					...array_map(function (string $label) use ($qb) {
+						return $qb->expr()->iLike('r0.label', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($label) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getBcc()),
 				)
 			);
 		}

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -743,22 +743,38 @@ class MessageMapper extends QBMapper {
 
 		if (!empty($query->getFrom())) {
 			$select->andWhere(
-				$qb->expr()->in('r0.email', $qb->createNamedParameter($query->getFrom(), IQueryBuilder::PARAM_STR_ARRAY))
+				$qb->expr()->orX(
+					...array_map(function (string $email) use ($qb) {
+						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getFrom())
+				)
 			);
 		}
 		if (!empty($query->getTo())) {
 			$select->andWhere(
-				$qb->expr()->in('r1.email', $qb->createNamedParameter($query->getTo(), IQueryBuilder::PARAM_STR_ARRAY))
+				$qb->expr()->orX(
+					...array_map(function (string $email) use ($qb) {
+						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getTo())
+				)
 			);
 		}
 		if (!empty($query->getCc())) {
 			$select->andWhere(
-				$qb->expr()->in('r2.email', $qb->createNamedParameter($query->getCc(), IQueryBuilder::PARAM_STR_ARRAY))
+				$qb->expr()->orX(
+					...array_map(function (string $email) use ($qb) {
+						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getCc())
+				)
 			);
 		}
 		if (!empty($query->getBcc())) {
 			$select->andWhere(
-				$qb->expr()->in('r3.email', $qb->createNamedParameter($query->getBcc(), IQueryBuilder::PARAM_STR_ARRAY))
+				$qb->expr()->orX(
+					...array_map(function (string $email) use ($qb) {
+						return $qb->expr()->iLike('r0.email', $qb->createNamedParameter('%' . $this->db->escapeLikeParameter($email) . '%', IQueryBuilder::PARAM_STR));
+					}, $query->getBcc())
+				)
 			);
 		}
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/3562

Search only found exact matches before (full string and correct case). Now it searches with wildcard, case-independent and also looks into the label of a recipient.

How to test
1) Search by partial email address, e.g. messages from *@gmail.com*
2) Search by recipient label, e.g. *jane doe*

main branch: no results
here: results