### PR TITLE
fix(search): Show placeholder for the mailbox search input

### DIFF
--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -8,6 +8,7 @@
 			<input v-model="query"
 				type="text"
 				class="search-messages--input"
+				:placeholder="t('mail', 'Search in mailbox')"
 				:aria-label="t('mail', 'Search in mailbox')"
 				@click="toggleButtons">
 			<NcButton type="tertiary" class="search-messages--filter" @click="moreSearchActions = true">


### PR DESCRIPTION
One day this will become an NcSelect. Today is not that day, so we add a HTML placeholder.

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2024-07-30 09-52-49](https://github.com/user-attachments/assets/5e17713f-16c7-4e97-9b08-67d92792c09b) | ![Bildschirmfoto vom 2024-07-30 09-54-35](https://github.com/user-attachments/assets/a191e329-7674-43c2-88cb-ca7f09f74aef) | 
