### PR TITLE
fix: ellips the subject and position of the important icon

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -903,8 +903,6 @@ export default {
 			text-overflow: ellipsis;
 			white-space: nowrap;
 			line-height: 130%;
-			display: flex;
-			align-items: center;
 		}
 	}
 	&__preview-text {
@@ -939,7 +937,7 @@ export default {
 	// In message list, but not the one in the action menu
 	&.app-content-list-item-star {
 	background-image: none;
-	left: 7px;
+	left: 15px;
 	top: 13px;
 	opacity: 1;
 
@@ -951,6 +949,7 @@ export default {
 }
 .important-one-line.app-content-list-item-star:deep() {
 	top: 6px !important;
+	left: 7px;
 }
 
 .app-content-list-item-select-checkbox {
@@ -1035,7 +1034,7 @@ export default {
 }
 .icon-important.app-content-list-item-star:deep() {
 	position: absolute;
-	top: 12px;
+	top: 14px;
 	z-index: 1;
 }
 .app-content-list-item-star.favorite-icon-style {


### PR DESCRIPTION
this fixes the impotant icon position
before
![Screenshot from 2024-07-24 12-12-26](https://github.com/user-attachments/assets/751362c1-1195-44a3-beb5-1944d1be794a)

after
![Screenshot from 2024-07-24 12-33-32](https://github.com/user-attachments/assets/76957787-d014-4baf-89a3-7e5d30c49b52)

and
the ellipsed subject reported here #9838 
![Screenshot from 2024-07-24 12-34-14](https://github.com/user-attachments/assets/c128c1fb-7a86-486c-9b4d-b1dd6425b94f)
