### PR TITLE
Added missing check to see if envelope is eligible to be removed

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -451,7 +451,7 @@ export default {
 		async markSelectionJunk() {
 			for (const envelope of this.selectedEnvelopes) {
 				if (!envelope.flags.$junk) {
-					this.$store.dispatch('toggleEnvelopeJunk', {
+					await this.$store.dispatch('toggleEnvelopeJunk', {
 						envelope,
 						removeEnvelope: await this.$store.dispatch('moveEnvelopeToJunk', envelope),
 					})
@@ -459,15 +459,15 @@ export default {
 			}
 			this.unselectAll()
 		},
-		markSelectionNotJunk() {
-			this.selectedEnvelopes.forEach((envelope) => {
+		async markSelectionNotJunk() {
+			for (const envelope of this.selectedEnvelopes) {
 				if (envelope.flags.$junk) {
-					this.$store.dispatch('toggleEnvelopeJunk', {
+					await this.$store.dispatch('toggleEnvelopeJunk', {
 						envelope,
-						removeEnvelope: true,
+						removeEnvelope: await this.$store.dispatch('moveEnvelopeToJunk', envelope),
 					})
 				}
-			})
+			}
 			this.unselectAll()
 		},
 		favoriteOrUnfavoriteAll() {


### PR DESCRIPTION
Followup to #8762 which was missing this PRs changes:
> @auroraanna Aloha, could you send a pull request to also adjust markSelectionNotJunk() to use for of + await like for markSelectionJunk? Sorry I overlooked it in my first review.
>
> -- @kesselb

The `moveEnvelopeToJunk` action covers both cases according to @kesselb so `markSelectionNotJunk()` should have it too.