### PR TITLE
Master password: Make sure accounts without password are included

### DIFF
--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -70,17 +70,6 @@ class ProvisioningMiddleware extends Middleware {
 		try {
 			$this->provisioningManager->provisionSingleUser($configs, $user);
 			$password = $this->credentialStore->getLoginCredentials()->getPassword();
-
-			// FIXME: Need to check for an empty string here too?
-			// The password is empty (and not null) when using WebAuthn passwordless login.
-			// Maybe research other providers as well.
-			// Ref \OCA\Mail\Controller\PageController::index()
-			//     -> inital state for password-is-unavailable
-			if ($password === null) {
-				// Nothing to update, might be passwordless signin
-				$this->logger->debug('No password set for ' . $user->getUID());
-				return;
-			}
 			$this->provisioningManager->updatePassword(
 				$user,
 				$password,

--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -336,7 +336,7 @@ class Manager {
 			if ($provisioning->getMasterPasswordEnabled() === true && $provisioning->getMasterPassword() !== null) {
 				$password = $provisioning->getMasterPassword();
 				$this->logger->debug('Password set to master password for ' . $user->getUID());
-			} else if ($password === null) {
+			} elseif ($password === null) {
 				$this->logger->debug('No password set for ' . $user->getUID());
 				return;
 			}

--- a/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/ProvisioningMiddlewareTest.php
@@ -160,8 +160,6 @@ class ProvisioningMiddlewareTest extends TestCase {
 		$credentials->expects($this->once())
 			->method('getPassword')
 			->willReturn(null);
-		$this->provisioningManager->expects($this->never())
-			->method('updatePassword');
 
 		$this->middleware->beforeController(
 			$this->createMock(PageController::class),


### PR DESCRIPTION
Previously only accounts with a password set would be provisioned with the master password, this patch fixes that.

<s>One potential problem with this patch is that it copies a function from here:

https://github.com/nextcloud/mail/blob/c1e332d163302590c8ad6a2292951f224a1497bb/lib/Service/Provisioning/Manager.php#L358-L375

If we make that function public in the provisioning manager, we could reuse the code better, so that might be something to consider.</s>

Edit: This concern is addressed now.