### PR TITLE
fix: listen to more out-of-office events to prevent missed changes

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -89,7 +89,10 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Dashboard\IAPIWidgetV2;
 use OCP\IServerContainer;
 use OCP\Search\IFilteringProvider;
+use OCP\User\Events\OutOfOfficeChangedEvent;
+use OCP\User\Events\OutOfOfficeClearedEvent;
 use OCP\User\Events\OutOfOfficeEndedEvent;
+use OCP\User\Events\OutOfOfficeScheduledEvent;
 use OCP\User\Events\OutOfOfficeStartedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
@@ -147,9 +150,16 @@ class Application extends App implements IBootstrap {
 
 		// TODO: drop condition if nextcloud < 28 is not supported anymore
 		if (class_exists(OutOfOfficeStartedEvent::class)
-		 && class_exists(OutOfOfficeEndedEvent::class)) {
+			&& class_exists(OutOfOfficeEndedEvent::class)
+			&& class_exists(OutOfOfficeChangedEvent::class)
+			&& class_exists(OutOfOfficeClearedEvent::class)
+			&& class_exists(OutOfOfficeScheduledEvent::class)
+		) {
 			$context->registerEventListener(OutOfOfficeStartedEvent::class, OutOfOfficeListener::class);
 			$context->registerEventListener(OutOfOfficeEndedEvent::class, OutOfOfficeListener::class);
+			$context->registerEventListener(OutOfOfficeChangedEvent::class, OutOfOfficeListener::class);
+			$context->registerEventListener(OutOfOfficeClearedEvent::class, OutOfOfficeListener::class);
+			$context->registerEventListener(OutOfOfficeScheduledEvent::class, OutOfOfficeListener::class);
 		}
 
 		$context->registerMiddleWare(ErrorMiddleware::class);

--- a/lib/Listener/OutOfOfficeListener.php
+++ b/lib/Listener/OutOfOfficeListener.php
@@ -31,29 +31,49 @@ use Exception;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
 use OCA\Mail\Service\OutOfOfficeService;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\OutOfOfficeChangedEvent;
+use OCP\User\Events\OutOfOfficeClearedEvent;
 use OCP\User\Events\OutOfOfficeEndedEvent;
+use OCP\User\Events\OutOfOfficeScheduledEvent;
 use OCP\User\Events\OutOfOfficeStartedEvent;
 use Psr\Log\LoggerInterface;
 
 /**
- * @template-implements IEventListener<Event|OutOfOfficeStartedEvent|OutOfOfficeEndedEvent>
+ * @template-implements IEventListener<Event|OutOfOfficeStartedEvent|OutOfOfficeEndedEvent|OutOfOfficeScheduledEvent|OutOfOfficeChangedEvent|OutOfOfficeClearedEvent>
  */
 class OutOfOfficeListener implements IEventListener {
 	public function __construct(
 		private AccountService $accountService,
 		private OutOfOfficeService $outOfOfficeService,
 		private LoggerInterface $logger,
+		private ITimeFactory $timeFactory,
 	) {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof OutOfOfficeStartedEvent) && !($event instanceof OutOfOfficeEndedEvent)) {
+		if (!($event instanceof OutOfOfficeStartedEvent)
+			&& !($event instanceof OutOfOfficeEndedEvent)
+			&& !($event instanceof OutOfOfficeScheduledEvent)
+			&& !($event instanceof OutOfOfficeChangedEvent)
+			&& !($event instanceof OutOfOfficeClearedEvent)
+		) {
 			return;
 		}
 
 		$eventData = $event->getData();
+
+		// We could simply enable the out-of-office responder in any case as it has its own date
+		// check. However, this way it is only enabled when really necessary and the second date
+		// check inside the sieve script acts as a redundancy.
+		$now = $this->timeFactory->getTime();
+		$enabled = $now >= $eventData->getStartDate() && $now < $eventData->getEndDate();
+		if (($event instanceof OutOfOfficeClearedEvent) || ($event instanceof OutOfOfficeEndedEvent)) {
+			$enabled = false;
+		}
+
 		$accounts = $this->accountService->findByUserId($event->getData()->getUser()->getUID());
 		foreach ($accounts as $account) {
 			if (!$account->getMailAccount()->getOutOfOfficeFollowsSystem()) {
@@ -61,7 +81,7 @@ class OutOfOfficeListener implements IEventListener {
 			}
 
 			$state = new OutOfOfficeState(
-				($event instanceof OutOfOfficeStartedEvent),
+				$enabled,
 				new DateTimeImmutable('@' . $eventData->getStartDate()),
 				new DateTimeImmutable('@' . $eventData->getEndDate()),
 				$eventData->getShortMessage(),

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,9 +47,12 @@
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
 				<referencedClass name="OCP\TextProcessing\Task" />
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
-				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" />
-				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" />
-				<referencedClass name="OCP\User\IAvailabilityCoordinator" />
+				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeScheduledEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeChangedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeClearedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\IAvailabilityCoordinator" /><!-- 28+ -->
 			</errorLevel>
 		</UndefinedClass>
 		<UndefinedDocblockClass>
@@ -61,6 +64,11 @@
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
+				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeScheduledEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeChangedEvent" /><!-- 28+ -->
+				<referencedClass name="OCP\User\Events\OutOfOfficeClearedEvent" /><!-- 28+ -->
 			</errorLevel>
 		</UndefinedDocblockClass>
 		<UndefinedFunction>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -4,6 +4,9 @@
     <InvalidArgument>
       <code>OutOfOfficeListener::class</code>
       <code>OutOfOfficeListener::class</code>
+      <code>OutOfOfficeListener::class</code>
+      <code>OutOfOfficeListener::class</code>
+      <code>OutOfOfficeListener::class</code>
     </InvalidArgument>
     <MissingDependency>
       <code>FilteringProvider</code>
@@ -49,9 +52,5 @@
     <MoreSpecificImplementedParamType>
       <code>$event</code>
     </MoreSpecificImplementedParamType>
-    <UndefinedDocblockClass>
-      <code>OutOfOfficeListener</code>
-      <code>OutOfOfficeListener</code>
-    </UndefinedDocblockClass>
   </file>
 </files>


### PR DESCRIPTION
Ref https://github.com/nextcloud/server/pull/41778

## About `OutOfOfficeStartedEvent` and `OutOfOfficeEndedEvent`

In theory it is superfluous to listen for the `OutOfOfficeStartedEvent` and `OutOfOfficeEndedEvent` events. However, I opted to keep listening for them and only really "enable" the sieve script when the out-of-office period is ongoing.

Please also refer to my lengthy comment in the code.