### PR TITLE
fix: background-color of outbox-button

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -221,15 +221,10 @@ to {
 	z-index: 1;
 }
 .outbox {
-	margin-left: 6px;
+	margin: 6px 6px 0 6px;
 	width: auto;
 	&__border {
 		border-top: 1px solid var(--color-background-darker);
-	}
-	:deep(.app-navigation-entry) {
-		&.active {
-			background-color: transparent !important;
-		}
 	}
 }
 .mail-settings {


### PR DESCRIPTION
fixes: #9707 

Before:
![336733757-46ea6125-6761-49a5-bfa9-3a4d8742dcda](https://github.com/nextcloud/mail/assets/107960207/eee7b4e7-8206-43a9-bd76-e4b35e035073)

After:
![Bildschirmfoto vom 2024-07-05 11-27-36](https://github.com/nextcloud/mail/assets/107960207/72019514-21bb-4845-b185-4843ee483665)
![Bildschirmfoto vom 2024-07-05 11-27-12](https://github.com/nextcloud/mail/assets/107960207/ef750cba-0171-47d3-9c7c-35d2d61aa25c)

