### PR TITLE
fix: Hack CSS to restore envelope styling

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1016,7 +1016,12 @@ export default {
 	margin-top: 6px;
 	margin-bottom: 6px;
 }
+:deep(.list-item) {
+	flex-wrap: wrap;
+}
 :deep(.list-item__extra) {
 	margin-top: 9px;
+	flex-basis: 100%;
+	padding-left: 40px;
 }
 </style>


### PR DESCRIPTION
Hack approach for a short-term fix of https://github.com/nextcloud/mail/issues/9334.

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2024-02-29 11-00-23](https://github.com/nextcloud/mail/assets/1374172/f2f90ec5-076c-4a47-aac1-d63d16ad6425) | ![Bildschirmfoto vom 2024-02-29 10-59-56](https://github.com/nextcloud/mail/assets/1374172/1b59e9bf-195f-4696-b0ee-a006aac0be42) | 



