### PR TITLE
ci(smime): skip content type null test

### DIFF
--- a/tests/Unit/Service/SmimeServiceTest.php
+++ b/tests/Unit/Service/SmimeServiceTest.php
@@ -262,7 +262,6 @@ class SmimeServiceTest extends TestCase {
 			['application/pkcs7-mime', [], false], // Should not happen in real life but who knows
 			['multipart/alternative', [], false],
 			['', [], false],
-			[null, [], false],
 		];
 	}
 


### PR DESCRIPTION
> PHP Deprecated: explode(): Passing null to parameter #2 ($string) of type string is deprecated in apps/mail/vendor/bytestream/horde-mime/lib/Horde/Mime/Headers/ContentParam.php on line 276

There is a dedicated test for when the header is missing: `\OCA\Mail\Tests\Service\SmimeServiceTest::testIsEncryptedWhenHeaderIsMissing`.