### PR TITLE
fix(search): URL-encode all parameters to preserve special characters

### DIFF
--- a/lib/Service/Search/FilterStringParser.php
+++ b/lib/Service/Search/FilterStringParser.php
@@ -25,6 +25,8 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service\Search;
 
+use function urldecode;
+
 class FilterStringParser {
 	public function parse(?string $filter): SearchQuery {
 		$query = new SearchQuery();
@@ -49,7 +51,8 @@ class FilterStringParser {
 			return false;
 		}
 
-		[$type, $param] = explode(':', $token);
+		[$type, $encodedParam] = explode(':', $token);
+		$param = urldecode($encodedParam);
 		$type = strtolower($type);
 		$flagMap = [
 			'answered' => Flag::is(Flag::ANSWERED),
@@ -102,9 +105,7 @@ class FilterStringParser {
 				$query->addBcc($param);
 				return true;
 			case 'subject':
-				// from frontend part subject:My+search+text
-				$subject = str_replace('+', ' ', $param);
-				$query->addSubject($subject);
+				$query->addSubject($param);
 				return true;
 			case 'tags':
 				$tags = explode(',', $param);

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -378,10 +378,7 @@ export default {
 			let _search = ''
 			Object.entries(this.filterData).filter(([key, val]) => {
 				if (val !== '' && val !== null) {
-					if (val.indexOf(' ') !== -1) {
-						val = val.replace(/ /g, '+')
-					}
-					_search += `${key}:${val} `
+					_search += `${key}:${encodeURI(val)} `
 				}
 				return val
 			})


### PR DESCRIPTION
Working with https://github.com/nextcloud/mail/pull/8645 I noticed that spaces are replaced with `+`, so it's impossible to search for emails from "jane doe" because it becomes "from:jane+doe", which never matches.

This changes the logic to properly encode and decode any special characters in a search parameter.