### PR TITLE
fix: mailbox error empty content alignment

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<div :class="{'empty-content':!hasMessages && !loadingEnvelopes}">
+	<div :class="{'empty-content': (!hasMessages && !loadingEnvelopes) || error}">
 		<Error v-if="error"
 			:error="t('mail', 'Could not open mailbox')"
 			message=""


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![Screenshot_20240701_160249](https://github.com/nextcloud/mail/assets/1479486/3f1d7ca9-54b4-4470-b276-cfa392e01f1c) | ![grafik](https://github.com/nextcloud/mail/assets/1479486/940c6a79-d630-4546-bcdb-5e5217e885b9) |
