### PR TITLE
chore: merge duplicated tagging code

### DIFF
--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -430,7 +430,8 @@ class MailManagerTest extends TestCase {
 		$this->imapClientFactory->expects($this->any())
 			->method('getClient')
 			->willReturn($client);
-		$mb = $this->createMock(Mailbox::class);
+		$mb = new Mailbox();
+		$mb->setName('INBOX');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
@@ -458,7 +459,8 @@ class MailManagerTest extends TestCase {
 		$this->imapClientFactory->expects($this->any())
 			->method('getClient')
 			->willReturn($client);
-		$mb = $this->createMock(Mailbox::class);
+		$mb = new Mailbox();
+		$mb->setName('INBOX');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')
@@ -489,7 +491,8 @@ class MailManagerTest extends TestCase {
 		$this->imapClientFactory->expects($this->any())
 			->method('getClient')
 			->willReturn($client);
-		$mb = $this->createMock(Mailbox::class);
+		$mb = new Mailbox();
+		$mb->setName('INBOX');
 		$this->mailboxMapper->expects($this->once())
 			->method('find')
 			->with($account, 'INBOX')


### PR DESCRIPTION
Get rid of some duplicated code I noticed the other day. Merge `tagMessagesWithClient` and `tagMessage`.

Best reviewed as https://github.com/nextcloud/mail/pull/9568/files?w=1.