### PR TITLE
fix: Alien envelopes that vanish and reappear continuously

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -284,13 +284,13 @@ export default {
 			return
 		}
 
-		const mailbox = state.mailboxes[envelopes[0].mailboxId]
 		const idToDateInt = (id) => state.envelopes[id].dateInt
 
 		const listId = normalizedEnvelopeListId(query)
 		const orderByDateInt = orderBy(idToDateInt, state.preferences['sort-order'] === 'newest' ? 'desc' : 'asc')
 
 		envelopes.forEach((envelope) => {
+			const mailbox = state.mailboxes[envelope.mailboxId]
 			const existing = mailbox.envelopeLists[listId] || []
 			normalizeTags(state, envelope)
 			Vue.set(state.envelopes, envelope.databaseId, Object.assign({}, state.envelopes[envelope.databaseId] || {}, envelope))


### PR DESCRIPTION
When adding envelopes to the store we must only append them to the mailbox they belong to, or the unified inbox. If they are added to any other mailbox, the sync removes them, adds them back, removes them, adds them, removes them, ...

## How to test

1. Add account 1
2. Add account 2
3. Reload the page
4. Watch

main: some messages continuously vanish and return
here: view stays unchanged even with background sync

Fixes https://github.com/nextcloud/mail/issues/9132