### PR TITLE
Remove instance name from share link add button

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -659,7 +659,7 @@ export default {
 				keysMissing: [],
 			},
 			editorMode: (this.body?.format !== 'html') ? EDITOR_MODE_TEXT : EDITOR_MODE_HTML,
-			addShareLink: t('mail', 'Add share link from {productName} Files', { productName: OC?.theme?.name ?? 'Nextcloud' }),
+			addShareLink: t('mail', 'Add share link from Files'),
 			requestMdnVal: this.requestMdn,
 			changeSignature: false,
 			loadingIndicatorTo: false,


### PR DESCRIPTION
Just check the commit. IMO, the variable (which seems to incorporate the instance name) is unnecessary and makes the working unnecessarily long.