### PR TITLE
chore: Fix undeclared class properties in integration tests

### DIFF
--- a/tests/Integration/Db/LocalAttachmentMapperTest.php
+++ b/tests/Integration/Db/LocalAttachmentMapperTest.php
@@ -47,6 +47,9 @@ class LocalAttachmentMapperTest extends TestCase {
 	/** @var LocalAttachmentMapper */
 	private $mapper;
 
+	/** @var LocalMessageMapper */
+	private $localMessageMapper;
+
 	/** @var ITimeFactory|MockObject */
 	private $timeFactory;
 

--- a/tests/Integration/Service/DraftServiceIntegrationTest.php
+++ b/tests/Integration/Service/DraftServiceIntegrationTest.php
@@ -120,8 +120,8 @@ class DraftServiceIntegrationTest extends TestCase {
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
-		$this->db = OC::$server->getDatabaseConnection();
-		$qb = $this->db->getQueryBuilder();
+		$db = OC::$server->getDatabaseConnection();
+		$qb = $db->getQueryBuilder();
 		$delete = $qb->delete($this->mapper->getTableName());
 		$delete->execute();
 


### PR DESCRIPTION
PHPUnit output is hard to read otherwise.