### PR TITLE
fix(autoresponder): use subject placeholder instead of ooo short message

### DIFF
--- a/lib/Controller/OutOfOfficeController.php
+++ b/lib/Controller/OutOfOfficeController.php
@@ -120,7 +120,7 @@ class OutOfOfficeController extends Controller {
 				true,
 				new DateTimeImmutable("@" . $currentOutOfOfficeData->getStartDate()),
 				new DateTimeImmutable("@" . $currentOutOfOfficeData->getEndDate()),
-				$currentOutOfOfficeData->getShortMessage(),
+				'Re: ${subject}',
 				$currentOutOfOfficeData->getMessage(),
 			);
 			$this->outOfOfficeService->update($mailAccount, $state);

--- a/lib/Listener/OutOfOfficeListener.php
+++ b/lib/Listener/OutOfOfficeListener.php
@@ -84,7 +84,7 @@ class OutOfOfficeListener implements IEventListener {
 				$enabled,
 				new DateTimeImmutable('@' . $eventData->getStartDate()),
 				new DateTimeImmutable('@' . $eventData->getEndDate()),
-				$eventData->getShortMessage(),
+				'Re: ${subject}',
 				$eventData->getMessage(),
 			);
 			try {

--- a/tests/Unit/Controller/OutOfOfficeControllerTest.php
+++ b/tests/Unit/Controller/OutOfOfficeControllerTest.php
@@ -193,7 +193,7 @@ class OutOfOfficeControllerTest extends TestCase {
 				self::assertTrue($state->isEnabled());
 				self::assertEquals(new DateTimeImmutable("@$startDate"), $state->getStart());
 				self::assertEquals(new DateTimeImmutable("@$endDate"), $state->getEnd());
-				self::assertEquals('Subject', $state->getSubject());
+				self::assertEquals('Re: ${subject}', $state->getSubject());
 				self::assertEquals('Message', $state->getMessage());
 				return true;
 			}));


### PR DESCRIPTION
Fix #9219 

On second thought, it is more professional to use the standard `Re: ...` format. We already implemented it for the custom autoresponder.

This also provides consistency across all mail/sieve servers as it doesn't depend on the actual implementation of the default subject.

**Note:** I tested this locally and it works fine.