### PR TITLE
Fix attachment downloadUrl in OCS getMail endpoint

### DIFF
--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -322,7 +322,7 @@ class MessageApiController extends OCSController {
 	 * @return array
 	 */
 	private function enrichDownloadUrl(int $id, array $attachment) {
-		$downloadUrl = $this->urlGenerator->linkToOCSRouteAbsolute('mail.messageApi.downloadAttachment',
+		$downloadUrl = $this->urlGenerator->linkToOCSRouteAbsolute('mail.messageApi.getAttachment',
 			[
 				'id' => $id,
 				'attachmentId' => $attachment['id'],


### PR DESCRIPTION
It was always returning `/ocs/v2.php` because the `mail.messageApi.downloadAttachment` does not exist.