### PR TITLE
fix(db): Identify retention and snooze mailboxes uniquely

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Positive:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>3.5.0-alpha.1</version>
+	<version>3.5.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Greta Doçi</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/BackgroundJob/TrashRetentionJob.php
+++ b/lib/BackgroundJob/TrashRetentionJob.php
@@ -112,7 +112,6 @@ class TrashRetentionJob extends TimedJob {
 			return;
 		}
 
-		$processedMessageIds = [];
 		$client = $this->clientFactory->getClient($account);
 		try {
 			foreach ($messages as $message) {
@@ -122,16 +121,13 @@ class TrashRetentionJob extends TimedJob {
 					$message->getUid(),
 					$client,
 				);
-
-				$messageId = $message->getMessageId();
-				if ($messageId !== null) {
-					$processedMessageIds[] = $messageId;
-				}
+				$this->messageRetentionMapper->deleteByMailboxIdAndUid(
+					$message->getMailboxId(),
+					$message->getUid(),
+				);
 			}
 		} finally {
 			$client->logout();
 		}
-
-		$this->messageRetentionMapper->deleteByMessageIds($processedMessageIds);
 	}
 }

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -131,6 +131,7 @@ interface IMailManager {
 	 * @param int $uid
 	 * @param Account $destinationAccount
 	 * @param string $destFolderId
+	 * @return int the new UID
 	 *
 	 * @throws ServiceException
 	 */
@@ -138,7 +139,7 @@ interface IMailManager {
 		string $sourceFolderId,
 		int $uid,
 		Account $destinationAccount,
-		string $destFolderId);
+		string $destFolderId): int;
 
 	/**
 	 * @param Account $account
@@ -322,10 +323,10 @@ interface IMailManager {
 	 * @param Account $dstAccount
 	 * @param Mailbox $dstMailbox
 	 * @param string $threadRootId
-	 * @return void
+	 * @return int[] the new UIDs
 	 * @throws ServiceException
 	 */
-	public function moveThread(Account $srcAccount, Mailbox $srcMailbox, Account $dstAccount, Mailbox $dstMailbox, string $threadRootId): void;
+	public function moveThread(Account $srcAccount, Mailbox $srcMailbox, Account $dstAccount, Mailbox $dstMailbox, string $threadRootId): array;
 
 	/**
 	 * @param Account $account

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1427,10 +1427,17 @@ class MessageMapper extends QBMapper {
 
 		$select = $qb->select('m.*')
 			->from($this->getTableName(), 'm')
-			->join('m', 'mail_messages_retention', 'mr', $qb->expr()->eq(
-				'm.message_id',
-				'mr.message_id',
-				IQueryBuilder::PARAM_STR,
+			->join('m', 'mail_messages_retention', 'mr', $qb->expr()->andX(
+				$qb->expr()->eq(
+					'm.mailbox_id',
+					'mr.mailbox_id',
+					IQueryBuilder::PARAM_INT,
+				),
+				$qb->expr()->eq(
+					'm.uid',
+					'mr.uid',
+					IQueryBuilder::PARAM_INT,
+				),
 			))
 			->where(
 				$qb->expr()->eq(
@@ -1461,10 +1468,17 @@ class MessageMapper extends QBMapper {
 
 		$select = $qb->select('m.*')
 			->from($this->getTableName(), 'm')
-			->join('m', 'mail_messages_snoozed', 'mr', $qb->expr()->eq(
-				'm.message_id',
-				'mr.message_id',
-				IQueryBuilder::PARAM_STR,
+			->join('m', 'mail_messages_snoozed', 'mr', $qb->expr()->andX(
+				$qb->expr()->eq(
+					'm.mailbox_id',
+					'mr.mailbox_id',
+					IQueryBuilder::PARAM_INT,
+				),
+				$qb->expr()->eq(
+					'm.uid',
+					'mr.uid',
+					IQueryBuilder::PARAM_INT,
+				),
 			))
 			->where(
 				$qb->expr()->eq(

--- a/lib/Db/MessageRetention.php
+++ b/lib/Db/MessageRetention.php
@@ -29,21 +29,27 @@ namespace OCA\Mail\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method void setMessageId(string $messageId)
- * @method string getMessageId()
+ * @method void setMailboxId(int $mailboxId)
+ * @method int getMailboxId()
+ * @method void setUid(int $uid)
+ * @method int getUid()
  * @method void setKnownSince(int $knownSince)
  * @method int getKnownSince()
  */
 class MessageRetention extends Entity {
 
-	/** @var string */
-	protected $messageId;
+	/** @var int */
+	protected $mailboxId;
+
+	/** @var int */
+	protected $uid;
 
 	/** @var int */
 	protected $knownSince;
 
 	public function __construct() {
-		$this->addType('messageId', 'string');
+		$this->addType('mailboxId', 'integer');
+		$this->addType('uid', 'integer');
 		$this->addType('knownSince', 'integer');
 	}
 }

--- a/lib/Db/MessageSnooze.php
+++ b/lib/Db/MessageSnooze.php
@@ -29,8 +29,10 @@ namespace OCA\Mail\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method void setMessageId(string $messageId)
- * @method string getMessageId()
+ * @method void setMailboxId(int $mailboxId)
+ * @method int getMailboxId()
+ * @method void setUid(int $uid)
+ * @method int getUid()
  * @method void setSnoozedUntil(int $snoozeUntil)
  * @method int getSnoozedUntil()
  * @method void setSrcMailboxId(int $srcMailboxId)
@@ -38,8 +40,11 @@ use OCP\AppFramework\Db\Entity;
  */
 class MessageSnooze extends Entity {
 
-	/** @var string */
-	protected $messageId;
+	/** @var int */
+	protected $mailboxId;
+
+	/** @var int */
+	protected $uid;
 
 	/** @var int */
 	protected $snoozedUntil;
@@ -48,7 +53,8 @@ class MessageSnooze extends Entity {
 	protected $srcMailboxId;
 
 	public function __construct() {
-		$this->addType('messageId', 'string');
+		$this->addType('mailboxId', 'integer');
+		$this->addType('uid', 'integer');
 		$this->addType('snoozedUntil', 'integer');
 		$this->addType('srcMailboxId', 'integer');
 	}

--- a/lib/Db/MessageSnoozeMapper.php
+++ b/lib/Db/MessageSnoozeMapper.php
@@ -47,16 +47,21 @@ class MessageSnoozeMapper extends QBMapper {
 	 *
 	 * @return int|null
 	 */
-	public function getSrcMailboxId(string $messageId): ?int {
+	public function getSrcMailboxId(int $mailboxId, int $uid): ?int {
 		$qb = $this->db->getQueryBuilder();
 
 		$select = $qb->select('src_mailbox_id')
 			->from($this->getTableName())
 			->where(
 				$qb->expr()->eq(
-					'message_id',
-					$qb->createNamedParameter($messageId, IQueryBuilder::PARAM_STR),
-					IQueryBuilder::PARAM_STR
+					'mailbox_id',
+					$qb->createNamedParameter($mailboxId, IQueryBuilder::PARAM_INT),
+					IQueryBuilder::PARAM_INT
+				),
+				$qb->expr()->eq(
+					'uid',
+					$qb->createNamedParameter($uid, IQueryBuilder::PARAM_INT),
+					IQueryBuilder::PARAM_INT
 				),
 				$qb->expr()->isNotNull(
 					'src_mailbox_id'
@@ -73,17 +78,24 @@ class MessageSnoozeMapper extends QBMapper {
 	}
 
 	/**
-	 * Deletes DB Entry for a waked message
-	 *
-	 * @param string[] $messageIds
-	 *
-	 * @return void
+	 * Deletes DB Entry for woken message
 	 */
-	public function deleteByMessageIds(array $messageIds): void {
+	public function deleteByMailboxIdAndUid(int $mailboxId, int $uid): void {
 		$qb = $this->db->getQueryBuilder();
 
 		$delete = $qb->delete($this->getTableName())
-			->where($qb->expr()->in('message_id', $qb->createNamedParameter($messageIds, IQueryBuilder::PARAM_STR_ARRAY)));
+			->where(
+				$qb->expr()->eq(
+					'mailbox_id',
+					$qb->createNamedParameter($mailboxId, IQueryBuilder::PARAM_INT),
+					IQueryBuilder::PARAM_INT,
+				),
+				$qb->expr()->eq(
+					'uid',
+					$qb->createNamedParameter($uid, IQueryBuilder::PARAM_INT),
+					IQueryBuilder::PARAM_INT,
+				),
+			);
 
 		$delete->executeStatement();
 	}

--- a/lib/Db/ThreadMapper.php
+++ b/lib/Db/ThreadMapper.php
@@ -71,25 +71,4 @@ class ThreadMapper extends QBMapper {
 		return $rows;
 	}
 
-	/**
-	 * @return array<array-key, array{messageId: string}>
-	 */
-	public function findMessageIdsByThreadRoot(string $threadRootId): array {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select('messages.message_id')
-			->from($this->tableName, 'messages')
-			->where(
-				$qb->expr()->eq('messages.thread_root_id', $qb->createNamedParameter($threadRootId, IQueryBuilder::PARAM_STR)),
-			)->groupBy('messages.message_id');
-
-		$result = $qb->executeQuery();
-		$rows = array_map(static function (array $row) {
-			return [
-				'messageId' => (string)$row[0]
-			];
-		}, $result->fetchAll(\PDO::FETCH_NUM));
-		$result->closeCursor();
-
-		return $rows;
-	}
 }

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -317,17 +317,21 @@ class MessageMapper {
 	 * @param string $sourceFolderId
 	 * @param int $messageId
 	 * @param string $destFolderId
+	 * @return int the new UID
 	 */
 	public function move(Horde_Imap_Client_Base $client,
 		string $sourceFolderId,
 		int $messageId,
-		string $destFolderId): void {
+		string $destFolderId): int {
 		try {
-			$client->copy($sourceFolderId, $destFolderId,
+			$mapping = $client->copy($sourceFolderId, $destFolderId,
 				[
 					'ids' => new Horde_Imap_Client_Ids($messageId),
 					'move' => true,
+					'force_map' => true,
 				]);
+
+			return $mapping[$messageId];
 		} catch (Horde_Imap_Client_Exception $e) {
 			$this->logger->debug($e->getMessage(),
 				[

--- a/lib/Listener/MessageKnownSinceListener.php
+++ b/lib/Listener/MessageKnownSinceListener.php
@@ -66,7 +66,8 @@ class MessageKnownSinceListener implements IEventListener {
 			}
 
 			$retention = new MessageRetention();
-			$retention->setMessageId($message->getMessageId());
+			$retention->setMailboxId($message->getMailboxId());
+			$retention->setUid($message->getUid());
 			$retention->setKnownSince($now);
 			$this->messageRetentionMapper->insert($retention);
 		}

--- a/lib/Migration/Version3400Date20230907103114.php
+++ b/lib/Migration/Version3400Date20230907103114.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3400Date20230907103114 extends SimpleMigrationStep {
+
+	private IDBConnection $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		foreach (['mail_messages_retention', 'mail_messages_snoozed'] as $tableName) {
+			$qb = $this->connection->getQueryBuilder();
+			$query = $qb->delete($tableName);
+			$query->executeStatement();
+		}
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$retentionTable = $schema->getTable('mail_messages_retention');
+		if ($retentionTable->hasIndex('mail_msg_retention_msgid_idx')) {
+			$retentionTable->dropColumn('mail_msg_retention_msgid_idx');
+		}
+		if ($retentionTable->hasColumn('message_id')) {
+			$retentionTable->dropColumn('message_id');
+		}
+		if (!$retentionTable->hasColumn('mailbox_id')) {
+			$retentionTable->addColumn('mailbox_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+		}
+		if (!$retentionTable->hasColumn('uid')) {
+			$retentionTable->addColumn('uid', Types::INTEGER, [
+				'notnull' => true,
+			]);
+		}
+		if (!$retentionTable->hasIndex('mail_msg_retention_mbuid_idx')) {
+			$retentionTable->addUniqueIndex(['mailbox_id', 'uid'], 'mail_msg_retention_mbuid_idx');
+		}
+
+		$snoozedTable = $schema->getTable('mail_messages_snoozed');
+		if ($snoozedTable->hasIndex('mail_msg_snoozed_msgid_idx')) {
+			$snoozedTable->dropColumn('mail_msg_snoozed_msgid_idx');
+		}
+		if ($snoozedTable->hasColumn('message_id')) {
+			$snoozedTable->dropColumn('message_id');
+		}
+		if (!$snoozedTable->hasColumn('mailbox_id')) {
+			$snoozedTable->addColumn('mailbox_id', Types::INTEGER, [
+				'notnull' => true,
+			]);
+		}
+		if (!$snoozedTable->hasColumn('uid')) {
+			$snoozedTable->addColumn('uid', Types::INTEGER, [
+				'notnull' => true,
+			]);
+		}
+		if (!$snoozedTable->hasIndex('mail_msg_snoozed_mbuid_idx')) {
+			$snoozedTable->addUniqueIndex(['mailbox_id', 'uid'], 'mail_msg_snoozed_mbuid_idx');
+		}
+
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "3.5.0-alpha.1",
+  "version": "3.5.0-alpha2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "3.5.0-alpha.1",
+      "version": "3.5.0-alpha2",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "37.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "3.5.0-alpha.1",
+  "version": "3.5.0-alpha2",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,

--- a/tests/Unit/Job/TrashRetentionJobTest.php
+++ b/tests/Unit/Job/TrashRetentionJobTest.php
@@ -112,6 +112,7 @@ class TrashRetentionJobTest extends TestCase {
 		$account = new Account($dbAccount);
 		$trash = new Mailbox();
 		$message = new Message();
+		$message->setMailboxId(123);
 		$message->setUid(420);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 

--- a/tests/Unit/Listener/MessageKnownSinceListenerTest.php
+++ b/tests/Unit/Listener/MessageKnownSinceListenerTest.php
@@ -60,23 +60,24 @@ class MessageKnownSinceListenerTest extends TestCase {
 		);
 	}
 
-	public function testHandle() {
+	public function testHandle(): void {
 		$dbAccount = new MailAccount();
 		$dbAccount->setTrashRetentionDays(60);
 		$dbAccount->setTrashMailboxId(420);
 		$account = new Account($dbAccount);
 		$mailbox = $this->createMock(Mailbox::class);
 		$message1 = new Message();
-		$message1->setMessageId('<foobar@local.host>');
+		$message1->setUid(11);
 		$message1->setMailboxId(420);
 		$message2 = new Message();
-		$message2->setMessageId('<foobar2@local.host>');
+		$message2->setUid(12);
 		$message2->setMailboxId(1);
 		$messages = [$message1, $message2];
 		$event = new NewMessagesSynchronized($account, $mailbox, $messages);
 
 		$messageRetention = new MessageRetention();
-		$messageRetention->setMessageId('<foobar@local.host>');
+		$messageRetention->setUid(11);
+		$messageRetention->setMailboxId(420);
 		$messageRetention->setKnownSince(1000);
 
 		$this->timeFactory->expects($this->once())
@@ -89,7 +90,7 @@ class MessageKnownSinceListenerTest extends TestCase {
 		$this->messageKnownSinceListener->handle($event);
 	}
 
-	public function testHandleWithoutRetention() {
+	public function testHandleWithoutRetention(): void {
 		$dbAccount = new MailAccount();
 		$dbAccount->setTrashRetentionDays(null);
 		$dbAccount->setTrashMailboxId(420);


### PR DESCRIPTION
The IMAP message id is not unique across mailboxes or accounts. Multiple accounts that receive the same message will cause a conflict.