### PR TITLE
fix(threading): Run manual garbage collection

### DIFF
--- a/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
+++ b/lib/Listener/AccountSynchronizedThreadUpdaterListener.php
@@ -34,6 +34,7 @@ use OCA\Mail\IMAP\Threading\ThreadBuilder;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use function array_chunk;
+use function gc_collect_cycles;
 use function iterator_to_array;
 
 /**
@@ -79,6 +80,10 @@ class AccountSynchronizedThreadUpdaterListener implements IEventListener {
 
 			$logger->debug("Chunk of " . self::WRITE_IDS_CHUNK_SIZE . " messages updated");
 		}
+
+		// Free memory
+		unset($flattened, $threads, $messages);
+		gc_collect_cycles();
 	}
 
 	/**


### PR DESCRIPTION
Threading always has to load a lot of data. It naturally needs a lot of memory. This explicitly frees the variables once they are no longer needed and triggers the PHP GC.

For an account with 1700 threads I see
- main: 16122696 bytes in use at the end of `occ mail:account:sync`
- here: 10121136 bytes in use at the end of `occ mail:account:sync`