### PR TITLE
fix(mailto): show empty thread view on handler

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -167,7 +167,9 @@ export default {
 			return 3
 		},
 		showThread() {
-			return (this.mailbox.isPriorityInbox === true || this.hasEnvelopes) && this.$route.name === 'message'
+			return (this.mailbox.isPriorityInbox === true || this.hasEnvelopes)
+				&& this.$route.name === 'message'
+				&& this.$route.params.threadId !== 'mailto'
 		},
 		query() {
 			if (this.$route.params.filter === 'starred') {


### PR DESCRIPTION
Fix #8733 

## After

![grafik](https://github.com/nextcloud/mail/assets/1479486/96b04c67-0d8d-4cc5-b38d-bd3074574a96)
