### PR TITLE
fix: Sanitize forward slashes from name before generating url

### DIFF
--- a/lib/Dashboard/MailWidget.php
+++ b/lib/Dashboard/MailWidget.php
@@ -161,7 +161,7 @@ abstract class MailWidget implements IAPIWidget, IIconWidget, IOptionWidget {
 					$this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', [
 						'guestName' => $firstFrom
 							? ($firstFrom->getLabel()
-								? $firstFrom->getLabel()
+								? str_replace('/', '-', $firstFrom->getLabel())
 								: $firstFrom->getEmail())
 							: '',
 						'size' => 44,


### PR DESCRIPTION
Sanitize any forward slashes from guest user name before generating a url

Fixes https://github.com/nextcloud/mail/pull/9553