### PR TITLE
ci: Silence PR feedback acount about Nextcloud GmbH employees

### DIFF
--- a/.github/workflows/pr-feedback.yml
+++ b/.github/workflows/pr-feedback.yml
@@ -30,5 +30,5 @@ jobs:
             Thank you for contributing to Nextcloud and we hope to hear from you soon!
           days-before-feedback: 14
           start-date: "2023-07-10"
-          exempt-authors: "${{ steps.scrape.outputs.users }},nextcloud-command,nextcloud-android-bot,skjnldsv,datenangebot"
+          exempt-authors: "${{ steps.scrape.outputs.users }},nextcloud-command,nextcloud-android-bot,skjnldsv,datenangebot,GVodyanov,JohannesGGE"
           exempt-bots: true


### PR DESCRIPTION
There have been dozens of false reports in the past few days. This should silence them.