### PR TITLE
fix: center the list item name

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1087,10 +1087,14 @@ export default {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+:deep(.list-item-content__name) {
+	align-self: center;
+}
 .envelope__subtitle__subject.one-line {
 	&::after {
 		content: '\00B7';
 		margin: 12px;
 	}
 }
+
 </style>


### PR DESCRIPTION
before
![Screenshot from 2024-07-10 15-36-01](https://github.com/nextcloud/mail/assets/12728974/5a2eebe7-b273-48ee-84e8-b7f08143417b)

after
![Screenshot from 2024-07-10 15-34-56](https://github.com/nextcloud/mail/assets/12728974/6e663e1d-e0a2-403a-a026-75bcfc3f32c0)
