### PR TITLE
fix(sender-details): show contact names again

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -37,10 +37,7 @@
 				<template #icon>
 					<IconDetails :size="20" />
 				</template>
-				{{ t('mail', 'Contacts with this address') }}:
-				<span>
-					{{ contactsWithEmailComputed }}
-				</span>
+				{{ t('mail', 'Contacts with this address') }}: {{ contactsWithEmailComputed }}
 			</ButtonVue>
 			<div v-if="selection === ContactSelectionStateEnum.select" class="contact-menu">
 				<ButtonVue


### PR DESCRIPTION
Fix: #8325

Regression of: #6995

|before|after|
|--|--|
|![image](https://github.com/nextcloud/mail/assets/74607597/02040513-2294-4744-a6e7-822de831fbdd)|![image](https://github.com/nextcloud/mail/assets/74607597/147b5a90-2989-4676-adf7-b59281ecdbd4)|