### PR TITLE
SML Markup rendering

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"php": ">=8.0 <=8.3",
 		"ext-openssl": "*",
 		"arthurhoaro/favicon": "^2.0.0",
-		"audriga/html2jsonld-php": "dev-master as 1.x-dev",
+		"audriga/html2jsonld-php": ">=1.0.0",
 		"bamarni/composer-bin-plugin": "^1.8.2",
 		"bytestream/horde-exception": "^2.2.0",
 		"bytestream/horde-imap-client": "^2.33.1",
@@ -87,12 +87,6 @@
 				"arthurhoaro/favicon",
 				"gravatarphp/gravatar"
 			]
-		}
-	},
-	"repositories": {
-		"private": {
-			"type": "vcs",
-			"url": "git@bitbucket.org:audriga/html2jsonld-php.git"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"php": ">=8.0 <=8.3",
 		"ext-openssl": "*",
 		"arthurhoaro/favicon": "^2.0.0",
+		"audriga/html2jsonld-php": "dev-master as 1.x-dev",
 		"bamarni/composer-bin-plugin": "^1.8.2",
 		"bytestream/horde-exception": "^2.2.0",
 		"bytestream/horde-imap-client": "^2.33.1",
@@ -86,6 +87,12 @@
 				"arthurhoaro/favicon",
 				"gravatarphp/gravatar"
 			]
+		}
+	},
+	"repositories": {
+		"private": {
+			"type": "vcs",
+			"url": "git@bitbucket.org:audriga/html2jsonld-php.git"
 		}
 	}
 }

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -51,6 +51,7 @@ use OCA\Mail\Model\SmimeData;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\ItineraryService;
+use OCA\Mail\Service\SchemaService;
 use OCA\Mail\Service\SmimeService;
 use OCA\Mail\Service\SnoozeService;
 use OCP\AppFramework\Controller;
@@ -77,6 +78,7 @@ class MessagesController extends Controller {
 	private IMailManager $mailManager;
 	private IMailSearch $mailSearch;
 	private ItineraryService $itineraryService;
+	private SchemaService $schemaService;
 	private ?string $currentUserId;
 	private LoggerInterface $logger;
 	private ?Folder $userFolder;
@@ -99,6 +101,7 @@ class MessagesController extends Controller {
 		IMailManager $mailManager,
 		IMailSearch $mailSearch,
 		ItineraryService $itineraryService,
+		SchemaService $schemaService,
 		?string $UserId,
 		$userFolder,
 		LoggerInterface $logger,
@@ -119,6 +122,7 @@ class MessagesController extends Controller {
 		$this->mailManager = $mailManager;
 		$this->mailSearch = $mailSearch;
 		$this->itineraryService = $itineraryService;
+		$this->schemaService = $schemaService;
 		$this->currentUserId = $UserId;
 		$this->userFolder = $userFolder;
 		$this->logger = $logger;
@@ -242,6 +246,20 @@ class MessagesController extends Controller {
 		if ($itineraries) {
 			$json['itineraries'] = $itineraries;
 		}
+
+		/*
+		 * TODO:
+		 * 
+		 * Here, the plan is to add and read config options to be able to determine
+		 * whether the user wants to use the extraction/rendering of KItinerary or 
+		 * the html2jsonld library for extraction and subsequently jsonld2html for
+		 * rendering schema markup in the mail message.
+		 */
+		$schema = $this->schemaService->extract($account, $mailbox, $message->getUid());
+		if ($schema) {
+			$json["schema"] = $schema;
+		}
+
 		$json['attachments'] = array_map(function ($a) use ($id) {
 			return $this->enrichDownloadUrl(
 				$id,

--- a/lib/Service/SchemaService.php
+++ b/lib/Service/SchemaService.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ *
+ * @copyright Copyright (c) 2023, Gerke Frölje (gerke@audriga.com)
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
+use SML\Html2JsonLd\Util\MarkupUtil;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\IMAP\MessageMapper;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Log\LoggerInterface;
+use stdClass;
+
+class SchemaService {
+	private const CACHE_PREFIX = 'mail_schema';
+	private const CACHE_TTL = 7 * 24 * 3600;
+
+	/** @var IMAPClientFactory */
+	private $clientFactory;
+
+	/** @var MessageMapper */
+	private $messageMapper;
+
+	/** @var ItineraryExtractor */
+	private $extractor;
+
+	/** @var ICache */
+	private $cache;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(IMAPClientFactory $clientFactory,
+		MessageMapper $messageMapper,
+		ICacheFactory $cacheFactory,
+		LoggerInterface $logger) {
+		$this->clientFactory = $clientFactory;
+		$this->messageMapper = $messageMapper;
+		$this->cache = $cacheFactory->createLocal(self::CACHE_PREFIX);
+		$this->logger = $logger;
+	}
+
+	private function buildCacheKey(Account $account, Mailbox $mailbox, int $id): string {
+		return $account->getId() . '_' . $mailbox->getName() . '_' . $id;
+	}
+
+	public function getCached(Account $account, Mailbox $mailbox, int $id) {
+		if ($cached = ($this->cache->get($this->buildCacheKey($account, $mailbox, $id)))) {
+			return json_decode($cached);
+		}
+
+		return null;
+	}
+
+    public function extract(Account $account, Mailbox $mailbox, int $id)
+    {
+		if ($cached = ($this->getCached($account, $mailbox, $id))) {
+			return $cached;
+		}
+
+        $client = $this->clientFactory->getClient($account);
+        $schema = null;
+
+        try {
+			$htmlBody = $this->messageMapper->getHtmlBody($client, $mailbox->getName(), $id, $account->getUserId());
+			if ($htmlBody !== null) {
+                $schema = json_decode(MarkupUtil::getJsonLdFromHtmlString($htmlBody, "www.example.com"));
+				
+				if (is_null($schema)) {
+					$this->logger->debug('Found no schema entries in the message HTML body');
+				} else {
+                	$this->logger->debug('Extracted ' . (is_array($schema) ? count($schema) : '1') . ' schema entries from the message HTML body');
+				}
+			} else {
+				$this->logger->debug('Message does not have an HTML body, can\'t extract schema info');
+			}
+		} finally {
+			$client->logout();
+		}
+
+		$cache_key = $this->buildCacheKey($account, $mailbox, $id);
+		$this->cache->set($cache_key, json_encode($schema), self::CACHE_TTL);
+
+        return $schema;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ical.js": "^1.5.0",
     "iframe-resizer": "^4.3.9",
     "js-base64": "^3.7.5",
+    "jsonld2html": "^1.0.0",
     "jstz": "^2.1.1",
     "lodash": "^4.17.21",
     "md5": "^2.3.0",

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -36,6 +36,9 @@
 		<div v-if="itineraries.length > 0" class="message-itinerary">
 			<Itinerary :entries="itineraries" :message-id="message.messageId" />
 		</div>
+		<div v-if="Object.entries(schema).length > 0" class="message-schema">
+			<Schema :json="schema"/>
+		</div>
 		<div v-if="message.scheduling.length > 0" class="message-imip">
 			<Imip v-for="scheduling in message.scheduling"
 				:key="scheduling.id"
@@ -84,6 +87,7 @@ import { NcButton } from '@nextcloud/vue'
 import { html, plain } from '../util/text.js'
 import { isPgpgMessage } from '../crypto/pgp.js'
 import Itinerary from './Itinerary.vue'
+import Schema from './Schema'
 import MessageAttachments from './MessageAttachments.vue'
 import MessageEncryptedBody from './MessageEncryptedBody.vue'
 import MessageHTMLBody from './MessageHTMLBody.vue'
@@ -96,6 +100,7 @@ export default {
 	name: 'Message',
 	components: {
 		Itinerary,
+		Schema,
 		MessageAttachments,
 		MessageEncryptedBody,
 		MessageHTMLBody,
@@ -139,6 +144,9 @@ export default {
 		},
 		itineraries() {
 			return this.message.itineraries ?? []
+		},
+		schema() {
+			return this.message.schema ?? {}
 		},
 	},
 	methods: {

--- a/src/components/Schema.vue
+++ b/src/components/Schema.vue
@@ -1,0 +1,262 @@
+<!--
+ -
+ - @copyright Copyright (c) 2023, Gerke Frölje (gerke@audriga.com)
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+	<div class="schema">
+		<div v-html="html"></div>
+		<div class="schema-action-bar">
+			<SchemaActionBar v-on:update-from-live-uri="updateData" />
+		</div>
+	</div>
+</template>
+
+<script>
+import Jsonld2html from 'jsonld2html'
+import SchemaActionBar from './SchemaActionBar'
+
+export default {
+	name: 'Schema',
+	components: {
+    	SchemaActionBar
+	},
+	props: {
+		json: {
+			type: Object,
+			required: false,
+		},
+		messageId: {
+			type: String,
+			required: false,
+		},
+	},
+	data: function() {
+		return {
+			html: ""
+		};
+	},
+	created () {
+		this.getRenderedSchema() 
+	},
+	methods: {
+		getRenderedSchema() {
+			const rendered = Jsonld2html.render(this.json)
+
+			this.html = rendered
+
+			return rendered
+		},
+		async updateData(updatedValues) {
+			this.json["name"] = "Hollerallee 99, 28215 Bremen"
+
+			for (const key in updatedValues) {
+				if (this.data.hasOwnProperty(key)) {
+					this.data[key] = updatedValues[key]
+				}
+			}
+
+			this.getRenderedSchema()
+		}
+	}
+}
+
+</script>
+<style scoped>
+.schema {
+
+	/* Box surrounding the displayed card and posible actions. */
+	display: flex;
+	width: fit-content;
+	flex-direction: column;
+	margin: 50px;
+	border: 2px none var(--color-border);
+	border-radius: 16px;
+	padding: 10px;
+	align-items: left;
+
+	box-shadow: 0px 0px 10px 0px var(--color-box-shadow);
+}
+
+.full-schema {
+
+	/* Useful for debugging the component. */
+	display: none;
+	font-size: x-small;
+	opacity: 0.4;
+	font-weight: lighter;
+
+}
+
+.schema >>> .smlCard {
+
+	max-width: 600px;
+
+	display: flex;
+	flex-direction: column;
+
+	gap: 5px;
+
+	/* round corners*/
+	border: 2px solid var(--color-border);
+	border-radius: 6px;
+
+	/* padding in the card*/
+	padding: 20px;
+
+	background: var(--color-main-background);
+
+
+}
+
+.schema >>> .smlCard .header {
+
+	/* create a bottom border from left to right */
+	border-block-end: 2px solid var(--color-border);
+	margin: -10px -20px 0px -20px;
+
+	padding-bottom: 10px;
+
+	/* add spacing before text */
+	text-indent: 20px;
+
+	font-size: 20px;
+	font-weight: bold;
+
+	color: var(--color-main-text);
+
+}
+
+.schema >>> .smlCardRow {
+
+	/*Layout Settings*/
+
+	/* declaring the card class to a flex-contatiner */
+	display: flex;
+
+	/* setting the alignment of the childs to vertical row layout*/
+	flex-direction: row;
+
+	/* the items in the container are able to wrap, works like a line break */
+	flex-wrap: nowrap;
+
+	/* align the items horizontally in the cointainer to left side (flex-start) */
+	justify-content: flex-start;
+
+}
+
+.schema >>> .smlCardRow .text_column {
+
+	display: flex;
+
+	/* setting the alignment of the childs to vertical row layout*/
+	flex-direction: column;
+
+	/* the items in the container are able to wrap, works like a line break */
+	flex-wrap: nowrap;
+
+	/* align the items horizontally in the cointainer to left side (flex-start) */
+	justify-content: flex-start;
+
+	/* align the items vertically in the center */
+	align-items: flex-start;
+
+	/* minimum height , same as the picture box*/
+	min-height: 100px;
+	max-height: 150px;
+
+	flex-basis: 90%;
+
+	/* this property is needed to make the truncating working for the child elements*/
+	min-width: 0;
+
+	margin-left: 20px
+
+}
+
+.schema >>> .smlCardRow .card_title {
+
+	margin: 4px 0px;
+
+
+	font-size: 20px;
+	font-weight: bold;
+	min-height: 20%;
+
+	color: var(--color-main-text);
+
+	/* settings for truncating single line text */
+    max-width: 95%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow-x: auto;
+	
+}
+
+.schema >>> .smlCardRow .card_content {
+
+	margin-top: 4px;
+	margin-bottom: 4px;
+
+	font-size: 16px;
+
+	color: var(--color-main-text);
+
+	/* this is for truncating multiline texts*/
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 4;
+	overflow: auto;
+
+}
+
+.schema >>> .smlCardRow .image_column {
+
+	/* declaring the card class to a flex-contatiner */
+	display: flex;
+
+	/* align the items vertically in the center */
+	align-items: center;
+
+	/* align the items horizontally in the cointainer to center */
+	justify-content: center;
+
+	min-height: 100px;
+	min-width: 100px;
+	max-width: 100px;
+
+	/* in case of bigger elements in the box, cut off the sides*/
+	overflow: hidden;
+
+}
+
+.schema >>> .smlCardRow img {
+
+	display: block;
+	max-width: 100px;
+	max-height: 100px;
+	min-width: 100px;
+
+}
+
+.schema >>> br {
+	display: none;
+}
+
+</style>

--- a/src/components/SchemaActionBar.vue
+++ b/src/components/SchemaActionBar.vue
@@ -1,0 +1,186 @@
+<!--
+ -
+ - @copyright Copyright (c) 2023, Gerke Frölje <gerke@audriga.com>
+ -
+ - @license GNU AGPL version 3 or any later version
+ -
+ - This program is free software: you can redistribute it and/or modify
+ - it under the terms of the GNU Affero General Public License as
+ - published by the Free Software Foundation, either version 3 of the
+ - License, or (at your option) any later version.
+ -
+ - This program is distributed in the hope that it will be useful,
+ - but WITHOUT ANY WARRANTY; without even the implied warranty of
+ - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ - GNU Affero General Public License for more details.
+ -
+ - You should have received a copy of the GNU Affero General Public License
+ - along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ -
+ -->
+
+<template>
+    <div class="action-bar">
+        <NcActions
+        :force-name="true"
+        :secondary="true"
+        :inline="1" >
+            <NcActionButton v-if="schemaType === 'Recipe'"
+            :aria-label="t('mail', 'Add Recipe To Cookbook')"
+            @click.prevent="sendRecipeToCookbook()" >     
+                <template #icon>
+                    <IconLoading v-if="recipeSendLoading"
+					    :size="20" />
+                    <SilverwareForkKnifeIcon v-else-if="recipeSendSuccess === null"
+                        :size="20" />
+                    <CheckIcon v-else-if="recipeSendSuccess === true"
+                        :size="20" />
+                    <CloseIcon v-else-if="recipeSendSuccess === false"
+                        :size="20" />
+                </template>
+                Add Recipe To Cookbook
+            </NcActionButton>
+            <NcActionButton v-if="schemaType === 'Place' && hasLiveUri"
+            :aria-label="t('mail', 'Refresh Live Location')"
+            @click.prevent="refreshLiveUri()" >
+                <template #icon>
+                    <IconLoading v-if="refreshLocationLoading"
+					    :size="20" />
+                    <MapMarkerIcon v-else
+                        :size="20" />
+                </template>
+                Refresh Live Location
+            </NcActionButton>
+            <NcActionButton v-if="schemaType === 'Place'"
+            :aria-label="t('mail', 'Open in Google Maps')"
+            @click.prevent="openLocationInGoogleMaps()" >
+                <template #icon>
+                    <MapSearchOutlineIcon
+                        :size="20" />
+                </template>
+                Open in Google Maps
+            </NcActionButton>
+            <NcActionButton v-if="hasUrlValue"
+                :aria-label="t('mail','Open Source URL')"
+                @click.prevent="openUrlInNewWindow()" >
+                <template #icon>
+                    <OpenInNewIcon
+                        :title="t('mail', 'Open Source URL')"
+                        :size="20" />
+                </template>
+                Open Source URL
+            </NcActionButton>
+        </NcActions>
+    </div>
+</template>
+
+<script>
+
+import { NcActionButton } from '@nextcloud/vue'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import SilverwareForkKnifeIcon from 'vue-material-design-icons/SilverwareForkKnife'
+import CheckIcon from 'vue-material-design-icons/Check'
+import CloseIcon from 'vue-material-design-icons/Close'
+import OpenInNewIcon from 'vue-material-design-icons/OpenInNew'
+import MapMarkerIcon from 'vue-material-design-icons/MapMarker'
+import MapSearchOutlineIcon from 'vue-material-design-icons/MapSearchOutline'
+import IconLoading from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+
+export default {
+	name: 'SchemaActionBar',
+	components: {
+        NcActions,
+	    NcActionButton,
+	    SilverwareForkKnifeIcon,
+        CheckIcon,
+        CloseIcon,
+        OpenInNewIcon,
+        MapMarkerIcon,
+        MapSearchOutlineIcon,
+        IconLoading,
+    },
+    data: function() {
+        return {
+            recipeSendSuccess: null,
+            recipeSendLoading: false,
+            refreshLocationLoading: false,
+        }
+    },
+    computed: {
+        schemaType() {
+            return this.$parent.json['@type']
+        },
+        hasUrlValue() {
+            return this.$parent.json.hasOwnProperty('url')
+        },
+        hasLiveUri() {
+            return this.$parent.json.hasOwnProperty('liveUri')
+        }
+    },
+    methods: {
+        async sendRecipeToCookbook () {
+            try {
+                this.recipeSendLoading = true;
+
+				const success = this.$store.dispatch('sendRecipeToCookbook', {
+						recipe: this.$parent.json,
+				})
+
+				success.then((value) => {
+                    this.recipeSendSuccess = value
+                    this.recipeSendLoading = false
+                })
+
+			} catch (e) {
+                this.recipeSendLoading = false
+				throw e
+			}
+		},
+        refreshLiveUri() {
+            
+            try {
+                this.refreshLocationLoading = true
+
+                const result = this.$store.dispatch('callLiveUri', {
+                    liveUri: this.$parent.json["liveUri"],
+				})
+                
+				result.then((updatedValues) => { 
+                    this.refreshLocationLoading = false
+                    this.$emit('update-from-live-uri', updatedValues)
+                })
+			} catch (e) {
+                this.refreshLocationLoading = false
+				throw e
+			}
+
+        },
+        openLocationInGoogleMaps() {
+            const lat = this.$parent.json["geo"]["latitude"]
+            const lon = this.$parent.json["geo"]["longitude"]
+
+            const url = 'https://www.google.com/maps/search/?api=1&query=' + lat + ',' + lon
+
+            window.open(url, '_blank').focus()
+        },
+        openUrlInNewWindow() {
+            window.open(this.json["url"], '_blank').focus()
+        },
+    }
+}
+</script>
+
+<style scoped>
+
+.action-bar {
+    display: flex;
+    justify-content: flex-end;
+
+    padding-top: 10px;
+}
+
+.action-bar:empty {
+    display: none;
+}
+
+</style>

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -279,3 +279,15 @@ export async function sendMdn(id, data) {
 		throw convertAxiosError(e)
 	}
 }
+
+export async function sendRecipe(json) {
+	const url = generateUrl('/apps/cookbook/api/v1/recipes')
+
+	try {
+		const result = await axios.post(url, json)
+
+		return result.status >= 200 && result.status < 300
+	} catch (e) {
+		return false
+	}
+}

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -80,6 +80,7 @@ import {
 	unSnoozeMessage,
 	updateEnvelopeTag,
 	deleteTag,
+	sendRecipe,
 } from '../service/MessageService.js'
 import { moveDraft, updateDraft } from '../service/DraftService.js'
 import * as AliasService from '../service/AliasService.js'
@@ -1497,6 +1498,17 @@ export default {
 			data: {
 				snoozeMailboxId,
 			},
+		})
+	},
+	async sendRecipeToCookbook({ commit }, { recipe }) {
+		return handleHttpAuthErrors(commit, async () => {
+			try {
+				const result = await sendRecipe(recipe)
+				
+				return result
+			} catch (e) {
+				throw e
+			}
 		})
 	},
 }


### PR DESCRIPTION
Support mails containing JSON-LD with Schema.org data.

This adds initial support for the upcoming SML standard (see [SML IETF WG](https://datatracker.ietf.org/wg/sml) and https://structured.email ) by implementing:

* schema extraction from HTML body of a mail via https://github.com/audriga/html2jsonld-php
* generic schema rendering via https://github.com/audriga/jsonld2html-cards

**Note on schema extraction library:** audriga/html2jsonld-php is NOT supposed to replace KItinerary. KItinerary is clearly the more powerful solution. However, KItinerary cannot be used in some Nextcloud installations (e.g. #8322 or #7899 ) . audriga/html2jsonld-php is supposed to be a light-weight alternative for some usage scenarios. The idea is to use html2jsonld-php only if configured.