### PR TITLE
perf: Add performance logger to clean up

### DIFF
--- a/lib/BackgroundJob/CleanupJob.php
+++ b/lib/BackgroundJob/CleanupJob.php
@@ -28,20 +28,24 @@ namespace OCA\Mail\BackgroundJob;
 use OCA\Mail\Service\CleanupService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
 
 class CleanupJob extends TimedJob {
 	private CleanupService $cleanupService;
+	private LoggerInterface $logger;
 
 	public function __construct(ITimeFactory $time,
-		CleanupService $cleanupService) {
+		CleanupService $cleanupService,
+		LoggerInterface $logger) {
 		parent::__construct($time);
 		$this->cleanupService = $cleanupService;
+		$this->logger = $logger;
 
 		$this->setInterval(24 * 60 * 60);
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument): void {
-		$this->cleanupService->cleanUp();
+		$this->cleanupService->cleanUp($this->logger);
 	}
 }

--- a/lib/Command/CleanUp.php
+++ b/lib/Command/CleanUp.php
@@ -24,17 +24,22 @@ declare(strict_types=1);
 namespace OCA\Mail\Command;
 
 use OCA\Mail\Service\CleanupService;
+use OCA\Mail\Support\ConsoleLoggerDecorator;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanUp extends Command {
 	private CleanupService $cleanupService;
+	private LoggerInterface $logger;
 
-	public function __construct(CleanupService $cleanupService) {
+	public function __construct(CleanupService $cleanupService,
+		LoggerInterface $logger) {
 		parent::__construct();
 
 		$this->cleanupService = $cleanupService;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -46,7 +51,9 @@ class CleanUp extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$this->cleanupService->cleanUp();
+		$logger = new ConsoleLoggerDecorator($this->logger, $output);
+
+		$this->cleanupService->cleanUp($logger);
 
 		return 0;
 	}


### PR DESCRIPTION
Helps gather data for https://github.com/nextcloud/mail/issues/9079.

```
$ php occ mail:clean-up -vvv
[debug] clean up - delete orphan aliases took 0s. 10/10MB memory used
[debug] clean up - delete orphan mailboxes took 0s. 10/10MB memory used
[debug] clean up - delete orphan messages took 0s. 10/10MB memory used
[debug] clean up - delete orphan collected addresses took 0s. 10/10MB memory used
[debug] clean up - delete orphan tags took 0s. 10/10MB memory used
[debug] clean up - delete duplicate tags took 0s. 10/10MB memory used
[debug] clean up - delete expired messages took 0s. 10/10MB memory used
[debug] clean up - delete orphan snoozes took 0s. 10/10MB memory used
[debug] clean up - delete orphan classifiers took 1s. 11/11MB memory used
[debug] clean up took 1s
```