### PR TITLE
Reset additional background styles from toolbar in CKEditor

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -397,7 +397,15 @@ https://github.com/ckeditor/ckeditor5/issues/1142
  .ck .ck-reset {
 	background: var(--color-main-background) !important;
  }
- .custom-item-username {
+.ck-list__item {
+	.ck-off {
+		background:var(--color-main-background) !important;
+	}
+	.ck-on {
+		background:var(--color-primary-element-light) !important;
+	}
+}
+.custom-item-username {
 	color: var(--color-main-text) !important;
  }
  .link-title{
@@ -413,6 +421,7 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	border-radius : 8px !important;
 	padding : 4px 8px !important;
 	display :block;
+	background:var(--color-main-background)!important;
  }
  .custom-item:hover {
 	background:var(--color-primary-element-light)!important;
@@ -422,12 +431,7 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	padding :4px 8px !important;
 	display : block;
 	width : 100% !important;
- }
- .ck-off{
 	background:var(--color-main-background)!important;
- }
- .ck-on{
-	background:var(--color-primary-element-light)!important;
  }
  .link-container:hover {
 	background:var(--color-primary-element-light)!important;


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9489

Revert background styles from https://github.com/nextcloud/mail/pull/9469

🏚️ Before | 🏡 After
---|---
![image](https://github.com/nextcloud/mail/assets/6078378/43bfe1b4-c37a-4c5e-9872-3694849db49d) | ![Screenshot from 2024-03-28 16-46-10](https://github.com/nextcloud/mail/assets/6078378/1bce715c-488e-43ed-8016-0de13047902f)

@hamza221 is it ok in your eyes?