### PR TITLE
fix: add repair job to deleted duplicated cached messages

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -66,6 +66,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 			<step>OCA\Mail\Migration\MakeItineraryExtractorExecutable</step>
 			<step>OCA\Mail\Migration\ProvisionAccounts</step>
 			<step>OCA\Mail\Migration\RepairMailTheads</step>
+			<step>OCA\Mail\Migration\DeleteDuplicateUids</step>
 		</post-migration>
 	</repair-steps>
 	<commands>

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1659,4 +1659,55 @@ class MessageMapper extends QBMapper {
 
 		return $this->findEntities($select);
 	}
+
+	/**
+	 * Delete all duplicated cached messages.
+	 * Some messages (with the same mailbox_id and uid) where inserted twice and this method cleans
+	 * up the duplicated rows.
+	 */
+	public function deleteDuplicateUids(): void {
+		$qb = $this->db->getQueryBuilder();
+		$result = $qb->select('t1.id', 't1.mailbox_id', 't1.uid')
+			->from($this->getTableName(), 't1')
+			->innerJoin('t1', $this->getTableName(), 't2', $qb->expr()->andX(
+				$qb->expr()->eq('t1.mailbox_id', 't2.mailbox_id', IQueryBuilder::PARAM_INT),
+				$qb->expr()->eq('t1.uid', 't2.uid', IQueryBuilder::PARAM_INT),
+				$qb->expr()->neq('t1.id', 't2.id', IQueryBuilder::PARAM_INT),
+			))
+			->groupBy('mailbox_id', 'uid')
+			->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		if (empty($rows)) {
+			return;
+		}
+
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete($this->getTableName())
+			->where(
+				$deleteQb->expr()->neq(
+					'id',
+					$deleteQb->createParameter('id'),
+					IQueryBuilder::PARAM_INT,
+				),
+				$deleteQb->expr()->eq(
+					'mailbox_id',
+					$deleteQb->createParameter('mailbox_id'),
+					IQueryBuilder::PARAM_INT,
+				),
+				$deleteQb->expr()->eq(
+					'uid',
+					$deleteQb->createParameter('uid'),
+					IQueryBuilder::PARAM_INT,
+				),
+			);
+
+		foreach ($rows as $row) {
+			$deleteQb->setParameter('id', $row['id'], IQueryBuilder::PARAM_INT);
+			$deleteQb->setParameter('mailbox_id', $row['mailbox_id'], IQueryBuilder::PARAM_INT);
+			$deleteQb->setParameter('uid', $row['uid'], IQueryBuilder::PARAM_INT);
+			$deleteQb->executeStatement();
+		}
+	}
 }

--- a/lib/Migration/DeleteDuplicateUids.php
+++ b/lib/Migration/DeleteDuplicateUids.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use OCA\Mail\Db\MessageMapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class DeleteDuplicateUids implements IRepairStep {
+	public function __construct(
+		private MessageMapper $messageMapper,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Delete duplicated cached messages';
+	}
+
+	public function run(IOutput $output): void {
+		$this->messageMapper->deleteDuplicateUids();
+	}
+}


### PR DESCRIPTION
This prepares the database to the make the `mailbox_id` + `uid` index unique. Currently, there might be some duplicated cached message which are unique. They were most likely inserted twice due to a race condition.

https://github.com/nextcloud/mail/blob/8f9310f2697d8fddb33ac49c8cc3a9b9fd6d6146/lib/Listener/OptionalIndicesListener.php#L86-L92