### PR TITLE
fix: close the ncselect dropdown when clicked somewhere else

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -985,7 +985,10 @@ export default {
 	},
 	methods: {
 		clearOnBlur(event) {
-			return this.recipientSearchTerms[event].includes('@')
+			if (this.recipientSearchTerms[event]) {
+				return this.recipientSearchTerms[event].includes('@')
+			}
+			return false
 		},
 		handleShow(event) {
 			this.$emit('show-toolbar', event)


### PR DESCRIPTION
noticed while testing #9801 
when i select a 'to' and i want to add a 'cc' the dropdown doesnt close

![Screenshot from 2024-07-05 14-34-31](https://github.com/nextcloud/mail/assets/12728974/2550d537-18f3-4e72-8556-5c1073599b82)
