### PR TITLE
enh: add backend check for download permission for cloud attachements

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -41,6 +41,14 @@
       <code>IAPIWidgetV2</code>
     </UndefinedClass>
   </file>
+  <file src="lib/Service/Attachment/AttachmentService.php">
+    <UndefinedDocblockClass occurrences="2">
+      <code>OCA\Files_Sharing\SharedStorage</code>
+    </UndefinedDocblockClass>
+    <UndefinedClass occurrences="1">
+      <code>SharedStorage</code>
+    </UndefinedClass>
+  </file>
   <file src="lib/Dashboard/UnreadMailWidgetV2.php">
     <MissingDependency>
       <code>MailWidgetV2</code>


### PR DESCRIPTION
For now it silently Fails on draft/outbox  save/update
- [x] Find a way to reflect in the front end for versions prior to 3.6 if needed (not needed)