### PR TITLE
feat: implement admin setting to disable classification by default

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -351,6 +351,11 @@ return [
 			'verb' => 'PUT'
 		],
 		[
+			'name' => 'settings#setImportanceClassificationEnabledByDefault',
+			'url' => '/api/settings/importance-classification-default',
+			'verb' => 'PUT'
+		],
+		[
 			'name' => 'trusted_senders#setTrusted',
 			'url' => '/api/trustedsenders/{email}',
 			'verb' => 'PUT'

--- a/lib/Command/TrainAccount.php
+++ b/lib/Command/TrainAccount.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -25,8 +26,8 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Command;
 
-use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\Classification\ImportanceClassifier;
 use OCA\Mail\Support\ConsoleLoggerDecorator;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -42,19 +43,19 @@ class TrainAccount extends Command {
 
 	private AccountService $accountService;
 	private ImportanceClassifier $classifier;
-	private IUserPreferences $preferences;
 	private LoggerInterface $logger;
+	private ClassificationSettingsService $classificationSettingsService;
 
 	public function __construct(AccountService $service,
 		ImportanceClassifier $classifier,
-		IUserPreferences $preferences,
+		ClassificationSettingsService $classificationSettingsService,
 		LoggerInterface $logger) {
 		parent::__construct();
 
 		$this->accountService = $service;
 		$this->classifier = $classifier;
 		$this->logger = $logger;
-		$this->preferences = $preferences;
+		$this->classificationSettingsService = $classificationSettingsService;
 	}
 
 	/**
@@ -78,7 +79,7 @@ class TrainAccount extends Command {
 			$output->writeln("<error>account $accountId does not exist</error>");
 			return 1;
 		}
-		if ($this->preferences->getPreference($account->getUserId(), 'tag-classified-messages') === 'false') {
+		if (!$this->classificationSettingsService->isClassificationEnabled($account->getUserId())) {
 			$output->writeln("<info>classification is turned off for account $accountId</info>");
 			return 2;
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -35,6 +35,7 @@ use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\AliasesService;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\OutboxService;
 use OCA\Mail\Service\SmimeService;
 use OCA\Viewer\Event\LoadViewer;
@@ -83,6 +84,7 @@ class PageController extends Controller {
 	private AiIntegrationsService $aiIntegrationsService;
 	private IUserManager $userManager;
 	private ?IAvailabilityCoordinator $availabilityCoordinator;
+	private ClassificationSettingsService $classificationSettingsService;
 
 	public function __construct(string $appName,
 		IRequest $request,
@@ -103,7 +105,8 @@ class PageController extends Controller {
 		SmimeService     $smimeService,
 		AiIntegrationsService $aiIntegrationsService,
 		IUserManager $userManager,
-		ContainerInterface $container) {
+		ContainerInterface $container,
+		ClassificationSettingsService $classificationSettingsService) {
 		parent::__construct($appName, $request);
 
 		$this->urlGenerator = $urlGenerator;
@@ -123,6 +126,7 @@ class PageController extends Controller {
 		$this->smimeService = $smimeService;
 		$this->aiIntegrationsService = $aiIntegrationsService;
 		$this->userManager = $userManager;
+		$this->classificationSettingsService = $classificationSettingsService;
 
 		// TODO: inject directly if support for nextcloud < 28 is dropped
 		try {
@@ -211,7 +215,7 @@ class PageController extends Controller {
 				'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
 				'search-priority-body' => $this->preferences->getPreference($this->currentUserId, 'search-priority-body', 'false'),
 				'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
-				'tag-classified-messages' => $this->preferences->getPreference($this->currentUserId, 'tag-classified-messages', 'true'),
+				'tag-classified-messages' => $this->classificationSettingsService->isClassificationEnabled($this->currentUserId) ? 'true' : 'false',
 			]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -29,6 +30,7 @@ use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Exception\ValidationException;
 use OCA\Mail\Http\JsonResponse as HttpJsonResponse;
 use OCA\Mail\Service\AntiSpamService;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
@@ -42,19 +44,21 @@ class SettingsController extends Controller {
 	private ProvisioningManager $provisioningManager;
 	private AntiSpamService $antiSpamService;
 	private ContainerInterface $container;
-
 	private IConfig $config;
+	private ClassificationSettingsService $classificationSettingsService;
 
 	public function __construct(IRequest $request,
 		ProvisioningManager $provisioningManager,
 		AntiSpamService $antiSpamService,
 		IConfig $config,
-		ContainerInterface $container) {
+		ContainerInterface $container,
+		ClassificationSettingsService $classificationSettingsService) {
 		parent::__construct(Application::APP_ID, $request);
 		$this->provisioningManager = $provisioningManager;
 		$this->antiSpamService = $antiSpamService;
 		$this->config = $config;
 		$this->container = $container;
+		$this->classificationSettingsService = $classificationSettingsService;
 	}
 
 	public function index(): JSONResponse {
@@ -127,6 +131,11 @@ class SettingsController extends Controller {
 
 	public function setEnabledLlmProcessing(bool $enabled): JSONResponse {
 		$this->config->setAppValue('mail', 'llm_processing', $enabled ? 'yes' : 'no');
+		return new JSONResponse([]);
+	}
+
+	public function setImportanceClassificationEnabledByDefault(bool $enabledByDefault): JSONResponse {
+		$this->classificationSettingsService->setClassificationEnabledByDefault($enabledByDefault);
 		return new JSONResponse([]);
 	}
 

--- a/lib/Service/Classification/ClassificationSettingsService.php
+++ b/lib/Service/Classification/ClassificationSettingsService.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Service\Classification;
+
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\Contracts\IUserPreferences;
+use OCP\IConfig;
+
+class ClassificationSettingsService {
+	public function __construct(
+		private IUserPreferences $preferences,
+		private IConfig $config,
+	) {
+	}
+
+	/**
+	 * Whether the classification by importance is enabled for a given user.
+	 */
+	public function isClassificationEnabled(string $userId): bool {
+		$appConfig = $this->config->getAppValue(
+			Application::APP_ID,
+			'importance_classification_default',
+			'yes',
+		);
+		$preference = $this->preferences->getPreference(
+			$userId,
+			'tag-classified-messages',
+			$appConfig === 'yes' ? 'true' : 'false',
+		);
+		return $preference === 'true';
+	}
+
+	/**
+	 * Whether to classify important mails by default for all users that did not yet toggle the
+	 * preference themselves.
+	 */
+	public function isClassificationEnabledByDefault(): bool {
+		return $this->config->getAppValue(
+			Application::APP_ID,
+			'importance_classification_default',
+			'yes'
+		) === 'yes';
+	}
+
+	/**
+	 * Enable or disable the classification of important mails for all users that did not yet toggle
+	 * the preference themselves.
+	 */
+	public function setClassificationEnabledByDefault(bool $enabledByDefault): void {
+		$this->config->setAppValue(
+			Application::APP_ID,
+			'importance_classification_default',
+			$enabledByDefault ? 'yes' : 'no',
+		);
+	}
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -30,6 +30,7 @@ use OCA\Mail\Integration\GoogleIntegration;
 use OCA\Mail\Integration\MicrosoftIntegration;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\AntiSpamService;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -53,6 +54,7 @@ class AdminSettings implements ISettings {
 	private MicrosoftIntegration $microsoftIntegration;
 	private IConfig $config;
 	private AiIntegrationsService $aiIntegrationsService;
+	private ClassificationSettingsService $classificationSettingsService;
 
 	public function __construct(IInitialStateService $initialStateService,
 		ProvisioningManager $provisioningManager,
@@ -60,7 +62,8 @@ class AdminSettings implements ISettings {
 		GoogleIntegration $googleIntegration,
 		MicrosoftIntegration $microsoftIntegration,
 		IConfig $config,
-		AiIntegrationsService $aiIntegrationsService) {
+		AiIntegrationsService $aiIntegrationsService,
+		ClassificationSettingsService $classificationSettingsService) {
 		$this->initialStateService = $initialStateService;
 		$this->provisioningManager = $provisioningManager;
 		$this->antiSpamService = $antiSpamService;
@@ -68,6 +71,7 @@ class AdminSettings implements ISettings {
 		$this->microsoftIntegration = $microsoftIntegration;
 		$this->config = $config;
 		$this->aiIntegrationsService = $aiIntegrationsService;
+		$this->classificationSettingsService = $classificationSettingsService;
 	}
 
 	public function getForm() {
@@ -142,6 +146,12 @@ class AdminSettings implements ISettings {
 			Application::APP_ID,
 			'microsoft_oauth_redirect_url',
 			$this->microsoftIntegration->getRedirectUrl(),
+		);
+
+		$this->initialStateService->provideInitialState(
+			Application::APP_ID,
+			'importance_classification_default',
+			$this->classificationSettingsService->isClassificationEnabledByDefault(),
 		);
 
 		return new TemplateResponse(Application::APP_ID, 'settings-admin');

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -163,6 +163,21 @@
 			</article>
 		</div>
 		<div class="app-description">
+			<h3>{{ t('mail', 'Enable classification by importance by default') }}</h3>
+			<article>
+				<p>
+					{{ t('mail', 'The Mail app can classify incoming emails by importance using machine learning. This feature is enabled by default but can be disabled by default here. Individual users will still be able to toggle the feature for their accounts.') }}
+				</p>
+				<p>
+					<NcCheckboxRadioSwitch type="switch"
+						:checked="isImportanceClassificationEnabledByDefault"
+						@update:checked="setImportanceClassificationEnabledByDefault">
+						{{ t('mail', 'Enable classification of important mails by default') }}
+					</NcCheckboxRadioSwitch>
+				</p>
+			</article>
+		</div>
+		<div class="app-description">
 			<h3>
 				{{
 					t(
@@ -278,6 +293,7 @@ import {
 	updateAllowNewMailAccounts,
 	updateLlmEnabled,
 	updateEnabledSmartReply,
+	setImportanceClassificationEnabledByDefault,
 } from '../../service/SettingsService.js'
 
 const googleOauthClientId = loadState('mail', 'google_oauth_client_id', null) ?? undefined
@@ -340,7 +356,8 @@ export default {
 			isLlmSummaryConfigured: loadState('mail', 'enabled_llm_summary_backend'),
 			isLlmEnabled: loadState('mail', 'llm_processing', true),
 			isLlmFreePromptConfigured: loadState('mail', 'enabled_llm_free_prompt_backend'),
-
+			isClassificationEnabledByDefault: loadState('mail', 'llm_processing', true),
+			isImportanceClassificationEnabledByDefault: loadState('mail', 'importance_classification_default', true),
 		}
 	},
 	methods: {
@@ -399,6 +416,15 @@ export default {
 		},
 		async updateEnabledSmartReply(checked) {
 			await updateEnabledSmartReply(checked)
+		},
+		async setImportanceClassificationEnabledByDefault(enabledByDefault) {
+			try {
+				await setImportanceClassificationEnabledByDefault(enabledByDefault)
+				this.isImportanceClassificationEnabledByDefault = !this.isImportanceClassificationEnabledByDefault
+			} catch (error) {
+				showError(t('mail', 'Could not save default classification setting'))
+				logger.error('Could not save default classification setting', { error })
+			}
 		},
 	},
 }

--- a/src/service/SettingsService.js
+++ b/src/service/SettingsService.js
@@ -2,6 +2,7 @@
  * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0-or-later
  *
@@ -93,4 +94,15 @@ export const updateEnabledSmartReply = async (enabled) => {
 	}
 	const resp = await axios.put(url, data)
 	return resp.data
+}
+
+/**
+ * @param {boolean} enabledByDefault
+ * @return {Promise<void>}
+ */
+export const setImportanceClassificationEnabledByDefault = async (enabledByDefault) => {
+	const url = generateUrl('/apps/mail/api/settings/importance-classification-default')
+	await axios.put(url, {
+		enabledByDefault,
+	})
 }

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -33,6 +33,7 @@ use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\AliasesService;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\MailManager;
 use OCA\Mail\Service\OutboxService;
 use OCA\Mail\Service\SmimeService;
@@ -116,6 +117,9 @@ class PageControllerTest extends TestCase {
 	/** @var ContainerInterface|MockObject */
 	private $container;
 
+	/** @var ClassificationSettingsService|MockObject */
+	private $classificationSettingsService;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -139,6 +143,7 @@ class PageControllerTest extends TestCase {
 		$this->smimeService = $this->createMock(SmimeService::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->container = $this->createMock(ContainerInterface::class);
+		$this->classificationSettingsService = $this->createMock(ClassificationSettingsService::class);
 
 		$this->controller = new PageController(
 			$this->appName,
@@ -161,6 +166,7 @@ class PageControllerTest extends TestCase {
 			$this->aiIntegrationsService,
 			$this->userManager,
 			$this->container,
+			$this->classificationSettingsService,
 		);
 	}
 
@@ -168,7 +174,7 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createMock(Mailbox::class);
-		$this->preferences->expects($this->exactly(9))
+		$this->preferences->expects($this->exactly(8))
 			->method('getPreference')
 			->willReturnMap([
 				[$this->userId, 'account-settings', '[]', json_encode([])],
@@ -178,9 +184,12 @@ class PageControllerTest extends TestCase {
 				[$this->userId, 'collect-data', 'true', 'true'],
 				[$this->userId, 'search-priority-body', 'false', 'false'],
 				[$this->userId, 'start-mailbox-id', null, '123'],
-				[$this->userId, 'tag-classified-messages', 'true', 'true'],
 				[$this->userId, 'layout-mode', 'vertical-split', 'vertical-split'],
 			]);
+		$this->classificationSettingsService->expects(self::once())
+			->method('isClassificationEnabled')
+			->with($this->userId)
+			->willReturn(false);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
 			->with($this->userId)
@@ -322,7 +331,7 @@ class PageControllerTest extends TestCase {
 			'app-version' => '1.2.3',
 			'collect-data' => 'true',
 			'start-mailbox-id' => '123',
-			'tag-classified-messages' => 'true',
+			'tag-classified-messages' => 'false',
 			'search-priority-body' => 'false',
 			'layout-mode' => 'vertical-split',
 		]);

--- a/tests/Unit/Service/Classification/ClassificationSettingsServiceTest.php
+++ b/tests/Unit/Service/Classification/ClassificationSettingsServiceTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\Classification;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Contracts\IUserPreferences;
+use OCA\Mail\Service\Classification\ClassificationSettingsService;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ClassificationSettingsServiceTest extends TestCase {
+	private ClassificationSettingsService $service;
+
+	/** @var IUserPreferences|MockObject */
+	private $preferences;
+
+	/** @var IConfig|MockObject */
+	private $config;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->preferences = $this->createMock(IUserPreferences::class);
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->service = new ClassificationSettingsService(
+			$this->preferences,
+			$this->config,
+		);
+	}
+
+	public static function isClassificationEnabledDataProvider(): array {
+		return [
+			['yes', 'true', true],
+			['yes', 'false', false],
+			['no', 'false', false],
+			['no', 'true', true],
+		];
+	}
+
+	/**
+	 * @dataProvider isClassificationEnabledDataProvider
+	 */
+	public function testIsClassificationEnabled(
+		string $appConfig,
+		string $preference,
+		bool $expected,
+	): void {
+		$this->config->expects(self::once())
+			->method('getAppValue')
+			->with('mail', 'importance_classification_default', 'yes')
+			->willReturn($appConfig);
+		$this->preferences->expects(self::once())
+			->method('getPreference')
+			->with('user', 'tag-classified-messages', $appConfig === 'yes' ? 'true' : 'false')
+			->willReturn($preference);
+
+		$this->assertEquals($expected, $this->service->isClassificationEnabled('user'));
+	}
+
+	public static function isClassificationEnabledByDefaultDataProvider(): array {
+		return [
+			['yes', true],
+			['no', false],
+		];
+	}
+
+	/**
+	 * @dataProvider isClassificationEnabledByDefaultDataProvider
+	 */
+	public function testIsImportanceClassificationEnabledByDefault(
+		string $appConfig,
+		bool $expected,
+	): void {
+		$this->config->expects(self::once())
+			->method('getAppValue')
+			->with('mail', 'importance_classification_default', 'yes')
+			->willReturn($appConfig);
+
+		$this->assertEquals($expected, $this->service->isClassificationEnabledByDefault());
+	}
+
+	public static function setClassificationEnabledByDefaultDataProvider(): array {
+		return [
+			[true, 'yes'],
+			[false, 'no'],
+		];
+	}
+
+	/**
+	 * @dataProvider setClassificationEnabledByDefaultDataProvider
+	 */
+	public function testSetClassificationEnabledByDefault(
+		bool $enabledByDefault,
+		string $expectedAppConfig,
+	): void {
+		$this->config->expects(self::once())
+			->method('setAppValue')
+			->with('mail', 'importance_classification_default', $expectedAppConfig);
+
+		$this->service->setClassificationEnabledByDefault($enabledByDefault);
+	}
+
+}

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -53,7 +53,7 @@ class AdminSettingsTest extends TestCase {
 	}
 
 	public function testGetForm() {
-		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(11))
+		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(12))
 			->method('provideInitialState')
 			->withConsecutive(
 				[
@@ -109,6 +109,11 @@ class AdminSettingsTest extends TestCase {
 				[
 					Application::APP_ID,
 					'microsoft_oauth_redirect_url',
+					$this->anything()
+				],
+				[
+					Application::APP_ID,
+					'importance_classification_default',
 					$this->anything()
 				],
 			);


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/6390

This settings only adjusts the default value for users that haven't configured it yet.

## Admin settings -> Groupware

(Just below the LLM settings)

![importance-classification-setting](https://github.com/nextcloud/mail/assets/1479486/9aa2765d-0392-4253-b1d1-ad579039d45b)