### PR TITLE
feat(integration): Combine all LLM feature flags

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>3.6.0-alpha.3</version>
+	<version>3.6.0-alpha.4</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -346,13 +346,8 @@ return [
 			'verb' => 'POST'
 		],
 		[
-			'name' => 'settings#setEnabledThreadSummary',
-			'url' => '/api/settings/threadsummary',
-			'verb' => 'PUT'
-		],
-		[
-			'name' => 'settings#setEnabledSmartReplies',
-			'url' => '/api/settings/smartreply',
+			'name' => 'settings#setEnabledLlmProcessing',
+			'url' => '/api/settings/llm',
 			'verb' => 'PUT'
 		],
 		[

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -277,13 +277,13 @@ class PageController extends Controller {
 		);
 
 		$this->initialStateService->provideInitialState(
-			'enabled_thread_summary',
-			$this->config->getAppValue('mail', 'enabled_thread_summary', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
+			'llm_summaries_available',
+			$this->config->getAppValue('mail', 'llm_processing', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
 		);
 
 		$this->initialStateService->provideInitialState(
-			'enabled_smart_reply',
-			$this->config->getAppValue('mail', 'enabled_smart_reply', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
+			'llm_freeprompt_available',
+			$this->config->getAppValue('mail', 'llm_processing', 'no') === 'yes' && $this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -125,12 +125,9 @@ class SettingsController extends Controller {
 		$this->config->setAppValue('mail', 'allow_new_mail_accounts', $allowed ? 'yes' : 'no');
 	}
 
-	public function setEnabledThreadSummary(bool $enabled) {
-		$this->config->setAppValue('mail', 'enabled_thread_summary', $enabled ? 'yes' : 'no');
-	}
-
-	public function setEnabledSmartReplies(bool $enabled) {
-		$this->config->setAppValue('mail', 'enabled_smart_reply', $enabled ? 'yes' : 'no');
+	public function setEnabledLlmProcessing(bool $enabled): JSONResponse {
+		$this->config->setAppValue('mail', 'llm_processing', $enabled ? 'yes' : 'no');
+		return new JSONResponse([]);
 	}
 
 }

--- a/lib/Migration/Version3600Date20240227172825.php
+++ b/lib/Migration/Version3600Date20240227172825.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3600Date20240227172825 extends SimpleMigrationStep {
+
+	public function __construct(private IAppConfig $appConfig) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$allowThreadSummary = $this->appConfig->getAppValue('enabled_thread_summary', 'no');
+		$this->appConfig->deleteAppValue('enabled_thread_summary');
+		if ($allowThreadSummary !== 'yes') {
+			return null;
+		}
+		$allowSmartReplies = $this->appConfig->getAppValue('enabled_smart_reply', 'no');
+		$this->appConfig->deleteAppValue('enabled_smart_reply');
+		if ($allowSmartReplies !== 'yes') {
+			return null;
+		}
+
+		$this->appConfig->setAppValue('llm_processing', 'yes');
+
+		return null;
+	}
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -94,14 +94,8 @@ class AdminSettings implements ISettings {
 
 		$this->initialStateService->provideInitialState(
 			Application::APP_ID,
-			'enabled_thread_summary',
-			$this->config->getAppValue('mail', 'enabled_thread_summary', 'no') === 'yes'
-		);
-
-		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
-			'enabled_smart_reply',
-			$this->config->getAppValue('mail', 'enabled_smart_reply', 'no') === 'yes'
+			'llm_processing',
+			$this->config->getAppValue('mail', 'llm_processing', 'no') === 'yes'
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "3.6.0-alpha2",
+  "version": "3.6.0-alpha4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "3.6.0-alpha2",
+      "version": "3.6.0-alpha4",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "37.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "3.6.0-alpha2",
+  "version": "3.6.0-alpha4",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,

--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -102,7 +102,7 @@ export default {
 			selectedCalendar: undefined,
 			description: this.envelope.previewText,
 			generatingData: false,
-			enabledThreadSummary: loadState('mail', 'enabled_thread_summary', false),
+			llmProcessingEnabled: loadState('mail', 'llm_summaries_available', false),
 		}
 	},
 	computed: {
@@ -129,7 +129,7 @@ export default {
 	},
 	methods: {
 		async generateEventData() {
-			if (!this.enabledThreadSummary) {
+			if (!this.llmProcessingEnabled) {
 				return
 			}
 			try {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -93,7 +93,7 @@ export default {
 			expandedThreads: [],
 			participantsToDisplay: 999,
 			resizeDebounced: debounce(500, this.updateParticipantsToDisplay),
-			enabledThreadSummary: loadState('mail', 'enabled_thread_summary', false),
+			enabledThreadSummary: loadState('mail', 'llm_summaries_available', false),
 			summaryText: '',
 			summaryError: false,
 		}

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -386,7 +386,7 @@ export default {
 			showTaskModal: false,
 			showTagModal: false,
 			rawMessage: '', // Will hold the raw source of the message when requested
-			enabledSmartReply: loadState('mail', 'enabled_smart_reply', false),
+			enabledSmartReply: loadState('mail', 'llm_freeprompt_available', false),
 		}
 	},
 	computed: {

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -148,26 +148,16 @@
 		</div>
 		<div v-if="isLlmSummaryConfigured"
 			class="app-description">
-			<h3>{{ t('mail', 'Enable thread summary') }}</h3>
+			<h3>{{ t('mail', 'Enable text processing through LLMs') }}</h3>
 			<article>
 				<p>
-					<NcCheckboxRadioSwitch :checked.sync="enabledThreadSummary"
-						type="switch"
-						@update:checked="updateEnabledThreadSummary">
-						{{ t('mail','Enable thread summaries') }}
-					</NcCheckboxRadioSwitch>
+					{{ t('mail', 'The Mail app can process user data with the help of the configured large language model and provide assistance features like thread summaries, smart replies and event agendas.') }}
 				</p>
-			</article>
-		</div>
-		<div v-if="isLlmFreePromptConfigured"
-			class="app-description">
-			<h3>{{ t('mail', 'Enable smart replies') }}</h3>
-			<article>
 				<p>
-					<NcCheckboxRadioSwitch :checked.sync="enabledSmartReplies"
+					<NcCheckboxRadioSwitch :checked.sync="isLlmEnabled"
 						type="switch"
-						@update:checked="updateEnabledSmartReply">
-						{{ t('mail','Enable smart replies') }}
+						@update:checked="updateLlmEnabled">
+						{{ t('mail', 'Enable LLM processing') }}
 					</NcCheckboxRadioSwitch>
 				</p>
 			</article>
@@ -286,7 +276,7 @@ import {
 	updateProvisioningSettings,
 	provisionAll,
 	updateAllowNewMailAccounts,
-	updateEnabledThreadSummary,
+	updateLlmEnabled,
 	updateEnabledSmartReply,
 } from '../../service/SettingsService.js'
 
@@ -347,9 +337,8 @@ export default {
 				loading: false,
 			},
 			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts', true),
-			enabledThreadSummary: loadState('mail', 'enabled_thread_summary', false),
-			enabledSmartReplies: loadState('mail', 'enabled_smart_reply', false),
 			isLlmSummaryConfigured: loadState('mail', 'enabled_llm_summary_backend'),
+			isLlmEnabled: loadState('mail', 'llm_processing', true),
 			isLlmFreePromptConfigured: loadState('mail', 'enabled_llm_free_prompt_backend'),
 
 		}
@@ -405,8 +394,8 @@ export default {
 		async updateAllowNewMailAccounts(checked) {
 			await updateAllowNewMailAccounts(checked)
 		},
-		async updateEnabledThreadSummary(checked) {
-			await updateEnabledThreadSummary(checked)
+		async updateLlmEnabled(checked) {
+			await updateLlmEnabled(checked)
 		},
 		async updateEnabledSmartReply(checked) {
 			await updateEnabledSmartReply(checked)

--- a/src/service/SettingsService.js
+++ b/src/service/SettingsService.js
@@ -77,8 +77,8 @@ export const updateAllowNewMailAccounts = (allowed) => {
 	return axios.post(url, data).then((resp) => resp.data)
 }
 
-export const updateEnabledThreadSummary = async (enabled) => {
-	const url = generateUrl('/apps/mail/api/settings/threadsummary')
+export const updateLlmEnabled = async (enabled) => {
+	const url = generateUrl('/apps/mail/api/settings/llm')
 	const data = {
 		enabled,
 	}

--- a/src/tests/unit/components/EventModal.vue.spec.js
+++ b/src/tests/unit/components/EventModal.vue.spec.js
@@ -42,7 +42,7 @@ describe('EventModal', () => {
 			},
 		})
 
-		expect(view.vm.enabledThreadSummary).toBe(false)
+		expect(view.vm.llmProcessingEnabled).toBe(false)
 		expect(view.vm.eventTitle).toBe('Sub?')
 		expect(view.vm.description).toBe('prev')
 	})

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -260,8 +260,8 @@ class PageControllerTest extends TestCase {
 				['mail', 'microsoft_oauth_tenant_id' ],
 				['core', 'backgroundjobs_mode', 'ajax' ],
 				['mail', 'allow_new_mail_accounts', 'yes'],
-				['mail', 'enabled_thread_summary', 'no'],
-				['mail', 'enabled_smart_reply', 'no'],
+				['mail', 'llm_processing', 'no'],
+				['mail', 'llm_processing', 'no'],
 			)->willReturnOnConsecutiveCalls(
 				$this->returnValue('1.2.3'),
 				$this->returnValue(''),
@@ -309,8 +309,8 @@ class PageControllerTest extends TestCase {
 				['disable-scheduled-send', false],
 				['disable-snooze', false],
 				['allow-new-accounts', true],
-				['enabled_thread_summary', false],
-				['enabled_smart_reply', false],
+				['llm_summaries_available', false],
+				['llm_freeprompt_available', false],
 				['smime-certificates', []],
 			);
 

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -53,7 +53,7 @@ class AdminSettingsTest extends TestCase {
 	}
 
 	public function testGetForm() {
-		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(12))
+		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(11))
 			->method('provideInitialState')
 			->withConsecutive(
 				[
@@ -73,12 +73,7 @@ class AdminSettingsTest extends TestCase {
 				],
 				[
 					Application::APP_ID,
-					'enabled_thread_summary',
-					$this->anything()
-				],
-				[
-					Application::APP_ID,
-					'enabled_smart_reply',
+					'llm_processing',
 					$this->anything()
 				],
 				[


### PR DESCRIPTION
Writing docs for https://github.com/nextcloud/mail/issues/9321 made me realized how strange it is to have kind-of duplicate settings for the three LLM features. They are equally "bad" if you don't like LLM processing. So it's most likely that someone enables *all* or *none* of these.

* Introduce new config key, adjust code
* Add migration to migrate previous config keys