### PR TITLE
fix(setup): Increase rate limit

### DIFF
--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -103,12 +103,12 @@ class AutoConfigController extends Controller {
 	 * @param int $port
 	 *
 	 * @NoAdminRequired
-	 * @UserRateThrottle(limit=10, period=60)
+	 * @UserRateThrottle(limit=30, period=60)
 	 *
 	 * @return JsonResponse
 	 */
 	#[TrapError]
-	#[UserRateLimit(limit: 10, period: 60)]
+	#[UserRateLimit(limit: 30, period: 60)]
 	public function testConnectivity(string $host, int $port): JsonResponse {
 		if (!in_array($port, [143, 993, 465, 587])) {
 			return JsonResponse::fail('Port not allowed');


### PR DESCRIPTION
Accounts with many MX records might have many connections to test. It was reported that 6 MX entries cause 24 concurrent requests to test the connection. After 10 of them succeed, the rest fails with 429.