### PR TITLE
fix(imap): Only rate limit actual auth errors

### DIFF
--- a/lib/IMAP/ImapClientRateLimitingDecorator.php
+++ b/lib/IMAP/ImapClientRateLimitingDecorator.php
@@ -72,7 +72,8 @@ class ImapClientRateLimitingDecorator extends Horde_Imap_Client_Socket {
 		try {
 			return parent::_login();
 		} catch (Horde_Imap_Client_Exception $e) {
-			if ($e->getCode() === Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED) {
+			if ($e->getCode() === Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED
+				&& $e->getMessage() === 'Authentication failed.') {
 				$current = $this->cache->inc($cacheKey);
 			}
 			throw $e;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9156

https://github.com/bytestream/Imap_Client/blob/79612af5452730db98e6a73bf9270c3f5512b9a2/lib/Horde/Imap/Client/Socket.php#L5046-L5052 is what we want to rate limit.
https://github.com/bytestream/Imap_Client/blob/79612af5452730db98e6a73bf9270c3f5512b9a2/lib/Horde/Imap/Client/Socket.php#L570-L576 is a horde fallback, but possibly not a real authentication failure. We should not consider this for the rate limit counter.