### PR TITLE
fix: Align version number in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "37.1.0",


### PR DESCRIPTION
Auto-generated fix of npm audit