### PR TITLE
Move mail settings into a modal

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -83,9 +83,6 @@
 					:account="account" />
 			</div>
 		</AppSettingsSection>
-		<AppSettingsSection id="trusted-sender" :title="t('mail', 'Trusted senders')">
-			<TrustedSenders />
-		</AppSettingsSection>
 		<AppSettingsSection v-if="account && !account.provisioningId"
 			id="mail-server"
 			:title="t('mail', 'Mail server')">
@@ -119,7 +116,6 @@ import AccountDefaultsSettings from '../components/AccountDefaultsSettings.vue'
 import SignatureSettings from '../components/SignatureSettings.vue'
 import AliasSettings from '../components/AliasSettings.vue'
 import { NcAppSettingsDialog as AppSettingsDialog, NcAppSettingsSection as AppSettingsSection } from '@nextcloud/vue'
-import TrustedSenders from './TrustedSenders.vue'
 import SieveAccountForm from './SieveAccountForm.vue'
 import SieveFilterForm from './SieveFilterForm.vue'
 import OutOfOfficeForm from './OutOfOfficeForm.vue'
@@ -133,7 +129,6 @@ export default {
 	components: {
 		SieveAccountForm,
 		SieveFilterForm,
-		TrustedSenders,
 		AccountForm,
 		AliasSettings,
 		EditorSettings,

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -1,139 +1,167 @@
 <template>
-	<div>
-		<router-link v-if="allowNewMailAccounts" to="/setup" class="app-settings-button button primary new-button">
-			<IconAdd :size="20" />
-			{{ t('mail', 'Add mail account') }}
-		</router-link>
-
-		<p v-if="loadingPrioritySettings" class="app-settings">
-			{{ prioritySettingsText }}
-		</p>
-		<p v-else class="app-settings">
-			<input id="priority-inbox-toggle"
-				class="checkbox"
-				type="checkbox"
-				:checked="searchPriorityBody"
-				@change="onToggleSearchPriorityBody">
-			<label for="priority-inbox-toggle">{{ prioritySettingsText }}</label>
-		</p>
-
-		<p v-if="loadingOptOutSettings" class="app-settings">
-			<IconLoading :size="20" />
-			{{ optOutSettingsText }}
-		</p>
-		<p v-else class="app-settings">
-			<input id="data-collection-toggle"
-				class="checkbox"
-				type="checkbox"
-				:checked="useDataCollection"
-				@change="onToggleCollectData">
-			<label for="data-collection-toggle">{{ optOutSettingsText }}</label>
-		</p>
-
-		<p v-if="toggleAutoTagging" class="app-settings">
-			<IconLoading :size="20" />
-			{{ autoTaggingText }}
-		</p>
-		<p v-else class="app-settings">
-			<input id="auto-tagging-toggle"
-				class="checkbox"
-				type="checkbox"
-				:checked="useAutoTagging"
-				@change="onToggleAutoTagging">
-			<label for="auto-tagging-toggle">{{ autoTaggingText }}</label>
-		</p>
-
-		<p v-if="loadingAvatarSettings" class="app-settings avatar-settings">
-			<IconLoading :size="20" />
-			{{ t('mail', 'Use Gravatar and favicon avatars') }}
-		</p>
-		<p v-else class="app-settings">
-			<input id="gravatar-enabled"
-				class="checkbox"
-				type="checkbox"
-				:checked="useExternalAvatars"
-				@change="onToggleExternalAvatars">
-			<label for="gravatar-enabled">{{ t('mail', 'Use Gravatar and favicon avatars') }}</label>
-		</p>
-
-		<p v-if="loadingReplySettings" class="app-settings reply-settings">
-			<IconLoading :size="20" />
-			{{ replySettingsText }}
-		</p>
-		<p v-else class="app-settings">
-			<input id="bottom-reply-enabled"
-				class="checkbox"
-				type="checkbox"
-				:checked="useBottomReplies"
-				@change="onToggleButtonReplies">
-			<label for="bottom-reply-enabled">{{ replySettingsText }}</label>
-		</p>
-
-		<p>
-			<ButtonVue type="secondary"
-				class="app-settings-button"
-				:aria-label="t('mail', 'Register as application for mail links')"
-				@click="registerProtocolHandler">
-				<template #icon>
-					<IconEmail :size="20" />
-				</template>
-				{{ t('mail', 'Register as application for mail links') }}
-			</ButtonVue>
-		</p>
-
-		<ButtonVue class="app-settings-button"
-			type="secondary"
-			:aria-label="t('mail', 'Show keyboard shortcuts')"
-			@click.prevent.stop="showKeyboardShortcuts"
-			@shortkey="toggleKeyboardShortcuts">
-			<template #icon>
-				<IconInfo :size="20" />
-			</template>
-			{{ t('mail', 'Show keyboard shortcuts') }}
-		</ButtonVue>
-		<KeyboardShortcuts v-if="displayKeyboardShortcuts" @close="closeKeyboardShortcuts" />
-
-		<ButtonVue class="app-settings-button"
-			type="secondary"
-			:aria-label="t('mail', 'Manage S/MIME certificates')"
-			@click.prevent.stop="displaySmimeCertificateModal = true">
-			<template #icon>
-				<IconLock :size="20" />
-			</template>
-			{{ t('mail', 'Manage S/MIME certificates') }}
-		</ButtonVue>
-		<SmimeCertificateModal v-if="displaySmimeCertificateModal"
-			@close="displaySmimeCertificateModal = false" />
-		<h2 class="section-title">
-			Sorting
-		</h2>
-		<div class="sorting">
-			<CheckboxRadioSwitch class="sorting__switch"
-				:checked="sortOrder"
-				value="newest"
-				name="order_radio"
-				type="radio"
-				@update:checked="onSortByDate">
-				{{ t('mail', 'Newest') }}
-			</CheckboxRadioSwitch>
-			<CheckboxRadioSwitch class="sorting__switch"
-				:checked="sortOrder"
-				value="oldest"
-				name="order_radio"
-				type="radio"
-				@update:checked="onSortByDate">
-				{{ t('mail', 'Oldest') }}
-			</CheckboxRadioSwitch>
-		</div>
-
-		<p class="mailvelope-section">
-			{{ t('mail', 'Looking for a way to encrypt your emails?') }}
-		</p>
-		<a href="https://www.mailvelope.com/"
-			target="_blank"
-			rel="noopener noreferrer">
-			{{ t('mail', 'Install Mailvelope browser extension here') }}
-		</a>
+	<div class="app-settings">
+		<NcAppSettingsDialog id="app-settings-dialog"
+			:title="t('mail', 'Mail settings')"
+			:show-navigation="true"
+			:open.sync="showSettings">
+			<NcAppSettingsSection id="account-settings" :title="t('mail', 'Account creation')">
+				<NcButton v-if="allowNewMailAccounts"
+					type="primary"
+					to="/setup"
+					:aria-label="t('mail', 'Add mail account')"
+					class="app-settings-button">
+					<template #icon>
+						<IconAdd :size="20" />
+					</template>
+					{{ t('mail', 'Add mail account') }}
+				</NcButton>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="body-settings" :title="t('mail', 'Activate body search')">
+				<p v-if="loadingPrioritySettings" class="app-settings">
+					{{ prioritySettingsText }}
+				</p>
+				<p v-else class="app-settings">
+					<input id="priority-inbox-toggle"
+						class="checkbox"
+						type="checkbox"
+						:checked="searchPriorityBody"
+						@change="onToggleSearchPriorityBody">
+					<label for="priority-inbox-toggle">{{ prioritySettingsText }}</label>
+				</p>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="data-settings" :title="t('mail', 'Data collection consent')">
+				<p class="settings-hint">
+					{{ t('mail', 'Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally.') }}
+				</p>
+				<p v-if="loadingOptOutSettings" class="app-settings">
+					<IconLoading :size="20" />
+					{{ optOutSettingsText }}
+				</p>
+				<p v-else class="app-settings">
+					<input id="data-collection-toggle"
+						class="checkbox"
+						type="checkbox"
+						:checked="useDataCollection"
+						@change="onToggleCollectData">
+					<label for="data-collection-toggle">{{ optOutSettingsText }}</label>
+				</p>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="autotagging-settings" :title="t('mail', 'Auto tagging text')">
+				<p v-if="toggleAutoTagging" class="app-settings">
+					<IconLoading :size="20" />
+					{{ autoTaggingText }}
+				</p>
+				<p v-else class="app-settings">
+					<input id="auto-tagging-toggle"
+						class="checkbox"
+						type="checkbox"
+						:checked="useAutoTagging"
+						@change="onToggleAutoTagging">
+					<label for="auto-tagging-toggle">{{ autoTaggingText }}</label>
+				</p>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="trusted-sender" :title="t('mail', 'Trusted senders')">
+				<TrustedSenders />
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="gavatar-settings" :title="t('mail', 'Gavatar settings')">
+				<p v-if="loadingAvatarSettings" class="app-settings avatar-settings">
+					<IconLoading :size="20" />
+					{{ t('mail', 'Use Gravatar and favicon avatars') }}
+				</p>
+				<p v-else class="app-settings">
+					<input id="gravatar-enabled"
+						class="checkbox"
+						type="checkbox"
+						:checked="useExternalAvatars"
+						@change="onToggleExternalAvatars">
+					<label for="gravatar-enabled">{{ t('mail', 'Use Gravatar and favicon avatars') }}</label>
+				</p>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="reply-settings" :title="t('mail', 'Reply text position')">
+				<p v-if="loadingReplySettings" class="app-settings reply-settings">
+					<IconLoading :size="20" />
+					{{ replySettingsText }}
+				</p>
+				<p v-else class="app-settings">
+					<input id="bottom-reply-enabled"
+						class="checkbox"
+						type="checkbox"
+						:checked="useBottomReplies"
+						@change="onToggleButtonReplies">
+					<label for="bottom-reply-enabled">{{ replySettingsText }}</label>
+				</p>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="mailto-settings" :title="t('mail', 'Mailto')">
+				<p class="settings-hint">
+					{{ t('mail', 'Register as application for mail links') }}
+				</p>
+				<NcButton type="secondary"
+					class="app-settings-button"
+					:aria-label="t('mail', 'Register as application for mail links')"
+					@click="registerProtocolHandler">
+					<template #icon>
+						<IconEmail :size="20" />
+					</template>
+					{{ t('mail', 'Register') }}
+				</NcButton>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="keyboard-settings" :title="t('mail', 'Keyboard')">
+				<NcButton class="app-settings-button"
+					type="secondary"
+					:aria-label="t('mail', 'Show keyboard shortcuts')"
+					@click.prevent.stop="showKeyboardShortcuts"
+					@shortkey="toggleKeyboardShortcuts">
+					<template #icon>
+						<IconInfo :size="20" />
+					</template>
+					{{ t('mail', 'Show keyboard shortcuts') }}
+				</NcButton>
+				<KeyboardShortcuts v-if="displayKeyboardShortcuts" @close="closeKeyboardShortcuts" />
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="smime-settings" :title="t('mail', 'S/MIME')">
+				<NcButton class="app-settings-button"
+					type="secondary"
+					:aria-label="t('mail', 'Manage S/MIME certificates')"
+					@click.prevent.stop="displaySmimeCertificateModal = true">
+					<template #icon>
+						<IconLock :size="20" />
+					</template>
+					{{ t('mail', 'Manage S/MIME certificates') }}
+				</NcButton>
+				<SmimeCertificateModal v-if="displaySmimeCertificateModal"
+					@close="displaySmimeCertificateModal = false" />
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="sorting-settings" :title="t('mail', 'Sorting')">
+				<div class="sorting">
+					<CheckboxRadioSwitch class="sorting__switch"
+						:checked="sortOrder"
+						value="newest"
+						name="order_radio"
+						type="radio"
+						@update:checked="onSortByDate">
+						{{ t('mail', 'Newest') }}
+					</CheckboxRadioSwitch>
+					<CheckboxRadioSwitch class="sorting__switch"
+						:checked="sortOrder"
+						value="oldest"
+						name="order_radio"
+						type="radio"
+						@update:checked="onSortByDate">
+						{{ t('mail', 'Oldest') }}
+					</CheckboxRadioSwitch>
+				</div>
+			</NcAppSettingsSection>
+			<NcAppSettingsSection id="mailvelope-settings" :title="t('mail', 'Mailvelope')">
+				<p class="mailvelope-section">
+					{{ t('mail', 'Looking for a way to encrypt your emails?') }}
+				</p>
+				<a href="https://www.mailvelope.com/"
+					target="_blank"
+					rel="noopener noreferrer">
+					{{ t('mail', 'Install Mailvelope browser extension by clicking here') }}
+				</a>
+			</NcAppSettingsSection>
+		</NcAppSettingsDialog>
 	</div>
 </template>
 
@@ -141,7 +169,7 @@
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 
-import { NcButton as ButtonVue, NcLoadingIcon as IconLoading, NcCheckboxRadioSwitch as CheckboxRadioSwitch } from '@nextcloud/vue'
+import { NcAppSettingsSection, NcAppSettingsDialog, NcButton, NcLoadingIcon as IconLoading, NcCheckboxRadioSwitch as CheckboxRadioSwitch } from '@nextcloud/vue'
 
 import IconInfo from 'vue-material-design-icons/Information.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -150,11 +178,13 @@ import IconLock from 'vue-material-design-icons/Lock.vue'
 import Logger from '../logger.js'
 import KeyboardShortcuts from '../views/KeyboardShortcuts.vue'
 import SmimeCertificateModal from './smime/SmimeCertificateModal.vue'
+import TrustedSenders from './TrustedSenders.vue'
 
 export default {
 	name: 'AppSettingsMenu',
 	components: {
-		ButtonVue,
+		TrustedSenders,
+		NcButton,
 		KeyboardShortcuts,
 		IconInfo,
 		IconEmail,
@@ -163,6 +193,14 @@ export default {
 		IconLock,
 		SmimeCertificateModal,
 		CheckboxRadioSwitch,
+		NcAppSettingsDialog,
+		NcAppSettingsSection,
+	},
+	props: {
+		open: {
+			required: true,
+			type: Boolean,
+		},
 	},
 	data() {
 		return {
@@ -170,7 +208,7 @@ export default {
 			prioritySettingsText: t('mail', 'Search in the body of messages in priority Inbox'),
 			loadingPrioritySettings: false,
 			// eslint-disable-next-line
-			optOutSettingsText: t('mail', 'Allow the app to collect data about your interactions. Based on this data, the app will adapt to your preferences. The data will only be stored locally.'),
+			optOutSettingsText: t('mail', 'Activate'),
 			loadingOptOutSettings: false,
 			// eslint-disable-next-line
 			replySettingsText: t('mail', 'Put my text to the bottom of a reply instead of on top of it.'),
@@ -181,6 +219,7 @@ export default {
 			toggleAutoTagging: false,
 			displaySmimeCertificateModal: false,
 			sortOrder: 'newest',
+			showSettings: false,
 		}
 	},
 	computed: {
@@ -203,10 +242,25 @@ export default {
 			return this.$store.getters.getPreference('allow-new-accounts', true)
 		},
 	},
+	watch: {
+		showSettings(value) {
+			if (!value) {
+				this.$emit('update:open', value)
+			}
+		},
+		async open(value) {
+			if (value) {
+				await this.onOpen()
+			}
+		},
+	},
 	mounted() {
 		this.sortOrder = this.$store.getters.getPreference('sort-order', 'newest')
 	},
 	methods: {
+		async onOpen() {
+			this.showSettings = true
+		},
 		onToggleButtonReplies(e) {
 			this.loadingReplySettings = true
 
@@ -392,5 +446,13 @@ p.app-settings {
 	&__switch{
 		width: 50%;
 	}
+}
+.mail-creation-button {
+	width: 100%;
+}
+.settings-hint {
+	margin-top: -12px;
+	margin-bottom: 6px;
+	color: var(--color-text-maxcontrast);
 }
 </style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -67,18 +67,23 @@
 			<div v-if="outboxMessages.length !== 0" class="outbox__border">
 				<NavigationOutbox class="outbox" />
 			</div>
-			<AppNavigationSettings :title="t('mail', 'Mail settings')">
-				<template #icon>
-					<IconSetting :size="20" />
-				</template>
-				<AppSettingsMenu />
-			</AppNavigationSettings>
+			<div class="mail-settings">
+				<NcButton class="mail-settings__button"
+					:close-after-click="true"
+					@click="showMailSettings">
+					<template #icon>
+						<IconSetting :size="20" />
+					</template>
+					{{ t('mail', 'Mail settings') }}
+				</NcButton>
+			</div>
 		</template>
+		<AppSettingsMenu :open.sync="showSettings" />
 	</AppNavigation>
 </template>
 
 <script>
-import { NcAppNavigation as AppNavigation, NcAppNavigationSettings as AppNavigationSettings, NcAppNavigationSpacer as AppNavigationSpacer } from '@nextcloud/vue'
+import { NcButton, NcAppNavigation as AppNavigation, NcAppNavigationSpacer as AppNavigationSpacer } from '@nextcloud/vue'
 import NewMessageButtonHeader from './NewMessageButtonHeader.vue'
 
 import NavigationAccount from './NavigationAccount.vue'
@@ -92,8 +97,8 @@ import { UNIFIED_ACCOUNT_ID } from '../store/constants.js'
 export default {
 	name: 'Navigation',
 	components: {
+		NcButton,
 		AppNavigation,
-		AppNavigationSettings,
 		AppNavigationSpacer,
 		AppSettingsMenu,
 		NavigationAccount,
@@ -106,6 +111,7 @@ export default {
 	data() {
 		return {
 			refreshing: false,
+			showSettings: false,
 		}
 	},
 	computed: {
@@ -146,6 +152,9 @@ export default {
 		},
 	},
 	methods: {
+		showMailSettings() {
+			this.showSettings = true
+		},
 		isCollapsed(account, mailbox) {
 			if (mailbox.specialRole === 'inbox') {
 				// INBOX is always visible
@@ -235,6 +244,15 @@ to {
 		&.active {
 			background-color: transparent !important;
 		}
+	}
+}
+.mail-settings {
+	padding: calc(var(--default-grid-baseline, 4px) * 2);
+
+	&__button {
+		width: 100% !important;
+		justify-content: start !important;
+
 	}
 }
 


### PR DESCRIPTION
- [X] Move settings into a modal via AppSettingsDialogs dialog
- [x] Polish the new modal
- [x] Move the global Trusted senders from account settings modals to the app settings modal.

fixes #6896 