### PR TITLE
fix(printing): Fix long emails getting cut for print

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<NcContent app-name="mail">
+	<NcContent app-name="mail" class="mail-content">
 		<Navigation />
 		<Outbox v-if="$route.name === 'outbox'" />
 		<MailboxThread v-else-if="activeAccount"
@@ -170,7 +170,28 @@ export default {
 
 </script>
 
+<style lang="scss">
+@media print {
+	body {
+		/*
+		 * Nextcloud uses an inner scrolling but we need the
+		 * full page to scroll for print
+		 */
+		position: relative;
+		height: initial;
+	}
+}
+</style>
+
 <style lang="scss" scoped>
+@media print {
+	.mail-content {
+		height: initial;
+		/* needs important because of a more specific selector */
+		position: relative !important;
+	}
+}
+
 :deep(.app-content-details) {
 	margin: 0 auto;
 	max-width: 900px;


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/mail/issues/8866.

| Before | After |
|--------|--------|
| ![image](https://github.com/nextcloud/mail/assets/1374172/72ae9298-a10f-4305-bef2-9c35f2440d9f) | ![image](https://github.com/nextcloud/mail/assets/1374172/e8c7e3fe-4642-4141-b243-ef821fff95c6) | 

## How to test

1. Open a long email
2. Click <kbd>Ctrl</kbd>+<kbd>p</kbd>