### PR TITLE
fix(composer): Adjust expand/collapse cc/bcc icon size

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -86,8 +86,8 @@
 				<button :title="t('mail','Toggle recipients list mode')"
 					:class="{'active':!autoLimit}"
 					@click.prevent="toggleViewMode">
-					<UnfoldMoreHorizontal v-if="autoLimit" :size="24" />
-					<UnfoldLessHorizontal v-else :size="24" />
+					<UnfoldMoreHorizontal v-if="autoLimit" :size="16" />
+					<UnfoldLessHorizontal v-else :size="16" />
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
Icons are now smaller. This updates the hard coded numbers.

| Header | Header |
|--------|--------|
| ![Bildschirmfoto vom 2024-07-17 14-54-48](https://github.com/user-attachments/assets/e045f739-46e8-4a95-aa2c-49ff3f06f4b0) | ![Bildschirmfoto vom 2024-07-17 14-55-29](https://github.com/user-attachments/assets/8475d6fa-7690-4cad-aa85-49f49438a26b) | 



