### PR TITLE
Smart replies for mail

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -281,6 +281,11 @@ return [
 			'verb' => 'POST'
 		],
 		[
+			'name' => 'messages#smartReply',
+			'url' => '/api/messages/{messageId}/smartreply',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'avatars#url',
 			'url' => '/api/avatars/url/{email}',
 			'verb' => 'GET'
@@ -343,6 +348,11 @@ return [
 		[
 			'name' => 'settings#setEnabledThreadSummary',
 			'url' => '/api/settings/threadsummary',
+			'verb' => 'PUT'
+		],
+		[
+			'name' => 'settings#setEnabledSmartReplies',
+			'url' => '/api/settings/smartreply',
 			'verb' => 'PUT'
 		],
 		[

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -53,6 +53,8 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\TextProcessing\FreePromptTaskType;
+use OCP\TextProcessing\SummaryTaskType;
 use OCP\User\IAvailabilityCoordinator;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
@@ -276,7 +278,12 @@ class PageController extends Controller {
 
 		$this->initialStateService->provideInitialState(
 			'enabled_thread_summary',
-			$this->config->getAppValue('mail', 'enabled_thread_summary', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable()
+			$this->config->getAppValue('mail', 'enabled_thread_summary', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
+		);
+
+		$this->initialStateService->provideInitialState(
+			'enabled_smart_reply',
+			$this->config->getAppValue('mail', 'enabled_smart_reply', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -34,8 +34,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IConfig;
 use OCP\IRequest;
-use OCP\TextProcessing\IManager;
-use OCP\TextProcessing\SummaryTaskType;
 use Psr\Container\ContainerInterface;
 
 use function array_merge;
@@ -131,12 +129,8 @@ class SettingsController extends Controller {
 		$this->config->setAppValue('mail', 'enabled_thread_summary', $enabled ? 'yes' : 'no');
 	}
 
-	public function isLlmConfigured() {
-		try {
-			$manager = $this->container->get(IManager::class);
-		} catch (\Throwable $e) {
-			return new JSONResponse(['data' => false]);
-		}
-		return new JSONResponse(['data' => in_array(SummaryTaskType::class, $manager->getAvailableTaskTypes(), true)]);
+	public function setEnabledSmartReplies(bool $enabled) {
+		$this->config->setAppValue('mail', 'enabled_smart_reply', $enabled ? 'yes' : 'no');
 	}
+
 }

--- a/lib/Service/AiIntegrations/Cache.php
+++ b/lib/Service/AiIntegrations/Cache.php
@@ -45,7 +45,7 @@ class Cache {
 	 * @param array $ids
 	 * @return string
 	 */
-	private function buildUrlKey(array $ids): string {
+	public function buildUrlKey(array $ids): string {
 		return base64_encode(json_encode($ids));
 	}
 
@@ -53,10 +53,10 @@ class Cache {
 	/**
 	 * @param array $ids
 	 *
-	 * @return string|false the summary if cached, false if cached but no value or not cached
+	 * @return string|false the value if cached, false if cached but no value or not cached
 	 */
-	public function getSummary(array $ids) {
-		$cached = $this->cache->get($this->buildUrlKey($ids));
+	public function getValue(string $key) {
+		$cached = $this->cache->get($key);
 
 		if (is_null($cached) || $cached === false) {
 			return false;
@@ -66,13 +66,13 @@ class Cache {
 	}
 
 	/**
-	 * @param array $ids
-	 * @param string|null $summary
+	 * @param string $key
+	 * @param string|null $value
 	 *
 	 * @return void
 	 */
-	public function addSummary(array $ids, ?string $summary): void {
-		$this->cache->set($this->buildUrlKey($ids), $summary === null ? false : $summary, self::CACHE_TTL);
+	public function addValue(string $key, ?string $value): void {
+		$this->cache->set($key, $value === null ? false : $value, self::CACHE_TTL);
 	}
 
 

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -36,6 +36,8 @@ use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\LDAP\ILDAPProvider;
 use OCP\Settings\ISettings;
+use OCP\TextProcessing\FreePromptTaskType;
+use OCP\TextProcessing\SummaryTaskType;
 
 class AdminSettings implements ISettings {
 	/** @var IInitialStateService */
@@ -98,8 +100,20 @@ class AdminSettings implements ISettings {
 
 		$this->initialStateService->provideInitialState(
 			Application::APP_ID,
-			'enabled_llm_backend',
-			$this->aiIntegrationsService->isLlmAvailable()
+			'enabled_smart_reply',
+			$this->config->getAppValue('mail', 'enabled_smart_reply', 'no') === 'yes'
+		);
+
+		$this->initialStateService->provideInitialState(
+			Application::APP_ID,
+			'enabled_llm_free_prompt_backend',
+			$this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
+		);
+
+		$this->initialStateService->provideInitialState(
+			Application::APP_ID,
+			'enabled_llm_summary_backend',
+			$this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
 		);
 
 		$this->initialStateService->provideLazyInitialState(

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,6 +47,7 @@
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
 				<referencedClass name="OCP\TextProcessing\Task" />
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
+				<referencedClass name="OCP\TextProcessing\FreePromptTaskType" />
 				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeScheduledEvent" /><!-- 28+ -->

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -536,6 +536,11 @@ export default {
 			required: false,
 			default: () => [],
 		},
+		smartReply: {
+			type: String,
+			required: false,
+			default: undefined,
+		},
 		sendAt: {
 			type: Number,
 			default: undefined,
@@ -1069,6 +1074,9 @@ export default {
 		onEditorReady(editor) {
 			this.bodyVal = editor.getData()
 			this.insertSignature()
+			if (this.smartReply) {
+				this.bus.$emit('append-to-body-at-cursor', this.smartReply)
+			}
 		},
 		onChangeSendLater(value) {
 			this.sendAtVal = value ? Number.parseInt(value, 10) : undefined

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -56,11 +56,30 @@
 			:message="message" />
 		<MessageAttachments :attachments="message.attachments" :envelope="envelope" />
 		<div id="reply-composer" />
+		<div v-if="smartReplies.length>0" class="reply-buttons">
+			<NcButton type="primary"
+				@click="onReply">
+				<template #icon>
+					<ReplyIcon />
+				</template>
+				Reply
+			</NcButton>
+			<NcButton v-for="(reply,index) in smartReplies"
+				:key="index"
+				type="secondary"
+				@click="onReply(reply)">
+				<template #icon>
+					<ReplyIcon />
+				</template>
+				{{ reply }}
+			</NcButton>
+		</div>
 	</div>
 </template>
 
 <script>
 import { generateUrl } from '@nextcloud/router'
+import { NcButton } from '@nextcloud/vue'
 
 import { html, plain } from '../util/text.js'
 import { isPgpgMessage } from '../crypto/pgp.js'
@@ -71,6 +90,7 @@ import MessageHTMLBody from './MessageHTMLBody.vue'
 import MessagePlainTextBody from './MessagePlainTextBody.vue'
 import Imip from './Imip.vue'
 import LockOffIcon from 'vue-material-design-icons/LockOff.vue'
+import ReplyIcon from 'vue-material-design-icons/Reply.vue'
 
 export default {
 	name: 'Message',
@@ -82,6 +102,8 @@ export default {
 		MessagePlainTextBody,
 		Imip,
 		LockOffIcon,
+		ReplyIcon,
+		NcButton,
 	},
 	props: {
 		envelope: {
@@ -96,6 +118,11 @@ export default {
 			required: false,
 			type: Boolean,
 			default: false,
+		},
+		smartReplies: {
+			required: false,
+			type: Array,
+			default: () => [],
 		},
 	},
 	computed: {
@@ -112,6 +139,11 @@ export default {
 		},
 		itineraries() {
 			return this.message.itineraries ?? []
+		},
+	},
+	methods: {
+		onReply(replyBody = '') {
+			this.$emit('reply', replyBody)
 		},
 	},
 }
@@ -143,5 +175,17 @@ export default {
 		// Fix alignment with message
 		margin-top: -5px;
 	}
+}
+.reply-buttons{
+	display: flex;
+	justify-content: end;
+
+	& > * {
+		margin: 5px;
+		top: 0 !important;
+		left: 0 !important;
+
+	}
+
 }
 </style>

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -80,6 +80,7 @@
 				:forward-from="composerData.forwardFrom"
 				:send-at="composerData.sendAt * 1000"
 				:forwarded-messages="forwardedMessages"
+				:smart-reply="smartReply"
 				:can-save-draft="canSaveDraft"
 				:saving-draft="savingDraft"
 				:draft-saved="draftSaved"
@@ -194,6 +195,9 @@ export default {
 		},
 		forwardedMessages() {
 			return this.composerMessage?.options?.forwardedMessages ?? []
+		},
+		smartReply() {
+			return this.composerData?.smartReply ?? null
 		},
 	},
 	created() {

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -146,7 +146,7 @@
 				</p>
 			</article>
 		</div>
-		<div v-if="isLlmConfigured"
+		<div v-if="isLlmSummaryConfigured"
 			class="app-description">
 			<h3>{{ t('mail', 'Enable thread summary') }}</h3>
 			<article>
@@ -155,6 +155,19 @@
 						type="switch"
 						@update:checked="updateEnabledThreadSummary">
 						{{ t('mail','Enable thread summaries') }}
+					</NcCheckboxRadioSwitch>
+				</p>
+			</article>
+		</div>
+		<div v-if="isLlmFreePromptConfigured"
+			class="app-description">
+			<h3>{{ t('mail', 'Enable smart replies') }}</h3>
+			<article>
+				<p>
+					<NcCheckboxRadioSwitch :checked.sync="enabledSmartReplies"
+						type="switch"
+						@update:checked="updateEnabledSmartReply">
+						{{ t('mail','Enable smart replies') }}
 					</NcCheckboxRadioSwitch>
 				</p>
 			</article>
@@ -274,6 +287,7 @@ import {
 	provisionAll,
 	updateAllowNewMailAccounts,
 	updateEnabledThreadSummary,
+	updateEnabledSmartReply,
 } from '../../service/SettingsService.js'
 
 const googleOauthClientId = loadState('mail', 'google_oauth_client_id', null) ?? undefined
@@ -334,7 +348,10 @@ export default {
 			},
 			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts', true),
 			enabledThreadSummary: loadState('mail', 'enabled_thread_summary', false),
-			isLlmConfigured: loadState('mail', 'enabled_llm_backend'),
+			enabledSmartReplies: loadState('mail', 'enabled_smart_reply', false),
+			isLlmSummaryConfigured: loadState('mail', 'enabled_llm_summary_backend'),
+			isLlmFreePromptConfigured: loadState('mail', 'enabled_llm_free_prompt_backend'),
+
 		}
 	},
 	methods: {
@@ -390,6 +407,9 @@ export default {
 		},
 		async updateEnabledThreadSummary(checked) {
 			await updateEnabledThreadSummary(checked)
+		},
+		async updateEnabledSmartReply(checked) {
+			await updateEnabledSmartReply(checked)
 		},
 	},
 }

--- a/src/service/AiIntergrationsService.js
+++ b/src/service/AiIntergrationsService.js
@@ -15,3 +15,16 @@ export const summarizeThread = async (threadId) => {
 		throw convertAxiosError(e)
 	}
 }
+export const smartReply = async (messageId) => {
+	const url = generateUrl('/apps/mail/api/messages/{messageId}/smartreply', {
+		messageId,
+	})
+
+	try {
+		const resp = await axios.get(url)
+		if (resp.status === 204) throw convertAxiosError()
+		return resp.data
+	} catch (e) {
+		throw convertAxiosError(e)
+	}
+}

--- a/src/service/SettingsService.js
+++ b/src/service/SettingsService.js
@@ -85,3 +85,12 @@ export const updateEnabledThreadSummary = async (enabled) => {
 	const resp = await axios.put(url, data)
 	return resp.data
 }
+
+export const updateEnabledSmartReply = async (enabled) => {
+	const url = generateUrl('/apps/mail/api/settings/smartreply')
+	const data = {
+		enabled,
+	}
+	const resp = await axios.put(url, data)
+	return resp.data
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -385,8 +385,14 @@ export default {
 					})
 
 					data.body = html(resp.data)
+					if (reply.suggestedReply) {
+						data.body.value = `<p>${reply.suggestedReply}<\\p>` + data.body.value
+					}
 				} else {
 					data.body = plain(original.body)
+					if (reply.suggestedReply) {
+						data.body.value = `${reply.suggestedReply}\n` + data.body.value
+					}
 				}
 
 				if (reply.mode === 'reply') {
@@ -400,6 +406,7 @@ export default {
 							body: data.body,
 							originalBody: data.body,
 							replyTo: reply.data,
+							smartReply: reply.smartReply,
 						},
 					})
 					return

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -214,8 +214,9 @@ export default {
 	 * @param payload.data
 	 * @param payload.forwardedMessages
 	 * @param payload.originalSendAt
+	 * @param payload.smartReply
 	 */
-	startComposerSession(state, { type, data, forwardedMessages, originalSendAt }) {
+	startComposerSession(state, { type, data, forwardedMessages, originalSendAt, smartReply }) {
 		state.composerSessionId = state.nextComposerSessionId
 		state.nextComposerSessionId++
 		state.newMessage = {
@@ -224,6 +225,7 @@ export default {
 			options: {
 				forwardedMessages,
 				originalSendAt,
+				smartReply,
 			},
 			indicatorDisabled: false,
 		}

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -48,6 +48,7 @@ use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Model\Message;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\ItineraryService;
 use OCA\Mail\Service\MailManager;
 use OCA\Mail\Service\SmimeService;
@@ -139,6 +140,9 @@ class MessagesControllerTest extends TestCase {
 	private $userPreferences;
 	private SnoozeService $snoozeService;
 
+	/** @var MockObject|AiIntegrationsService */
+	private $aiIntegrationsService;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -163,6 +167,7 @@ class MessagesControllerTest extends TestCase {
 		$this->dkimService = $this->createMock(IDkimService::class);
 		$this->userPreferences = $this->createMock(IUserPreferences::class);
 		$this->snoozeService = $this->createMock(SnoozeService::class);
+		$this->aiIntegrationsService = $this->createMock(AiIntegrationsService::class);
 
 		$timeFactory = $this->createMocK(ITimeFactory::class);
 		$timeFactory->expects($this->any())
@@ -194,6 +199,7 @@ class MessagesControllerTest extends TestCase {
 			$this->dkimService,
 			$this->userPreferences,
 			$this->snoozeService,
+			$this->aiIntegrationsService,
 		);
 
 		$this->account = $this->createMock(Account::class);

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -251,7 +251,7 @@ class PageControllerTest extends TestCase {
 				['version', '0.0.0', '26.0.0'],
 				['app.mail.attachment-size-limit', 0, 123],
 			]);
-		$this->config->expects($this->exactly(7))
+		$this->config->expects($this->exactly(8))
 			->method('getAppValue')
 			->withConsecutive(
 				[ 'mail', 'installed_version' ],
@@ -261,6 +261,7 @@ class PageControllerTest extends TestCase {
 				['core', 'backgroundjobs_mode', 'ajax' ],
 				['mail', 'allow_new_mail_accounts', 'yes'],
 				['mail', 'enabled_thread_summary', 'no'],
+				['mail', 'enabled_smart_reply', 'no'],
 			)->willReturnOnConsecutiveCalls(
 				$this->returnValue('1.2.3'),
 				$this->returnValue(''),
@@ -292,7 +293,7 @@ class PageControllerTest extends TestCase {
 			->method('getLoginCredentials')
 			->willReturn($loginCredentials);
 
-		$this->initialState->expects($this->exactly(15))
+		$this->initialState->expects($this->exactly(16))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
@@ -309,6 +310,7 @@ class PageControllerTest extends TestCase {
 				['disable-snooze', false],
 				['allow-new-accounts', true],
 				['enabled_thread_summary', false],
+				['enabled_smart_reply', false],
 				['smime-certificates', []],
 			);
 

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -53,7 +53,7 @@ class AdminSettingsTest extends TestCase {
 	}
 
 	public function testGetForm() {
-		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(10))
+		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(12))
 			->method('provideInitialState')
 			->withConsecutive(
 				[
@@ -78,7 +78,17 @@ class AdminSettingsTest extends TestCase {
 				],
 				[
 					Application::APP_ID,
-					'enabled_llm_backend',
+					'enabled_smart_reply',
+					$this->anything()
+				],
+				[
+					Application::APP_ID,
+					'enabled_llm_free_prompt_backend',
+					$this->anything()
+				],
+				[
+					Application::APP_ID,
+					'enabled_llm_summary_backend',
 					$this->anything()
 				],
 				[


### PR DESCRIPTION
Fixes  #8505

| Composer | Message |
|--------|--------|
| <img width="630" alt="image" src="https://github.com/nextcloud/mail/assets/40746210/f07c2f74-0bd1-4ed5-b720-201537dc2f3e"> | <img width="811" alt="image" src="https://github.com/nextcloud/mail/assets/40746210/63c77e20-c498-4740-8344-79e6bd080c2b"> | 



- [x] Add caching
- [x] Fix composer update 
- [x] unit tests 
- [x] Better prompt 
- [x] Work on email body, not preview text

For now at least one prompt is executed for every opened message
- [x]  Find a way to filter out Promotional / generated emails without the use of LLM

