### PR TITLE
ci: Adjust stable branches for the npm audit fix

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable3.6', 'stable3.5']
+        branches: ['main', 'stable3.7', 'stable3.6']
 
     name: npm-audit-fix-${{ matrix.branches }}
 


### PR DESCRIPTION
3.6 is out, 3.7 is in pre-release state.