### PR TITLE
fix(outbox): Revive item subname

### DIFF
--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -12,7 +12,7 @@
 		<template #icon>
 			<Avatar :display-name="avatarDisplayName" :email="avatarEmail" />
 		</template>
-		<template #subtitle>
+		<template #subname>
 			{{ subjectForSubtitle }}
 		</template>
 		<template #actions>


### PR DESCRIPTION
Improves https://github.com/nextcloud/groupware/issues/80#issuecomment-2252014332 slightly by filling the correct named component slot.