### PR TITLE
fix: remove deprecated prototype.substr() method

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -39,8 +39,8 @@ const transformMailboxName = (account, mailbox) => {
 		/**
 		 * Sub-mailbox, e.g. 'Archive.2020' or 'INBOX.Archive.2020'
 		 */
-		mailbox.displayName = mailbox.name.substr(mailbox.name.lastIndexOf(mailbox.delimiter) + 1)
-		mailbox.path = mailbox.name.substr(0, mailbox.name.lastIndexOf(mailbox.delimiter))
+		mailbox.displayName = mailbox.name.substring(mailbox.name.lastIndexOf(mailbox.delimiter) + 1)
+		mailbox.path = mailbox.name.substring(0, mailbox.name.lastIndexOf(mailbox.delimiter))
 	} else if (account.personalNamespace && mailbox.name.startsWith(account.personalNamespace)) {
 		/**
 		 * Top-level mailbox, but with a personal namespace, e.g. 'INBOX.Sent'

--- a/src/util/eventAttendee.js
+++ b/src/util/eventAttendee.js
@@ -27,8 +27,8 @@
  * @return {string} URI without a mailto prefix
  */
 export function removeMailtoPrefix(uri) {
-	if (uri.startsWith('mailto:')) {
-		return uri.substr(7)
+	if (uri.startsWith('mailto:') || uri.startsWith('MAILTO:')) {
+		return uri.substring(7)
 	}
 
 	return uri


### PR DESCRIPTION
Apparently substr() is dead: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr