### PR TITLE
feat: add recipient info on the right side of the composer

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Controller;
 
+use OCA\Contacts\Event\LoadContactsOcaApiEvent;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IUserPreferences;
@@ -318,6 +319,11 @@ class PageController extends Controller {
 		$csp->addAllowedFrameDomain('\'self\'');
 		$response->setContentSecurityPolicy($csp);
 		$this->dispatcher->dispatchTyped(new RenderReferenceEvent());
+
+		if (class_exists(LoadContactsOcaApiEvent::class)) {
+			$this->dispatcher->dispatchTyped(new LoadContactsOcaApiEvent());
+		}
+
 		return $response;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@vue/babel-preset-app": "^5.0.8",
         "address-rfc2822": "^2.2.2",
         "color-convert": "^2.0.1",
+        "core-js": "^3.37.1",
         "debounce-promise": "^3.1.2",
         "dompurify": "^3.2.1",
         "html-to-text": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@vue/babel-preset-app": "^5.0.8",
     "address-rfc2822": "^2.2.2",
     "color-convert": "^2.0.1",
+    "core-js": "^3.37.1",
     "debounce-promise": "^3.1.2",
     "dompurify": "^3.2.1",
     "html-to-text": "^9.0.5",

--- a/src/components/DisplayContactDetails.vue
+++ b/src/components/DisplayContactDetails.vue
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+<template>
+	<div ref="contactDetails" />
+</template>
+
+<script>
+import logger from '../logger.js'
+
+export default {
+	props: {
+		email: {
+			type: String,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			vm: null,
+		}
+	},
+	async mounted() {
+		const mountContactDetails = window.OCA?.Contacts?.mountContactDetails
+		if (mountContactDetails) {
+			try {
+				this.vm = await mountContactDetails(this.$refs.contactDetails, this.email)
+			} catch (error) {
+				logger.error(`Failed to mount contact details: ${error}`)
+			}
+		}
+	},
+	async beforeDestroy() {
+		if (this.vm) {
+			this.vm.$destroy()
+		}
+	},
+}
+</script>

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -243,7 +243,7 @@ export default {
 				.length > 0
 		},
 		importantMessagesInitialPageSize() {
-			if (window.innerHeight > 900) {
+			if (window.innerHeight > 1024) {
 				return 7
 			}
 			if (window.innerHeight > 750) {

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<Modal v-if="showMessageComposer"
-		:size="largerModal ? 'large' : 'normal'"
+		:size="modalSize"
 		:name="modalTitle"
 		:additional-trap-elements="additionalTrapElements"
 		@close="$event.type === 'click' ? onClose() : onMinimize()">
@@ -26,10 +26,10 @@
 				</NcButton>
 			</template>
 		</EmptyContent>
-		<Loading v-else-if="uploadingAttachments" :hint="t('mail', 'Uploading attachments …')" role="alert" />
-		<Loading v-else-if="sending"
-			:hint="t('mail', 'Sending …')"
+		<Loading v-else-if="uploadingAttachments"
+			:hint="t('mail', 'Uploading attachments …')"
 			role="alert" />
+		<Loading v-else-if="sending" :hint="t('mail', 'Sending …')" role="alert" />
 		<EmptyContent v-else-if="warning"
 			:name="t('mail', 'Warning sending your message')"
 			class="empty-content"
@@ -51,65 +51,73 @@
 			</template>
 		</EmptyContent>
 		<template v-else>
-			<NcButton class="maximize-button"
-				type="tertiary-no-background"
-				:aria-label="t('mail', 'Maximize composer')"
-				@click="onMaximize">
-				<template #icon>
-					<MaximizeIcon v-if="!largerModal" :size="16" />
-					<DefaultComposerIcon v-else :size="16" />
-				</template>
-			</NcButton>
-			<NcButton class="minimize-button"
-				type="tertiary-no-background"
-				:aria-label="t('mail', 'Minimize composer')"
-				@click="onMinimize">
-				<template #icon>
-					<MinimizeIcon :size="16" />
-				</template>
-			</NcButton>
+			<div :class="['modal-content', { 'with-recipient': composerData.to && composerData.to.length > 0 }]">
+				<div class="left-pane">
+					<NcButton class="maximize-button"
+						type="tertiary-no-background"
+						:aria-label="t('mail', 'Maximize composer')"
+						@click="onMaximize">
+						<template #icon>
+							<MaximizeIcon v-if="!largerModal" :size="20" />
+							<DefaultComposerIcon v-else :size="20" />
+						</template>
+					</NcButton>
+					<NcButton class="minimize-button"
+						type="tertiary-no-background"
+						:aria-label="t('mail', 'Minimize composer')"
+						@click="onMinimize">
+						<template #icon>
+							<MinimizeIcon :size="20" />
+						</template>
+					</NcButton>
 
-			<Composer ref="composer"
-				:from-account="composerData.accountId"
-				:from-alias="composerData.aliasId"
-				:to="composerData.to"
-				:cc="composerData.cc"
-				:bcc="composerData.bcc"
-				:subject="composerData.subject"
-				:attachments-data="composerData.attachments"
-				:body="composerData.body"
-				:editor-body="convertEditorBody(composerData)"
-				:in-reply-to-message-id="composerData.inReplyToMessageId"
-				:reply-to="composerData.replyTo"
-				:forward-from="composerData.forwardFrom"
-				:send-at="composerData.sendAt * 1000"
-				:forwarded-messages="forwardedMessages"
-				:smart-reply="smartReply"
-				:can-save-draft="canSaveDraft"
-				:saving-draft="savingDraft"
-				:draft-saved="draftSaved"
-				:smime-sign="composerData.smimeSign"
-				:smime-encrypt="composerData.smimeEncrypt"
-				:is-first-open="modalFirstOpen"
-				:request-mdn="composerData.requestMdn"
-				:accounts="accounts"
-				@update:from-account="patchComposerData({ accountId: $event })"
-				@update:from-alias="patchComposerData({ aliasId: $event })"
-				@update:to="patchComposerData({ to: $event })"
-				@update:cc="patchComposerData({ cc: $event })"
-				@update:bcc="patchComposerData({ bcc: $event })"
-				@update:subject="patchComposerData({ subject: $event })"
-				@update:attachments-data="patchComposerData({ attachments: $event })"
-				@update:editor-body="patchComposerData({ editorBody: $event })"
-				@update:send-at="patchComposerData({ sendAt: $event / 1000 })"
-				@update:smime-sign="patchComposerData({ smimeSign: $event })"
-				@update:smime-encrypt="patchComposerData({ smimeSign: $event })"
-				@update:request-mdn="patchComposerData({ requestMdn: $event })"
-				@draft="onDraft"
-				@discard-draft="discardDraft"
-				@upload-attachment="onAttachmentUploading"
-				@send="onSend"
-				@show-toolbar="handleShow" />
+					<Composer ref="composer"
+						:from-account="composerData.accountId"
+						:from-alias="composerData.aliasId"
+						:to="composerData.to"
+						:cc="composerData.cc"
+						:bcc="composerData.bcc"
+						:subject="composerData.subject"
+						:attachments-data="composerData.attachments"
+						:body="composerData.body"
+						:editor-body="convertEditorBody(composerData)"
+						:in-reply-to-message-id="composerData.inReplyToMessageId"
+						:reply-to="composerData.replyTo"
+						:forward-from="composerData.forwardFrom"
+						:send-at="composerData.sendAt * 1000"
+						:forwarded-messages="forwardedMessages"
+						:smart-reply="smartReply"
+						:can-save-draft="canSaveDraft"
+						:saving-draft="savingDraft"
+						:draft-saved="draftSaved"
+						:smime-sign="composerData.smimeSign"
+						:smime-encrypt="composerData.smimeEncrypt"
+						:is-first-open="modalFirstOpen"
+						:request-mdn="composerData.requestMdn"
+						:accounts="accounts"
+						@update:from-account="patchComposerData({ accountId: $event })"
+						@update:from-alias="patchComposerData({ aliasId: $event })"
+						@update:to="patchComposerData({ to: $event })"
+						@update:cc="patchComposerData({ cc: $event })"
+						@update:bcc="patchComposerData({ bcc: $event })"
+						@update:subject="patchComposerData({ subject: $event })"
+						@update:attachments-data="patchComposerData({ attachments: $event })"
+						@update:editor-body="patchComposerData({ editorBody: $event })"
+						@update:send-at="patchComposerData({ sendAt: $event / 1000 })"
+						@update:smime-sign="patchComposerData({ smimeSign: $event })"
+						@update:smime-encrypt="patchComposerData({ smimeSign: $event })"
+						@update:request-mdn="patchComposerData({ requestMdn: $event })"
+						@draft="onDraft"
+						@discard-draft="discardDraft"
+						@upload-attachment="onAttachmentUploading"
+						@send="onSend"
+						@show-toolbar="handleShow" />
+				</div>
+
+				<div v-if="showRecipientPane" class="right-pane">
+					<RecipientInfo />
+				</div>
+			</div>
 		</template>
 	</Modal>
 </template>
@@ -138,6 +146,7 @@ import DefaultComposerIcon from 'vue-material-design-icons/ArrowCollapse.vue'
 import { deleteDraft, saveDraft, updateDraft } from '../service/DraftService.js'
 import useOutboxStore from '../store/outboxStore.js'
 import { mapStores } from 'pinia'
+import RecipientInfo from './RecipientInfo.vue'
 
 export default {
 	name: 'NewMessageModal',
@@ -150,6 +159,7 @@ export default {
 		MinimizeIcon,
 		MaximizeIcon,
 		DefaultComposerIcon,
+		RecipientInfo,
 	},
 	props: {
 		accounts: {
@@ -174,6 +184,12 @@ export default {
 			cookedComposerData: undefined,
 			changed: false,
 			largerModal: false,
+			isLargeScreen: window.innerWidth >= 1024,
+			isMaximized: false,
+			recipient: {
+				name: '',
+				email: '',
+			},
 		}
 	},
 	computed: {
@@ -194,6 +210,15 @@ export default {
 			}
 			return t('mail', 'New message')
 		},
+		hasContactDetailsApi() {
+			return !!window.OCA?.Contacts?.mountContactDetails
+		},
+		showRecipientPane() {
+			return this.hasContactDetailsApi
+				&& this.composerData.to
+				&& this.composerData.to.length > 0
+				&& !this.isMaximized
+		},
 		composerMessage() {
 			return this.$store.getters.composerMessage
 		},
@@ -205,6 +230,11 @@ export default {
 		},
 		smartReply() {
 			return this.composerData?.smartReply ?? null
+		},
+		modalSize() {
+			return this.isLargeScreen && this.hasContactDetailsApi && this.composerData.to && this.composerData.to.length > 0
+				? 'large'
+				: (this.largerModal ? 'large' : 'normal')
 		},
 	},
 	created() {
@@ -218,11 +248,16 @@ export default {
 		await this.$nextTick()
 		this.updateCookedComposerData()
 		await this.openModalSize()
+		window.addEventListener('resize', this.checkScreenSize)
 	},
 	beforeDestroy() {
 		window.removeEventListener('beforeunload', this.onBeforeUnload)
+		window.removeEventListener('resize', this.checkScreenSize)
 	},
 	methods: {
+		checkScreenSize() {
+			this.isLargeScreen = window.innerWidth >= 1024
+		},
 		async openModalSize() {
 			try {
 				const sizePreference = this.$store.getters.getPreference('modalSize')
@@ -232,6 +267,7 @@ export default {
 			}
 		},
 		async onMaximize() {
+			this.isMaximized = !this.isMaximized
 			this.largerModal = !this.largerModal
 			try {
 				await this.$store.dispatch('savePreference', {
@@ -241,6 +277,16 @@ export default {
 			} catch (error) {
 				console.error('Failed to save preference', error)
 			}
+		},
+		async onMinimize() {
+			this.isMaximized = false
+			this.modalFirstOpen = false
+
+			await this.$store.dispatch('closeMessageComposer')
+			if (!this.$store.getters.composerMessageIsSaved && this.changed) {
+				await this.onDraft(this.cookedComposerData, { showToast: true })
+			}
+
 		},
 		handleShow(element) {
 			this.additionalTrapElements.push(element)
@@ -528,15 +574,6 @@ export default {
 				console.info('No unsaved changes. See you!')
 			}
 		},
-		async onMinimize() {
-			this.modalFirstOpen = false
-
-			await this.$store.dispatch('closeMessageComposer')
-			if (!this.$store.getters.composerMessageIsSaved && this.changed) {
-				await this.onDraft(this.cookedComposerData, { showToast: true })
-			}
-
-		},
 		async onClose() {
 			this.$store.commit('setComposerIndicatorDisabled', true)
 			await this.onMinimize()
@@ -590,5 +627,33 @@ export default {
 .empty-content{
 	height: 100%;
 	display: flex;
+}
+.modal-content {
+	display: flex;
+	height: 100%;
+	flex-direction: row;
+	width: 100%;
+}
+
+.left-pane {
+	flex: 1;
+	overflow-y: auto;
+}
+
+.right-pane {
+	flex: 0 0 400px;
+	overflow-y: auto;
+	padding-left: 5px;
+	border-left: 1px solid #ccc;
+	@media (max-width: 1024px) {
+		display: none;
+	}
+}
+
+.modal-content.with-recipient .left-pane {
+	flex: 1;
+}
+.modal-content .left-pane {
+	width: 100%;
 }
 </style>

--- a/src/components/RecipientInfo.vue
+++ b/src/components/RecipientInfo.vue
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+<template>
+	<div class="recipient-info">
+		<!-- For a single recipient -->
+		<div v-if="recipients.length === 1" class="recipient-info__single">
+			<div class="recipient-info__header">
+				<div class="recipient-info__avatar">
+					<Avatar :display-name="recipients[0].label"
+						:email="recipients[0].email"
+						:size="55"
+						:disable-tooltip="true"
+						:disable-menu="true" />
+				</div>
+				<div class="recipient-info__details">
+					<DisplayContactDetails :email="recipients[0].email" />
+				</div>
+			</div>
+		</div>
+
+		<!-- For multiple recipients -->
+		<div v-else class="recipient-info__multiple">
+			<div v-for="(recipient, index) in recipients" :key="recipient.email" class="recipient-info__item">
+				<div class="recipient-info__header">
+					<div class="recipient-info__avatar">
+						<Avatar :display-name="recipient.label"
+							:email="recipient.email"
+							:size="55"
+							:disable-tooltip="true"
+							:disable-menu="true" />
+					</div>
+					<div v-if="!expandedRecipients[index]" class="recipient-info__name">
+						<h6>{{ recipient.email }}</h6>
+					</div>
+					<div class="recipient-info__expand-toggle" @click="toggleExpand(index)">
+						<template v-if="isExpanded(index)">
+							<div class="recipient-info__show-less">
+								<IconArrowUp :size="16" />
+								<span>{{ t('mail', 'Show less') }}</span>
+							</div>
+						</template>
+						<template v-else>
+							<IconArrowDown :size="16" />
+							<span>{{ t('mail', 'Show more') }}</span>
+						</template>
+					</div>
+				</div>
+				<div v-show="expandedRecipients[index]" class="recipient-info__details">
+					<DisplayContactDetails :email="recipient.email" />
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import IconArrowDown from 'vue-material-design-icons/ArrowDown.vue'
+import IconArrowUp from 'vue-material-design-icons/ArrowUp.vue'
+import Avatar from './Avatar.vue'
+import DisplayContactDetails from './DisplayContactDetails.vue'
+
+export default {
+	components: {
+		Avatar,
+		IconArrowDown,
+		IconArrowUp,
+		DisplayContactDetails,
+	},
+	data() {
+		return {
+			expandedRecipients: [],
+		}
+	},
+	computed: {
+		...mapGetters(['composerMessage']),
+		recipients() {
+			return this.composerMessage.data.to
+		},
+	},
+	watch: {
+		recipients: {
+			immediate: true,
+			handler() {
+				this.expandedRecipients = this.recipients.map(() => false)
+			},
+		},
+	},
+	methods: {
+		toggleExpand(index) {
+			this.$set(this.expandedRecipients, index, !this.expandedRecipients[index])
+		},
+		isExpanded(index) {
+			return this.expandedRecipients[index]
+		},
+	},
+}
+</script>
+<style scoped lang="scss">
+.recipient-info {
+	display: inline;
+	width: 100%;
+
+	&__single {
+		width: 400px;
+		display: inline-block;
+	}
+
+	&__avatar {
+		margin-top: 20px;
+		display: inline;
+		float: left;
+		padding: 20px;
+	}
+
+	&__details {
+		max-width: 100%;
+	}
+
+	&__multiple {
+		margin-top: 10px;
+		display: flex;
+		flex-direction: column;
+	}
+
+	&__item {
+		margin-bottom: 10px;
+	}
+
+	&__expand-toggle {
+		cursor: pointer;
+		display: flex;
+		gap: 5px;
+	}
+
+	&__header {
+		display: contents;
+	}
+
+	&__name {
+		margin-top: 50px;
+	}
+
+	&__show-less {
+		margin-top: 40px;
+	}
+}
+</style>


### PR DESCRIPTION
fixes #9622
requires: https://github.com/nextcloud/contacts/pull/4194
to do

- [x]  change the classes to BEM styling.


PR description:
When a user is added to the "To" field in the mail composer, a right pane displays the contact details from their profile. Adding a second recipient collapses the list of contact details, with an option to toggle the visibility of the pane to view the data. Clicking the "maximize" button removes the right pane entirely to focus on the composer. Reducing the composer size restores the right pane, making the contact details visible again.

Single recipient
![Screenshot from 2024-11-26 12-33-46](https://github.com/user-attachments/assets/df09035d-f9d3-4a07-93bb-2a529af51850)
2 recipients collapsed view
![Screenshot from 2024-11-26 12-33-56](https://github.com/user-attachments/assets/c82419a4-12fd-49aa-9947-596e96758b32)
2 reicpients, 1 expanded
![Screenshot from 2024-11-26 12-34-10](https://github.com/user-attachments/assets/a7b74065-213e-4203-874c-4711c59b5dbb)





