### PR TITLE
fix: align reply and attachment icon with subject

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -872,11 +872,19 @@ export default {
 	}
 
 	&__subtitle {
+		display: flex;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		align-items: center;
 		&__subject {
+			flex: 1;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
 			line-height: 130%;
+			display: flex;
+			align-items: center;
 		}
 	}
 	&__preview-text {
@@ -1027,13 +1035,12 @@ export default {
 	height: 16px;
 	width: 16px;
 }
-.seen-icon-style {
+.seen-icon-style,
+.attachment-icon-style  {
 	opacity: .6;
-	display: inline;
-}
-.attachment-icon-style {
-	opacity: .6;
-	display: inline;
+	display: inline-flex;
+	align-items: center;
+	margin-right: 5px;
 }
 :deep(.list-item__anchor) {
 	margin-top: 6px;
@@ -1056,6 +1063,7 @@ export default {
 .line-two.one-line {
 	display: flex;
 	overflow: hidden;
+	align-items: center;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }


### PR DESCRIPTION
after
![Screenshot from 2024-06-24 16-58-06](https://github.com/nextcloud/mail/assets/12728974/0fb2a65d-2d08-40b5-8a81-d0b185fff233)

fixes #9716 