### PR TITLE
fix(navigation): Only make mailboxes with children collapsible

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -28,7 +28,7 @@
 			accountId: mailbox.accountId,
 			isValidDropTarget,
 		}"
-		:allow-collapse="true"
+		:allow-collapse="hasSubMailboxes"
 		:menu-open.sync="menuOpen"
 		:force-menu="true"
 		:name="title"


### PR DESCRIPTION
Hard to say when this was introduced. https://github.com/nextcloud/mail/commit/268148a22039bcc9fd4b205dc5288f656ad27d36? The upstream component didn't change in years.

Fixes https://github.com/nextcloud/mail/issues/9442.

## How to test

1. Open the app
2. Look at the navigation
main: all mailboxes have the collapse/expand icon
here: only mailboxes with children have it