### PR TITLE
fix(unsubscribe): fix button style

### DIFF
--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -84,13 +84,13 @@
 					</div>
 				</div>
 				<div class="envelope__header__left__unsubscribe">
-					<NcActionButton
+					<NcButton
 						v-if="message && message.dkimValid && (message.unsubscribeUrl || message.unsubscribeMailto)"
 						type="tertiary"
 						class="envelope__header__unsubscribe"
 						@click="showListUnsubscribeConfirmation = true">
 						{{ t('mail', 'Unsubscribe') }}
-					</NcActionButton>
+					</NcButton>
 				</div>
 			</router-link>
 			<div class="right">
@@ -261,7 +261,7 @@
 </template>
 <script>
 import Avatar from './Avatar'
-import { NcActionButton, NcModal } from '@nextcloud/vue'
+import { NcActionButton, NcButton, NcModal } from '@nextcloud/vue'
 import ConfirmModal from './ConfirmationModal.vue'
 import Error from './Error'
 import importantSvg from '../../img/important.svg'
@@ -315,6 +315,7 @@ export default {
 		ConfirmModal,
 		Avatar,
 		NcActionButton,
+		NcButton,
 		Error,
 		IconFavorite,
 		JunkIcon,


### PR DESCRIPTION
Renamed a forgotten ButtonVue to NCActionButton here: https://github.com/nextcloud/mail/pull/8985

But NcButton is needed not NCActionButton.

|before #8985 (ButtonVue)|after #8985 (NCActionButton)|now (NcButton)|
|--|--|--|
|![image](https://github.com/nextcloud/mail/assets/74607597/032d7819-25a7-4be3-a4bf-1460e3e25dcd)|![image](https://github.com/nextcloud/mail/assets/74607597/12cb30cc-9969-4571-a8d7-accc5ada196c)|![image](https://github.com/nextcloud/mail/assets/74607597/549ca4df-b0ec-4a4f-8316-20d29236fcb6)|