### PR TITLE
fix(snooze): Add cleanup orphan db entries

### DIFF
--- a/lib/Service/CleanupService.php
+++ b/lib/Service/CleanupService.php
@@ -30,6 +30,7 @@ use OCA\Mail\Db\CollectedAddressMapper;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Db\MessageRetentionMapper;
+use OCA\Mail\Db\MessageSnoozeMapper;
 use OCA\Mail\Db\TagMapper;
 
 class CleanupService {
@@ -50,18 +51,22 @@ class CleanupService {
 
 	private MessageRetentionMapper $messageRetentionMapper;
 
+	private MessageSnoozeMapper $messageSnoozeMapper;
+
 	public function __construct(AliasMapper $aliasMapper,
 		MailboxMapper $mailboxMapper,
 		MessageMapper $messageMapper,
 		CollectedAddressMapper $collectedAddressMapper,
 		TagMapper $tagMapper,
-		MessageRetentionMapper $messageRetentionMapper) {
+		MessageRetentionMapper $messageRetentionMapper,
+		MessageSnoozeMapper $messageSnoozeMapper) {
 		$this->aliasMapper = $aliasMapper;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->collectedAddressMapper = $collectedAddressMapper;
 		$this->tagMapper = $tagMapper;
 		$this->messageRetentionMapper = $messageRetentionMapper;
+		$this->messageSnoozeMapper = $messageSnoozeMapper;
 	}
 
 	public function cleanUp(): void {
@@ -72,5 +77,6 @@ class CleanupService {
 		$this->tagMapper->deleteOrphans();
 		$this->tagMapper->deleteDuplicates();
 		$this->messageRetentionMapper->deleteOrphans();
+		$this->messageSnoozeMapper->deleteOrphans();
 	}
 }


### PR DESCRIPTION
Fix: #8763 

Adds a cleanup call to delete all db entries in the snooze table that should have been unsnoozed 30d ago. We assume that these messages no longer exist in the snoozed mailbox.