### PR TITLE
fix(tags): Hide Notjunk tag

### DIFF
--- a/src/components/tags.js
+++ b/src/components/tags.js
@@ -9,6 +9,7 @@ export const hiddenTags = {
 	has_cal: '',
 	'has cal': '',
 	hasnoattachment: '',
+	notjunk: '',
 	loadremoteimages: '',
 	'unsubscribe newsletter': '',
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9918

I could not test this. Both email servers I tested with automatically unset Notjunk once it's set.