### PR TITLE
Avoid calling Mailbox.vue::loadEnvelopes twice when switching between two accounts

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -138,9 +138,6 @@ export default {
 		},
 	},
 	watch: {
-		account() {
-			this.loadEnvelopes()
-		},
 		mailbox() {
 			this.loadEnvelopes()
 				.then(() => {


### PR DESCRIPTION
Continuation of #6301 
fixes https://github.com/nextcloud/mail/issues/3746
before
![Screenshot from 2023-10-10 19-05-41](https://github.com/nextcloud/mail/assets/12728974/eabcf771-bb91-4602-a0a9-fe0adce46e5d)

after
![Screenshot from 2023-10-10 19-06-04](https://github.com/nextcloud/mail/assets/12728974/ca75a283-8a78-46a5-948d-30e28031e70b)

The account watcher is no longer needed. Fetching messages on mailbox change is all we need