### PR TITLE
perf(db): optimise indices of mail tables

### DIFF
--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -57,6 +57,64 @@ class OptionalIndicesListener implements IEventListener {
 				],
 			);
 		}
+
+		$event->addMissingIndex(
+			'mail_messages',
+			'mail_messages_strucanalyz_idx',
+			['structure_analyzed']
+		);
+
+		$event->addMissingIndex(
+			'mail_classifiers',
+			'mail_class_creat_idx',
+			['created_at']
+		);
+
+		$event->addMissingIndex(
+			'mail_accounts',
+			'mail_acc_prov_idx',
+			['provisioning_id']
+		);
+
+		$event->addMissingIndex(
+			'mail_aliases',
+			'mail_alias_accid_idx',
+			['account_id']
+		);
+
+		if (method_exists($event, 'replaceIndex')) {
+			$event->replaceIndex(
+				'mail_messages',
+				['mail_messages_mb_id_uid'],
+				'mail_messages_mb_id_uid_uidx',
+				['mailbox_id', 'uid'],
+				true
+			);
+
+			$event->replaceIndex(
+				'mail_smime_certificates',
+				['mail_smime_certs_uid_idx'],
+				'mail_smime_certs_uid_email_idx',
+				['user_id', 'email_address'],
+				false
+			);
+
+			$event->replaceIndex(
+				'mail_trusted_senders',
+				['mail_trusted_senders_type'],
+				'mail_trusted_senders_idx',
+				['user_id', 'email', 'type'],
+				false
+			);
+
+			$event->replaceIndex(
+				'mail_coll_addresses',
+				['mail_coll_addr_userid_index', 'mail_coll_addr_email_index'],
+				'mail_coll_idx',
+				['user_id', 'email', 'display_name'],
+				false
+			);
+		}
 	}
 
 }

--- a/lib/Migration/Version1100Date20210304143008.php
+++ b/lib/Migration/Version1100Date20210304143008.php
@@ -52,7 +52,8 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 				'default' => false
 			]);
 			$tagsTable->setPrimaryKey(['id']);
-			$tagsTable->addIndex(['user_id'], 'mail_msg_tags_usr_id_index');
+			// Dropped in Version3600Date20240205180726 because mail_msg_tags_usr_id_index is redundant with mail_msg_tags_usr_lbl_idx
+			// $tagsTable->addIndex(['user_id'], 'mail_msg_tags_usr_id_index');
 			$tagsTable->addUniqueIndex(
 				[
 					'user_id',

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -167,7 +167,9 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 		// Add named indices
 		$messagesTable->addIndex(['mailbox_id', 'flag_important', 'flag_deleted', 'flag_seen'], 'mail_messages_id_flags');
 		$messagesTable->addIndex(['mailbox_id', 'flag_deleted', 'flag_flagged'], 'mail_messages_id_flags2');
-		$messagesTable->addIndex(['mailbox_id'], 'mail_messages_mailbox_id');
+		// Dropped in Version3600Date20240205180726 because mail_messages_mailbox_id is redundant with mail_messages_mb_id_uid
+		// $messagesTable->addIndex(['mailbox_id'], 'mail_messages_mailbox_id');
+
 		// mail_messages_msgid_idx was added later and may not exist until optional indices are created
 		$messagesTable->addIndex(
 			['message_id'],

--- a/lib/Migration/Version2300Date20221216115727.php
+++ b/lib/Migration/Version2300Date20221216115727.php
@@ -67,7 +67,8 @@ class Version2300Date20221216115727 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['id'], 'mail_smime_certs_id_idx');
 			$table->addIndex(['user_id'], 'mail_smime_certs_uid_idx');
-			$table->addIndex(['id', 'user_id'], 'mail_smime_certs_id_uid_idx');
+			// Dropped in Version3600Date20240205180726
+			// $table->addIndex(['id', 'user_id'], 'mail_smime_certs_id_uid_idx');
 		}
 
 		return $schema;

--- a/lib/Migration/Version3600Date20240205180726.php
+++ b/lib/Migration/Version3600Date20240205180726.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Johannes Merkel <mail@johannesgge.de>
+ *
+ * @author Johannes Merkel <mail@johannesgge.de>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3600Date20240205180726 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$mailboxesTable = $schema->getTable('mail_messages');
+
+		if ($mailboxesTable->hasIndex('mail_messages_mailbox_id')) {
+			$mailboxesTable->dropIndex('mail_messages_mailbox_id');
+		}
+
+		$mailboxesTable = $schema->getTable('mail_smime_certificates');
+
+		if ($mailboxesTable->hasIndex('mail_smime_certs_id_uid_idx')) {
+			$mailboxesTable->dropIndex('mail_smime_certs_id_uid_idx');
+		}
+
+		$mailboxesTable = $schema->getTable('mail_tags');
+
+		if ($mailboxesTable->hasIndex('mail_msg_tags_usr_id_index')) {
+			$mailboxesTable->dropIndex('mail_msg_tags_usr_id_index');
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Fix: #9162 

Needs https://github.com/nextcloud/server/pull/43209 to also replace indices.

What should happen:

## oc_mail_messages

- add index on `structure_analyzed` -> `mail_messages_strucanalyz_idx`
- drop index `mail_messages_mailbox_id` because `mail_messages_mb_id_uid` already contains `mailbox_id` on first position
- make `mail_messages_mb_id_uid` unique -> `mail_messages_mb_id_uid_uidx`

## oc_mail_classifiers

- add index on `created_at` -> `mail_class_creat_idx`

## oc_mail_accounts

- add index on `provisioning_id` -> `mail_acc_prov_idx`

## oc_mail_smime_certificates

- extend `mail_smime_certs_uid_idx` to cover `(user_id,email_address)` -> `mail_smime_certs_uid_email_idx`
- drop `mail_smime_certs_id_uid_idx`

## oc_mail_tags

- drop `mail_msg_tags_usr_id_index` because `mail_msg_tags_usr_lbl_idx` already contains `user_id` on first position

## oc_mail_aliases

- add index on `account_id` -> `mail_alias_accid_idx`

## oc_mail_trusted_senders

- add index on `(user_id,email,type)` and drop `mail_trusted_senders_type` -> `mail_trusted_senders_idx`

## oc_mail_coll_addresses

- add index on `(user_id, email, display_name)` and drop `mail_coll_addr_userid_index` and `mail_coll_addr_email_index` -> `mail_coll_idx`