### PR TITLE
Improve and fix account settings modal header

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -27,10 +27,11 @@
 		:open="open"
 		:show-navigation="true"
 		:additional-trap-elements="trapElements"
+		:title="t('mail', 'Account settings')"
 		@update:open="updateOpen">
 		<AppSettingsSection
-			id="account-settings"
-			:title="t('mail', 'Account settings')">
+			id="alias-settings"
+			:title="t('mail', 'Aliases')">
 			<AliasSettings :account="account" @rename-primary-alias="scrollToAccountSettings" />
 		</AppSettingsSection>
 		<AppSettingsSection

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -216,10 +216,4 @@ h2 {
 .app-settings-section {
 margin-bottom: 45px;
 }
-
-// Fix weird modal glitches on Firefox when toggling autoresponder
-:deep(.modal-container),
-:deep(.app-settings__wrapper) {
-	position: unset !important;
-}
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/8649

I tested the autoresponder in Firefox to make sure that https://github.com/nextcloud/mail/pull/7428 is still gone.

For the before picture see https://github.com/nextcloud/mail/issues/8649.

**Warning:** Only the close button fix can be backported.

## After

![grafik](https://github.com/nextcloud/mail/assets/1479486/85969aae-df3a-457f-a1c7-1119c229d3a2)