### PR TITLE
fix(integration): Honor sharing to group members restriction

### DIFF
--- a/lib/Service/Group/NextcloudGroupService.php
+++ b/lib/Service/Group/NextcloudGroupService.php
@@ -58,7 +58,10 @@ class NextcloudGroupService implements IGroupService {
 	}
 
 	public function search(string $term): array {
-		if ($this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes') !== 'yes') {
+		$c1 = $this->config->getAppValue('core', 'shareapi_allow_group_sharing', 'yes');
+		$c2 = $this->config->getAppValue('core', 'shareapi_only_share_with_group_members', 'no');
+		if ($c1 !== 'yes'
+			|| $c2 !== 'no') {
 			return [];
 		}
 		$groups = $this->groupManager->search($term);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/8595 with a minimal approach. The server settings are reeeeaaally complex. You can allow sharing, but restrict to groups, but allow some groups on top. This is hard to replicate in the Mail app. I suggest we simply turn off the group integration when advanced sharing settings are on.

## How to test

1. Create two users with distinct groups
2. Check *Restrict users to only share with users in their groups*
3. Try to send to groups

main: you can pick any group
here: you can not pick any groups