### PR TITLE
style(mail navigation): remove unnecessary spacing

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -41,7 +41,6 @@
 					<NavigationAccountExpandCollapse v-if="!group.account.isUnified && group.isCollapsible"
 						:key="'collapse-' + group.account.id"
 						:account="group.account" />
-					<AppNavigationSpacer :key="'spacer-' + group.account.id" />
 				</template>
 			</template>
 		</template>
@@ -65,7 +64,7 @@
 </template>
 
 <script>
-import { NcButton, NcAppNavigation as AppNavigation, NcAppNavigationSpacer as AppNavigationSpacer } from '@nextcloud/vue'
+import { NcButton, NcAppNavigation as AppNavigation } from '@nextcloud/vue'
 import NewMessageButtonHeader from './NewMessageButtonHeader.vue'
 
 import NavigationAccount from './NavigationAccount.vue'
@@ -83,7 +82,6 @@ export default {
 	components: {
 		NcButton,
 		AppNavigation,
-		AppNavigationSpacer,
 		AppSettingsMenu,
 		NavigationAccount,
 		NavigationAccountExpandCollapse,

--- a/src/components/NewMessageButtonHeader.vue
+++ b/src/components/NewMessageButtonHeader.vue
@@ -91,7 +91,6 @@ export default {
 	justify-content: space-between;
 	padding: calc(var(--default-grid-baseline, 4px) * 2);
 	gap: 4px;
-	height: 61px;
 }
 .refresh__button {
 	background-color: transparent;


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/9835

| A | B |
| - | - |
|![Screenshot from 2024-07-17 14-10-14](https://github.com/user-attachments/assets/f3c73dff-5bb3-4b26-a07b-a261dd664c69)| ![Screenshot from 2024-07-17 14-06-39](https://github.com/user-attachments/assets/3283e4e8-800c-4731-b81e-390ec563848c) |

For unnecessary spacing under captions, see https://github.com/nextcloud-libraries/nextcloud-vue/pull/5815