### PR TITLE
fix(integration): Allow LLM event titles/agendas for non-admins

### DIFF
--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -183,6 +183,9 @@ class ThreadController extends Controller {
 		return new JSONResponse(['data' => $summary]);
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
 	public function generateEventData(int $id): JSONResponse {
 		try {
 			$message = $this->mailManager->getMessage($this->currentUserId, $id);


### PR DESCRIPTION
The feature only works for admin right now.