### PR TITLE
fix: inconsistent encoding in saved sent messages

### DIFF
--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -148,7 +148,12 @@ class MailTransmission implements IMailTransmission {
 		// Send the message
 		try {
 			$mail->send($transport, false, false);
-			$localMessage->setRaw($mail->getRaw(false));
+			// FIXME: Fix encoding inconsistencies upstream and use stream=false instead
+			//        - stream=false defaults to 7bit quoted-printable
+			//        - stream=true defaults to 8bit
+			//        However, the headers are taken from the base part and always indicate the 8bit
+			//		  encoding.
+			$localMessage->setRaw(stream_get_contents($mail->getRaw(true)));
 		} catch (Horde_Mime_Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			if (in_array($e->getCode(), self::RETRIABLE_CODES, true)) {

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -109,6 +109,12 @@ class MailTransmissionTest extends TestCase {
 			->method('create')
 			->with($account)
 			->willReturn($transport);
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
 		$this->transmission->sendMessage($account, $localMessage);
 	}
@@ -171,6 +177,12 @@ class MailTransmissionTest extends TestCase {
 		$this->aliasService->expects(self::once())
 			->method('find')
 			->willReturn($alias);
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
 		$this->transmission->sendMessage($account, $localMessage);
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
@@ -217,6 +229,12 @@ class MailTransmissionTest extends TestCase {
 			);
 		$this->transmissionService->expects(self::once())
 			->method('handleAttachment');
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
 		$this->transmission->sendMessage($account, $localMessage);
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
@@ -247,6 +265,12 @@ class MailTransmissionTest extends TestCase {
 			->method('create')
 			->with($account)
 			->willReturn($transport);
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
 		$this->transmission->sendMessage($account, $localMessage);
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());


### PR DESCRIPTION
Upstream fix at https://github.com/bytestream/Mime/pull/7 or https://github.com/bytestream/Mime/pull/8 (both were tested locally)

**TL;DR:** Sent email bodies are saved as 7bit quoted-printable but the headers say 8bit.

I switched to the streamed implementation of `getRaw()` for now. The streamed implementation is also broken but a bit less broken as it defaults to 8bit. I did some bisecting and we used `stream=true` before https://github.com/nextcloud/mail/pull/9364 but now we use `stream=false` because the string is cached in the db (outbox table).

## How to reproduce?

1. Send some mail with complex UTF-8 chars, e.g. `‘` or nbsp.
2. Wait for it be sent.
3. Have a look at the sent mail in your sent mailbox.
4. Observe weird chars because the mail has inconsistent encoding (headers vs. body).

## Screenshots

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud/mail/assets/1479486/36ebd642-6883-4b28-8812-3c1b5b7b6aae) | ![grafik](https://github.com/nextcloud/mail/assets/1479486/75bc4cf3-307e-454c-8755-4c5a72fb2b92) |