### PR TITLE
chore(tests): Clean-up phpunit.unit.xml

### DIFF
--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 bootstrap="bootstrap.php"
 		 verbose="true"
-		 timeoutForSmallTests="900"
-		 timeoutForMediumTests="900"
-		 timeoutForLargeTests="900"
-		 convertErrorsToExceptions="true"
-		 convertNoticesToExceptions="true"
-		 convertWarningsToExceptions="true"
-		 cacheResult="true"
-		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">../lib</directory>
-    </include>
-    <exclude>
-      <directory suffix=".php">../mail/lib/Vendor</directory>
-    </exclude>
-    <report>
-      <clover outputFile="./clover.unit.xml"/>
-    </report>
-  </coverage>
-  <testsuite name="Mail app tests">
-    <directory suffix="Test.php">Unit</directory>
-  </testsuite>
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
+	<testsuite name="Mail app tests">
+    	<directory suffix="Test.php">Unit</directory>
+	</testsuite>
+	<coverage>
+		<include>
+			<directory suffix=".php">../lib</directory>
+		</include>
+		<exclude>
+			<directory suffix=".php">../mail/lib/Vendor</directory>
+		</exclude>
+		<report>
+			<clover outputFile="./clover.unit.xml"/>
+		</report>
+	</coverage>
 </phpunit>


### PR DESCRIPTION
- Fix spacing (it was bugging me)
- Switch up ordering
- Validate against correct schema version
- Remove options that are using default values (convert{Errors, Notices, Warnings}ToExceptions=true, cacheResult=true)
- Remove small/medium/large timeouts which aren't being used (and are all the same anyhow)
  - note: we're effectively using `defaultTimeLimit` globally currently (which defaults to `0`)