### PR TITLE
fix(setup): Rate limit auto config attempts

### DIFF
--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -34,6 +34,7 @@ use OCA\Mail\Service\AutoConfig\IspDb;
 use OCA\Mail\Service\AutoConfig\MxRecord;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\IRequest;
 use OCP\Security\IRemoteHostValidator;
 use function in_array;
@@ -60,10 +61,12 @@ class AutoConfigController extends Controller {
 	 * @param string $email
 	 *
 	 * @NoAdminRequired
+	 * @UserRateThrottle(limit: 5, period: 60)
 	 *
 	 * @return JsonResponse
 	 */
 	#[TrapError]
+	#[UserRateLimit(limit: 5, period: 60)]
 	public function queryIspdb(string $email): JsonResponse {
 		$rfc822Address = new Horde_Mail_Rfc822_Address($email);
 		if (!$rfc822Address->valid || !$this->hostValidator->isValid($rfc822Address->host)) {
@@ -78,10 +81,12 @@ class AutoConfigController extends Controller {
 	 * @param string $email
 	 *
 	 * @NoAdminRequired
+	 * @UserRateThrottle(limit: 5, period: 60)
 	 *
 	 * @return JsonResponse
 	 */
 	#[TrapError]
+	#[UserRateLimit(limit: 5, period: 60)]
 	public function queryMx(string $email): JsonResponse {
 		$rfc822Address = new Horde_Mail_Rfc822_Address($email);
 		if (!$rfc822Address->valid || !$this->hostValidator->isValid($rfc822Address->host)) {
@@ -98,10 +103,12 @@ class AutoConfigController extends Controller {
 	 * @param int $port
 	 *
 	 * @NoAdminRequired
+	 * @UserRateThrottle(limit: 10, period: 60)
 	 *
 	 * @return JsonResponse
 	 */
 	#[TrapError]
+	#[UserRateLimit(limit: 10, period: 60)]
 	public function testConnectivity(string $host, int $port): JsonResponse {
 		if (!in_array($port, [143, 993, 465, 587])) {
 			return JsonResponse::fail('Port not allowed');

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -638,6 +638,8 @@ export default {
 						this.feedback = t('mail', 'SMTP connection failed')
 					} else if (error.message === CONSENT_ABORTED) {
 						this.feedback = t('mail', 'Authorization pop-up closed')
+					} else if (error.response?.status === 429) {
+						this.feedback = t('mail', 'Configuration discovery temporarily not available. Please try again later.')
 					} else {
 						this.feedback = t('mail', 'There was an error while setting up your account')
 					}


### PR DESCRIPTION
If a user sends more attempts they either have incorrect options anyway or just try to overload the server.

## How to test

1) Open the app
2) Click *+ New account* in the navigation
3) Enter some invalid email address
4) Hammer the *Connect* button

`main`: You can try endlessly
here: You can try a bunch of times, then you see a nice error message:

![image](https://github.com/nextcloud/mail/assets/1374172/840545f2-a839-41dc-86ec-88526c9deaef)
