### PR TITLE
Fix the white space on small screen for the threads

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -377,6 +377,12 @@ export default {
 		}
 	}
 }
+@media only screen and (max-width: 1024px) {
+	#mail-thread-header-fields,
+	h2 {
+		margin-top: -20px;
+	}
+}
 
 .attachment-popover {
 	position: sticky;


### PR DESCRIPTION
This is a quick fixup for the white space on small screen for threads. The main issue is the back button, that creates the white space, but i dont see how we can fix that on the nc/vue component. For now, i would go for this fixup.

after
![Screenshot from 2023-08-21 12-57-26](https://github.com/nextcloud/mail/assets/12728974/6b728611-4e02-4a75-bf03-27ae7378d87b)
fixes #8251 