### PR TITLE
fix(Snooze): Allow snoozing gmail messages

### DIFF
--- a/lib/Db/ThreadMapper.php
+++ b/lib/Db/ThreadMapper.php
@@ -80,7 +80,7 @@ class ThreadMapper extends QBMapper {
 			->from($this->tableName, 'messages')
 			->where(
 				$qb->expr()->eq('messages.thread_root_id', $qb->createNamedParameter($threadRootId, IQueryBuilder::PARAM_STR)),
-			);
+			)->groupBy('messages.message_id');
 
 		$result = $qb->executeQuery();
 		$rows = array_map(static function (array $row) {


### PR DESCRIPTION
fix: #8724 

Due to the message appearing twice in the account (a folder which holds all mails) the snooze thread tries to insert the message twice in the db. Column is unique, so the server respons with error.

Also interesting for further implementation/bugfixing: When the message is snoozed and moved back by the normal move, the message can't be snoozed again because the db entry won't be deleted (probably because the move fails in the wake job).