### PR TITLE
[stable3.5] fix(autoresponder): use subject placeholder instead of ooo short message

### DIFF
--- a/lib/Controller/OutOfOfficeController.php
+++ b/lib/Controller/OutOfOfficeController.php
@@ -119,7 +119,7 @@ class OutOfOfficeController extends Controller {
 				true,
 				new DateTimeImmutable("@" . $currentOutOfOfficeData->getStartDate()),
 				new DateTimeImmutable("@" . $currentOutOfOfficeData->getEndDate()),
-				$currentOutOfOfficeData->getShortMessage(),
+				'Re: ${subject}',
 				$currentOutOfOfficeData->getMessage(),
 			);
 			$this->outOfOfficeService->update($mailAccount, $state);

--- a/lib/Listener/OutOfOfficeListener.php
+++ b/lib/Listener/OutOfOfficeListener.php
@@ -84,7 +84,7 @@ class OutOfOfficeListener implements IEventListener {
 				$enabled,
 				new DateTimeImmutable('@' . $eventData->getStartDate()),
 				new DateTimeImmutable('@' . $eventData->getEndDate()),
-				$eventData->getShortMessage(),
+				'Re: ${subject}',
 				$eventData->getMessage(),
 			);
 			try {

--- a/tests/Unit/Controller/OutOfOfficeControllerTest.php
+++ b/tests/Unit/Controller/OutOfOfficeControllerTest.php
@@ -193,7 +193,7 @@ class OutOfOfficeControllerTest extends TestCase {
 				self::assertTrue($state->isEnabled());
 				self::assertEquals(new DateTimeImmutable("@$startDate"), $state->getStart());
 				self::assertEquals(new DateTimeImmutable("@$endDate"), $state->getEnd());
-				self::assertEquals('Subject', $state->getSubject());
+				self::assertEquals('Re: ${subject}', $state->getSubject());
 				self::assertEquals('Message', $state->getMessage());
 				return true;
 			}));


### PR DESCRIPTION
Manual backport of #9228 

Hmm weird, the cherry-pick applied cleanly ...