### PR TITLE
fix(provisioning): Clean up orphaned accounts

### DIFF
--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -65,7 +65,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getEditorMode()
  * @method void setEditorMode(string $editorMode)
  * @method int|null getProvisioningId()
- * @method void setProvisioningId(int $provisioningId)
+ * @method void setProvisioningId(int|null $provisioningId)
  * @method int getOrder()
  * @method void setOrder(int $order)
  * @method bool|null getShowSubscribedOnly()

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -151,6 +151,24 @@ class MailAccountMapper extends QBMapper {
 		$delete->executeStatement();
 	}
 
+	public function deleteProvisionedOrphanAccounts(): void {
+		$inner = $this->db->getQueryBuilder()
+			->select('id')
+			->from('mail_provisionings');
+
+		$delete = $this->db->getQueryBuilder();
+		$delete->delete($this->getTableName())
+			->where(
+				$delete->expr()->isNotNull('provisioning_id'),
+				$delete->expr()->notIn(
+					'provisioning_id',
+					$delete->createFunction($inner->getSQL()),
+					IQueryBuilder::PARAM_INT_ARRAY
+				));
+
+		$delete->executeStatement();
+	}
+
 	/**
 	 * @return MailAccount[]
 	 */

--- a/lib/Service/CleanupService.php
+++ b/lib/Service/CleanupService.php
@@ -27,6 +27,7 @@ namespace OCA\Mail\Service;
 
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\CollectedAddressMapper;
+use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Db\MessageRetentionMapper;
@@ -38,6 +39,8 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use Psr\Log\LoggerInterface;
 
 class CleanupService {
+	private MailAccountMapper $mailAccountMapper;
+
 	/** @var AliasMapper */
 	private $aliasMapper;
 
@@ -60,7 +63,8 @@ class CleanupService {
 	private PersistenceService $classifierPersistenceService;
 	private ITimeFactory $timeFactory;
 
-	public function __construct(AliasMapper $aliasMapper,
+	public function __construct(MailAccountMapper $mailAccountMapper,
+		AliasMapper $aliasMapper,
 		MailboxMapper $mailboxMapper,
 		MessageMapper $messageMapper,
 		CollectedAddressMapper $collectedAddressMapper,
@@ -77,6 +81,7 @@ class CleanupService {
 		$this->messageRetentionMapper = $messageRetentionMapper;
 		$this->messageSnoozeMapper = $messageSnoozeMapper;
 		$this->classifierPersistenceService = $classifierPersistenceService;
+		$this->mailAccountMapper = $mailAccountMapper;
 		$this->timeFactory = $timeFactory;
 	}
 
@@ -85,6 +90,8 @@ class CleanupService {
 			$this->timeFactory,
 			$logger
 		))->start('clean up');
+		$this->mailAccountMapper->deleteProvisionedOrphanAccounts();
+		$task->step('delete orphan provisioned accounts');
 		$this->aliasMapper->deleteOrphans();
 		$task->step('delete orphan aliases');
 		$this->mailboxMapper->deleteOrphans();

--- a/tests/Integration/Db/MailAccountMapperTest.php
+++ b/tests/Integration/Db/MailAccountMapperTest.php
@@ -28,10 +28,13 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IDBConnection;
+use function random_int;
 
 /**
  * @group DB
+ * @covers \OCA\Mail\Db\MailAccountMapper
  */
 class MailAccountMapperTest extends TestCase {
 	use DatabaseTransaction;
@@ -105,5 +108,15 @@ class MailAccountMapperTest extends TestCase {
 		$this->assertNotNull($c->getId());
 		$this->assertNotNull($b->getId());
 		$this->assertEquals($b->getId(), $c->getId());
+	}
+
+	public function testDeleteProvisionedOrphans(): void {
+		$this->account->setProvisioningId(random_int(1, 10000));
+		$this->mapper->insert($this->account);
+
+		$this->mapper->deleteProvisionedOrphanAccounts();
+
+		$this->expectException(DoesNotExistException::class);
+		$this->mapper->findById($this->account->getId());
 	}
 }


### PR DESCRIPTION
Due to https://github.com/nextcloud/mail/pull/8606 I've had a defunct account on my dev env. It was impossible to get rid of, except for manipulating the db.

This adds logic to clean-up such accounts automatically.

Fixes https://github.com/nextcloud/mail/issues/6889

## How to test

1) Create an account
2) Change the account's `provisioning_id` to a random number
3) Try to get rid of the account

main: it's impossible :angry: 
here: `occ mail:clean-up` :sunglasses: 