### PR TITLE
fix(composer): duplicate label in to, cc and bcc selects

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1217,16 +1217,10 @@ export default {
 			this.onNewAddr(addr, this.selectBcc)
 		},
 		onNewAddr(addr, list) {
-			if (list.some((recipient) => recipient.email === addr)) {
+			if (list.some((recipient) => recipient.email === addr.email)) {
 				return
 			}
-			let res = addr
-			if (!this.allRecipients.some((recipient) => recipient.email === addr)) {
-				res = {
-					...addr,
-					email: addr.label,
-				}
-			}
+			let res = { ...addr }
 			this.newRecipients.push(res)
 			list.push(res)
 			this.saveDraftDebounced()


### PR DESCRIPTION
This fixes selecting to, cc and bcc recipients in the composer. It also fixes sending messages.

I'm not sure about potential side effect as I'm not sure what the code I removed does. It might be a regression from the recent update of `nextcloud/vue` to v8.