### PR TITLE
feat(snooze): Disable snooze on AJAX cron

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -236,10 +236,14 @@ class PageController extends Controller {
 			);
 		}
 
-		// Disable scheduled send in frontend if ajax cron is used because it is unreliable
+		// Disable snooze and scheduled send in frontend if ajax cron is used because it is unreliable
 		$cronMode = $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
 		$this->initialStateService->provideInitialState(
 			'disable-scheduled-send',
+			$cronMode === 'ajax',
+		);
+		$this->initialStateService->provideInitialState(
+			'disable-snooze',
 			$cronMode === 'ajax',
 		);
 

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -165,7 +165,7 @@
 					</template>
 					{{ t('mail', 'Edit tags') }}
 				</ActionButton>
-				<ActionButton
+				<ActionButton v-if="!isSnoozeDisabled"
 					:close-after-click="false"
 					@click="showSnoozeOptions">
 					<template #icon>
@@ -384,6 +384,7 @@ import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import CalendarClock from 'vue-material-design-icons/CalendarClock'
 import AlarmIcon from 'vue-material-design-icons/Alarm'
 import moment from '@nextcloud/moment'
+import { mapGetters } from 'vuex'
 
 export default {
 	name: 'Envelope',
@@ -475,6 +476,9 @@ export default {
 		}
 	},
 	computed: {
+		...mapGetters([
+			'isSnoozeDisabled',
+		]),
 		messageLongDate() {
 			return messageDateTime(new Date(this.data.dateInt))
 		},

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -91,7 +91,8 @@
 				</template>
 				{{ t('mail', 'Move message') }}
 			</ActionButton>
-			<ActionButton :close-after-click="false"
+			<ActionButton v-if="!isSnoozeDisabled"
+				:close-after-click="false"
 				@click="snoozeActionsOpen = true">
 				<template #icon>
 					<AlarmIcon :title="t('mail', 'Snooze')"
@@ -293,6 +294,7 @@ import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput'
 import AlarmIcon from 'vue-material-design-icons/Alarm'
 import logger from '../logger'
 import moment from '@nextcloud/moment'
+import { mapGetters } from 'vuex'
 
 export default {
 	name: 'MenuEnvelope',
@@ -374,6 +376,9 @@ export default {
 		}
 	},
 	computed: {
+		...mapGetters([
+			'isSnoozeDisabled',
+		]),
 		account() {
 			const accountId = this.envelope.accountId ?? this.mailbox.accountId
 			return this.$store.getters.getAccount(accountId)

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,7 @@ const accounts = loadState('mail', 'accounts', [])
 const tags = loadState('mail', 'tags', [])
 const outboxMessages = loadState('mail', 'outbox-messages')
 const disableScheduledSend = loadState('mail', 'disable-scheduled-send')
+const disableSnooze = loadState('mail', 'disable-snooze')
 const googleOauthUrl = loadState('mail', 'google-oauth-url', null)
 const microsoftOauthUrl = loadState('mail', 'microsoft-oauth-url', null)
 
@@ -128,6 +129,7 @@ tags.forEach(tag => store.commit('addTag', { tag }))
 outboxMessages.forEach(message => store.commit('outbox/addMessage', { message }))
 
 store.commit('setScheduledSendingDisabled', disableScheduledSend)
+store.commit('setSnoozeDisabled', disableSnooze)
 store.commit('setGoogleOauthUrl', googleOauthUrl)
 store.commit('setMicrosoftOauthUrl', microsoftOauthUrl)
 

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -115,6 +115,7 @@ export const getters = {
 		return state.tagList.map(tagId => state.tags[tagId])
 	},
 	isScheduledSendingDisabled: (state) => state.isScheduledSendingDisabled,
+	isSnoozeDisabled: (state) => state.isSnoozeDisabled,
 	googleOauthUrl: (state) => state.googleOauthUrl,
 	microsoftOauthUrl: (state) => state.microsoftOauthUrl,
 	getActiveSieveScript: (state) => (accountId) => state.sieveScript[accountId],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -100,6 +100,7 @@ export default new Store({
 				tags: {},
 				tagList: [],
 				isScheduledSendingDisabled: false,
+				isSnoozeDisabled: false,
 				currentUserPrincipal: undefined,
 				googleOauthUrl: null,
 				sieveScript: {},

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -460,6 +460,9 @@ export default {
 	setScheduledSendingDisabled(state, value) {
 		state.isScheduledSendingDisabled = value
 	},
+	setSnoozeDisabled(state, value) {
+		state.isSnoozeDisabled = value
+	},
 	setActiveSieveScript(state, { accountId, scriptData }) {
 		Vue.set(state.sieveScript, accountId, scriptData)
 	},

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -79,7 +79,6 @@ class MailAccountTest extends TestCase {
 			'quotaPercentage' => 10,
 			'trashRetentionDays' => 60,
 			'junkMailboxId' => null,
-			'moveJunk' => false,
 			'snoozeMailboxId' => null
 		], $a->toJson());
 	}
@@ -115,7 +114,6 @@ class MailAccountTest extends TestCase {
 			'quotaPercentage' => null,
 			'trashRetentionDays' => 60,
 			'junkMailboxId' => null,
-			'moveJunk' => false,
 			'snoozeMailboxId' => null,
 		];
 		$a = new MailAccount($expected);

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -275,7 +275,7 @@ class PageControllerTest extends TestCase {
 			->method('getLoginCredentials')
 			->willReturn($loginCredentials);
 
-		$this->initialState->expects($this->exactly(13))
+		$this->initialState->expects($this->exactly(14))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
@@ -288,6 +288,7 @@ class PageControllerTest extends TestCase {
 				['prefill_email', 'jane@doe.cz'],
 				['outbox-messages', []],
 				['disable-scheduled-send', false],
+				['disable-snooze', false],
 				['allow-new-accounts', true],
 				['enabled_thread_summary', false],
 				['smime-certificates', []],


### PR DESCRIPTION
Fix: #8745

Don't allow to snooze mails if AJAX is selected as background cron trigger.