### PR TITLE
feat(integration): Use LLM to fill event details

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -411,6 +411,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'thread#generateEventData',
+			'url' => '/api/thread/{id}/eventdata',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'outbox#send',
 			'url' => '/api/outbox/{id}',
 			'verb' => 'POST'

--- a/lib/Model/EventData.php
+++ b/lib/Model/EventData.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Model;
+
+use JsonSerializable;
+use ReturnTypeWillChange;
+
+class EventData implements JsonSerializable {
+
+	public function __construct(private string $summary,
+		private string $description) {
+	}
+
+	public function getSummary(): string {
+		return $this->summary;
+	}
+
+	public function getDescription(): string {
+		return $this->description;
+	}
+
+	#[ReturnTypeWillChange]
+	public function jsonSerialize() {
+		return [
+			'summary' => $this->summary,
+			'description' => $this->description,
+		];
+	}
+}

--- a/src/service/AiIntergrationsService.js
+++ b/src/service/AiIntergrationsService.js
@@ -15,6 +15,20 @@ export const summarizeThread = async (threadId) => {
 		throw convertAxiosError(e)
 	}
 }
+
+export const generateEventData = async (threadId) => {
+	const url = generateUrl('/apps/mail/api/thread/{threadId}/eventdata', {
+		threadId,
+	})
+
+	try {
+		const resp = await axios.get(url)
+		return resp.data.data
+	} catch (e) {
+		throw convertAxiosError(e)
+	}
+}
+
 export const smartReply = async (messageId) => {
 	const url = generateUrl('/apps/mail/api/messages/{messageId}/smartreply', {
 		messageId,

--- a/src/tests/unit/components/EventModal.vue.spec.js
+++ b/src/tests/unit/components/EventModal.vue.spec.js
@@ -1,0 +1,49 @@
+/*
+ * @copyright 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { loadState } from '@nextcloud/initial-state'
+
+import Nextcloud from '../../../mixins/Nextcloud.js'
+import EventModal from '../../../components/EventModal.vue'
+
+const localVue = createLocalVue()
+
+localVue.mixin(Nextcloud)
+
+describe('EventModal', () => {
+
+	it('renders default values', () => {
+		const view = shallowMount(EventModal, {
+			localVue,
+			propsData: {
+				envelope: {
+					subject: 'Sub?',
+					previewText: 'prev',
+				},
+			},
+		})
+
+		expect(view.vm.enabledThreadSummary).toBe(false)
+		expect(view.vm.eventTitle).toBe('Sub?')
+		expect(view.vm.description).toBe('prev')
+	})
+})

--- a/tests/Unit/Model/EventDataTest.php
+++ b/tests/Unit/Model/EventDataTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Mail\Tests\Unit\Model;
+
+use OCA\Mail\Model\EventData;
+use Test\TestCase;
+
+class EventDataTest extends TestCase {
+
+	public function testAll(): void {
+		$data = new EventData('sum', 'des');
+
+		self::assertSame('sum', $data->getSummary());
+		self::assertSame('des', $data->getDescription());
+	}
+
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -65,4 +65,11 @@
       <code>$event</code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="lib/Service/AiIntegrations/AiIntegrationsService.php">
+    <UndefinedDocblockClass>
+      <code>$manager</code>
+      <code>$manager</code>
+      <code>$manager</code>
+    </UndefinedDocblockClass>
+  </file>
 </files>


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/9321

![image](https://github.com/nextcloud/mail/assets/1374172/45512314-b0e9-4b25-9e96-befcb0ed56ec)

## Todo

- [x] MVC that puts the thread summary into DESCRIPTION
- [x] Dedicated event title and agenda generation
- [x] Tests

## How to test

1. Set up integration_openai
2. Enable thread summaries as admin
3. Open a message
4. Click ...
5. Click *More actions*
6. Click *Create event*

Main: summary, description taken from message data
Here: summary, description processed by openai