### PR TITLE
remove some warnings from jest frontend tests

### DIFF
--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -63,6 +63,7 @@ describe('Composer', () => {
 		const view = shallowMount(Composer, {
 			propsData: {
 				inReplyToMessageId: 'abc123',
+				isFirstOpen: true,
 			},
 			store,
 			localVue,
@@ -77,6 +78,7 @@ describe('Composer', () => {
 		const view = shallowMount(Composer, {
 			propsData: {
 				inReplyToMessageId: 'abc123',
+				isFirstOpen: true,
 			},
 			store,
 			localVue,
@@ -93,7 +95,8 @@ describe('Composer', () => {
 				inReplyToMessageId: 'abc123',
 				to: [
 					{ label: 'test', email: 'test@domain.tld' },
-				]
+				],
+				isFirstOpen: true,
 			},
 			store,
 			localVue,
@@ -106,6 +109,9 @@ describe('Composer', () => {
 
 	it('should not S/MIME sign messages if there are no certs', () => {
 		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return undefined
@@ -124,6 +130,9 @@ describe('Composer', () => {
 
 	it('should S/MIME sign messages if there are certs', () => {
 		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
@@ -142,6 +151,9 @@ describe('Composer', () => {
 
 	it('should not S/MIME encrypt messages if there are no certs', () => {
 		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return undefined
@@ -160,6 +172,9 @@ describe('Composer', () => {
 
 	it('should not S/MIME encrypt messages if there are missing recipient certs', () => {
 		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
@@ -181,6 +196,9 @@ describe('Composer', () => {
 
 	it('should S/MIME sign messages if there are certs', () => {
 		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
@@ -202,6 +220,9 @@ describe('Composer', () => {
 
 	it('generate title for submit button', () => {
 		const view = shallowMount(Composer, {
+            propsData: {
+				isFirstOpen: true,
+            },
 			store,
 			localVue,
 		})
@@ -221,6 +242,9 @@ describe('Composer', () => {
 
 	it('generate title for submit button (send later)', () => {
 		const view = shallowMount(Composer, {
+            propsData: {
+                isFirstOpen: true,
+            },
 			store,
 			localVue,
 		})

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -38,6 +38,10 @@ describe('Composer', () => {
 	let store
 
 	beforeEach(() => {
+		Object.defineProperty(window, "firstDay", {
+			value: 0
+		})
+
 		actions = {}
 		getters = {
 			accounts: () => [

--- a/src/tests/unit/components/ThreadEnvelope.vue.spec.js
+++ b/src/tests/unit/components/ThreadEnvelope.vue.spec.js
@@ -65,16 +65,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: undefined }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -95,16 +93,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 'x' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -125,16 +121,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 's' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -154,7 +148,10 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -162,11 +159,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { myAcls: undefined }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -187,7 +179,10 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -195,11 +190,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { myAcls: 'i' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -220,7 +210,10 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -228,11 +221,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { myAcls: undefined }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -253,7 +241,10 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -261,11 +252,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -286,16 +272,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 'x' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -316,17 +300,15 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: undefined }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -346,17 +328,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
-
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 's' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -376,16 +355,14 @@ describe('ThreadEnvelope', () => {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
 					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 'te' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -412,16 +389,14 @@ describe('ThreadEnvelope', () => {
 						hasAttachments: false,
 						draft: false,
 					},
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
 					return { myAcls: 'w' }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -449,7 +424,10 @@ describe('ThreadEnvelope', () => {
 						hasAttachments: false,
 						draft: false,
 					},
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -457,11 +435,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,
@@ -488,7 +461,10 @@ describe('ThreadEnvelope', () => {
 						hasAttachments: false,
 						draft: false,
 					},
+					subject: '',
+					dateInt: 1692200926180,
 				},
+				threadSubject: ''
 			},
 			computed: {
 				mailbox() {
@@ -496,11 +472,6 @@ describe('ThreadEnvelope', () => {
 				},
 				archiveMailbox() {
 					return { }
-				},
-			},
-			methods: {
-				filterSubject() {
-					return undefined;
 				},
 			},
 			store,


### PR DESCRIPTION
To avoid/remove

- Missing required prop: "isFirstOpen"
- "No firstDay found" 
- Missing required prop: "threadSubject"
- Invalid prop: type check failed for prop "timestamp". Expected Number, got Undefined
- overwriting methods via the `methods` property is deprecated and will be removed in the next major version.