### PR TITLE
fix: improve autoresponder time zone handling

### DIFF
--- a/lib/Service/OutOfOffice/OutOfOfficeState.php
+++ b/lib/Service/OutOfOffice/OutOfOfficeState.php
@@ -111,12 +111,12 @@ class OutOfOfficeState implements JsonSerializable {
 
 		$start = $this->getStart();
 		if ($start) {
-			$json['start'] = $start->format('Y-m-d');
+			$json['start'] = $start->format('c');
 		}
 
 		$end = $this->getEnd();
 		if ($end) {
-			$json['end'] = $end->format('Y-m-d');
+			$json['end'] = $end->format('c');
 		}
 
 		$json['subject'] = $this->getSubject();

--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -163,6 +163,7 @@ export default {
 			OOO_DISABLED,
 			OOO_ENABLED,
 			OOO_FOLLOW_SYSTEM,
+			initialized: false,
 			enabled: this.account.outOfOfficeFollowsSystem ? OOO_FOLLOW_SYSTEM : OOO_DISABLED,
 			enableLastDay: false,
 			firstDay: new Date(),
@@ -219,6 +220,10 @@ export default {
 	},
 	watch: {
 		enableLastDay(enableLastDay) {
+			if (!this.initialized) {
+				return
+			}
+
 			if (enableLastDay) {
 				this.lastDay = new Date(this.firstDay)
 				this.lastDay.setDate(this.lastDay.getDate() + 6)
@@ -227,6 +232,10 @@ export default {
 			}
 		},
 		firstDay(firstDay, previousFirstDay) {
+			if (!this.initialized) {
+				return
+			}
+
 			if (!this.enableLastDay) {
 				return
 			}
@@ -243,6 +252,7 @@ export default {
 	},
 	async mounted() {
 		await this.fetchState()
+		this.initialized = true
 	},
 	methods: {
 		async fetchState() {
@@ -253,11 +263,18 @@ export default {
 			} else {
 				this.enabled = state.enabled ? OOO_ENABLED : OOO_DISABLED
 			}
-			if (state.enabled) {
-				this.firstDay = state.start ? new Date(state.start) : new Date()
-				this.lastDay = state.end ? new Date(state.end) : null
+
+			if (state.enabled && state.start) {
+				this.firstDay = new Date(state.start)
 			}
-			this.enableLastDay = !!this.lastDay
+			if (state.enabled && state.end) {
+				this.lastDay = new Date(state.end)
+				// FIXME: The dav automation adds 23:59 and mail adds 24:00 hours to the last day.
+				//        Subtract 23 hours to get the actual date.
+				this.lastDay.setHours(this.lastDay.getHours() - 23, 0, 0, 0)
+				this.enableLastDay = true
+			}
+
 			this.subject = state.subject
 			this.message = toHtml(plain(state.message)).value
 		},
@@ -275,14 +292,26 @@ export default {
 						},
 					})
 				} else {
+					const firstDay = new Date(this.firstDay)
+					firstDay.setHours(0, 0, 0, 0)
+
+					let lastDay = null
+					if (this.lastDay) {
+						// Add 24 hours to the last day to include the whole day
+						lastDay = new Date(this.lastDay)
+						lastDay.setHours(24, 0, 0, 0)
+					}
+
+					// Date.toISOString() always returns the date in UTC
 					await OutOfOfficeService.update(this.account.id, {
 						enabled: this.enabled === OOO_ENABLED,
-						start: this.firstDay,
-						end: this.lastDay,
+						start: firstDay.toISOString(),
+						end: lastDay?.toISOString() ?? null,
 						subject: this.subject,
 						message: toPlain(html(this.message)).value, // CKEditor always returns html data
 						allowedRecipients: this.aliases,
 					})
+
 					this.$store.commit('patchAccount', {
 						account: this.account,
 						data: {

--- a/tests/Unit/Service/OutOfOffice/OutOfOfficeParserTest.php
+++ b/tests/Unit/Service/OutOfOffice/OutOfOfficeParserTest.php
@@ -49,8 +49,8 @@ class OutOfOfficeParserTest extends TestCase {
 		self::assertEquals($cleanedScript, $actual->getUntouchedSieveScript());
 		self::assertEquals(1, $actual->getState()->getVersion());
 		self::assertEquals(true, $actual->getState()->isEnabled());
-		self::assertEquals(new DateTimeImmutable("2022-09-02"), $actual->getState()->getStart());
-		self::assertEquals(new DateTimeImmutable("2022-09-08"), $actual->getState()->getEnd());
+		self::assertEquals(new DateTimeImmutable("2022-09-02T00:00:00+0100"), $actual->getState()->getStart());
+		self::assertEquals(new DateTimeImmutable("2022-09-08T23:59:00+0100"), $actual->getState()->getEnd());
 		self::assertEquals("On vacation", $actual->getState()->getSubject());
 		self::assertEquals("I'm on vacation.", $actual->getState()->getMessage());
 	}
@@ -79,6 +79,21 @@ class OutOfOfficeParserTest extends TestCase {
 		self::assertEquals(null, $actual->getState());
 	}
 
+	public function testParseOldEnabledResponder(): void {
+		$script = file_get_contents(__DIR__ . "/../../../data/sieve-vacation-on-no-tz.txt");
+		$cleanedScript = file_get_contents(__DIR__ . "/../../../data/sieve-vacation-cleaned.txt");
+
+		$actual = $this->outOfOfficeParser->parseOutOfOfficeState($script);
+		self::assertEquals($script, $actual->getSieveScript());
+		self::assertEquals($cleanedScript, $actual->getUntouchedSieveScript());
+		self::assertEquals(1, $actual->getState()->getVersion());
+		self::assertEquals(true, $actual->getState()->isEnabled());
+		self::assertEquals(new DateTimeImmutable("2022-09-02T00:00:00+0000"), $actual->getState()->getStart());
+		self::assertEquals(new DateTimeImmutable("2022-09-08T00:00:00+0000"), $actual->getState()->getEnd());
+		self::assertEquals("On vacation", $actual->getState()->getSubject());
+		self::assertEquals("I'm on vacation.", $actual->getState()->getMessage());
+	}
+
 	public function testBuildEnabledResponder(): void {
 		$script = file_get_contents(__DIR__ . "/../../../data/sieve-vacation-cleaned.txt");
 		$expected = file_get_contents(__DIR__ . "/../../../data/sieve-vacation-on.txt");
@@ -86,8 +101,8 @@ class OutOfOfficeParserTest extends TestCase {
 		$actual = $this->outOfOfficeParser->buildSieveScript(
 			new OutOfOfficeState(
 				true,
-				new DateTimeImmutable("2022-09-02"),
-				new DateTimeImmutable("2022-09-08"),
+				new DateTimeImmutable("2022-09-02T00:00:00+0100"),
+				new DateTimeImmutable("2022-09-08T23:59:00+0100"),
 				"On vacation",
 				"I'm on vacation.",
 			),
@@ -104,7 +119,7 @@ class OutOfOfficeParserTest extends TestCase {
 		$actual = $this->outOfOfficeParser->buildSieveScript(
 			new OutOfOfficeState(
 				true,
-				new DateTimeImmutable("2022-09-02"),
+				new DateTimeImmutable("2022-09-02T00:00:00+0100"),
 				null,
 				"On vacation",
 				"I'm on vacation.",
@@ -122,7 +137,7 @@ class OutOfOfficeParserTest extends TestCase {
 		$actual = $this->outOfOfficeParser->buildSieveScript(
 			new OutOfOfficeState(
 				true,
-				new DateTimeImmutable("2022-09-02"),
+				new DateTimeImmutable("2022-09-02T00:00:00+0100"),
 				null,
 				"On vacation",
 				"I'm on vacation.\n\"Hello, World!\"\n\\ escaped backslash",
@@ -140,7 +155,7 @@ class OutOfOfficeParserTest extends TestCase {
 		$actual = $this->outOfOfficeParser->buildSieveScript(
 			new OutOfOfficeState(
 				true,
-				new DateTimeImmutable("2022-09-02"),
+				new DateTimeImmutable("2022-09-02T00:00:00+0100"),
 				null,
 				"On vacation, \"Hello, World!\", \\ escaped backslash",
 				"I'm on vacation.",
@@ -158,8 +173,8 @@ class OutOfOfficeParserTest extends TestCase {
 		$actual = $this->outOfOfficeParser->buildSieveScript(
 			new OutOfOfficeState(
 				true,
-				new DateTimeImmutable("2022-09-02"),
-				new DateTimeImmutable("2022-09-08"),
+				new DateTimeImmutable("2022-09-02T00:00:00+0100"),
+				new DateTimeImmutable("2022-09-08T23:59:00+0100"),
 				'Re: ${subject}',
 				"I'm on vacation.",
 			),

--- a/tests/data/sieve-vacation-on-no-end-date.txt
+++ b/tests/data/sieve-vacation-on-no-end-date.txt
@@ -11,8 +11,8 @@ if address "From" "marketing@company.org" {
 }
 
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
-# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation","message":"I'm on vacation."}
-if currentdate :value "ge" "date" "2022-09-02" {
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation."}
+if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
 	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-no-tz.txt
+++ b/tests/data/sieve-vacation-on-no-tz.txt
@@ -11,8 +11,8 @@ if address "From" "marketing@company.org" {
 }
 
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
-# DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
-if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02","end":"2022-09-08","subject":"On vacation","message":"I'm on vacation."}
+if allof(currentdate :value "ge" "iso8601" "2022-09-01", currentdate :value "le" "iso8601" "2022-09-08") {
 	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-special-chars-message.txt
+++ b/tests/data/sieve-vacation-on-special-chars-message.txt
@@ -11,8 +11,8 @@ if address "From" "marketing@company.org" {
 }
 
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
-# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation","message":"I'm on vacation.\n\"Hello, World!\"\n\\ escaped backslash"}
-if currentdate :value "ge" "date" "2022-09-02" {
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation.\n\"Hello, World!\"\n\\ escaped backslash"}
+if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
 	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.
 \"Hello, World!\"
 \\ escaped backslash";

--- a/tests/data/sieve-vacation-on-special-chars-subject.txt
+++ b/tests/data/sieve-vacation-on-special-chars-subject.txt
@@ -11,8 +11,8 @@ if address "From" "marketing@company.org" {
 }
 
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
-# DATA: {"version":1,"enabled":true,"start":"2022-09-02","subject":"On vacation, \"Hello, World!\", \\ escaped backslash","message":"I'm on vacation."}
-if currentdate :value "ge" "date" "2022-09-02" {
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation, \"Hello, World!\", \\ escaped backslash","message":"I'm on vacation."}
+if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
 	vacation :days 4 :subject "On vacation, \"Hello, World!\", \\ escaped backslash" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-subject-placeholder.txt
+++ b/tests/data/sieve-vacation-on-subject-placeholder.txt
@@ -12,12 +12,12 @@ if address "From" "marketing@company.org" {
 }
 
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
-# DATA: {"version":1,"enabled":true,"start":"2022-09-02","end":"2022-09-08","subject":"Re: ${subject}","message":"I'm on vacation."}
+# DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"Re: ${subject}","message":"I'm on vacation."}
 set "subject" "";
 if header :matches "subject" "*" {
 	set "subject" "${1}";
 }
-if allof(currentdate :value "ge" "date" "2022-09-02", currentdate :value "le" "date" "2022-09-08") {
+if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
 	vacation :days 4 :subject "Re: ${subject}" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/9154

The date is now formatted correctly when:
1. Setting a single day absence in personal settings.
2. Setting a (single day) absence directly in the autoresponder form in Mail.

I forced sieve to compare the current date and the configured start/end based on ISO8601. Now, the comparison should be unambiguous and should never start early or end late (because of a drift etc.).

The browser's time zone is used when directly setting the autoresponder (as before).

I also fixed some issues in the form's initialization logic that would prevent the last day from ever being applied. It was overwritten all the time before.

## Examples

**Note:** I'm in the Europe/Berlin (`+0100`) time zone. My `00:00` is `23:00` in UTC.

### Case 1 (personal settings and follow system)
![grafik](https://github.com/nextcloud/mail/assets/1479486/919cc07a-b3a9-40f4-9b8d-8d7599edb4ec)
![grafik](https://github.com/nextcloud/mail/assets/1479486/f2a8ecdf-afb1-4e81-8428-94dc9b2cb6c4)

### Case 2 (autoresponder in Mail directly)
![grafik](https://github.com/nextcloud/mail/assets/1479486/aabde05e-6c29-4ef8-b86b-5a1485de811b)