### PR TITLE
fix(setup): Use MX record TLD for ISPDB lookup

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -112,7 +112,7 @@ return [
 		],
 		[
 			'name' => 'autoConfig#queryIspdb',
-			'url' => '/api/autoconfig/ispdb/{email}',
+			'url' => '/api/autoconfig/ispdb/{host}/{email}',
 			'verb' => 'GET',
 		],
 		[

--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -67,13 +67,13 @@ class AutoConfigController extends Controller {
 	 */
 	#[TrapError]
 	#[UserRateLimit(limit: 5, period: 60)]
-	public function queryIspdb(string $email): JsonResponse {
+	public function queryIspdb(string $host, string $email): JsonResponse {
 		$rfc822Address = new Horde_Mail_Rfc822_Address($email);
-		if (!$rfc822Address->valid || !$this->hostValidator->isValid($rfc822Address->host)) {
+		if (!$rfc822Address->valid || !$this->hostValidator->isValid($host)) {
 			return JsonResponse::fail('Invalid email address', Http::STATUS_UNPROCESSABLE_ENTITY)
 				->cacheFor(60 * 60, false, true);
 		}
-		$config = $this->ispDb->query($rfc822Address->host, $rfc822Address);
+		$config = $this->ispDb->query($host, $rfc822Address);
 		return JsonResponse::success($config)->cacheFor(5 * 60, false, true);
 	}
 

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -450,7 +450,7 @@ export default {
 		},
 		async detectConfig() {
 			this.loadingMessage = t('mail', 'Looking up configuration')
-			const config = await queryIspdb(this.emailAddress)
+			const config = await queryIspdb(this.emailAddress.split('@').pop(), this.emailAddress)
 			logger.debug('fetched auto config', { config })
 			// Apply settings to manual mode before submitting so the user
 			// can make modifications if the config fails
@@ -458,10 +458,26 @@ export default {
 				logger.debug('ISP DB config applied')
 				return true
 			} else {
-				this.loadingMessage = t('mail', 'Checking mail host connectivity')
 				const mxHosts = await queryMx(this.emailAddress)
 				logger.debug('MX hosts fetched', { mxHosts })
-				const imapAndSmtpHosts = mxHosts.flatMap(host => {
+
+				if (mxHosts.length) {
+					// Try the TLD of the MX
+					// FIXME: breaks with eTLDs like .co.uk
+					const tldMx = mxHosts[0].split('.').splice(-2).join('.').toLowerCase()
+					const mxConfig = await queryIspdb(
+						tldMx,
+						this.emailAddress,
+					)
+					logger.debug('fetched MX auto config', { mxConfig })
+					if (mxConfig && this.applyAutoConfig(mxConfig)) {
+						return true
+					}
+				}
+
+				// Test the highest priority MX for open IMAP/SMTP ports
+				this.loadingMessage = t('mail', 'Checking mail host connectivity')
+				const imapAndSmtpHosts = mxHosts.slice(0, 1).flatMap(host => {
 					return [993, 143, 465, 587].map(port => ({
 						host,
 						port,

--- a/src/service/AutoConfigService.js
+++ b/src/service/AutoConfigService.js
@@ -22,8 +22,8 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
-export async function queryIspdb(email) {
-	return (await axios.get(generateUrl('/apps/mail/api/autoconfig/ispdb/{email}', { email }))).data.data
+export async function queryIspdb(host, email) {
+	return (await axios.get(generateUrl('/apps/mail/api/autoconfig/ispdb/{host}/{email}', { host, email }))).data.data
 }
 
 export async function queryMx(email) {


### PR DESCRIPTION
1. MX points to server for outgoing email
2. TLD of MX points to the hoster
3. ISPDB of the hoster gives the IMAP/SMTP config
4. If ISPDB fails, try MX as IMAP/SMTP server

~~This is best enjoyed with https://github.com/nextcloud/mail/pull/9328~~ rebased