### PR TITLE
fix: PHP deprecations

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -451,7 +451,7 @@ class AccountsController extends Controller {
 				$this->logger->info("Draft " . $draftId . " could not be loaded: " . $e->getMessage());
 			}
 		}
-		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, [], $isHtml);
+		$messageData = NewMessageData::fromRequest($account, $subject, $body, $to, $cc, $bcc, [], $isHtml);
 
 		try {
 			/** @var Mailbox $draftsMailbox */
@@ -460,9 +460,9 @@ class AccountsController extends Controller {
 				$account,
 				$draftsMailbox,
 				Horde_Imap_Client::SYNC_NEWMSGSUIDS,
-				[],
+				false,
 				null,
-				false
+				[]
 			);
 			return new JSONResponse([
 				'id' => $this->mailManager->getMessageIdForUid($draftsMailbox, $newUID)

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -156,11 +156,11 @@ class MailboxesController extends Controller {
 				$account,
 				$mailbox,
 				Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+				!$init,
+				$lastMessageTimestamp,
 				array_map(static function ($id) {
 					return (int)$id;
 				}, $ids),
-				$lastMessageTimestamp,
-				!$init,
 				$order,
 				$query
 			);

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -105,11 +105,11 @@ class NewMessageData {
 
 	/**
 	 * @param Account $account
+	 * @param string $subject
+	 * @param string $body
 	 * @param string|null $to
 	 * @param string|null $cc
 	 * @param string|null $bcc
-	 * @param string $subject
-	 * @param string $body
 	 * @param array $attachments
 	 * @param bool $isHtml
 	 * @param bool $requestMdn
@@ -118,11 +118,11 @@ class NewMessageData {
 	 * @return NewMessageData
 	 */
 	public static function fromRequest(Account $account,
+		string $subject,
+		string $body,
 		?string $to = null,
 		?string $cc = null,
 		?string $bcc = null,
-		string $subject,
-		string $body,
 		array $attachments = [],
 		bool $isHtml = true,
 		bool $requestMdn = false,

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -98,10 +98,10 @@ class SyncService {
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param int $criteria
-	 * @param int[] $knownIds
 	 * @param bool $partialOnly
-	 *
 	 * @param string|null $filter
+	 *
+	 * @param int[] $knownIds
 	 *
 	 * @return Response
 	 * @throws ClientException
@@ -111,9 +111,9 @@ class SyncService {
 	public function syncMailbox(Account $account,
 		Mailbox $mailbox,
 		int $criteria,
-		?array $knownIds = null,
-		?int $lastMessageTimestamp,
 		bool $partialOnly,
+		?int $lastMessageTimestamp,
+		?array $knownIds = null,
 		string $sortOrder = IMailSearch::ORDER_NEWEST_FIRST,
 		?string $filter = null): Response {
 		if ($partialOnly && !$mailbox->isCached()) {

--- a/tests/Integration/IMAP/MessageMapperTest.php
+++ b/tests/Integration/IMAP/MessageMapperTest.php
@@ -91,9 +91,9 @@ class MessageMapperTest extends TestCase {
 			new Account($account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			false,
 			null,
-			null,
-			false
+			null
 		);
 
 		// Let's retrieve the DB to see if we have this tag!
@@ -121,9 +121,9 @@ class MessageMapperTest extends TestCase {
 			new Account($account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			true,
 			null,
-			null,
-			true
+			null
 		);
 
 		$messages = $messageMapper->findByUids($inbox, [$newUid]);

--- a/tests/Integration/MailboxSynchronizationTest.php
+++ b/tests/Integration/MailboxSynchronizationTest.php
@@ -86,9 +86,9 @@ class MailboxSynchronizationTest extends TestCase {
 			new Account($this->account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 
 		$jsonResponse = $this->foldersController->sync(
@@ -124,9 +124,9 @@ class MailboxSynchronizationTest extends TestCase {
 			new Account($this->account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 		// Second, put a new message into the mailbox
 		$message = $this->getMessageBuilder()
@@ -172,9 +172,9 @@ class MailboxSynchronizationTest extends TestCase {
 			new Account($this->account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 		$this->flagMessage($mailbox, $uid, $this->account);
 		$id = $mailManager->getMessageIdForUid($inbox, $uid);
@@ -215,9 +215,9 @@ class MailboxSynchronizationTest extends TestCase {
 			new Account($this->account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 		$this->deleteMessage($mailbox, $uid, $this->account);
 

--- a/tests/Integration/Migration/MigrateImportantFromImapAndDbTest.php
+++ b/tests/Integration/Migration/MigrateImportantFromImapAndDbTest.php
@@ -35,23 +35,16 @@ use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Migration\MigrateImportantFromImapAndDb;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class MigrateImportantFromImapAndDbTest extends TestCase {
-	/** @var MockObject */
-	private $client;
-
-	/** @var MockObject */
-	private $messageMapper;
-
-	/** @var MockObject */
-	private $mailboxMapper;
-
-	/** @var MockObject */
-	private $logger;
-
-	/** @var MigrateImportantFromImapAndDb */
-	private $migration;
+	private Horde_Imap_Client_Socket|MockObject $client;
+	private MockObject|MessageMapper $messageMapper;
+	private MailboxMapper|MockObject $mailboxMapper;
+	private MockObject|LoggerInterface $logger;
+	private MigrateImportantFromImapAndDb $migration;
+	private IMAPClientFactory|MockObject $clientFactory;
 
 	protected function setUp(): void {
 		$this->clientFactory = $this->createMock(IMAPClientFactory::class);

--- a/tests/Integration/Service/AntiSpamServiceIntegrationTest.php
+++ b/tests/Integration/Service/AntiSpamServiceIntegrationTest.php
@@ -91,9 +91,9 @@ class AntiSpamServiceIntegrationTest extends TestCase {
 			new Account($account),
 			$inbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			false,
 			null,
-			null,
-			false
+			null
 		);
 
 		// now we flag this message as junk

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -255,7 +255,7 @@ class MailTransmissionIntegrationTest extends TestCase {
 	}
 
 	public function testSaveNewDraft() {
-		$message = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', [], false);
+		$message = NewMessageData::fromRequest($this->account, 'greetings', 'hello there', 'recipient@domain.com', null, null, [], false);
 		[,,$uid] = $this->transmission->saveDraft($message);
 		// There should be a new mailbox …
 		$this->assertMailboxExists('Drafts');
@@ -266,9 +266,9 @@ class MailTransmissionIntegrationTest extends TestCase {
 	}
 
 	public function testReplaceDraft() {
-		$message1 = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello t', []);
+		$message1 = NewMessageData::fromRequest($this->account, 'greetings', 'hello t', 'recipient@domain.com', null, null, []);
 		[,,$uid] = $this->transmission->saveDraft($message1);
-		$message2 = NewMessageData::fromRequest($this->account, 'recipient@domain.com', null, null, 'greetings', 'hello there', []);
+		$message2 = NewMessageData::fromRequest($this->account, 'greetings', 'hello there', 'recipient@domain.com', null, null, []);
 		$previous = new Message();
 		$previous->setUid($uid);
 		$this->transmission->saveDraft($message2, $previous);

--- a/tests/Integration/Service/OutboxServiceIntegrationTest.php
+++ b/tests/Integration/Service/OutboxServiceIntegrationTest.php
@@ -226,9 +226,9 @@ class OutboxServiceIntegrationTest extends TestCase {
 			new Account($this->account),
 			$dbInbox,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 		/** @var MessageMapper $messageMapper */
 		$messageMapper = Server::get(MessageMapper::class);

--- a/tests/Unit/Model/NewMessageDataTest.php
+++ b/tests/Unit/Model/NewMessageDataTest.php
@@ -35,7 +35,7 @@ class NewMessageDataTest extends TestCase {
 		$subject = 'Hello';
 		$body = 'Hi!';
 		$attachments = [];
-		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments, false, true);
+		$messageData = NewMessageData::fromRequest($account, $subject, $body, $to, $cc, $bcc, $attachments, false, true);
 
 		$this->assertEquals($account, $messageData->getAccount());
 		$this->assertInstanceOf(AddressList::class, $messageData->getTo());
@@ -56,7 +56,7 @@ class NewMessageDataTest extends TestCase {
 		$subject = 'Hello';
 		$body = 'Hi!';
 		$attachments = [];
-		$messageData = NewMessageData::fromRequest($account, $to, $cc, $bcc, $subject, $body, $attachments);
+		$messageData = NewMessageData::fromRequest($account, $subject, $body, $to, $cc, $bcc, $attachments);
 
 		$this->assertEquals($account, $messageData->getAccount());
 		$this->assertInstanceOf(AddressList::class, $messageData->getTo());

--- a/tests/Unit/Service/AntiSpamServiceTest.php
+++ b/tests/Unit/Service/AntiSpamServiceTest.php
@@ -124,11 +124,11 @@ class AntiSpamServiceTest extends TestCase {
 			->willReturn('test@test.com');
 		$messageData = NewMessageData::fromRequest(
 			$event->getAccount(),
+			'Learn as Junk',
+			'Learn as Junk',
 			'test@test.com',
 			null,
 			null,
-			'Learn as Junk',
-			'Learn as Junk',
 			[['id' => 123, 'type' => 'message/rfc822']]
 		);
 
@@ -165,6 +165,16 @@ class AntiSpamServiceTest extends TestCase {
 			->method('getAppValue')
 			->with('mail', 'antispam_reporting_spam')
 			->willReturn('test@test.com');
+		$messageData = NewMessageData::fromRequest(
+			$event->getAccount(),
+			'Learn as Junk',
+			'Learn as Junk',
+			'test@test.com',
+			null,
+			null,
+			[['id' => 123, 'type' => 'message/rfc822']]
+		);
+
 		$this->dbMessageMapper->expects(self::once())
 			->method('getIdForUid')
 			->with($event->getMailbox(), 123)
@@ -221,6 +231,16 @@ class AntiSpamServiceTest extends TestCase {
 			->method('getAppValue')
 			->with('mail', 'antispam_reporting_spam')
 			->willReturn('test@test.com');
+		$messageData = NewMessageData::fromRequest(
+			$event->getAccount(),
+			'Learn as Not Junk',
+			'Learn as Not Junk',
+			'test@test.com',
+			null,
+			null,
+			[['id' => 123, 'type' => 'message/rfc822']]
+		);
+
 		$this->dbMessageMapper->expects(self::once())
 			->method('getIdForUid')
 			->with($event->getMailbox(), 123)

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -261,7 +261,7 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getMailAccount')->willReturn($mailAccount);
 		$account->method('getName')->willReturn('Test User');
 		$account->method('getEMailAddress')->willReturn('test@user');
-		$messageData = NewMessageData::fromRequest($account, 'to@d.com', '', '', 'sub', 'bod');
+		$messageData = NewMessageData::fromRequest($account, 'sub', 'bod', 'to@d.com', '', '');
 		$message = new Message();
 
 		$account->expects($this->once())

--- a/tests/Unit/Service/Sync/SyncServiceTest.php
+++ b/tests/Unit/Service/Sync/SyncServiceTest.php
@@ -99,9 +99,9 @@ class SyncServiceTest extends TestCase {
 			$account,
 			$mailbox,
 			42,
-			[],
-			null,
 			true,
+			null,
+			[],
 			'DESC'
 		);
 	}
@@ -141,9 +141,9 @@ class SyncServiceTest extends TestCase {
 			$account,
 			$mailbox,
 			0,
-			[],
+			false,
 			null,
-			false
+			[]
 		);
 
 		$this->assertEquals($expectedResponse, $response);


### PR DESCRIPTION
- [x] PHP Deprecated:  Optional parameter $knownIds declared before required parameter $partialOnly is implicitly treated as a required parameter in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Service/Sync/SyncService.php on line 111
- [x]  PHP Deprecated:  Optional parameter $to declared before required parameter $body is implicitly treated as a required parameter in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Model/NewMessageData.php on line 120
- [x] PHP Deprecated:  Optional parameter $cc declared before required parameter $body is implicitly treated as a required parameter in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Model/NewMessageData.php on line 120 
- [x] PHP Deprecated:  Optional parameter $bcc declared before required parameter $body is implicitly treated as a required parameter in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Model/NewMessageData.php on line 120
- [x] PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Integration\Service\MigrateImportantFromImapAndDbTest::$clientFactory is deprecated in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Integration/Migration/MigrateImportantFromImapAndDbTest.php on line 57
- [x] PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Integration\Db\LocalAttachmentMapperTest::$attachmentIds is deprecated in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Integration/Db/LocalAttachmentMapperTest.php on line 107
- [x] PHP Deprecated:  Creation of dynamic property OCA\Mail\Tests\Integration\Service\OutboxServiceIntegrationTest::$db is deprecated in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Integration/Service/OutboxServiceIntegrationTest.php on line 125