### PR TITLE
Fix alignment for settings buttons and it's icons

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -275,15 +275,24 @@ p.app-settings {
 	background-position: 10px center;
 	text-align: left;
 	margin-top: 6px;
+	width: 100%;
 }
 .app-settings-button.button.primary.new-button {
 	color: var(--color-primary-element-text);
 	//this style will be removed after we migrate also the  'add mail account' to material design
 	padding-left: 34px;
 	gap: 4px;
+	width: fit-content;
 }
 .app-settings-link {
 	text-decoration: underline;
+}
+::v-deep .button-vue__text {
+	text-overflow: clip;
+	white-space: normal;
+}
+::v-deep .button-vue__wrapper {
+	justify-content: flex-start;
 }
 .mailvelope-section {
 	padding-top: 15px;
@@ -300,11 +309,5 @@ p.app-settings {
 			box-shadow: 0 0 0 1px var(--color-primary-element);
 		}
 	}
-}
-.material-design-icon {
-	&.lock-icon {
-		margin-right: 10px;
-	}
-
 }
 </style>


### PR DESCRIPTION
Fixes #8681

Before:
![the buttons and icons within are not aligned nicely](https://user-images.githubusercontent.com/1374172/259053840-b0e3f216-4a61-4144-a799-8446cc47c1a3.png)
After: 
![the buttons and icons within are nicely aligned now and the butttons all have the same width](https://github.com/nextcloud/mail/assets/81317317/513d7253-6ffd-4e0a-9d80-366d247fa33b)

The buttons are all the same width now and the previous overflowing text is not cut off by and ellipsis anyone but broken into a new line. Also that lock icon doesn't have a margin-right anymore which made it not align with the other icons.

@GretaD said the buttons should maybe be the same width as the other ones in the sidebar outside of the mail settings but I don't agree. I think the buttons being smaller makes it clear that they're contained in the mail settings.

cc: @jancborchardt @nimishavijay What is your opinion on the design?