### PR TITLE
fix(composer): Prevent leaving the tab with unsaved changes

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -205,11 +205,15 @@ export default {
 		if (id) {
 			this.draftsPromise = Promise.resolve(id)
 		}
+		window.addEventListener('beforeunload', this.onBeforeUnload)
 	},
 	async mounted() {
 		await this.$nextTick()
 		this.updateCookedComposerData()
 		await this.openModalSize()
+	},
+	beforeDestroy() {
+		window.removeEventListener('beforeunload', this.onBeforeUnload)
 	},
 	methods: {
 		async openModalSize() {
@@ -503,6 +507,15 @@ export default {
 			this.changed = true
 			this.updateCookedComposerData()
 			await this.$store.dispatch('patchComposerData', data)
+		},
+		onBeforeUnload(e) {
+			if (this.canSaveDraft && this.changed) {
+				e.preventDefault()
+				e.returnValue = true
+				this.$store.dispatch('showMessageComposer')
+			} else {
+				console.info('No unsaved changes. See you!')
+			}
 		},
 		async onMinimize() {
 			this.modalFirstOpen = false


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6627

## How to test
1. Open the app
2. Start writing a new message
3. (optional: Minimize the composer)
4. Close the tab

Main: data is lost.
Here: browser ask the user if they really want to leave. If the composer was minimized it will be maximized.

Ref https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event