### PR TITLE
fix(setup) - correctly apply EMAILLOCALPART (take 2)

### DIFF
--- a/lib/Service/AutoConfig/IspDb.php
+++ b/lib/Service/AutoConfig/IspDb.php
@@ -136,7 +136,7 @@ class IspDb {
 				],
 				[
 					$email->bare_address,
-					$email->personal,
+					$email->mailbox,
 					$email->host,
 				],
 				(string)$server->username


### PR DESCRIPTION
Fixes #9221

This commit fixes issue #9221 - Mail autoconfigure does not correctly fill EMAILLOCALPART.

The Horde email class puts the email local part in 'mailbox' not 'personal'. Correcting this fixes mail account autoconfigure for mail hosts that use the EMAILLOCALPART for the user name in their IMAP or SMTP configurations.

Ref: https://dev.horde.org/api/master/lib/Mail/classes/Horde_Mail_Rfc822_Address.html#property_mailbox

(update: somehow I accidentally closed #9222 and don't know what I did - so I created this replacement PR)