### PR TITLE
fix(pi): section title margins affected by global styles

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -27,7 +27,8 @@
 						:open-first="mailbox.specialRole !== 'drafts'" />
 					<template v-else>
 						<div v-show="hasImportantEnvelopes" class="app-content-list-item">
-							<SectionTitle class="important" :name="t('mail', 'Important')" />
+							<SectionTitle class="section-title important"
+								:name="t('mail', 'Important')" />
 							<Popover trigger="hover focus">
 								<template #trigger>
 									<ButtonVue type="tertiary-no-background"
@@ -54,7 +55,7 @@
 							:collapsible="true"
 							:bus="bus" />
 						<SectionTitle v-show="hasImportantEnvelopes"
-							class="app-content-list-item other"
+							class="app-content-list-item section-title other"
 							:name="t('mail', 'Other')" />
 						<Mailbox class="nameother"
 							:account="unifiedAccount"
@@ -308,6 +309,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.section-title {
+	:deep(h2) {
+		margin: 0 !important;
+	}
+}
+
 .v-popover > .trigger > * {
 	z-index: 1;
 }


### PR DESCRIPTION
Does not need to be backported as the h* style changes were introduced on server master.

| Before | After |
| --- | --- |
| ![Screenshot_20240418_082048](https://github.com/nextcloud/mail/assets/1479486/265e16b2-2118-44fe-9de5-0aa2c96c0149) | ![Screenshot_20240418_082012](https://github.com/nextcloud/mail/assets/1479486/193232ea-a81e-4f0e-91b6-00e492df6c0b) |
