### PR TITLE
test: Run integration tests in transactions

### DIFF
--- a/tests/Integration/Db/LocalAttachmentMapperTest.php
+++ b/tests/Integration/Db/LocalAttachmentMapperTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Tests\Integration\Db;
 
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Db\LocalAttachment;
 use OCA\Mail\Db\LocalAttachmentMapper;
@@ -38,6 +39,8 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class LocalAttachmentMapperTest extends TestCase {
+	use DatabaseTransaction;
+
 	/** @var IDBConnection */
 	private $db;
 

--- a/tests/Integration/Db/LocalMessageMapperTest.php
+++ b/tests/Integration/Db/LocalMessageMapperTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Tests\Integration\Db;
 
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Db\LocalAttachmentMapper;
 use OCA\Mail\Db\LocalMessage;
@@ -39,6 +40,7 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class LocalMessageMapperTest extends TestCase {
+	use DatabaseTransaction;
 	use ImapTestAccount;
 
 	/** @var IDBConnection */

--- a/tests/Integration/Db/RecipientMapperTest.php
+++ b/tests/Integration/Db/RecipientMapperTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Tests\Integration\Db;
 
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Db\LocalAttachmentMapper;
 use OCA\Mail\Db\LocalMessage;
@@ -38,6 +39,7 @@ use OCP\IDBConnection;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class RecipientMapperTest extends TestCase {
+	use DatabaseTransaction;
 	use ImapTestAccount;
 
 	/** @var IDBConnection */


### PR DESCRIPTION
Integration tests for mappers delete all rows and insert fixtured before each test to assure a constant testing data set. The side effect of this is that dev envs break every time tests are run because data (like oc_recipients) vanishes.

Running these tests in transactions allows for a clean test environment while restoring the original data with a rollback.

## How to test
1) Set up a dev env
2) Add an account to Mail
3) Sync the account
4) Run `composer run test:integration`

main: oc_recipients table is cleared
here: oc_recipients table contents remain