### PR TITLE
fix: skip resending failed mails

### DIFF
--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -135,6 +135,9 @@ class LocalMessageMapper extends QBMapper {
 				$qb->expr()->isNotNull('send_at'),
 				$qb->expr()->eq('type', $qb->createNamedParameter($type, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
 				$qb->expr()->lte('send_at', $qb->createNamedParameter($time, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+				// Skip all failed mails for now
+				// FIXME: investigate why emails are sent over and over again and actually fix it
+				$qb->expr()->eq('status', $qb->createNamedParameter(LocalMessage::STATUS_RAW, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT)
 			)
 			->orderBy('send_at', 'asc');
 		$messages = $this->findEntities($select);

--- a/lib/Send/Chain.php
+++ b/lib/Send/Chain.php
@@ -39,6 +39,12 @@ class Chain {
 	}
 
 	public function process(Account $account, LocalMessage $localMessage): void {
+		// Skip all failed mails for now
+		// FIXME: investigate why emails are sent over and over again and actually fix it
+		if ($localMessage->getStatus() !== LocalMessage::STATUS_RAW) {
+			return;
+		}
+
 		$handlers = $this->sentMailboxHandler;
 		$handlers->setNext($this->antiAbuseHandler)
 			->setNext($this->sendHandler)

--- a/tests/Integration/Service/OutboxServiceIntegrationTest.php
+++ b/tests/Integration/Service/OutboxServiceIntegrationTest.php
@@ -350,6 +350,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setSubject('subject');
 		$message->setBody('message');
 		$message->setHtml(true);
+		$message->setStatus(LocalMessage::STATUS_RAW);
 
 		$to = [[
 			'label' => 'Penny',


### PR DESCRIPTION
Test via the following patch. It simulates the error case in which a mail is successfully sent but still registered as failed and thus will be sent over and over again.

```patch
diff --git a/lib/Service/MailTransmission.php b/lib/Service/MailTransmission.php
index c3122e9a9..4ac1e60cb 100644
--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -141,6 +141,7 @@ class MailTransmission implements IMailTransmission {
                try {
                        $mail->send($transport, false, false);
                        $localMessage->setRaw($mail->getRaw(false));
+                       throw new Horde_Mime_Exception('test');
                } catch (Horde_Mime_Exception $e) {
                        $localMessage->setStatus(LocalMessage::STATUS_SMPT_SEND_FAIL);
                        $this->logger->error($e->getMessage(), ['exception' => $e]);
```

Reset the cron job with the following SQL statement:

```sql
UPDATE oc_jobs
	SET last_checked=0,last_run=0
	WHERE class like '%Outbox%';
```

### Before

Mail is sent repeatedly on each cron job.

### After

Mail is sent once and then never again even if the simulated exception is thrown.