### PR TITLE
fix(outbox): handle indeterminate smtp errors

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,7 +29,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>3.7.0-alpha.1</version>
+	<version>3.7.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -82,8 +82,9 @@ class LocalMessage extends Entity implements JsonSerializable {
 	public const STATUS_SMPT_SEND_FAIL = 10;
 	public const STATUS_IMAP_SENT_MAILBOX_FAIL = 11;
 	public const STATUS_PROCESSED = 12;
+	public const STATUS_ERROR = 13;
 	/**
-	 * @var int<1,12>
+	 * @var int<1,13>
 	 * @psalm-var self::TYPE_*
 	 */
 	protected $type;

--- a/lib/Migration/Version3700Date20240430115406.php
+++ b/lib/Migration/Version3700Date20240430115406.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Anna Larch <anna.larch@gmx.net>
+ *
+ * @author Anna Larch <anna.larch@gmx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCA\Mail\Db\LocalMessage;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version3700Date20240430115406 extends SimpleMigrationStep {
+
+	public function __construct(private IDBConnection $connection) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$localMessagesTable = $schema->getTable('mail_local_messages');
+		if (!$localMessagesTable->hasColumn('status')) {
+			$localMessagesTable->addColumn('status', Types::INTEGER, [
+				'notnull' => false,
+				'default' => 0,
+			]);
+		}
+		if (!$localMessagesTable->hasColumn('raw')) {
+			$localMessagesTable->addColumn('raw', Types::TEXT, [
+				'notnull' => false,
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		// Let's buffer this a bit
+		$aMinuteAgo = time() - 60;
+		$query = $this->connection->getQueryBuilder();
+		$query->update('mail_local_messages')
+			->set('status', $query->createNamedParameter(11, IQueryBuilder::PARAM_INT))
+			->where(
+				$query->expr()->lt('send_at', $query->createNamedParameter($aMinuteAgo, IQueryBuilder::PARAM_INT)),
+				$query->expr()->eq('type', $query->createNamedParameter(LocalMessage::TYPE_OUTGOING, IQueryBuilder::PARAM_INT)),
+			);
+		$query->executeStatement();
+	}
+}

--- a/lib/Send/CopySentMessageHandler.php
+++ b/lib/Send/CopySentMessageHandler.php
@@ -35,7 +35,7 @@ class CopySentMessageHandler extends AHandler {
 	public function __construct(private IMAPClientFactory $imapClientFactory,
 		private MailboxMapper $mailboxMapper,
 		private LoggerInterface $logger,
-		private MessageMapper $messageMapper
+		private MessageMapper $messageMapper,
 	) {
 	}
 	public function process(Account $account, LocalMessage $localMessage): LocalMessage {

--- a/src/store/constants.js
+++ b/src/store/constants.js
@@ -28,5 +28,6 @@ export const PAGE_SIZE = 20
 export const UNDO_DELAY = TOAST_UNDO_TIMEOUT
 export const EDITOR_MODE_HTML = 'richtext'
 export const EDITOR_MODE_TEXT = 'plaintext'
-
+export const STATUS_RAW = 0
 export const STATUS_IMAP_SENT_MAILBOX_FAIL = 11
+export const STATUS_SMTP_ERROR = 13

--- a/tests/Unit/Send/ChainTest.php
+++ b/tests/Unit/Send/ChainTest.php
@@ -79,15 +79,8 @@ class ChainTest extends TestCase {
 		$expected->setStatus(LocalMessage::STATUS_PROCESSED);
 		$expected->setId(100);
 
-
-		$this->sentMailboxHandler->expects(self::any())
-			->method('setNext')
-			->withConsecutive(
-				[$this->antiAbuseHandler],
-				[$this->sentMailboxHandler],
-				[$this->copySentMessageHandler],
-				[$this->flagRepliedMessageHandler],
-			);
+		$this->sentMailboxHandler->expects(self::once())
+			->method('setNext');
 		$this->sentMailboxHandler->expects(self::once())
 			->method('process')
 			->with($account, $localMessage)
@@ -116,15 +109,8 @@ class ChainTest extends TestCase {
 		$expected->setStatus(LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL);
 		$expected->setId(100);
 
-
-		$this->sentMailboxHandler->expects(self::any())
-			->method('setNext')
-			->withConsecutive(
-				[$this->antiAbuseHandler],
-				[$this->sentMailboxHandler],
-				[$this->copySentMessageHandler],
-				[$this->flagRepliedMessageHandler],
-			);
+		$this->sentMailboxHandler->expects(self::once())
+			->method('setNext');
 		$this->sentMailboxHandler->expects(self::once())
 			->method('process')
 			->with($account, $localMessage)


### PR DESCRIPTION
Sometimes, if the SMTP server has connectivity issues, SMTP errors are thrown even if the mail has already been sent (although it's an indeterminate state :cat2: :atom: :skull: ). In those cases, we have no way to check if the email has actually been sent to all intended recipients.

This PR introduces a new state for these types of errors, and aims to give the user more information in the outbox list items on what happened. The outbox now allows (re)sending the message or copying the message to the sent outbox.

As yet to be addressed is the case where there are existing outbox messages that have failed previously. 
We should set them to the new error status. But, as their raw message text is not available, this will cause errors when trying to copy them to the sent mailbox. We could also treat them entirely different by checking for the raw body text and only allowing a resend and delete operation.

Some styling issues for the outbox are also blocking this issue.

To Do:

- [x] How to handle existing messages without `raw` body - rebuild the message body as a mime message from the stored data.
- [x] Styling the ListItem