### PR TITLE
Fix: inaccessible filepicker

### DIFF
--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -211,7 +211,7 @@ export default {
 	},
 	methods: {
 		filterAttachements(node) {
-			const downloadShareAttribute = JSON.parse(node.attributes['share-attributes']).find((shareAttribute) => shareAttribute.key === 'download')
+			const downloadShareAttribute = node.attributes['share-attributes'] ? JSON.parse(node.attributes['share-attributes'])?.find((shareAttribute) => shareAttribute.key === 'download') : undefined
 			const downloadPermissions = downloadShareAttribute !== undefined ? downloadShareAttribute.enabled : true
 			return (node.permissions & OC.PERMISSION_READ) && downloadPermissions
 		},


### PR DESCRIPTION
Before :  File picker loads forever,  crashes on the first non-shared node
<img width="938" alt="image" src="https://github.com/nextcloud/mail/assets/40746210/c1f02532-83f4-4088-83c0-53a1de37ace4">
