### PR TITLE
feat: load active sieve script on demand

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -128,6 +128,7 @@ import SieveFilterForm from './SieveFilterForm'
 import OutOfOfficeForm from './OutOfOfficeForm'
 import CertificateSettings from './CertificateSettings'
 import TrashRetentionSettings from './TrashRetentionSettings'
+import logger from '../logger'
 
 export default {
 	name: 'AccountSettings',
@@ -159,6 +160,7 @@ export default {
 	data() {
 		return {
 			trapElements: [],
+			fetchActiveSieveScript: this.account.sieveEnabled,
 		}
 	},
 	computed: {
@@ -172,10 +174,16 @@ export default {
 			return this.account.emailAddress
 		},
 	},
-	mounted() {
-		this.$store.dispatch('fetchActiveSieveScript', {
-			accountId: this.account.id,
-		})
+	watch: {
+		open(newState, oldState) {
+			if (newState === true && this.fetchActiveSieveScript === true) {
+				logger.debug(`Load active sieve script for account ${this.account.accountId}`)
+				this.fetchActiveSieveScript = false
+				this.$store.dispatch('fetchActiveSieveScript', {
+					accountId: this.account.id,
+				})
+			}
+		},
 	},
 	methods: {
 		scrollToAccountSettings() {


### PR DESCRIPTION
**How to reproduce**

- Open mail
- See xhr request for every configured mail account for the active sieve script


https://github.com/nextcloud/mail/pull/8466 added `dispatch(fetchActiveSieveScript)` to load the active script when the settings component is mounted.  

https://github.com/nextcloud/mail/pull/8524 changed the component from mounted on demand to always mounted and therefore triggers  `dispatch(fetchActiveSieveScript)` on page load. 

I'm using account.sieveEnabled as default for fetchActiveSieveScript to load only when sieve is enabled for the account. 