### PR TITLE
perf: Use local caches for avatars

### DIFF
--- a/lib/Service/Avatar/Cache.php
+++ b/lib/Service/Avatar/Cache.php
@@ -23,7 +23,7 @@ class Cache {
 	private $avatarFactory;
 
 	public function __construct(ICacheFactory $cacheFactory, AvatarFactory $avatarFactory) {
-		$this->cache = $cacheFactory->createDistributed('mail.avatars');
+		$this->cache = $cacheFactory->createLocal('mail.avatars');
 		$this->avatarFactory = $avatarFactory;
 	}
 

--- a/tests/Unit/Service/Avatar/CacheTest.php
+++ b/tests/Unit/Service/Avatar/CacheTest.php
@@ -36,7 +36,7 @@ class CacheTest extends TestCase {
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->cacheImpl = $this->createMock(ICache::class);
 		$this->cacheFactory->expects($this->once())
-			->method('createDistributed')
+			->method('createLocal')
 			->with('mail.avatars')
 			->willReturn($this->cacheImpl);
 		$this->avatarFactory = $this->createMock(AvatarFactory::class);


### PR DESCRIPTION
Local caches are faster. Distributed caches are only needed if cache is used for consistency. Populating avatar/provisioning caches for each application server should be cheaper than the remote cache access for a lot of requests reading avatars and provisionings.