### PR TITLE
fix(search): Improve quick search element alignment

### DIFF
--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -590,7 +590,7 @@ export default {
 
 	&__input {
 		min-height: 52px;
-		margin: -1px 0 0 52px;
+		margin: -1px 0 0 calc(var(--app-navigation-padding)*2 + var(--default-clickable-area));
 		padding-right: 3px; /* matches .app-content-list */
 		border-right: 1px solid var(--color-border);
 		position: relative;
@@ -731,7 +731,7 @@ export default {
 	width: auto;
 	height: auto;
 	z-index: 5;
-	right: 4px;
+	right: 7px; /* same spacing to the input border as top/bottom */
 	left: auto;
 	box-shadow: none !important;
 	background: transparent !important;


### PR DESCRIPTION
| State  | Screenshot  |
|-----------|---------------|
| Before | ![Bildschirmfoto vom 2024-07-26 12-44-02](https://github.com/user-attachments/assets/300f6cd2-f9a3-4f62-bc32-099fe32a6ff6) |
| After | ![Bildschirmfoto vom 2024-07-26 12-43-47](https://github.com/user-attachments/assets/8f044eea-a198-469f-a0ae-9d9c5a8e1422) | 

* Search input margin left is 2*nav padding + icon size (moves it slightly more to the left)
* Advanced search icon has balanced space to all three borders (moved slightly to the left)

For https://github.com/nextcloud/mail/issues/9919