### PR TITLE
fix(classification): Delete historic data

### DIFF
--- a/lib/Db/ClassifierMapper.php
+++ b/lib/Db/ClassifierMapper.php
@@ -58,4 +58,16 @@ class ClassifierMapper extends QBMapper {
 
 		return $this->findEntity($select);
 	}
+
+	public function findHistoric(int $threshold, int $limit) {
+		$qb = $this->db->getQueryBuilder();
+		$select = $qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->lte('created_at', $qb->createNamedParameter($threshold, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+			)
+			->orderBy('created_at', 'asc')
+			->setMaxResults($limit);
+		return $this->findEntities($select);
+	}
 }

--- a/lib/Service/CleanupService.php
+++ b/lib/Service/CleanupService.php
@@ -32,6 +32,7 @@ use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Db\MessageRetentionMapper;
 use OCA\Mail\Db\MessageSnoozeMapper;
 use OCA\Mail\Db\TagMapper;
+use OCA\Mail\Service\Classification\PersistenceService;
 
 class CleanupService {
 	/** @var AliasMapper */
@@ -53,13 +54,16 @@ class CleanupService {
 
 	private MessageSnoozeMapper $messageSnoozeMapper;
 
+	private PersistenceService $classifierPersistenceService;
+
 	public function __construct(AliasMapper $aliasMapper,
 		MailboxMapper $mailboxMapper,
 		MessageMapper $messageMapper,
 		CollectedAddressMapper $collectedAddressMapper,
 		TagMapper $tagMapper,
 		MessageRetentionMapper $messageRetentionMapper,
-		MessageSnoozeMapper $messageSnoozeMapper) {
+		MessageSnoozeMapper $messageSnoozeMapper,
+		PersistenceService $classifierPersistenceService) {
 		$this->aliasMapper = $aliasMapper;
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
@@ -67,6 +71,7 @@ class CleanupService {
 		$this->tagMapper = $tagMapper;
 		$this->messageRetentionMapper = $messageRetentionMapper;
 		$this->messageSnoozeMapper = $messageSnoozeMapper;
+		$this->classifierPersistenceService = $classifierPersistenceService;
 	}
 
 	public function cleanUp(): void {
@@ -78,5 +83,6 @@ class CleanupService {
 		$this->tagMapper->deleteDuplicates();
 		$this->messageRetentionMapper->deleteOrphans();
 		$this->messageSnoozeMapper->deleteOrphans();
+		$this->classifierPersistenceService->cleanUp();
 	}
 }


### PR DESCRIPTION
It's interesting to analyze for improvements but otherwise just bloats app data and the database.

## How to test

1) Set up an account
2) Run `mail:account:train` 10x 
3) Wait two months and a day (or change oc_mail_classifiers.created_at timestamps in the database)
4) Run `SELECT COUNT(*) FROM oc_mail_classifiers` and remember the number
5) Run `occ mail:clean-up`
6) Run `SELECT COUNT(*) FROM oc_mail_classifiers` and compare it to the number before