### PR TITLE
fix: set link icon size explicitly

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -397,6 +397,10 @@ https://github.com/ckeditor/ckeditor5/issues/1142
  }
  .link-title{
 	color: var(--color-main-text) !important;
+	margin-left: var(--default-grid-baseline) !important;
+ }
+ .link-icon {
+	width: 16px !important;
  }
  .custom-item {
 	width : 100% !important;


### PR DESCRIPTION
| b | a |
|--------|--------|
| <img width="683" alt="image" src="https://github.com/user-attachments/assets/777c14ec-08d0-4720-9cfd-a3641f5c45cf"> | <img width="683" alt="image" src="https://github.com/user-attachments/assets/088300b6-bd8e-4c30-a042-2fc2a2d6e78e"> | 