### PR TITLE
fix: only load thread summary for threads with at least 3 messages.

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -186,7 +186,7 @@ export default {
 	},
 	methods: {
 		async updateSummary() {
-			if (this.thread.length < 2 || !this.enabledThreadSummary) return
+			if (this.thread.length <= 2 || !this.enabledThreadSummary) return
 
 			this.summaryLoading = true
 			try {


### PR DESCRIPTION
https://github.com/nextcloud/mail/blob/bc94ce5bdf4b2abdba12d5791859a24e71353fff/src/components/Thread.vue#L161-L163