### PR TITLE
fix(.nextcloudignore): Exclude php-stemmer tests from package

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -38,4 +38,5 @@ codecov.yml
 /vendor/bin
 /vendor-bin
 /vendor/cerdic/css-tidy/css_optimiser.php
+/vendor/wamania/php-stemmer/test
 /webpack.*


### PR DESCRIPTION
Reduces package size by 18 MB
Fixes #9586 (a false positive from a security scanner)
