### PR TITLE
Implement Reply-To header support when replying

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -310,6 +310,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'messageId' => $this->getMessageId(),
 			'from' => $this->getFrom()->jsonSerialize(),
 			'to' => $this->getTo()->jsonSerialize(),
+			'replyTo' => $this->getReplyTo()->jsonSerialize(),
 			'cc' => $this->getCC()->jsonSerialize(),
 			'bcc' => $this->getBCC()->jsonSerialize(),
 			'subject' => $this->getSubject(),
@@ -426,17 +427,22 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		throw new Exception('not implemented');
 	}
 
+	/**
+	 * @return AddressList
+	 */
 	public function getReplyTo(): AddressList {
 		return $this->replyTo;
 	}
 
 	/**
-	 * @param string $id
+	 * @param AddressList $replyTo
+	 *
+	 * @throws Exception
 	 *
 	 * @return void
 	 */
-	public function setReplyTo(string $id) {
-		throw new Exception('not implemented');
+	public function setReplyTo(AddressList $replyTo) {
+		throw new Exception('IMAP message is immutable');
 	}
 
 	public function isEncrypted(): bool {

--- a/lib/Model/IMessage.php
+++ b/lib/Model/IMessage.php
@@ -72,6 +72,16 @@ interface IMessage {
 	/**
 	 * @return AddressList
 	 */
+	public function getReplyTo(): AddressList;
+
+	/**
+	 * @param AddressList $replyTo
+	 */
+	public function setReplyTo(AddressList $replyTo);
+
+	/**
+	 * @return AddressList
+	 */
 	public function getCC(): AddressList;
 
 	/**

--- a/lib/Model/Message.php
+++ b/lib/Model/Message.php
@@ -43,6 +43,9 @@ class Message implements IMessage {
 	private $to;
 
 	/** @var AddressList */
+	private $replyTo;
+
+	/** @var AddressList */
 	private $cc;
 
 	/** @var AddressList */
@@ -63,6 +66,7 @@ class Message implements IMessage {
 	public function __construct() {
 		$this->from = new AddressList();
 		$this->to = new AddressList();
+		$this->replyTo = new AddressList();
 		$this->cc = new AddressList();
 		$this->bcc = new AddressList();
 	}
@@ -124,6 +128,22 @@ class Message implements IMessage {
 	 */
 	public function setTo(AddressList $to) {
 		$this->to = $to;
+	}
+
+	/**
+	 * @return AddressList
+	 */
+	public function getReplyTo(): AddressList {
+		return $this->replyTo;
+	}
+
+	/**
+	 * @param AddressList $replyTo
+	 *
+	 * @return void
+	 */
+	public function setReplyTo(AddressList $replyTo) {
+		$this->replyTo = $replyTo;
 	}
 
 	/**

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -400,7 +400,7 @@ export default {
 					commit('startComposerSession', {
 						data: {
 							accountId: reply.data.accountId,
-							to: reply.data.from,
+							to: original.replyTo !== undefined ? original.replyTo : reply.data.from,
 							cc: [],
 							subject: buildReplySubject(reply.data.subject),
 							body: data.body,
@@ -416,7 +416,7 @@ export default {
 					const recipients = buildReplyRecipients(reply.data, {
 						email: account.emailAddress,
 						label: account.name,
-					})
+					}, original.replyTo)
 					commit('startComposerSession', {
 						data: {
 							accountId: reply.data.accountId,

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -147,6 +147,7 @@ class IMAPMessageTest extends TestCase {
 			'to' => [ [ 'label' => 'to@mail.com', 'email' => 'to@mail.com' ] ],
 			'cc' => [ [ 'label' => 'cc@mail.com', 'email' => 'cc@mail.com' ] ],
 			'bcc' => [ [ 'label' => 'bcc@mail.com', 'email' => 'bcc@mail.com' ] ],
+			'replyTo' => [ [ 'label' => 'reply-to@mail.com', 'email' => 'reply-to@mail.com' ] ],
 			'subject' => 'subject',
 			'dateInt' => 1451606400,
 			'flags' => [


### PR DESCRIPTION
The Reply-To header, if present, will take precedence over the From header. If the Reply-To data is undefined old behaviour is used.

Note that Horde libraries appear to internally determine reply_to property in the Horde_Imap_Client_Data_Envelope (unless Dovecot does it, but doubt). It was observed that reply_to property had the same value as from property in a mail that contained no Reply-To header. It is assumed that the Horde implementation makes sense, so just use the value as-is.

This notably fixes replying to mail from software reliant on the Reply-To header such as GitLab and GitHub notifications and many types of mail based ticketing (support) systems.

Closes #4075 
Closes #7538