### PR TITLE
fix(setup): Fix rate limit annotation syntax (#9216)

### DIFF
--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -61,7 +61,7 @@ class AutoConfigController extends Controller {
 	 * @param string $email
 	 *
 	 * @NoAdminRequired
-	 * @UserRateThrottle(limit: 5, period: 60)
+	 * @UserRateThrottle(limit=5, period=60)
 	 *
 	 * @return JsonResponse
 	 */
@@ -81,7 +81,7 @@ class AutoConfigController extends Controller {
 	 * @param string $email
 	 *
 	 * @NoAdminRequired
-	 * @UserRateThrottle(limit: 5, period: 60)
+	 * @UserRateThrottle(limit=5, period=60)
 	 *
 	 * @return JsonResponse
 	 */
@@ -103,7 +103,7 @@ class AutoConfigController extends Controller {
 	 * @param int $port
 	 *
 	 * @NoAdminRequired
-	 * @UserRateThrottle(limit: 10, period: 60)
+	 * @UserRateThrottle(limit=10, period=60)
 	 *
 	 * @return JsonResponse
 	 */


### PR DESCRIPTION
This PR fixes nextcloud/mail#9170.

- Automatic method reflector code expects "=" not ":" in Doc parameter lists. Ref: https://github.com/nextcloud/server/blob/7502c19ddd43853c3b4fad1e2df91aed19e6b626/lib/private/AppFramework/Utility/ControllerMethodReflector.php#L66