### PR TITLE
fix(imap): Pass flags as array for the STORE command

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -351,7 +351,7 @@ class MessageMapper {
 		string $mailbox): void {
 		$client->store($mailbox, [
 			'add' => [
-				Horde_Imap_Client::FLAG_SEEN,
+				[Horde_Imap_Client::FLAG_SEEN],
 			],
 		]);
 	}


### PR DESCRIPTION
`\Horde_Imap_Client_Base::store` takes arrays of flags:

>       - add: (array) An array of flags to add.

It still seems to have worked. Calling the method correctly doesn't hurt.