### PR TITLE
fix(Snooze): Sort snooze mailbox as specialUse

### DIFF
--- a/src/imap/MailboxSorter.js
+++ b/src/imap/MailboxSorter.js
@@ -23,7 +23,7 @@ import clone from 'lodash/fp/clone'
 
 const specialRolesOrder = ['all', 'inbox', 'flagged', 'drafts', 'sent', 'archive', 'junk', 'trash']
 
-export const sortMailboxes = (mailboxes) => {
+export const sortMailboxes = (mailboxes, account) => {
 	const c = clone(mailboxes)
 	c.sort((f1, f2) => {
 		if (f1.specialUse.length && f2.specialUse.length) {
@@ -39,6 +39,11 @@ export const sortMailboxes = (mailboxes) => {
 			return -1
 		} else if (f2.specialUse.length) {
 			return 1
+		} else if (f1.databaseId === account.snoozeMailboxId) {
+			// Sort Snoozed mailbox to specialRole mailboxes.
+			// Because this mailbox does not have specialUse,
+			// we need to check the databaseId for snoozeMailboxId
+			return -1
 		} else {
 			return f1.name.localeCompare(f2.name)
 		}

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -144,7 +144,7 @@ export default {
 		)
 
 		// Save the mailboxes to the store, but only keep IDs in the account's mailboxes list
-		const mailboxes = sortMailboxes(account.mailboxes || [])
+		const mailboxes = sortMailboxes(account.mailboxes || [], account)
 		Vue.set(account, 'mailboxes', [])
 		Vue.set(account, 'aliases', account.aliases ?? [])
 		mailboxes.map(addMailboxToState(state, account))

--- a/src/tests/unit/imap/MailboxSorter.spec.js
+++ b/src/tests/unit/imap/MailboxSorter.spec.js
@@ -26,14 +26,20 @@ describe('mailboxSorter', () => {
 		const mb1 = {
 			name: 'Inbox 1',
 			specialUse: [],
+			databaseId: 1,
 		}
 		const mb2 = {
 			name: 'Inbox 2',
 			specialUse: [],
+			databaseId: 2,
 		}
 		const mailboxes = [mb2, mb1]
 
-		const sorted = sortMailboxes(mailboxes)
+		const account = {
+			snoozeMailboxId: 0,
+		}
+
+		const sorted = sortMailboxes(mailboxes, account)
 
 		expect(sorted).toEqual([mb1, mb2])
 	})
@@ -42,14 +48,20 @@ describe('mailboxSorter', () => {
 		const mb1 = {
 			name: 'Inbox 1',
 			specialUse: [],
+			databaseId: 1,
 		}
 		const mb2 = {
 			name: 'Inbox 2',
 			specialUse: ['inbox'],
+			databaseId: 2,
 		}
 		const mailboxes = [mb1, mb2]
 
-		const sorted = sortMailboxes(mailboxes)
+		const account = {
+			snoozeMailboxId: 0,
+		}
+
+		const sorted = sortMailboxes(mailboxes, account)
 
 		expect(sorted).toEqual([mb2, mb1])
 	})
@@ -58,14 +70,20 @@ describe('mailboxSorter', () => {
 		const mb1 = {
 			name: 'Inbox 1',
 			specialUse: ['inbox'],
+			databaseId: 1,
 		}
 		const mb2 = {
 			name: 'Inbox 2',
 			specialUse: ['inbox'],
+			databaseId: 2,
 		}
 		const mailboxes = [mb1, mb2]
 
-		const sorted = sortMailboxes(mailboxes)
+		const account = {
+			snoozeMailboxId: 0,
+		}
+
+		const sorted = sortMailboxes(mailboxes, account)
 
 		expect(sorted).toEqual([mb1, mb2])
 	})
@@ -74,31 +92,46 @@ describe('mailboxSorter', () => {
 		const mb1 = {
 			name: 'Drafts',
 			specialUse: ['drafts'],
+			databaseId: 2,
 		}
 		const mb2 = {
 			name: 'Inbox',
 			specialUse: ['inbox'],
+			databaseId: 1,
 		}
 		const mb3 = {
 			name: 'Other 2',
 			specialUse: [],
+			databaseId: 3,
 		}
 		const mb4 = {
 			name: 'Other 1',
 			specialUse: [],
+			databaseId: 4,
 		}
 		const mb5 = {
 			name: 'Sent',
 			specialUse: ['sent'],
+			databaseId: 5,
 		}
 		const mb6 = {
 			name: 'Sent2',
 			specialUse: ['sent'],
+			databaseId: 6,
 		}
-		const mailboxes = [mb1, mb2, mb3, mb4, mb5, mb6]
+		const mb7 = {
+			name: 'Snoozed',
+			specialUse: [],
+			databaseId: 7,
+		}
+		const mailboxes = [mb1, mb2, mb3, mb4, mb5, mb6, mb7]
 
-		const sorted = sortMailboxes(mailboxes)
+		const account = {
+			snoozeMailboxId: 7,
+		}
 
-		expect(sorted).toEqual([mb2, mb1, mb5, mb6, mb4, mb3])
+		const sorted = sortMailboxes(mailboxes, account)
+
+		expect(sorted).toEqual([mb2, mb1, mb5, mb6, mb7, mb4, mb3])
 	})
 })


### PR DESCRIPTION
Fix: #8746 

If a dedicated snooze mailbox is selected in the account settings, it is shown as a special use mailbox before none special mailboxes

|before|after|
|---|---|
|![image](https://github.com/nextcloud/mail/assets/74607597/6332e6f8-376b-4bc3-9334-5da745d8c71e)|![image](https://github.com/nextcloud/mail/assets/74607597/7e2ab719-39b9-4082-815c-572815a0688d)|