### PR TITLE
fix(provisioning): Do not require master password if disabled

### DIFF
--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -196,7 +196,7 @@
 								v-model="masterPassword"
 								:disabled="loading"
 								type="password"
-								required>
+								:required="masterPasswordEnabled">
 							<label for="mail-master-password"> {{ t('mail', 'Master password') }} </label>
 						</div>
 					</div>
@@ -402,7 +402,7 @@ export default {
 			smtpPort: this.setting.smtpPort || 587,
 			smtpUser: this.setting.smtpUser || '%USERID%domain.com',
 			smtpSslMode: this.setting.smtpSslMode || 'tls',
-			masterPasswordEnabled: this.setting.masterPasswordEnabled || '',
+			masterPasswordEnabled: this.setting.masterPasswordEnabled === true,
 			masterPassword: this.setting.masterPassword || '',
 			sieveEnabled: this.setting.sieveEnabled || '',
 			sieveHost: this.setting.sieveHost || '',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9191

## How to test

1) Open the admin Groupware settings
2) Enter details of a fake provisioning (settings don't have to work for this), leave out the master password
3) Click *Save config*

main: browser asks you to fill in the master password
here: config can be saved