### PR TITLE
fix: drop index on mail_messages_retention.message_id

### DIFF
--- a/lib/Migration/Version3400Date20230819161945.php
+++ b/lib/Migration/Version3400Date20230819161945.php
@@ -28,11 +28,10 @@ namespace OCA\Mail\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
-use OCP\DB\Types;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version3300Date20230801124717 extends SimpleMigrationStep {
+class Version3400Date20230819161945 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
@@ -44,30 +43,9 @@ class Version3300Date20230801124717 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$accountsTable = $schema->getTable('mail_accounts');
-		if (!$accountsTable->hasColumn('trash_retention_days')) {
-			$accountsTable->addColumn('trash_retention_days', Types::INTEGER, [
-				'notnull' => false,
-				'default' => null,
-			]);
-		}
-
-		if (!$schema->hasTable('mail_messages_retention')) {
-			$messagesRetentionTable = $schema->createTable('mail_messages_retention');
-			$messagesRetentionTable->addColumn('id', Types::INTEGER, [
-				'autoincrement' => true,
-				'notnull' => true,
-				'length' => 4,
-			]);
-			$messagesRetentionTable->addColumn('message_id', Types::STRING, [
-				'notnull' => true,
-				'length' => 1024,
-			]);
-			$messagesRetentionTable->addColumn('known_since', Types::INTEGER, [
-				'notnull' => true,
-				'length' => 4,
-			]);
-			$messagesRetentionTable->setPrimaryKey(['id'], 'mail_msg_retention_id_idx');
+		$messagesRetentionTable = $schema->getTable('mail_messages_retention');
+		if ($messagesRetentionTable->hasIndex('mail_msg_retention_msgid_idx')) {
+			$messagesRetentionTable->dropIndex('mail_msg_retention_msgid_idx');
 		}
 
 		return $schema;


### PR DESCRIPTION
Fix #8748
Fix #8706

Followup to https://github.com/nextcloud/mail/pull/8627

Indeed a remark made 13 years ago [on Stackoverflow](https://stackoverflow.com/a/3489097):
> Think about the meaning of an index. It's quick access to a row when all your indexed fields are within the where clause. If an index is to long (in case of mysql more than 1000 bytes), it makes no sense to use an index, because it's probably slower than accessing the complete table with a full table scan.

Credits to @tmlmt for the research.

We just can't store such an index on such a wide column.