### PR TITLE
ci: Enforce conventional commits for backports

### DIFF
--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -1,0 +1,15 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+    branches:
+      - stable*
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
This allows us to generate conventional changelogs automatically for future Mail releases.