### PR TITLE
fix: save horde cache backend on imap client logout

### DIFF
--- a/lib/Cache/Cache.php
+++ b/lib/Cache/Cache.php
@@ -96,7 +96,6 @@ class Cache extends Horde_Imap_Client_Cache_Backend {
 	 */
 	protected function _initOb() {
 		$this->_cache = $this->_params['cacheob'];
-		register_shutdown_function([$this, 'save']);
 	}
 
 	/**

--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
  *
  * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -27,40 +28,53 @@ namespace OCA\Mail\IMAP;
 
 use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Socket;
+use OCA\Mail\Cache\Cache;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IMemcache;
 use function floor;
 
 /**
- * "Decorator" around Horde's IMAP client to add auth error rate limiting
+ * "Decorator" around Horde's IMAP client to add auth error rate limiting and save the cache on
+ * logout.
  *
  * This is not a real decorator because the component to decorate doesn't have
  * an interface, making it hard to base a decorator on composition.
  * For simplicity the component is decorated by inheritance.
  */
-class ImapClientRateLimitingDecorator extends Horde_Imap_Client_Socket {
+class HordeImapClient extends Horde_Imap_Client_Socket {
+	private ?IMemcache $rateLimiterCache = null;
+	private ?ITimeFactory $timeFactory = null;
+	private ?string $hash = null;
+	private ?Cache $cacheBackend = null;
 
-	private IMemcache $cache;
+	public function __construct(array $params) {
+		if (isset($params['cache']['backend']) && $params['cache']['backend'] instanceof Cache) {
+			$this->cacheBackend = $params['cache']['backend'];
+		}
 
-	private ITimeFactory $timeFactory;
-	private string $hash;
-
-	public function __construct(array $params,
-		string $hash,
-		IMemcache $cache,
-		ITimeFactory $timeFactory) {
 		parent::__construct($params);
-		$this->cache = $cache;
+	}
+
+	public function enableRateLimiter(
+		IMemcache $cache,
+		string $hash,
+		ITimeFactory $timeFactory,
+	): void {
+		$this->rateLimiterCache = $cache;
 		$this->timeFactory = $timeFactory;
 		$this->hash = $hash;
 	}
 
 	protected function _login() {
+		if ($this->rateLimiterCache === null) {
+			return parent::_login();
+		}
+
 		$now = $this->timeFactory->getTime();
 		$window = floor($now / (3 * 60 * 60));
 		$cacheKey = $this->hash . $window;
 
-		$counter = $this->cache->get($cacheKey);
+		$counter = $this->rateLimiterCache->get($cacheKey);
 		if ($counter !== null && $counter >= 3) {
 			// Enough errors. Let's fail without involving IMAP
 			throw new Horde_Imap_Client_Exception(
@@ -74,10 +88,17 @@ class ImapClientRateLimitingDecorator extends Horde_Imap_Client_Socket {
 		} catch (Horde_Imap_Client_Exception $e) {
 			if ($e->getCode() === Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED
 				&& $e->getMessage() === 'Authentication failed.') {
-				$current = $this->cache->inc($cacheKey);
+				$this->rateLimiterCache->inc($cacheKey);
 			}
 			throw $e;
 		}
 	}
 
+	public function logout() {
+		if ($this->cacheBackend !== null) {
+			$this->cacheBackend->save();
+		}
+
+		parent::logout();
+	}
 }

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
  *
  * Mail
  *
@@ -143,10 +144,14 @@ class IMAPClientFactory {
 		if ($this->config->getSystemValue('debug', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
 		}
+
+		$client = new HordeImapClient($params);
+
 		$rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
 		if ($rateLimitingCache instanceof IMemcache) {
-			return new ImapClientRateLimitingDecorator($params, $paramHash, $rateLimitingCache, $this->timeFactory);
+			$client->enableRateLimiter($rateLimitingCache, $paramHash, $this->timeFactory);
 		}
-		return new Horde_Imap_Client_Socket($params);
+
+		return $client;
 	}
 }

--- a/tests/Integration/IMAP/IMAPClientFactoryTest.php
+++ b/tests/Integration/IMAP/IMAPClientFactoryTest.php
@@ -29,8 +29,8 @@ use Horde_Imap_Client_Socket;
 use OC\Memcache\Redis;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\IMAP\HordeImapClient;
 use OCA\Mail\IMAP\IMAPClientFactory;
-use OCA\Mail\IMAP\ImapClientRateLimitingDecorator;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
@@ -127,7 +127,7 @@ class IMAPClientFactoryTest extends TestCase {
 			->willReturn('notmypassword');
 
 		$client = $this->factory->getClient($account);
-		self::assertInstanceOf(ImapClientRateLimitingDecorator::class, $client);
+		self::assertInstanceOf(HordeImapClient::class, $client);
 		foreach ([1, 2, 3] as $attempts) {
 			try {
 				$client->login();


### PR DESCRIPTION
Should help with not detecting vanished mails when syncing through a background cron job. Previously, the cache was only saved when the PHP process shuts down which may cause data races.