### PR TITLE
enh(outbox): add debug logging

### DIFF
--- a/lib/Listener/AntiAbuseListener.php
+++ b/lib/Listener/AntiAbuseListener.php
@@ -57,7 +57,7 @@ class AntiAbuseListener implements IEventListener {
 		if (!($event instanceof BeforeMessageSentEvent)) {
 			return;
 		}
-
+		$this->logger->debug('Handle anti abuse protection');
 		$user = $this->userManager->get($event->getAccount()->getUserId());
 		if ($user === null) {
 			$this->logger->error('User {user} for mail account {id} does not exist', [

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -85,6 +85,7 @@ class DeleteDraftListener implements IEventListener {
 	 * @param Message $draft
 	 */
 	private function deleteDraft(Account $account, Message $draft): void {
+		$this->logger->debug('Deleting draft message');
 		$client = $this->imapClientFactory->getClient($account);
 		try {
 			$draftsMailbox = $this->getDraftsMailbox($account);

--- a/lib/Listener/FlagRepliedMessageListener.php
+++ b/lib/Listener/FlagRepliedMessageListener.php
@@ -72,6 +72,7 @@ class FlagRepliedMessageListener implements IEventListener {
 		if (!($event instanceof MessageSentEvent) || $event->getRepliedToMessageId() === null) {
 			return;
 		}
+		$this->logger->debug('Flagging messages as replied to');
 
 		$messages = $this->dbMessageMapper->findByMessageId($event->getAccount(), $event->getRepliedToMessageId());
 		if ($messages === []) {
@@ -81,6 +82,7 @@ class FlagRepliedMessageListener implements IEventListener {
 		try {
 			$client = $this->imapClientFactory->getClient($event->getAccount());
 			foreach ($messages as $message) {
+				$this->logger->debug('Flagging message as replied to for message id ' . $message->getMessageId());
 				try {
 					$mailbox = $this->mailboxMapper->findById($message->getMailboxId());
 					//ignore read-only mailboxes

--- a/lib/Listener/InteractionListener.php
+++ b/lib/Listener/InteractionListener.php
@@ -62,6 +62,7 @@ class InteractionListener implements IEventListener {
 		if (!($event instanceof MessageSentEvent)) {
 			return;
 		}
+		$this->logger->debug('"Contacted recently" event triggered');
 		if (!class_exists(ContactInteractedWithEvent::class)) {
 			$this->logger->debug(ContactInteractedWithEvent::class . ' does not exist, ignoring the event');
 			return;
@@ -75,7 +76,12 @@ class InteractionListener implements IEventListener {
 			->merge($event->getMessage()->getBCC());
 		foreach ($recipients->iterate() as $recipient) {
 			$interactionEvent = new ContactInteractedWithEvent($user);
-			$email = $recipient->getEmail();
+			try {
+				$email = $recipient->getEmail();
+			} catch (\Exception $e) {
+				$this->logger->debug('Could not convert recipient email');
+				throw $e;
+			}
 			if ($email === null) {
 				// Weird, bot ok
 				continue;

--- a/lib/Listener/MessageCacheUpdaterListener.php
+++ b/lib/Listener/MessageCacheUpdaterListener.php
@@ -49,7 +49,9 @@ class MessageCacheUpdaterListener implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
+		$this->logger->debug('Updating local message cache');
 		if ($event instanceof MessageFlaggedEvent) {
+			$this->logger->debug('Updating regular flags for message uid ' . $event->getUid());
 			$messages = $this->mapper->findByUids($event->getMailbox(), [$event->getUid()]);
 			$message = reset($messages);
 
@@ -62,6 +64,7 @@ class MessageCacheUpdaterListener implements IEventListener {
 
 			$this->mapper->update($message);
 		} elseif ($event instanceof MessageDeletedEvent) {
+			$this->logger->debug('Deleting the local message cache for message uid ' . $event->getMessageId());
 			$this->mapper->deleteByUid(
 				$event->getMailbox(),
 				$event->getMessageId()

--- a/lib/Listener/SaveSentMessageListener.php
+++ b/lib/Listener/SaveSentMessageListener.php
@@ -66,7 +66,7 @@ class SaveSentMessageListener implements IEventListener {
 		if (!($event instanceof MessageSentEvent)) {
 			return;
 		}
-
+		$this->logger->debug('Moving message to SENT mailbox');
 		$sentMailboxId = $event->getAccount()->getMailAccount()->getSentMailboxId();
 		if ($sentMailboxId === null) {
 			$this->logger->warning("No sent mailbox exists, can't save sent message");
@@ -87,12 +87,14 @@ class SaveSentMessageListener implements IEventListener {
 
 		$client = $this->imapClientFactory->getClient($event->getAccount());
 		try {
+			$this->logger->debug('Trying to move message to SENT mailbox');
 			$this->messageMapper->save(
 				$client,
 				$sentMailbox,
 				$event->getMail()
 			);
 		} catch (Horde_Imap_Client_Exception $e) {
+			$this->logger->debug('Failed moving message to SENT mailbox', ['exception' => $e]);
 			throw new ServiceException('Could not save sent message on IMAP', 0, $e);
 		} finally {
 			$client->logout();

--- a/lib/Service/AntiAbuseService.php
+++ b/lib/Service/AntiAbuseService.php
@@ -69,7 +69,7 @@ class AntiAbuseService {
 			$this->logger->debug('Anti abuse detection is off');
 			return;
 		}
-
+		$this->logger->debug('Anti abuse detection on - checking number of users and rate limit');
 		$this->checkNumberOfRecipients($user, $messageData);
 		$this->checkRateLimits($user, $messageData);
 	}

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -160,6 +160,7 @@ class AttachmentService implements IAttachmentService {
 	}
 
 	public function deleteLocalMessageAttachments(string $userId, int $localMessageId): void {
+		$this->logger->debug('Deleting message attachments for user ' . $userId . ' with message id ' .  $localMessageId);
 		$attachments = $this->mapper->findByLocalMessageId($userId, $localMessageId);
 		// delete db entries
 		$this->mapper->deleteForLocalMessage($userId, $localMessageId);


### PR DESCRIPTION
Trying to trace the code path for https://github.com/nextcloud/mail/issues/8435 needs more extensive logging to see where the issue is triggered.

This PR adds debug logging to code paths touched by an outbox message.

Put as blocked because YAGNI for regular use.