### PR TITLE
feat(provisioning): Master password support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>3.5.0-beta.1</version>
+	<version>3.5.0-beta.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Db/Provisioning.php
+++ b/lib/Db/Provisioning.php
@@ -51,6 +51,10 @@ use ReturnTypeWillChange;
  * @method void setSmtpPort(int $smtpPort)
  * @method string getSmtpSslMode()
  * @method void setSmtpSslMode(string $smtpSslMode)
+ * @method bool|null getMasterPasswordEnabled()
+ * @method void setMasterPasswordEnabled(bool $masterPasswordEnabled)
+ * @method string|null getMasterPassword()
+ * @method void setMasterPassword(string $masterPassword)
  * @method bool|null getSieveEnabled()
  * @method void setSieveEnabled(bool $sieveEnabled)
  * @method string|null getSieveHost()
@@ -70,6 +74,7 @@ use ReturnTypeWillChange;
  */
 class Provisioning extends Entity implements JsonSerializable {
 	public const WILDCARD = '*';
+	public const MASTER_PASSWORD_PLACEHOLDER = '********';
 
 	protected $provisioningDomain;
 	protected $emailTemplate;
@@ -81,6 +86,8 @@ class Provisioning extends Entity implements JsonSerializable {
 	protected $smtpHost;
 	protected $smtpPort;
 	protected $smtpSslMode;
+	protected $masterPasswordEnabled;
+	protected $masterPassword;
 	protected $sieveEnabled;
 	protected $sieveUser;
 	protected $sieveHost;
@@ -93,6 +100,8 @@ class Provisioning extends Entity implements JsonSerializable {
 	public function __construct() {
 		$this->addType('imapPort', 'integer');
 		$this->addType('smtpPort', 'integer');
+		$this->addType('masterPasswordEnabled', 'boolean');
+		$this->addType('masterPassword', 'string');
 		$this->addType('sieveEnabled', 'boolean');
 		$this->addType('sievePort', 'integer');
 		$this->addType('ldapAliasesProvisioning', 'boolean');
@@ -112,6 +121,8 @@ class Provisioning extends Entity implements JsonSerializable {
 			'smtpHost' => $this->getSmtpHost(),
 			'smtpPort' => $this->getSmtpPort(),
 			'smtpSslMode' => $this->getSmtpSslMode(),
+			'masterPasswordEnabled' => $this->getMasterPasswordEnabled(),
+			'masterPassword' => !empty($this->getMasterPassword()) ? self::MASTER_PASSWORD_PLACEHOLDER : null,
 			'sieveEnabled' => $this->getSieveEnabled(),
 			'sieveUser' => $this->getSieveUser(),
 			'sieveHost' => $this->getSieveHost(),

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -125,6 +125,11 @@ class ProvisioningMapper extends QBMapper {
 		$provisioning->setSmtpPort((int)$data['smtpPort']);
 		$provisioning->setSmtpSslMode($data['smtpSslMode']);
 
+		$provisioning->setMasterPasswordEnabled((bool)($data['masterPasswordEnabled'] ?? false));
+		if (isset($data['masterPassword']) && $data['masterPassword'] !== Provisioning::MASTER_PASSWORD_PLACEHOLDER) {
+			$provisioning->setMasterPassword($data['masterPassword']);
+		}
+
 		$provisioning->setSieveEnabled((bool)$data['sieveEnabled']);
 		$provisioning->setSieveHost($data['sieveHost'] ?? '');
 		$provisioning->setSieveUser($data['sieveUser'] ?? '');

--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -70,6 +70,7 @@ class ProvisioningMiddleware extends Middleware {
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);
 			$password = $this->credentialStore->getLoginCredentials()->getPassword();
+
 			// FIXME: Need to check for an empty string here too?
 			// The password is empty (and not null) when using WebAuthn passwordless login.
 			// Maybe research other providers as well.
@@ -82,7 +83,8 @@ class ProvisioningMiddleware extends Middleware {
 			}
 			$this->provisioningManager->updatePassword(
 				$user,
-				$password
+				$password,
+				$configs
 			);
 		} catch (CredentialsUnavailableException | PasswordUnavailableException $e) {
 			// Nothing to update

--- a/lib/Migration/Version3500Date20231005091430.php
+++ b/lib/Migration/Version3500Date20231005091430.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @codeCoverageIgnore
+ */
+class Version3500Date20231005091430 extends SimpleMigrationStep {
+	/** @var IConfig */
+	protected $config;
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/** @var LoggerInterface */
+	protected $logger;
+
+	public function __construct(IConfig $config, IDBConnection $connection, LoggerInterface $logger) {
+		$this->config = $config;
+		$this->connection = $connection;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$provisioningTable = $schema->getTable('mail_provisionings');
+		if (!$provisioningTable->hasColumn('master_password_enabled')) {
+			$provisioningTable->addColumn('master_password_enabled', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+		if (!$provisioningTable->hasColumn('master_password')) {
+			$provisioningTable->addColumn('master_password', Types::STRING, [
+				'notnull' => false,
+				'length' => 256,
+			]);
+		}
+
+		return $schema;
+	}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "3.5.0-beta1",
+  "version": "3.5.0-beta2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "3.5.0-beta1",
+      "version": "3.5.0-beta2",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "37.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "3.5.0-beta1",
+  "version": "3.5.0-beta2",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -182,7 +182,8 @@ export default {
 		 * @return {boolean} True if the account should be disabled
 		 */
 		isDisabled(account) {
-			return this.passwordIsUnavailable && !!account.provisioningId
+
+			return (this.passwordIsUnavailable && !!account.provisioningId) && !!this.$store.getters.masterPasswordEnabled
 		},
 	},
 }

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -199,6 +199,32 @@
 				</div>
 				<div class="settings-group">
 					<div class="group-title">
+						{{ t('mail', 'Master password') }}
+					</div>
+					<div class="group-inputs">
+						<div>
+							<input
+								:id="'mail-master-password-enabled' + setting.id"
+								v-model="masterPasswordEnabled"
+								type="checkbox"
+								class="checkbox">
+							<label :for="'mail-master-password-enabled' + setting.id">
+								{{ t('mail', 'Use master password') }}
+							</label>
+						</div>
+						<div>
+							<input
+								id="mail-master-password"
+								v-model="masterPassword"
+								:disabled="loading"
+								type="password"
+								required>
+							<label for="mail-master-password"> {{ t('mail', 'Master password') }} </label>
+						</div>
+					</div>
+				</div>
+				<div class="settings-group">
+					<div class="group-title">
 						{{ t('mail', 'Sieve') }}
 					</div>
 					<div class="group-inputs">
@@ -411,6 +437,8 @@ export default {
 			smtpPort: this.setting.smtpPort || 587,
 			smtpUser: this.setting.smtpUser || '%USERID%domain.com',
 			smtpSslMode: this.setting.smtpSslMode || 'tls',
+			masterPasswordEnabled: this.setting.masterPasswordEnabled || '',
+			masterPassword: this.setting.masterPassword || '',
 			sieveEnabled: this.setting.sieveEnabled || '',
 			sieveHost: this.setting.sieveHost || '',
 			sievePort: this.setting.sievePort || '',
@@ -443,6 +471,8 @@ export default {
 				smtpHost: this.smtpHost,
 				smtpPort: this.smtpPort,
 				smtpSslMode: this.smtpSslMode,
+				masterPasswordEnabled: this.masterPasswordEnabled,
+				masterPassword: this.masterPassword,
 				sieveEnabled: this.sieveEnabled,
 				sieveUser: this.sieveUser,
 				sieveHost: this.sieveHost,
@@ -474,6 +504,8 @@ export default {
 					smtpHost: this.smtpHost,
 					smtpPort: this.smtpPort,
 					smtpSslMode: this.smtpSslMode,
+					masterPasswordEnabled: this.masterPasswordEnabled,
+					masterPassword: this.masterPassword,
 					sieveEnabled: this.sieveEnabled,
 					sieveUser: this.sieveUser,
 					sieveHost: this.sieveHost,

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -117,6 +117,7 @@ export const getters = {
 	isScheduledSendingDisabled: (state) => state.isScheduledSendingDisabled,
 	isSnoozeDisabled: (state) => state.isSnoozeDisabled,
 	googleOauthUrl: (state) => state.googleOauthUrl,
+	masterPasswordEnabled: (state) => state.masterPasswordEnabled,
 	microsoftOauthUrl: (state) => state.microsoftOauthUrl,
 	getActiveSieveScript: (state) => (accountId) => state.sieveScript[accountId],
 	getCurrentUserPrincipal: (state) => state.currentUserPrincipal,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -103,6 +103,7 @@ export default new Store({
 				isSnoozeDisabled: false,
 				currentUserPrincipal: undefined,
 				googleOauthUrl: null,
+				masterPasswordEnabled: false,
 				sieveScript: {},
 				calendars: [],
 				smimeCertificates: [],

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -479,6 +479,9 @@ export default {
 	setGoogleOauthUrl(state, url) {
 		state.googleOauthUrl = url
 	},
+	setMasterPasswordEnabled(state, value) {
+		state.masterPasswordEnabled = value
+	},
 	setMicrosoftOauthUrl(state, url) {
 		state.microsoftOauthUrl = url
 	},

--- a/tests/Unit/Db/ProvisioningTest.php
+++ b/tests/Unit/Db/ProvisioningTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\Provisioning;
+
+/**
+ * @covers \OCA\Mail\Db\Provisioning
+ */
+class ProvisioningTest extends TestCase {
+
+	public function testJsonSerialize(): void {
+		$provisioning = new Provisioning();
+
+		$data = $provisioning->jsonSerialize();
+
+		self::assertArrayHasKey('masterPasswordEnabled', $data);
+	}
+
+}

--- a/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
@@ -217,7 +217,8 @@ class ProvisioningMiddlewareTest extends TestCase {
 			->method('updatePassword')
 			->with(
 				$user,
-				'123456'
+				'123456',
+				$configs
 			);
 
 		$this->middleware->beforeController(


### PR DESCRIPTION
Amended and squashed version of https://github.com/nextcloud/mail/pull/8917.

## How to test

1) Build https://github.com/ChristophWurst/docker-imap-devel/pull/13
2) Set up provisioning for the static password from the config file

## How to test – Alternative

1) Set up provisioning with your testing account's email address and the "static" IMAP password :wink: 
2) Verify the account works
