### PR TITLE
fix(composer): Revive ckeditor translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ckeditor/ckeditor5-alignment": "37.1.0",
         "@ckeditor/ckeditor5-basic-styles": "37.1.0",
         "@ckeditor/ckeditor5-block-quote": "37.1.0",
+        "@ckeditor/ckeditor5-build-decoupled-document": "^37.1.0",
         "@ckeditor/ckeditor5-core": "37.1.0",
         "@ckeditor/ckeditor5-dev-utils": "37.0.1",
         "@ckeditor/ckeditor5-dev-webpack-plugin": "~31.1.13",
@@ -1956,10 +1957,34 @@
         "node-fetch": "^3.3.0"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-37.1.0.tgz",
+      "integrity": "sha512-SKjcsKqVw1EpZ3P0HaLDmPwf0Kv9qaqwUsp9Lv0InpPWlvubTCH4YwJ/bC7uh0NApQdygJ10S1CKn7/bSDrT4A==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-alignment": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-37.1.0.tgz",
       "integrity": "sha512-VIlkssFj5Ajo6nClDnx7eWDgIkhFUMsNeR7o0xB7gfgqeLmBNKQvNr0oIRI8RQxG0/VWogWKJ68PBZ4Y22uIag==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autoformat": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-37.1.0.tgz",
+      "integrity": "sha512-wZSuqsD6oz06fbE2zCn8PUDyax5YUDWFnB/26piLBu0HteRYFXJtIq6s2vA+zBbFfR3FL7362t+DP9VEHGigtw==",
       "dependencies": {
         "ckeditor5": "^37.1.0"
       },
@@ -1992,6 +2017,63 @@
         "npm": ">=5.7.1"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-build-decoupled-document": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-37.1.0.tgz",
+      "integrity": "sha512-EP1rSIdcrFJ/xAhLahvpzDOFz4nZ0RF9mAG0QBXvxBEqAUxKXE3BOILINhMwcHcqye1UBvitefGnWa8LEU6rfA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "^37.1.0",
+        "@ckeditor/ckeditor5-alignment": "^37.1.0",
+        "@ckeditor/ckeditor5-autoformat": "^37.1.0",
+        "@ckeditor/ckeditor5-basic-styles": "^37.1.0",
+        "@ckeditor/ckeditor5-block-quote": "^37.1.0",
+        "@ckeditor/ckeditor5-ckbox": "^37.1.0",
+        "@ckeditor/ckeditor5-ckfinder": "^37.1.0",
+        "@ckeditor/ckeditor5-cloud-services": "^37.1.0",
+        "@ckeditor/ckeditor5-easy-image": "^37.1.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "^37.1.0",
+        "@ckeditor/ckeditor5-essentials": "^37.1.0",
+        "@ckeditor/ckeditor5-font": "^37.1.0",
+        "@ckeditor/ckeditor5-heading": "^37.1.0",
+        "@ckeditor/ckeditor5-image": "^37.1.0",
+        "@ckeditor/ckeditor5-indent": "^37.1.0",
+        "@ckeditor/ckeditor5-link": "^37.1.0",
+        "@ckeditor/ckeditor5-list": "^37.1.0",
+        "@ckeditor/ckeditor5-media-embed": "^37.1.0",
+        "@ckeditor/ckeditor5-paragraph": "^37.1.0",
+        "@ckeditor/ckeditor5-paste-from-office": "^37.1.0",
+        "@ckeditor/ckeditor5-table": "^37.1.0",
+        "@ckeditor/ckeditor5-typing": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckbox": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-37.1.0.tgz",
+      "integrity": "sha512-XcbQPFkGevxKLilM28szORH/PZyR39cLwogZgothLXX4aPiiBGox8ldN6uI7cTaDkGjxzvaBF1AvHhcAPGs5pA==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ckfinder": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-37.1.0.tgz",
+      "integrity": "sha512-zgNldaJC9g3o0zy2plmIffO1SyPsBDVdVq65Y6zoT4YXqandpEwjdR/kGFwHBYr6hdMz4MsaPDXRXxYIAwU0LA==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-37.1.0.tgz",
@@ -2002,6 +2084,18 @@
         "@ckeditor/ckeditor5-utils": "^37.1.0",
         "@ckeditor/ckeditor5-widget": "^37.1.0",
         "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-cloud-services": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-37.1.0.tgz",
+      "integrity": "sha512-C5a+DKu1afASJVC0fl62WMjwaMIEulG/B2uyXySY6hXdHVC3aZkX0Z1Csn7QA2E0nk3KMkoGxCLWXJnsJk2gtg==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -2289,6 +2383,18 @@
         "webpack": "^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-easy-image": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-37.1.0.tgz",
+      "integrity": "sha512-1pu7IF0gpfIUVPci06kQaf76jvJkavFmbkK6MpxjccFsCVa2HONgyPfbMHvBLb2J5TBm/IeN+yHF/qmKiIMTKg==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-37.1.0.tgz",
@@ -2392,6 +2498,18 @@
         "npm": ">=5.7.1"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-indent": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-37.1.0.tgz",
+      "integrity": "sha512-RBuyGV0um9l8dKwnugF0mfiL9H+AsaErhudcgfBhPFCoRQ3+vyQF3Mg14+iKdP2hybJQ6OaT+6a1P8OPzrq85Q==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-link": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-37.1.0.tgz",
@@ -2410,6 +2528,19 @@
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-37.1.0.tgz",
       "integrity": "sha512-hV1fNhpMkivlVuwRx0TVSEzPgciQa14uV/lbnhCmjT33WDrh8hAcYFK+kJx+9dB1OzNtyTlsMA/DxUJPdNr9TA==",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "^37.1.0",
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-media-embed": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-37.1.0.tgz",
+      "integrity": "sha512-FFErNy2M+32rFeI6z16J38T7VVsqk5TDWkLRVqZF/5/VOBZ/TGcAjamEYkWnuzSHakuwDUbCwT+H3JVSKNnZJA==",
       "dependencies": {
         "@ckeditor/ckeditor5-ui": "^37.1.0",
         "ckeditor5": "^37.1.0"
@@ -2446,6 +2577,18 @@
         "npm": ">=5.7.1"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-paste-from-office": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-37.1.0.tgz",
+      "integrity": "sha512-4l+Wt6HCG1yraQhCfRegReWoviLkEzqPb/6QxoFiqOZkzUCmCCTgGTwL709fOg3sE5hxYd4tfPb9ARQuOkfmgQ==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-37.1.0.tgz",
@@ -2466,6 +2609,19 @@
         "@ckeditor/ckeditor5-core": "^37.1.0",
         "@ckeditor/ckeditor5-ui": "^37.1.0",
         "@ckeditor/ckeditor5-utils": "^37.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=5.7.1"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-table": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-37.1.0.tgz",
+      "integrity": "sha512-XXAGEZtpRz9Y0ZZtrDZCYy8jFLOVNnfgQIoSH+SJjSGyaR/DjlmLPXpSiO3R8Y8s7dRncBqK8Z0JEST7UwfdGg==",
+      "dependencies": {
+        "ckeditor5": "^37.1.0",
+        "lodash-es": "^4.17.15"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -20741,10 +20897,26 @@
         "node-fetch": "^3.3.0"
       }
     },
+    "@ckeditor/ckeditor5-adapter-ckfinder": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-37.1.0.tgz",
+      "integrity": "sha512-SKjcsKqVw1EpZ3P0HaLDmPwf0Kv9qaqwUsp9Lv0InpPWlvubTCH4YwJ/bC7uh0NApQdygJ10S1CKn7/bSDrT4A==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
     "@ckeditor/ckeditor5-alignment": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-37.1.0.tgz",
       "integrity": "sha512-VIlkssFj5Ajo6nClDnx7eWDgIkhFUMsNeR7o0xB7gfgqeLmBNKQvNr0oIRI8RQxG0/VWogWKJ68PBZ4Y22uIag==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
+    "@ckeditor/ckeditor5-autoformat": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-37.1.0.tgz",
+      "integrity": "sha512-wZSuqsD6oz06fbE2zCn8PUDyax5YUDWFnB/26piLBu0HteRYFXJtIq6s2vA+zBbFfR3FL7362t+DP9VEHGigtw==",
       "requires": {
         "ckeditor5": "^37.1.0"
       }
@@ -20765,6 +20937,51 @@
         "ckeditor5": "^37.1.0"
       }
     },
+    "@ckeditor/ckeditor5-build-decoupled-document": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-decoupled-document/-/ckeditor5-build-decoupled-document-37.1.0.tgz",
+      "integrity": "sha512-EP1rSIdcrFJ/xAhLahvpzDOFz4nZ0RF9mAG0QBXvxBEqAUxKXE3BOILINhMwcHcqye1UBvitefGnWa8LEU6rfA==",
+      "requires": {
+        "@ckeditor/ckeditor5-adapter-ckfinder": "^37.1.0",
+        "@ckeditor/ckeditor5-alignment": "^37.1.0",
+        "@ckeditor/ckeditor5-autoformat": "^37.1.0",
+        "@ckeditor/ckeditor5-basic-styles": "^37.1.0",
+        "@ckeditor/ckeditor5-block-quote": "^37.1.0",
+        "@ckeditor/ckeditor5-ckbox": "^37.1.0",
+        "@ckeditor/ckeditor5-ckfinder": "^37.1.0",
+        "@ckeditor/ckeditor5-cloud-services": "^37.1.0",
+        "@ckeditor/ckeditor5-easy-image": "^37.1.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "^37.1.0",
+        "@ckeditor/ckeditor5-essentials": "^37.1.0",
+        "@ckeditor/ckeditor5-font": "^37.1.0",
+        "@ckeditor/ckeditor5-heading": "^37.1.0",
+        "@ckeditor/ckeditor5-image": "^37.1.0",
+        "@ckeditor/ckeditor5-indent": "^37.1.0",
+        "@ckeditor/ckeditor5-link": "^37.1.0",
+        "@ckeditor/ckeditor5-list": "^37.1.0",
+        "@ckeditor/ckeditor5-media-embed": "^37.1.0",
+        "@ckeditor/ckeditor5-paragraph": "^37.1.0",
+        "@ckeditor/ckeditor5-paste-from-office": "^37.1.0",
+        "@ckeditor/ckeditor5-table": "^37.1.0",
+        "@ckeditor/ckeditor5-typing": "^37.1.0"
+      }
+    },
+    "@ckeditor/ckeditor5-ckbox": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-37.1.0.tgz",
+      "integrity": "sha512-XcbQPFkGevxKLilM28szORH/PZyR39cLwogZgothLXX4aPiiBGox8ldN6uI7cTaDkGjxzvaBF1AvHhcAPGs5pA==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
+    "@ckeditor/ckeditor5-ckfinder": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-37.1.0.tgz",
+      "integrity": "sha512-zgNldaJC9g3o0zy2plmIffO1SyPsBDVdVq65Y6zoT4YXqandpEwjdR/kGFwHBYr6hdMz4MsaPDXRXxYIAwU0LA==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
     "@ckeditor/ckeditor5-clipboard": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-37.1.0.tgz",
@@ -20775,6 +20992,14 @@
         "@ckeditor/ckeditor5-utils": "^37.1.0",
         "@ckeditor/ckeditor5-widget": "^37.1.0",
         "lodash-es": "^4.17.15"
+      }
+    },
+    "@ckeditor/ckeditor5-cloud-services": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-37.1.0.tgz",
+      "integrity": "sha512-C5a+DKu1afASJVC0fl62WMjwaMIEulG/B2uyXySY6hXdHVC3aZkX0Z1Csn7QA2E0nk3KMkoGxCLWXJnsJk2gtg==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
       }
     },
     "@ckeditor/ckeditor5-core": {
@@ -20982,6 +21207,14 @@
         }
       }
     },
+    "@ckeditor/ckeditor5-easy-image": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-37.1.0.tgz",
+      "integrity": "sha512-1pu7IF0gpfIUVPci06kQaf76jvJkavFmbkK6MpxjccFsCVa2HONgyPfbMHvBLb2J5TBm/IeN+yHF/qmKiIMTKg==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
     "@ckeditor/ckeditor5-editor-balloon": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-37.1.0.tgz",
@@ -21053,6 +21286,14 @@
         "lodash-es": "^4.17.15"
       }
     },
+    "@ckeditor/ckeditor5-indent": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-37.1.0.tgz",
+      "integrity": "sha512-RBuyGV0um9l8dKwnugF0mfiL9H+AsaErhudcgfBhPFCoRQ3+vyQF3Mg14+iKdP2hybJQ6OaT+6a1P8OPzrq85Q==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
     "@ckeditor/ckeditor5-link": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-37.1.0.tgz",
@@ -21067,6 +21308,15 @@
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-37.1.0.tgz",
       "integrity": "sha512-hV1fNhpMkivlVuwRx0TVSEzPgciQa14uV/lbnhCmjT33WDrh8hAcYFK+kJx+9dB1OzNtyTlsMA/DxUJPdNr9TA==",
+      "requires": {
+        "@ckeditor/ckeditor5-ui": "^37.1.0",
+        "ckeditor5": "^37.1.0"
+      }
+    },
+    "@ckeditor/ckeditor5-media-embed": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-37.1.0.tgz",
+      "integrity": "sha512-FFErNy2M+32rFeI6z16J38T7VVsqk5TDWkLRVqZF/5/VOBZ/TGcAjamEYkWnuzSHakuwDUbCwT+H3JVSKNnZJA==",
       "requires": {
         "@ckeditor/ckeditor5-ui": "^37.1.0",
         "ckeditor5": "^37.1.0"
@@ -21091,6 +21341,14 @@
         "@ckeditor/ckeditor5-utils": "^37.1.0"
       }
     },
+    "@ckeditor/ckeditor5-paste-from-office": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-37.1.0.tgz",
+      "integrity": "sha512-4l+Wt6HCG1yraQhCfRegReWoviLkEzqPb/6QxoFiqOZkzUCmCCTgGTwL709fOg3sE5hxYd4tfPb9ARQuOkfmgQ==",
+      "requires": {
+        "ckeditor5": "^37.1.0"
+      }
+    },
     "@ckeditor/ckeditor5-remove-format": {
       "version": "37.1.0",
       "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-37.1.0.tgz",
@@ -21107,6 +21365,15 @@
         "@ckeditor/ckeditor5-core": "^37.1.0",
         "@ckeditor/ckeditor5-ui": "^37.1.0",
         "@ckeditor/ckeditor5-utils": "^37.1.0"
+      }
+    },
+    "@ckeditor/ckeditor5-table": {
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-37.1.0.tgz",
+      "integrity": "sha512-XXAGEZtpRz9Y0ZZtrDZCYy8jFLOVNnfgQIoSH+SJjSGyaR/DjlmLPXpSiO3R8Y8s7dRncBqK8Z0JEST7UwfdGg==",
+      "requires": {
+        "ckeditor5": "^37.1.0",
+        "lodash-es": "^4.17.15"
       }
     },
     "@ckeditor/ckeditor5-theme-lark": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ckeditor/ckeditor5-alignment": "37.1.0",
     "@ckeditor/ckeditor5-basic-styles": "37.1.0",
     "@ckeditor/ckeditor5-block-quote": "37.1.0",
+    "@ckeditor/ckeditor5-build-decoupled-document": "^37.1.0",
     "@ckeditor/ckeditor5-core": "37.1.0",
     "@ckeditor/ckeditor5-dev-utils": "37.0.1",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "~31.1.13",

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -284,7 +284,7 @@ export default {
 					/* webpackMode: "lazy-once" */
 					/* webpackPrefetch: true */
 					/* webpackPreload: true */
-					`@ckeditor/ckeditor5-build-balloon/build/translations/${language}`
+					`@ckeditor/ckeditor5-build-decoupled-document/build/translations/${language}`
 				)
 				this.showEditor(language)
 			} catch (error) {


### PR DESCRIPTION
### Before

```
WARNING in ./src/components/TextEditor.vue?vue&type=script&lang=js (./node_modules/babel-loader/lib/index.js!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/TextEditor.vue?vue&type=script&lang=js) 188:14-192:81
Module not found: Error: Can't resolve '@ckeditor/ckeditor5-build-balloon/build/translations' in 'nextcloud/apps/mail/src/components'
 @ ./src/components/TextEditor.vue?vue&type=script&lang=js 1:0-169 1:185-188 1:190-356 1:190-356
 @ ./src/components/TextEditor.vue 2:0-61 3:0-56 3:0-56 11:2-8
 @ ./node_modules/babel-loader/lib/index.js!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/Composer.vue?vue&type=script&lang=js 26:0-42 60:4-14
 @ ./src/components/Composer.vue?vue&type=script&lang=js 1:0-167 1:183-186 1:188-352 1:188-352
 @ ./src/components/Composer.vue 2:0-59 3:0-54 3:0-54 10:2-8
 @ ./node_modules/babel-loader/lib/index.js!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/NewMessageModal.vue?vue&type=script&lang=js 6:0-38 22:4-12
 @ ./src/components/NewMessageModal.vue?vue&type=script&lang=js 1:0-174 1:190-193 1:195-366 1:195-366
 @ ./src/components/NewMessageModal.vue 2:0-66 3:0-61 3:0-61 10:2-8
 @ ./node_modules/babel-loader/lib/index.js!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/views/Home.vue?vue&type=script&lang=js 18:27-114
 @ ./src/views/Home.vue?vue&type=script&lang=js 1:0-163 1:179-182 1:184-344 1:184-344
 @ ./src/views/Home.vue 2:0-55 3:0-50 3:0-50 10:2-8
 @ ./src/router.js 4:19-45
 @ ./src/main.js 35:0-33 44:12-18 153:2-8

webpack 5.91.0 compiled with 1 warning in 22040 ms
```

### After

![Bildschirmfoto vom 2024-05-22 19-34-28](https://github.com/nextcloud/mail/assets/1374172/45227acf-61ca-4ace-888e-063c8b1cb425)
