### PR TITLE
fix: thread padding

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -339,7 +339,7 @@ export default {
 	flex-direction: row;
 	justify-content: space-between;
 	align-items: center;
-	padding: 30px 0;
+	padding: 0 0 10px 0;
 	// somehow ios doesn't care about this !important rule
 	// so we have to manually set left/right padding to chidren
 	// for 100% to be used
@@ -360,13 +360,16 @@ export default {
 #mail-thread-header-fields {
 	// initial width
 	width: 0;
-	padding-left: 70px;
+	// while scrolling, the back button overlaps with subject on small screen
+	padding-left: 86px;
 	// grow and try to fill 100%
 	flex: 1 1 auto;
 	h2,
 	p {
 		padding-bottom: 7px;
 		margin-bottom: 0;
+		// some h2 styling coming from server add some space on top
+		margin-top: 5px;
 	}
 
 	p {


### PR DESCRIPTION
in different layouts
before
![Screenshot from 2024-07-24 12-06-25](https://github.com/user-attachments/assets/3ee079a8-19db-4704-8ee7-581a37eb72c7)
![Screenshot from 2024-07-24 12-05-59](https://github.com/user-attachments/assets/869ad599-986b-442d-a016-ee5fa572b1d4)

after

![Screenshot from 2024-07-24 12-02-07](https://github.com/user-attachments/assets/dded4558-ff70-407d-a2ba-cf7de03982ce)
![Screenshot from 2024-07-24 12-01-52](https://github.com/user-attachments/assets/403c2522-3fec-461c-bbf9-f6b84ebd7656)

fixes #9786