### PR TITLE
Snooze mvp follow up

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -390,18 +390,25 @@ class MessagesController extends Controller {
 	 *
 	 * @param int $id
 	 * @param int $unixTimestamp
+	 * @param int $destMailboxId
 	 *
 	 * @return JSONResponse
+	 * @throws ClientException
+	 * @throws ServiceException
 	 */
 	#[TrapError]
-	public function snooze(int $id, int $unixTimestamp): JSONResponse {
+	public function snooze(int $id, int $unixTimestamp, int $destMailboxId): JSONResponse {
 		try {
 			$message = $this->mailManager->getMessage($this->currentUserId, $id);
+			$srcMailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
+			$dstMailbox = $this->mailManager->getMailbox($this->currentUserId, $destMailboxId);
+			$srcAccount = $this->accountService->find($this->currentUserId, $srcMailbox->getAccountId());
+			$dstAccount = $this->accountService->find($this->currentUserId, $dstMailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->snoozeService->snoozeMessage($message, $unixTimestamp);
+		$this->snoozeService->snoozeMessage($message, $unixTimestamp, $srcAccount, $srcMailbox, $dstAccount, $dstMailbox);
 
 		return new JSONResponse();
 	}

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -104,18 +104,25 @@ class ThreadController extends Controller {
 	 *
 	 * @param int $id
 	 * @param int $unixTimestamp
+	 * @param int $destMailboxId
 	 *
 	 * @return JSONResponse
+	 * @throws ClientException
+	 * @throws ServiceException
 	 */
 	#[TrapError]
-	public function snooze(int $id, int $unixTimestamp): JSONResponse {
+	public function snooze(int $id, int $unixTimestamp, int $destMailboxId): JSONResponse {
 		try {
 			$selectedMessage = $this->mailManager->getMessage($this->currentUserId, $id);
+			$srcMailbox = $this->mailManager->getMailbox($this->currentUserId, $selectedMessage->getMailboxId());
+			$srcAccount = $this->accountService->find($this->currentUserId, $srcMailbox->getAccountId());
+			$dstMailbox = $this->mailManager->getMailbox($this->currentUserId, $destMailboxId);
+			$dstAccount = $this->accountService->find($this->currentUserId, $dstMailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$this->snoozeService->snoozeThread($selectedMessage, $unixTimestamp);
+		$this->snoozeService->snoozeThread($selectedMessage, $unixTimestamp, $srcAccount, $srcMailbox, $dstAccount, $dstMailbox);
 
 		return new JSONResponse();
 	}

--- a/lib/Db/MessageSnoozeMapper.php
+++ b/lib/Db/MessageSnoozeMapper.php
@@ -41,19 +41,15 @@ class MessageSnoozeMapper extends QBMapper {
 	/**
 	 * Deletes DB Entry for a waked message
 	 *
-	 * @param string $messageId
+	 * @param string[] $messageIds
 	 *
 	 * @return void
 	 */
-	public function deleteByMessageId(string $messageId): void {
+	public function deleteByMessageIds(array $messageIds): void {
 		$qb = $this->db->getQueryBuilder();
 
 		$delete = $qb->delete($this->getTableName())
-			->where($qb->expr()->eq(
-				'message_id',
-				$qb->createNamedParameter($messageId, IQueryBuilder::PARAM_STR),
-				IQueryBuilder::PARAM_STR,
-			));
+			->where($qb->expr()->in('message_id', $qb->createNamedParameter($messageIds, IQueryBuilder::PARAM_STR_ARRAY)));
 
 		$delete->executeStatement();
 	}

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -499,14 +499,9 @@ export default {
 			logger.info(`snoozing message ${this.envelope.databaseId}`)
 
 			try {
-				// Adds DB entry
 				await this.$store.dispatch('snoozeMessage', {
 					id: this.envelope.databaseId,
 					unixTimestamp: timestamp / 1000,
-				})
-				// Moves message
-				await this.$store.dispatch('moveMessage', {
-					id: this.envelope.databaseId,
 					destMailboxId: this.account.snoozeMailboxId,
 				})
 				showSuccess(t('mail', 'Message was snoozed'))

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -58,7 +58,7 @@
 					:size="20" />
 				<IconJunk v-else-if="mailbox.databaseId === account.junkMailboxId"
 					:size="20" />
-				<AlarmIcon v-else-if="mailbox.name === 'Snoozed'"
+				<AlarmIcon v-else-if="mailbox.databaseId === account.snoozeMailboxId"
 					:size="20" />
 				<IconFolderShared v-else-if="mailbox.shared"
 					:size="20" />

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -239,14 +239,14 @@ export function moveMessage(id, destFolderId) {
 	})
 }
 
-// Only adds DB entry, moving the message is done in a separate request
-export function snoozeMessage(id, unixTimestamp) {
+export function snoozeMessage(id, unixTimestamp, destMailboxId) {
 	const url = generateUrl('/apps/mail/api/messages/{id}/snooze', {
 		id,
 	})
 
 	return axios.post(url, {
 		unixTimestamp,
+		destMailboxId,
 	})
 }
 

--- a/src/service/ThreadService.js
+++ b/src/service/ThreadService.js
@@ -26,14 +26,13 @@ export async function moveThread(id, destMailboxId) {
 	}
 }
 
-// Only adds DB entry, moving the messages is done in a separate request
-export async function snoozeThread(id, unixTimestamp) {
+export async function snoozeThread(id, unixTimestamp, destMailboxId) {
 	const url = generateUrl('/apps/mail/api/thread/{id}/snooze', {
 		id,
 	})
 
 	try {
-		return await axios.post(url, { unixTimestamp })
+		return await axios.post(url, { unixTimestamp, destMailboxId })
 	} catch (e) {
 		throw convertAxiosError(e)
 	}


### PR DESCRIPTION
Fix: #8747 

This follow up is fixing some minor things:

- Update snooze options aligned to https://github.com/nextcloud/spreed/pull/10177
- Set alarm icon for selected dedicated mailbox (not just name match "Snoozed")
- Only one "snooze" request to the backend (not snooze and move)
- Enable snoozing message if DB entry for the message already exists
- Remove DB entry for the message if moving fails
- Move snooze logic to SnoozeService

