### PR TITLE
fix: deprecation warning for drafts controller test

### DIFF
--- a/tests/Unit/Controller/DraftsControllerTest.php
+++ b/tests/Unit/Controller/DraftsControllerTest.php
@@ -50,6 +50,7 @@ class DraftsControllerTest extends TestCase {
 	private ITimeFactory $timeFactory;
 	private AccountService $accountService;
 	private DraftsController $controller;
+	private SmimeService $smimeService;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
For https://github.com/ChristophWurst/setup-nextcloud/pull/9