### PR TITLE
style: Add trailing commas to src/

### DIFF
--- a/src/tests/unit/.eslintrc.js
+++ b/src/tests/unit/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
-  env: {
-    mocha: true
-  },
-  rules: {
-    'import/no-extraneous-dependencies': 'off'
-  }
+     env: {
+          mocha: true,
+     },
+     rules: {
+          'import/no-extraneous-dependencies': 'off',
+     },
 }

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -39,7 +39,7 @@ describe('Composer', () => {
 
 	beforeEach(() => {
 		Object.defineProperty(window, "firstDay", {
-			value: 0
+			value: 0,
 		})
 
 		actions = {}
@@ -151,7 +151,7 @@ describe('Composer', () => {
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return undefined
-				}
+				},
 			},
 			store,
 			localVue,
@@ -180,7 +180,7 @@ describe('Composer', () => {
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
-				}
+				},
 			},
 			store,
 			localVue,
@@ -209,7 +209,7 @@ describe('Composer', () => {
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return undefined
-				}
+				},
 			},
 			store,
 			localVue,
@@ -241,7 +241,7 @@ describe('Composer', () => {
 				},
 				missingSmimeCertificatesForRecipients() {
 					return ['john@foo.bar']
-				}
+				},
 			},
 			store,
 			localVue,
@@ -273,7 +273,7 @@ describe('Composer', () => {
 				},
 				missingSmimeCertificatesForRecipients() {
 					return []
-				}
+				},
 			},
 			store,
 			localVue,

--- a/src/tests/unit/components/ConfirmationModal.vue.spec.js
+++ b/src/tests/unit/components/ConfirmationModal.vue.spec.js
@@ -44,7 +44,7 @@ describe('ConfirmationModal', () => {
 	it('renders with custom button text', () => {
 		const view = shallowMount(ConfirmationModal, {
 			propsData: {
-				confirmText: 'Subscribe'
+				confirmText: 'Subscribe',
 			},
 			localVue,
 		})

--- a/src/tests/unit/components/Envelope.vue.spec.js
+++ b/src/tests/unit/components/Envelope.vue.spec.js
@@ -29,8 +29,8 @@ import Vuex from 'vuex';
 const localVue = createLocalVue()
 const $route = {
 	params: {
-		id: 1
-	}
+		id: 1,
+	},
 }
 
 localVue.use(Vuex)
@@ -67,13 +67,13 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 				account: {sentMailboxId:'1'},
 				mailbox: {
 					myAcls: undefined,
 					databaseId:'3',
-					specialRole:''
+					specialRole:'',
 				},
 			},
 			store,
@@ -98,7 +98,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -123,7 +123,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -147,7 +147,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			computed: {
@@ -177,7 +177,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			computed: {
@@ -207,7 +207,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			computed: {
@@ -237,7 +237,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			computed: {
@@ -267,7 +267,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -293,7 +293,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 
 				},
 			},
@@ -318,7 +318,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 
 				},
 			},
@@ -338,12 +338,12 @@ describe('Envelope', () => {
 				mailbox: {
 					specialRole:'',
 					databaseId:'3',
-					sentMailboxId:'1'
+					sentMailboxId:'1',
 				},
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -367,7 +367,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -391,7 +391,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,
@@ -415,7 +415,7 @@ describe('Envelope', () => {
 				data: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 				},
 			},
 			store,

--- a/src/tests/unit/components/Thread.vue.spec.js
+++ b/src/tests/unit/components/Thread.vue.spec.js
@@ -39,7 +39,7 @@ describe('Thread', () => {
 		actions = {
 			fetchThread: () => {
 				return []
-			}
+			},
 		},
 		getters = {
 			getEnvelope: () => (id) => {
@@ -102,7 +102,7 @@ describe('Thread', () => {
 							from: [],
 							to: [],
 							cc: [],
-						}
+						},
 					]
 				}
 				if (threadRootId === '456-789-123') {
@@ -151,7 +151,7 @@ describe('Thread', () => {
 							from: [],
 							to: [],
 							cc: [],
-						}
+						},
 					]
 				}
 				return []
@@ -198,13 +198,13 @@ describe('Thread', () => {
 						{
 							databaseId: 10,
 							name: 'INBOX',
-							specialRole: 'inbox'
+							specialRole: 'inbox',
 						},
 						{
 							databaseId: 11,
 							name: 'Test',
-							specialRole: ''
-						}
+							specialRole: '',
+						},
 					]
 				}
 				if (accountId === 200) {
@@ -212,27 +212,27 @@ describe('Thread', () => {
 						{
 							databaseId: 20,
 							name: 'INBOX',
-							specialRole: 'inbox'
+							specialRole: 'inbox',
 						},
 						{
 							databaseId: 21,
 							name: 'Test',
-							specialRole: ''
+							specialRole: '',
 						},
 						{
 							databaseId: 22,
 							name: 'Trash',
-							specialRole: 'trash'
+							specialRole: 'trash',
 						},
 						{
 							databaseId: 23,
 							name: 'Junk',
-							specialRole: 'junk'
-						}
+							specialRole: 'junk',
+						},
 					]
 				}
 				return []
-			}
+			},
 		}
 		store = new Vuex.Store({
 			actions,
@@ -245,9 +245,9 @@ describe('Thread', () => {
 			mocks: {
 				$route: {
 					params: {
-						threadId: 100
-					}
-				}
+						threadId: 100,
+					},
+				},
 			},
 			store,
 			localVue,
@@ -261,9 +261,9 @@ describe('Thread', () => {
 			mocks: {
 				$route: {
 					params: {
-						threadId: 200
-					}
-				}
+						threadId: 200,
+					},
+				},
 			},
 			store,
 			localVue,
@@ -277,9 +277,9 @@ describe('Thread', () => {
 			mocks: {
 				$route: {
 					params: {
-						threadId: 300
-					}
-				}
+						threadId: 300,
+					},
+				},
 			},
 			store,
 			localVue,
@@ -293,9 +293,9 @@ describe('Thread', () => {
 			mocks: {
 				$route: {
 					params: {
-						threadId: 301
-					}
-				}
+						threadId: 301,
+					},
+				},
 			},
 			store,
 			localVue,
@@ -311,9 +311,9 @@ describe('Thread', () => {
 			mocks: {
 				$route: {
 					params: {
-						threadId: 302
-					}
-				}
+						threadId: 302,
+					},
+				},
 			},
 			store,
 			localVue,

--- a/src/tests/unit/components/ThreadEnvelope.vue.spec.js
+++ b/src/tests/unit/components/ThreadEnvelope.vue.spec.js
@@ -64,11 +64,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -92,11 +92,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -120,11 +120,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -147,11 +147,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -178,11 +178,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -209,11 +209,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -240,11 +240,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -271,11 +271,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -299,12 +299,12 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -327,11 +327,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -354,11 +354,11 @@ describe('ThreadEnvelope', () => {
 				envelope: {
 					accountId: 123,
 					from: [{email:'info@test.com'}],
-					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false, },
+					flags: { seen:false, flagged:false, $junk:false, answered:false, hasAttachments:false, draft:false },
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -392,7 +392,7 @@ describe('ThreadEnvelope', () => {
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -427,7 +427,7 @@ describe('ThreadEnvelope', () => {
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {
@@ -464,7 +464,7 @@ describe('ThreadEnvelope', () => {
 					subject: '',
 					dateInt: 1692200926180,
 				},
-				threadSubject: ''
+				threadSubject: '',
 			},
 			computed: {
 				mailbox() {

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -518,14 +518,14 @@ describe('Vuex store actions', () => {
 
 	it('should move message to junk, no mailbox configured', async() => {
 		context.getters.getAccount.mockReturnValueOnce({
-			junkMailboxId: null
+			junkMailboxId: null,
 		})
 
 		const removeEnvelope = await actions.moveEnvelopeToJunk(context, {
 			flags: {
-				$junk: false
+				$junk: false,
 			},
-			mailboxId: 1
+			mailboxId: 1,
 		})
 
 		expect(removeEnvelope).toBeFalsy()
@@ -533,17 +533,17 @@ describe('Vuex store actions', () => {
 
 	it('should move message to inbox', async() => {
 		context.getters.getAccount.mockReturnValueOnce({
-			junkMailboxId: 10
+			junkMailboxId: 10,
 		})
 		context.getters.getInbox.mockReturnValueOnce({
-			databaseId: 1
+			databaseId: 1,
 		})
 
 		const removeEnvelope = await actions.moveEnvelopeToJunk(context, {
 			flags: {
-				$junk: true
+				$junk: true,
 			},
-			mailboxId: 10
+			mailboxId: 10,
 		})
 
 		expect(removeEnvelope).toBeTruthy()
@@ -551,15 +551,15 @@ describe('Vuex store actions', () => {
 
 	it('should move message to inbox, inbox not found', async() => {
 		context.getters.getAccount.mockReturnValueOnce({
-			junkMailboxId: 10
+			junkMailboxId: 10,
 		})
 		context.getters.getInbox.mockReturnValueOnce(undefined)
 
 		const removeEnvelope = await actions.moveEnvelopeToJunk(context, {
 			flags: {
-				$junk: true
+				$junk: true,
 			},
-			mailboxId: 10
+			mailboxId: 10,
 		})
 
 		expect(removeEnvelope).toBeFalsy()
@@ -567,14 +567,14 @@ describe('Vuex store actions', () => {
 
 	it('should not move messages', async() => {
 		context.getters.getAccount.mockReturnValueOnce({
-			junkMailboxId: null
+			junkMailboxId: null,
 		})
 
 		const removeEnvelope = await actions.moveEnvelopeToJunk(context, {
 			flags: {
-				$junk: true
+				$junk: true,
 			},
-			mailboxId: 10
+			mailboxId: 10,
 		})
 
 		expect(removeEnvelope).toBeFalsy()

--- a/src/tests/unit/store/getters.spec.js
+++ b/src/tests/unit/store/getters.spec.js
@@ -214,15 +214,15 @@ describe('Vuex store getters', () => {
 				{
 					name: 'Trash',
 					specialRole: 'trash',
-				}
-			]
+				},
+			],
 		}
 
 		const result = getters.findMailboxBySpecialRole(state, mockedGetters)('100', 'inbox')
 
 		expect(result).toEqual({
 			name: 'INBOX',
-			specialRole: 'inbox'
+			specialRole: 'inbox',
 		});
 	})
 
@@ -240,8 +240,8 @@ describe('Vuex store getters', () => {
 				{
 					name: 'Trash',
 					specialRole: 'trash',
-				}
-			]
+				},
+			],
 		}
 
 		const result = getters.findMailboxBySpecialRole(state, mockedGetters)('100', 'drafts')

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -82,7 +82,7 @@ describe('Vuex store mutations', () => {
 					delimiter: '.',
 				},
 			],
-			aliases: []
+			aliases: [],
 		})
 
 		expect(state).toEqual({
@@ -225,7 +225,7 @@ describe('Vuex store mutations', () => {
 					specialRole: 'archive',
 				},
 			],
-			aliases: []
+			aliases: [],
 		})
 
 		expect(state).toEqual({
@@ -311,7 +311,7 @@ describe('Vuex store mutations', () => {
 					specialRole: 'archive',
 				},
 			],
-			aliases: []
+			aliases: [],
 		})
 
 		expect(state).toEqual({

--- a/src/tests/unit/util/acl.spec.js
+++ b/src/tests/unit/util/acl.spec.js
@@ -35,7 +35,7 @@ describe('acl', () => {
 
 		it('allow when right included', () => {
 			const mailbox = {
-				myAcls: 'lrwstipekxa'
+				myAcls: 'lrwstipekxa',
 			}
 
 			const actual = mailboxHasRights(mailbox, 'l')
@@ -45,7 +45,7 @@ describe('acl', () => {
 
 		it('deny when right not included', () => {
 			const mailbox = {
-				myAcls: 'lrw'
+				myAcls: 'lrw',
 			}
 
 			const actual = mailboxHasRights(mailbox, 'iw')


### PR DESCRIPTION
In preparation of the upgrade from eslint 6 to 8.

```$ npx eslint --fix --parser '@babel/eslint-parser' --no-eslintrc --env es6 --rule 'comma-dangle: ['warn', 'always-multiline']' src/```