### PR TITLE
ci: Add npm audit fix workflow

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -1,0 +1,65 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Npm audit fix and compile
+
+on:
+  workflow_dispatch:
+  schedule:
+    # At 2:30 on Tuesday
+    - cron: '30 2 * * 2'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branches: ['main', 'stable3.5']
+
+    name: npm-audit-fix-${{ matrix.branches }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ matrix.branches }}
+
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
+        id: versions
+        with:
+          fallbackNode: '^20'
+          fallbackNpm: '^10'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
+
+      - name: Fix npm audit
+        run: |
+          npm audit fix
+
+      - name: Create Pull Request
+        if: always()
+        uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v5
+        with:
+          token: ${{ secrets.COMMAND_BOT_PAT }}
+          commit-message: "fix(deps): Apply npm audit fix"
+          committer: GitHub <noreply@github.com>
+          author: nextcloud-command <nextcloud-command@users.noreply.github.com>
+          signoff: true
+          branch: automated/noid/${{ matrix.branches }}-fix-npm-audit
+          title: "fix(deps): Apply npm audit fix"
+          body: |
+            Auto-generated fix of npm audit
+          labels: |
+            dependencies
+            3. to review


### PR DESCRIPTION
Renovate only updates direct dependencies when they are vulnerable. Transitive dependencies need other tools.

Automation runs Tuesday morning, the day we typically have releases.