### PR TITLE
[stable3.5] perf(db): Add message_id index for mail_messages table

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -66,6 +66,7 @@ use OCA\Mail\Listener\MessageKnownSinceListener;
 use OCA\Mail\Listener\MoveJunkListener;
 use OCA\Mail\Listener\NewMessageClassificationListener;
 use OCA\Mail\Listener\OauthTokenRefreshListener;
+use OCA\Mail\Listener\OptionalIndicesListener;
 use OCA\Mail\Listener\OutOfOfficeListener;
 use OCA\Mail\Listener\SaveSentMessageListener;
 use OCA\Mail\Listener\SpamReportListener;
@@ -87,6 +88,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Dashboard\IAPIWidgetV2;
+use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\IServerContainer;
 use OCP\Search\IFilteringProvider;
 use OCP\User\Events\OutOfOfficeChangedEvent;
@@ -128,6 +130,7 @@ class Application extends App implements IBootstrap {
 		$context->registerServiceAlias(IDkimService::class, DkimService::class);
 		$context->registerServiceAlias(IDkimValidator::class, DkimValidator::class);
 
+		$context->registerEventListener(AddMissingIndicesEvent::class, OptionalIndicesListener::class);
 		$context->registerEventListener(BeforeImapClientCreated::class, OauthTokenRefreshListener::class);
 		$context->registerEventListener(BeforeMessageSentEvent::class, AntiAbuseListener::class);
 		$context->registerEventListener(DraftSavedEvent::class, DeleteDraftListener::class);

--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Listener;
+
+use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<Event|OptionalIndicesListener>
+ */
+class OptionalIndicesListener implements IEventListener {
+
+	public function handle(Event $event): void {
+		if (!($event instanceof AddMissingIndicesEvent)) {
+			return;
+		}
+
+		$event->addMissingIndex(
+			'mail_messages',
+			'mail_messages_msgid_idx',
+			['message_id'],
+			[
+				'lengths' => [128],
+			],
+		);
+	}
+
+}

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -168,6 +168,13 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 		$messagesTable->addIndex(['mailbox_id', 'flag_important', 'flag_deleted', 'flag_seen'], 'mail_messages_id_flags');
 		$messagesTable->addIndex(['mailbox_id', 'flag_deleted', 'flag_flagged'], 'mail_messages_id_flags2');
 		$messagesTable->addIndex(['mailbox_id'], 'mail_messages_mailbox_id');
+		// mail_messages_msgid_idx was added later and may not exist until optional indices are created
+		$messagesTable->addIndex(
+			['message_id'],
+			'mail_messages_msgid_idx',
+			[],
+			['lengths' => [128]],
+		);
 
 		// Postgres doesn't allow for shortened indices, so let's skip the last index.
 		if ($this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -47,6 +47,7 @@
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
 				<referencedClass name="OCP\TextProcessing\Task" />
 				<referencedClass name="OCP\TextProcessing\SummaryTaskType" />
+				<referencedClass name="OCP\DB\Events\AddMissingIndicesEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeScheduledEvent" /><!-- 28+ -->
@@ -64,6 +65,7 @@
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
+				<referencedClass name="OCP\DB\Events\AddMissingIndicesEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeEndedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeStartedEvent" /><!-- 28+ -->
 				<referencedClass name="OCP\User\Events\OutOfOfficeScheduledEvent" /><!-- 28+ -->

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -2,6 +2,7 @@
 <files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
   <file src="lib/AppInfo/Application.php">
     <InvalidArgument>
+      <code>OptionalIndicesListener::class</code>
       <code>OutOfOfficeListener::class</code>
       <code>OutOfOfficeListener::class</code>
       <code>OutOfOfficeListener::class</code>
@@ -44,6 +45,17 @@
     <MissingDependency>
       <code>MailWidgetV2</code>
     </MissingDependency>
+  </file>
+  <file src="lib/Listener/OptionalIndicesListener.php">
+    <InvalidTemplateParam>
+      <code>IEventListener</code>
+    </InvalidTemplateParam>
+    <MoreSpecificImplementedParamType>
+      <code>$event</code>
+    </MoreSpecificImplementedParamType>
+    <TooManyArguments>
+      <code>addMissingIndex</code>
+    </TooManyArguments>
   </file>
   <file src="lib/Listener/OutOfOfficeListener.php">
     <InvalidTemplateParam>


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/mail/pull/9206.