### PR TITLE
Add static icon for unknown user

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -69,6 +69,7 @@
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
 								:subtitle="option.email"
+								:icon-class="!option.id ? 'icon-user' : null"
 								:url="option.photo"
 								:avatar-size="24" />
 						</div>
@@ -126,6 +127,7 @@
 								:name="option.label"
 								:subtitle="option.email"
 								:url="option.photo"
+								:icon-class="!option.id ? 'icon-user' : null"
 								:avatar-size="24" />
 						</div>
 					</template>
@@ -176,6 +178,7 @@
 								:name="option.label"
 								:subtitle="option.email"
 								:url="option.photo"
+								:icon-class="!option.id ? 'icon-user' : null"
 								:avatar-size="24" />
 						</div>
 					</template>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9099

Add static icon for unknown user to prevent new avatar generation for each input.

**Before:**

https://github.com/nextcloud/mail/assets/1374172/f12d01dd-a252-4765-8e3e-eca95c125553

**After:** 

![Screenshot from 2024-04-18 11-00-00](https://github.com/nextcloud/mail/assets/6078378/da27a8c0-0837-4fbf-9c4a-637ed41ed42a)
