### PR TITLE
fix: button text colour on dark theme

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -192,4 +192,7 @@ export default {
 :deep(.button-vue__icon) {
 	display: none !important;
 }
+:deep(.button-vue--vue-tertiary) {
+	color: var(--color-text-maxcontrast);
+}
 </style>


### PR DESCRIPTION
The tertiary button has `color=var(--color-main-text)` but on dark theme the color of the main text changes, but the background of the message is always white, this creates the issue of the color of the button to be very pale on dark theme.

fixes #7736
after

![Screenshot from 2024-07-24 14-47-45](https://github.com/user-attachments/assets/c87aff93-b214-4a14-acea-23292678f6e5)
