### PR TITLE
fix(db): Avoid dirty read for local message updates

### DIFF
--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -256,14 +256,14 @@ class LocalMessageMapper extends QBMapper {
 			$message = $this->update($message);
 
 			$this->recipientMapper->updateRecipients($message->getId(), $message->getRecipients(), $to, $cc, $bcc);
+			$recipients = $this->recipientMapper->findByLocalMessageId($message->getId());
+			$message->setRecipients($recipients);
 			$this->db->commit();
+			return $message;
 		} catch (Throwable $e) {
 			$this->db->rollBack();
 			throw $e;
 		}
-		$recipients = $this->recipientMapper->findByLocalMessageId($message->getId());
-		$message->setRecipients($recipients);
-		return $message;
 	}
 
 	public function deleteWithRecipients(LocalMessage $message): void {

--- a/tests/Integration/Db/LocalMessageMapperTest.php
+++ b/tests/Integration/Db/LocalMessageMapperTest.php
@@ -174,7 +174,7 @@ class LocalMessageMapperTest extends TestCase {
 		$this->assertCount(1, $row->getRecipients());
 	}
 
-	public function testUpdateWithRecipient(): void {
+	public function testUpdateWithRecipients(): void {
 		$results = $this->mapper->getAllForUser($this->account->getUserId());
 		$this->assertEmpty($results[0]->getRecipients());
 		// cleanup


### PR DESCRIPTION
When updating local messages we diff the recipients and INSERT/DELETE all changes. Afterwards, the current recipients for the updates message are fetched from the database. This is a textbook example of a causal read. It's likely that database clusters with weak consistency read dirty data.
I'm applying the quick and dirty fix here because the operation already happens in a transaction. The better performing fix would be to build the data in memory. We have everything we need and can refactor the SELECT away.