### PR TITLE
fix: composer session indicator height

### DIFF
--- a/src/components/ComposerSessionIndicator.vue
+++ b/src/components/ComposerSessionIndicator.vue
@@ -119,10 +119,7 @@ export default {
 	padding: 0 8px;
 
 	// Retain border radius from outer body container for visual consistency
-	height: calc(var(--body-container-radius) * 2);
 	border-radius: var(--body-container-radius);
-	//height: 44px;
-	//border-radius: var(--border-radius-pill);
 
 	// Mobile
 	@media (max-width: 1024px) {


### PR DESCRIPTION
Resolves https://github.com/nextcloud/mail/issues/9671

## After

| Server `master` | Server `stable29` |
| --- | --- |
| ![Screenshot_20240619_172053](https://github.com/nextcloud/mail/assets/1479486/0635c62b-f570-4576-adc3-280c38690d12) | ![Screenshot_20240619_172037](https://github.com/nextcloud/mail/assets/1479486/e455f31f-f90b-4235-9ff1-03cd15a7cc69) |