### PR TITLE
[Bugfix #9281]: Added check in condition if accounts are not equal to null

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,7 +6,7 @@
 			:account="activeAccount"
 			:mailbox="activeMailbox" />
 
-		<template v-if="hasComposerSession">
+		<template v-if="hasComposerSession && accounts !== null">
 			<ComposerSessionIndicator @close="onCloseMessageModal" />
 			<NewMessageModal ref="newMessageModal" :accounts="accounts" />
 		</template>


### PR DESCRIPTION
Resolves: #9281 

Summary:
1. Added check in condition if accounts are not equal to null

Before:
<img width="1507" alt="Screenshot 2024-02-10 at 10 42 00 PM" src="https://github.com/nextcloud/mail/assets/39839367/4a99298d-dd58-425c-85ff-42dedd5c8ad3">

After:
<img width="1507" alt="Screenshot 2024-02-10 at 10 44 33 PM" src="https://github.com/nextcloud/mail/assets/39839367/d29bd374-3ff6-486e-b432-24c0b98c299a">

