### PR TITLE
fix(db): Avoid dirty read for collected addresses

### DIFF
--- a/tests/Integration/Db/CollectedAddressMapperTest.php
+++ b/tests/Integration/Db/CollectedAddressMapperTest.php
@@ -125,18 +125,18 @@ class CollectedAddressMapperTest extends TestCase {
 		}
 	}
 
-	public function existsData() {
+	public function insertIfNewData(): array {
 		return [
-			['user1@example.com', true],
-			['user3@example.com', false],
+			['user1@example.com', false],
+			['user3@example.com', true],
 		];
 	}
 
 	/**
-	 * @dataProvider existsData
+	 * @dataProvider insertIfNewData
 	 */
-	public function testExists($email, $expected) {
-		$actual = $this->mapper->exists($this->userId, $email);
+	public function testExists($email, $expected): void {
+		$actual = $this->mapper->insertIfNew($this->userId, $email, null);
 
 		$this->assertSame($expected, $actual);
 	}

--- a/tests/Unit/Service/Autocompletion/AddressCollectorTest.php
+++ b/tests/Unit/Service/Autocompletion/AddressCollectorTest.php
@@ -48,7 +48,7 @@ class AddressCollectorTest extends TestCase {
 		);
 	}
 
-	public function testAddAddresses() {
+	public function testAddAddresses(): void {
 		$addresses = [
 			'"User" <user@example.com>',
 			'Example <example@user.com>',
@@ -64,37 +64,29 @@ class AddressCollectorTest extends TestCase {
 		$address2->setUserId($this->userId);
 
 		$this->mapper->expects($this->exactly(2))
-			->method('exists')
+			->method('insertIfNew')
 			->withConsecutive(
 				[$this->userId, 'user@example.com'],
 				[$this->userId, 'example@user.com']
 			)
 			->willReturnOnConsecutiveCalls(
-				false,
-				false
-			);
-		$this->mapper->expects($this->exactly(2))
-			->method('insert')
-			->withConsecutive(
-				[$address1],
-				[$address2]
+				true,
+				true,
 			);
 
 		$this->collector->addAddresses($this->userId, $addressList);
 	}
 
-	public function testAddDuplicateAddresses() {
+	public function testAddDuplicateAddresses(): void {
 		$addresses = [
 			'user@example.com',
 		];
 		$addressList = AddressList::parse($addresses);
 
 		$this->mapper->expects($this->once())
-			->method('exists')
+			->method('insertIfNew')
 			->with($this->userId, $addresses[0])
-			->will($this->returnValue(true));
-		$this->mapper->expects($this->never())
-			->method('insert');
+			->willReturn(false);
 
 		$this->collector->addAddresses($this->userId, $addressList);
 	}


### PR DESCRIPTION
The collected addresses system does a deduplication on application level, not with a database index. Every INSERT is preceded with a SELECT. As soon as two addresses are stored for one message, there is a potential dirty read.
This is a quick fix. The proper fix is to add a unique index in the database or simply get rid of this obsolete system.

Problem identified by @JohannesGGE for https://github.com/nextcloud/groupware/issues/24.