### PR TITLE
fix: add command to repair broken autoresponders

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -82,6 +82,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\Thread</command>
 		<command>OCA\Mail\Command\TrainAccount</command>
 		<command>OCA\Mail\Command\UpdateAccount</command>
+		<command>OCA\Mail\Command\UpdateSystemAutoresponders</command>
 	</commands>
 	<settings>
 		<admin>OCA\Mail\Settings\AdminSettings</admin>

--- a/lib/Command/UpdateSystemAutoresponders.php
+++ b/lib/Command/UpdateSystemAutoresponders.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Service\OutOfOfficeService;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpdateSystemAutoresponders extends Command {
+	public function __construct(
+		private MailAccountMapper $mailAccountMapper,
+		private IUserManager $userManager,
+		private OutOfOfficeService $outOfOfficeService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:repair:system-autoresponders');
+		$this->setDescription('Update sieve scripts of all accounts that follow the system out-of-office period');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		foreach ($this->mailAccountMapper->findAllWhereOooFollowsSystem() as $mailAccount) {
+			$accountId = $mailAccount->getId();
+			$userId = $mailAccount->getUserId();
+			$output->writeln("<info>Updating account $accountId of user $userId</info>");
+
+			$userId = $mailAccount->getUserId();
+			$user = $this->userManager->get($userId);
+			if ($user === null) {
+				$output->writeln("<comment>User $userId does not exist. Skipping ...</comment>");
+				continue;
+			}
+
+			$state = $this->outOfOfficeService->updateFromSystem($mailAccount, $user);
+			if ($state === null) {
+				$output->writeln(
+					"Disabled autoresponder of account $accountId",
+					OutputInterface::VERBOSITY_VERBOSE,
+				);
+			} else {
+				$output->writeln(
+					"Updated autoresponder of account $accountId",
+					OutputInterface::VERBOSITY_VERBOSE,
+				);
+			}
+		}
+
+		return 0;
+	}
+}

--- a/lib/Controller/OutOfOfficeController.php
+++ b/lib/Controller/OutOfOfficeController.php
@@ -36,32 +36,20 @@ use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
 use OCA\Mail\Service\OutOfOfficeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\User\IAvailabilityCoordinator;
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
 class OutOfOfficeController extends Controller {
-	private ?IAvailabilityCoordinator $availabilityCoordinator;
-
 	public function __construct(
 		IRequest $request,
-		ContainerInterface $container,
+		private ContainerInterface $container,
 		private IUserSession $userSession,
 		private AccountService $accountService,
 		private OutOfOfficeService $outOfOfficeService,
-		private ITimeFactory $timeFactory,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-
-		// TODO: inject directly if support for nextcloud < 28 is dropped
-		try {
-			$this->availabilityCoordinator = $container->get(IAvailabilityCoordinator::class);
-		} catch (ContainerExceptionInterface) {
-			$this->availabilityCoordinator = null;
-		}
 	}
 
 	/**
@@ -89,7 +77,7 @@ class OutOfOfficeController extends Controller {
 	 */
 	#[TrapError]
 	public function followSystem(int $accountId) {
-		if ($this->availabilityCoordinator === null) {
+		if (!$this->container->has(IAvailabilityCoordinator::class)) {
 			return JsonResponse::fail([], Http::STATUS_NOT_IMPLEMENTED);
 		}
 
@@ -109,26 +97,7 @@ class OutOfOfficeController extends Controller {
 			$this->accountService->update($mailAccount);
 		}
 
-		$state = null;
-		$now = $this->timeFactory->getTime();
-		$currentOutOfOfficeData = $this->availabilityCoordinator->getCurrentOutOfOfficeData($user);
-		if ($currentOutOfOfficeData !== null
-		 && $currentOutOfOfficeData->getStartDate() <= $now
-		 && $currentOutOfOfficeData->getEndDate() > $now) {
-			// In the middle of a running absence => enable auto responder
-			$state = new OutOfOfficeState(
-				true,
-				new DateTimeImmutable("@" . $currentOutOfOfficeData->getStartDate()),
-				new DateTimeImmutable("@" . $currentOutOfOfficeData->getEndDate()),
-				'Re: ${subject}',
-				$currentOutOfOfficeData->getMessage(),
-			);
-			$this->outOfOfficeService->update($mailAccount, $state);
-		} else {
-			// Absence has not yet started or has already ended => disable auto responder
-			$this->outOfOfficeService->disable($mailAccount);
-		}
-
+		$state = $this->outOfOfficeService->updateFromSystem($mailAccount, $user);
 		return JsonResponse::success($state);
 	}
 

--- a/lib/Service/OutOfOfficeService.php
+++ b/lib/Service/OutOfOfficeService.php
@@ -26,25 +26,43 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service;
 
+use DateTimeImmutable;
 use Horde\ManageSieve\Exception as ManageSieveException;
+use InvalidArgumentException;
 use JsonException;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\CouldNotConnectException;
 use OCA\Mail\Exception\OutOfOfficeParserException;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\OutOfOffice\OutOfOfficeParser;
 use OCA\Mail\Service\OutOfOffice\OutOfOfficeParserResult;
 use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUser;
+use OCP\User\IAvailabilityCoordinator;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class OutOfOfficeService {
+	private ?IAvailabilityCoordinator $availabilityCoordinator;
+
 	public function __construct(
 		private OutOfOfficeParser $outOfOfficeParser,
 		private SieveService $sieveService,
 		private LoggerInterface $logger,
 		private AliasesService $aliasesService,
+		private ITimeFactory $timeFactory,
+		ContainerInterface $container,
 	) {
+		// TODO: inject directly if we only support Nextcloud >= 28
+		try {
+			$this->availabilityCoordinator = $container->get(IAvailabilityCoordinator::class);
+		} catch (ContainerExceptionInterface $e) {
+			$this->availabilityCoordinator = null;
+		}
 	}
 
 	/**
@@ -82,6 +100,60 @@ class OutOfOfficeService {
 			]);
 			throw $e;
 		}
+	}
+
+	/**
+	 * Update a mail account's autoresponder from the out-of-office system setting of the corresponding user.
+	 * Note: This method throws if the given account doesn't follow system out-of-office settings.
+	 *
+	 * @param MailAccount $mailAccount The mail account to update
+	 * @param IUser $user The user the mail account belongs to
+	 *
+	 * @return OutOfOfficeState|null The new out-of-office state which has been applied
+	 * @throws ClientException
+	 * @throws CouldNotConnectException
+	 * @throws JsonException
+	 * @throws ManageSieveException
+	 * @throws OutOfOfficeParserException
+	 * @throws ServiceException
+	 * @throws InvalidArgumentException If the given mail account doesn't follow out-of-office settings
+	 */
+	public function updateFromSystem(MailAccount $mailAccount, IUser $user): ?OutOfOfficeState {
+		if ($this->availabilityCoordinator === null) {
+			throw new ServiceException('System out-of-office data is only available in Nextcloud >= 28');
+		}
+
+		if (!$mailAccount->getOutOfOfficeFollowsSystem()) {
+			throw new InvalidArgumentException('The mail account does not follow system out-of-office settings');
+		}
+
+		$userId = $user->getUID();
+		if ($mailAccount->getUserId() !== $userId) {
+			$accountId = $mailAccount->getId();
+			throw new ServiceException("Account $accountId doesn't belong to user $userId");
+		}
+
+		$state = null;
+		$now = $this->timeFactory->getTime();
+		$currentOutOfOfficeData = $this->availabilityCoordinator->getCurrentOutOfOfficeData($user);
+		if ($currentOutOfOfficeData !== null
+			&& $currentOutOfOfficeData->getStartDate() <= $now
+			&& $currentOutOfOfficeData->getEndDate() > $now) {
+			// In the middle of a running absence => enable auto responder
+			$state = new OutOfOfficeState(
+				true,
+				new DateTimeImmutable("@" . $currentOutOfOfficeData->getStartDate()),
+				new DateTimeImmutable("@" . $currentOutOfOfficeData->getEndDate()),
+				'Re: ${subject}',
+				$currentOutOfOfficeData->getMessage(),
+			);
+			$this->update($mailAccount, $state);
+		} else {
+			// Absence has not yet started or has already ended => disable auto responder
+			$this->disable($mailAccount);
+		}
+
+		return $state;
 	}
 
 	/**

--- a/tests/Unit/Controller/OutOfOfficeControllerTest.php
+++ b/tests/Unit/Controller/OutOfOfficeControllerTest.php
@@ -28,92 +28,56 @@ namespace Unit\Controller;
 
 use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use DateTimeImmutable;
 use OCA\Mail\Account;
 use OCA\Mail\Controller\OutOfOfficeController;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Http\JsonResponse;
 use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
+use OCP\AppFramework\Http;
 use OCP\IUser;
 use OCP\User\IAvailabilityCoordinator;
-use OCP\User\IOutOfOfficeData;
-use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Container\ContainerInterface;
 
 class OutOfOfficeControllerTest extends TestCase {
 	private ServiceMockObject $serviceMock;
 	private OutOfOfficeController $outOfOfficeController;
 
-	/** @var ContainerInterface|MockObject */
-	private $container;
-
-	/** @var IAvailabilityCoordinator|MockObject */
-	private $availabilityCoordinator;
-
 	protected function setUp(): void {
 		parent::setUp();
 
-		if (!interface_exists(IAvailabilityCoordinator::class)
-		 || !interface_exists(IOutOfOfficeData::class)) {
-			$this->markTestSkipped('Out-of-office feature is not available');
-		}
-
-		$this->container = $this->createMock(ContainerInterface::class);
-		$this->availabilityCoordinator = $this->createMock(IAvailabilityCoordinator::class);
-
-		$this->container->expects(self::once())
-			->method('get')
-			->with(IAvailabilityCoordinator::class)
-			->willReturn($this->availabilityCoordinator);
-
 		$this->serviceMock = $this->createServiceMock(OutOfOfficeController::class, [
 			'userId' => 'user',
-			'container' => $this->container,
 		]);
 		$this->outOfOfficeController = $this->serviceMock->getService();
 	}
 
-	private function createOutOfOfficeData(
-		string $id,
-		IUser $user,
-		int $startDate,
-		int $endDate,
-		string $subject,
-		string $message,
-	): ?IOutOfOfficeData {
-		if (!interface_exists(IOutOfOfficeData::class)) {
-			return null;
+	public function followSystemDataProvider(): array {
+		return [
+			[false],
+			[true],
+		];
+	}
+
+	/**
+	 * @dataProvider followSystemDataProvider
+	 */
+	public function testFollowSystem(bool $followSystem): void {
+		if (!interface_exists(IAvailabilityCoordinator::class)) {
+			$this->markTestSkipped('Out-of-office feature is not available');
+			return;
 		}
 
-		$data = $this->createMock(IOutOfOfficeData::class);
-		$data->method('getId')->willReturn($id);
-		$data->method('getUser')->willReturn($user);
-		$data->method('getStartDate')->willReturn($startDate);
-		$data->method('getEndDate')->willReturn($endDate);
-		$data->method('getShortMessage')->willReturn($subject);
-		$data->method('getMessage')->willReturn($message);
-		return $data;
-	}
+		$container = $this->serviceMock->getParameter('container');
+		$container->expects(self::once())
+			->method('has')
+			->with(IAvailabilityCoordinator::class)
+			->willReturn(true);
 
-
-	public function disabledOutOfOfficeDataProvider(): array {
 		$user = $this->createMock(IUser::class);
-		return [
-			[null],
-			[$this->createOutOfOfficeData('2', $user, 0, 1, '', '')],
-			[$this->createOutOfOfficeData('2', $user, PHP_INT_MAX - 1, PHP_INT_MAX, '', '')],
-			[$this->createOutOfOfficeData('2', $user, 0, 1500, 'Subject', 'Message')],
-		];
-	}
-
-	/**
-	 * @dataProvider disabledOutOfOfficeDataProvider
-	 */
-	public function testFollowSystemWithDisabledOutOfOffice(?IOutOfOfficeData $data): void {
-		$user = $this->createMock(IUser::class);
+		$state = $this->createMock(OutOfOfficeState::class);
 
 		$mailAccount = new MailAccount();
 		$mailAccount->setId(1);
-		$mailAccount->setOutOfOfficeFollowsSystem(false);
+		$mailAccount->setOutOfOfficeFollowsSystem($followSystem);
 		$account = new Account($mailAccount);
 
 		$userSession = $this->serviceMock->getParameter('userSession');
@@ -125,81 +89,26 @@ class OutOfOfficeControllerTest extends TestCase {
 			->method('findById')
 			->with(1)
 			->willReturn($account);
-		$timeFactory = $this->serviceMock->getParameter('timeFactory');
-		$timeFactory->expects(self::once())
-			->method('getTime')
-			->willReturn(1500);
-		$this->availabilityCoordinator->expects(self::once())
-			->method('getCurrentOutOfOfficeData')
-			->with($user)
-			->willReturn($data);
 		$outOfOfficeService = $this->serviceMock->getParameter('outOfOfficeService');
 		$outOfOfficeService->expects(self::once())
-			->method('disable')
-			->with($mailAccount);
-		$outOfOfficeService->expects(self::never())
-			->method('update');
+			->method('updateFromSystem')
+			->with($mailAccount, $user)
+			->willReturn($state);
 
-		$this->outOfOfficeController->followSystem(1);
+		$response = $this->outOfOfficeController->followSystem(1);
+		self::assertEquals($response, JsonResponse::success($state));
 
 		self::assertTrue($mailAccount->getOutOfOfficeFollowsSystem());
 	}
 
-	public function enabledOutOfOfficeDataProvider(): array {
-		$user = $this->createMock(IUser::class);
-		return [
-			[$this->createOutOfOfficeData('2', $user, 1000, 2000, 'Subject', 'Message')],
-			[$this->createOutOfOfficeData('2', $user, 1500, 2000, 'Subject', 'Message')],
-		];
-	}
+	public function testFollowSystemWithoutOutOfOfficeFeature(): void {
+		$container = $this->serviceMock->getParameter('container');
+		$container->expects(self::once())
+			->method('has')
+			->with(IAvailabilityCoordinator::class)
+			->willReturn(false);
 
-	/**
-	 * @dataProvider enabledOutOfOfficeDataProvider
-	 */
-	public function testFollowSystemWithEnabledOutOfOffice(?IOutOfOfficeData $data): void {
-		$startDate = $data->getStartDate();
-		$endDate = $data->getEndDate();
-
-		$user = $this->createMock(IUser::class);
-
-		$mailAccount = new MailAccount();
-		$mailAccount->setId(1);
-		$mailAccount->setOutOfOfficeFollowsSystem(false);
-		$account = new Account($mailAccount);
-
-		$userSession = $this->serviceMock->getParameter('userSession');
-		$userSession->expects(self::once())
-			->method('getUser')
-			->willReturn($user);
-		$accountService = $this->serviceMock->getParameter('accountService');
-		$accountService->expects(self::once())
-			->method('findById')
-			->with(1)
-			->willReturn($account);
-		$timeFactory = $this->serviceMock->getParameter('timeFactory');
-		$timeFactory->expects(self::once())
-			->method('getTime')
-			->willReturn(1500);
-		$this->availabilityCoordinator->expects(self::once())
-			->method('getCurrentOutOfOfficeData')
-			->with($user)
-			->willReturn($data);
-		$outOfOfficeService = $this->serviceMock->getParameter('outOfOfficeService');
-		$outOfOfficeService->expects(self::never())
-			->method('disable');
-		$outOfOfficeService->expects(self::once())
-			->method('update')
-			->with($mailAccount, self::callback(function (OutOfOfficeState $state) use ($endDate, $startDate): bool {
-				self::assertTrue($state->isEnabled());
-				self::assertEquals(new DateTimeImmutable("@$startDate"), $state->getStart());
-				self::assertEquals(new DateTimeImmutable("@$endDate"), $state->getEnd());
-				self::assertEquals('Re: ${subject}', $state->getSubject());
-				self::assertEquals('Message', $state->getMessage());
-				return true;
-			}));
-
-		$this->outOfOfficeController->followSystem(1);
-
-		self::assertTrue($mailAccount->getOutOfOfficeFollowsSystem());
+		$response = $this->outOfOfficeController->followSystem(1);
+		self::assertEquals($response, JsonResponse::fail([], Http::STATUS_NOT_IMPLEMENTED));
 	}
 }

--- a/tests/Unit/Service/OutOfOfficeServiceTest.php
+++ b/tests/Unit/Service/OutOfOfficeServiceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Unit\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Service\OutOfOffice\OutOfOfficeParserResult;
+use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
+use OCA\Mail\Service\OutOfOfficeService;
+use OCA\Mail\Sieve\NamedSieveScript;
+use OCP\IUser;
+use OCP\User\IAvailabilityCoordinator;
+use OCP\User\IOutOfOfficeData;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+
+class OutOfOfficeServiceTest extends TestCase {
+	private ServiceMockObject $serviceMock;
+	private OutOfOfficeService $outOfOfficeService;
+
+	/** @var ContainerInterface|MockObject */
+	private $container;
+
+	/** @var IAvailabilityCoordinator|MockObject */
+	private $availabilityCoordinator;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		if (!interface_exists(IAvailabilityCoordinator::class)
+			|| !interface_exists(IOutOfOfficeData::class)) {
+			$this->markTestSkipped('Out-of-office feature is not available');
+		}
+
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->availabilityCoordinator = $this->createMock(IAvailabilityCoordinator::class);
+
+		$this->container->expects(self::once())
+			->method('get')
+			->with(IAvailabilityCoordinator::class)
+			->willReturn($this->availabilityCoordinator);
+
+		$this->serviceMock = $this->createServiceMock(OutOfOfficeService::class, [
+			'container' => $this->container,
+		]);
+		$this->outOfOfficeService = $this->serviceMock->getService();
+	}
+
+	private function createOutOfOfficeData(
+		string $id,
+		IUser $user,
+		int $startDate,
+		int $endDate,
+		string $subject,
+		string $message,
+	): ?IOutOfOfficeData {
+		if (!interface_exists(IOutOfOfficeData::class)) {
+			return null;
+		}
+
+		$data = $this->createMock(IOutOfOfficeData::class);
+		$data->method('getId')->willReturn($id);
+		$data->method('getUser')->willReturn($user);
+		$data->method('getStartDate')->willReturn($startDate);
+		$data->method('getEndDate')->willReturn($endDate);
+		$data->method('getShortMessage')->willReturn($subject);
+		$data->method('getMessage')->willReturn($message);
+		return $data;
+	}
+
+	public function testFollowSystemWithNotFollowingAccount(): void {
+		$user = $this->createMock(IUser::class);
+
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setOutOfOfficeFollowsSystem(false);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('The mail account does not follow system out-of-office settings');
+		$this->outOfOfficeService->updateFromSystem($mailAccount, $user);
+	}
+
+	public function enabledOutOfOfficeDataProvider(): array {
+		$user = $this->createMock(IUser::class);
+		return [
+			[$this->createOutOfOfficeData('2', $user, 1000, 2000, 'Subject', 'Message')],
+			[$this->createOutOfOfficeData('2', $user, 1500, 2000, 'Subject', 'Message')],
+		];
+	}
+
+	/**
+	 * @dataProvider enabledOutOfOfficeDataProvider
+	 */
+	public function testUpdateFromSystemWithEnabledOutOfOffice(?IOutOfOfficeData $data): void {
+		$startDate = $data->getStartDate();
+		$endDate = $data->getEndDate();
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('user');
+
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setOutOfOfficeFollowsSystem(true);
+		$mailAccount->setUserId('user');
+		$mailAccount->setEmail('email@domain.com');
+
+		$timeFactory = $this->serviceMock->getParameter('timeFactory');
+		$timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1500);
+		$this->availabilityCoordinator->expects(self::once())
+			->method('getCurrentOutOfOfficeData')
+			->with($user)
+			->willReturn($data);
+		$sieveService = $this->serviceMock->getParameter('sieveService');
+		$sieveService->expects(self::once())
+			->method('getActiveScript')
+			->with('user', 1)
+			->willReturn(new NamedSieveScript('nextcloud', '# sieve script'));
+		$outOfOfficeParser = $this->serviceMock->getParameter('outOfOfficeParser');
+		$outOfOfficeParser->expects(self::once())
+			->method('parseOutOfOfficeState')
+			->with('# sieve script')
+			->willReturn(new OutOfOfficeParserResult(
+				null,
+				'# sieve script',
+				'# sieve script',
+			));
+		$outOfOfficeParser->expects(self::once())
+			->method('buildSieveScript')
+			->with(
+				new OutOfOfficeState(
+					true,
+					new DateTimeImmutable("@$startDate"),
+					new DateTimeImmutable("@$endDate"),
+					'Re: ${subject}',
+					$data->getMessage(),
+				),
+				'# sieve script',
+				['email@domain.com'],
+			)
+			->willReturn('# new sieve script');
+		$aliasesService = $this->serviceMock->getParameter('aliasesService');
+		$aliasesService->expects(self::once())
+			->method('findAll')
+			->with(1, 'user')
+			->willReturn([]);
+		$sieveService->expects(self::once())
+			->method('updateActiveScript')
+			->with('user', 1, '# new sieve script');
+
+		$state = $this->outOfOfficeService->updateFromSystem($mailAccount, $user);
+		self::assertTrue($state->isEnabled());
+		self::assertEquals(new DateTimeImmutable("@$startDate"), $state->getStart());
+		self::assertEquals(new DateTimeImmutable("@$endDate"), $state->getEnd());
+		self::assertEquals('Re: ${subject}', $state->getSubject());
+		self::assertEquals('Message', $state->getMessage());
+	}
+
+	public function disabledOutOfOfficeDataProvider(): array {
+		$user = $this->createMock(IUser::class);
+		return [
+			[$this->createOutOfOfficeData('2', $user, 1000, 1250, 'Subject', 'Message')],
+			[$this->createOutOfOfficeData('2', $user, 1750, 2000, 'Subject', 'Message')],
+		];
+	}
+
+	/**
+	 * @dataProvider disabledOutOfOfficeDataProvider
+	 */
+	public function testUpdateFromSystemWithDisabledOutOfOffice(?IOutOfOfficeData $data): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')
+			->willReturn('user');
+
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setOutOfOfficeFollowsSystem(true);
+		$mailAccount->setUserId('user');
+		$mailAccount->setEmail('email@domain.com');
+
+		$oldState = new OutOfOfficeState(true, null, null, 'Old subject', 'Old message');
+
+		$timeFactory = $this->serviceMock->getParameter('timeFactory');
+		$timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn(1500);
+		$this->availabilityCoordinator->expects(self::once())
+			->method('getCurrentOutOfOfficeData')
+			->with($user)
+			->willReturn($data);
+		$sieveService = $this->serviceMock->getParameter('sieveService');
+		$sieveService->expects(self::exactly(2))
+			->method('getActiveScript')
+			->with('user', 1)
+			->willReturn(new NamedSieveScript('nextcloud', '# sieve script'));
+		$outOfOfficeParser = $this->serviceMock->getParameter('outOfOfficeParser');
+		$outOfOfficeParser->expects(self::exactly(2))
+			->method('parseOutOfOfficeState')
+			->with('# sieve script')
+			->willReturn(new OutOfOfficeParserResult(
+				$oldState,
+				'# sieve script',
+				'# sieve script',
+			));
+		$outOfOfficeParser->expects(self::once())
+			->method('buildSieveScript')
+			->with(
+				new OutOfOfficeState(
+					false,
+					$oldState->getStart(),
+					$oldState->getEnd(),
+					$oldState->getSubject(),
+					$oldState->getMessage(),
+					$oldState->getVersion(),
+				),
+				'# sieve script',
+				['email@domain.com'],
+			)
+			->willReturn('# new sieve script');
+		$aliasesService = $this->serviceMock->getParameter('aliasesService');
+		$aliasesService->expects(self::once())
+			->method('findAll')
+			->with(1, 'user')
+			->willReturn([]);
+		$sieveService->expects(self::once())
+			->method('updateActiveScript')
+			->with('user', 1, '# new sieve script');
+
+		$state = $this->outOfOfficeService->updateFromSystem($mailAccount, $user);
+		self::assertNull($state);
+		self::assertFalse($oldState->isEnabled());
+	}
+}


### PR DESCRIPTION
Running `occ mail:repair:system-autoresponders` updates sieve scripts of all accounts that follow the out-of-office system settings.