### PR TITLE
ci: Turn off builds for pushes and merges to main/stable*

### DIFF
--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -5,13 +5,7 @@
 
 name: Lint info.xml
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -5,13 +5,7 @@
 
 name: Lint php
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-      - master
-      - stable*
+on: pull_request
 
 permissions:
   contents: read

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -5,13 +5,7 @@
 
 name: Static analysis
 
-on:
-  pull_request:
-  push:
-    branches:
-      - master
-      - main
-      - stable*
+on: pull_request
 
 concurrency:
   group: psalm-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
We don't check the results so CI minutes are used without purpose.