### PR TITLE
Drop ocp/nextcloud composer (dev) dependency and bump psr/log to ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
 		"youthweb/urllinker": "^2.0"
 	},
 	"require-dev": {
+		"beste/psr-testlogger": "^1.0",
 		"psalm/phar": "^5.25.0",
 		"roave/security-advisories": "dev-master"
 	},

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
 		"youthweb/urllinker": "^2.0"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "dev-stable26",
 		"psalm/phar": "^5.25.0",
 		"roave/security-advisories": "dev-master"
 	},

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"nextcloud/kitinerary-flatpak": "^1.0",
 		"nextcloud/kitinerary-sys": "^1.0.1",
 		"phpmailer/dkimvalidator": "^0.3.0",
-		"psr/log": "^1",
+		"psr/log": "^2",
 		"rubix/ml": "2.5.0",
 		"sabberworm/php-css-parser": "^8.6.0",
 		"youthweb/urllinker": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dea1081222036203e146d00d5db449b",
+    "content-hash": "fc7e2523f7ea6f152586165bf9579fdb",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3507,6 +3507,69 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "beste/psr-testlogger",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beste/psr-testlogger.git",
+                "reference": "405cf168378fdb0977f34d9abc36a4a31bf29315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beste/psr-testlogger/zipball/405cf168378fdb0977f34d9abc36a4a31bf29315",
+                "reference": "405cf168378fdb0977f34d9abc36a4a31bf29315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.1",
+                "psr/log": "^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.1.1",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^9.5.23",
+                "symfony/var-dumper": "^6.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Beste\\Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérôme Gamez",
+                    "email": "jerome@gamez.name"
+                }
+            ],
+            "description": "PSR-3 compliant test logger for developers who like tests and want to check if their application logs messages as they expect.",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/beste/psr-testlogger/issues",
+                "source": "https://github.com/beste/psr-testlogger/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jeromegamez",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-24T15:52:38+00:00"
+        },
         {
             "name": "psalm/phar",
             "version": "5.25.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80c4617cd066058ebcc98be47724d8d4",
+    "content-hash": "7dea1081222036203e146d00d5db449b",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2227,30 +2227,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.4",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2271,9 +2271,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "rubix/ml",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9af0f54b0cd833d7ae7525e48fee1d20",
+    "content-hash": "80c4617cd066058ebcc98be47724d8d4",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3508,119 +3508,6 @@
     ],
     "packages-dev": [
         {
-            "name": "adhocore/cli",
-            "version": "v1.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/adhocore/php-cli.git",
-                "reference": "3fde60a838912e71c82ed0f48048685dc32dbc77"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/3fde60a838912e71c82ed0f48048685dc32dbc77",
-                "reference": "3fde60a838912e71c82ed0f48048685dc32dbc77",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Ahc\\Cli\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jitendra Adhikari",
-                    "email": "jiten.adhikary@gmail.com"
-                }
-            ],
-            "description": "Command line interface library for PHP",
-            "keywords": [
-                "argument-parser",
-                "argv-parser",
-                "cli",
-                "cli-action",
-                "cli-app",
-                "cli-color",
-                "cli-option",
-                "cli-writer",
-                "command",
-                "console",
-                "console-app",
-                "php-cli",
-                "php8",
-                "stream-input",
-                "stream-output"
-            ],
-            "support": {
-                "issues": "https://github.com/adhocore/php-cli/issues",
-                "source": "https://github.com/adhocore/php-cli/tree/v1.7.1"
-            },
-            "funding": [
-                {
-                    "url": "https://paypal.me/ji10",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/adhocore",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-28T08:30:12+00:00"
-        },
-        {
-            "name": "nextcloud/ocp",
-            "version": "dev-stable26",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "92d0c03fc41b75647e05d9de743e1b3bda26af35"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/92d0c03fc41b75647e05d9de743e1b3bda26af35",
-                "reference": "92d0c03fc41b75647e05d9de743e1b3bda26af35",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4 || ~8.0 || ~8.1",
-                "psr/container": "^1.1.1",
-                "psr/event-dispatcher": "^1.0",
-                "psr/log": "^1.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "26.0.0-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "AGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Christoph Wurst",
-                    "email": "christoph@winzerhof-wurst.at"
-                }
-            ],
-            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
-            "support": {
-                "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
-            },
-            "time": "2023-05-18T00:34:12+00:00"
-        },
-        {
             "name": "psalm/phar",
             "version": "5.25.0",
             "source": {
@@ -3654,104 +3541,6 @@
                 "source": "https://github.com/psalm/phar/tree/5.25.0"
             },
             "time": "2024-06-19T20:02:02+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "1.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
-            },
-            "time": "2021-11-05T16:50:12+00:00"
-        },
-        {
-            "name": "psr/event-dispatcher",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/event-dispatcher.git",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\EventDispatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Standard interfaces for event handling.",
-            "keywords": [
-                "events",
-                "psr",
-                "psr-14"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/event-dispatcher/issues",
-                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
-            },
-            "time": "2019-01-08T18:20:26+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4322,7 +4111,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "gravatarphp/gravatar": 20,
-        "nextcloud/ocp": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/lib/Support/ConsoleLoggerDecorator.php
+++ b/lib/Support/ConsoleLoggerDecorator.php
@@ -25,49 +25,49 @@ class ConsoleLoggerDecorator implements LoggerInterface {
 		$this->consoleOutput = $consoleOutput;
 	}
 
-	public function emergency($message, array $context = []) {
+	public function emergency(string|\Stringable $message, array $context = []) {
 		$this->consoleOutput->writeln("<error>[emergency] $message</error>");
 
 		$this->inner->emergency($message, $context);
 	}
 
-	public function alert($message, array $context = []) {
+	public function alert(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<error>[alert] $message</error>");
 
 		$this->inner->alert($message, $context);
 	}
 
-	public function critical($message, array $context = []) {
+	public function critical(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<error>[critical] $message</error>");
 
 		$this->inner->critical($message, $context);
 	}
 
-	public function error($message, array $context = []) {
+	public function error(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<error>[error] $message</error>");
 
 		$this->inner->error($message, $context);
 	}
 
-	public function warning($message, array $context = []) {
+	public function warning(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("[warning] $message");
 
 		$this->inner->warning($message, $context);
 	}
 
-	public function notice($message, array $context = []) {
+	public function notice(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<info>[notice] $message</info>");
 
 		$this->inner->notice($message, $context);
 	}
 
-	public function info($message, array $context = []) {
+	public function info(string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<info>[info] $message</info>");
 
 		$this->inner->info($message, $context);
 	}
 
-	public function debug($message, array $context = []) {
+	public function debug(string|\Stringable $message, array $context = []): void {
 		if ($this->consoleOutput->getVerbosity() < OutputInterface::VERBOSITY_DEBUG) {
 			return;
 		}
@@ -77,7 +77,7 @@ class ConsoleLoggerDecorator implements LoggerInterface {
 		$this->inner->debug($message, $context);
 	}
 
-	public function log($level, $message, array $context = []) {
+	public function log($level, string|\Stringable $message, array $context = []): void {
 		$this->consoleOutput->writeln("<info>[log] $message</info>");
 
 		$this->inner->log($level, $message, $context);

--- a/tests/Unit/Listener/MoveJunkListenerTest.php
+++ b/tests/Unit/Listener/MoveJunkListenerTest.php
@@ -18,7 +18,7 @@ use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Listener\MoveJunkListener;
 use Psr\Log\LoggerInterface;
-use Psr\Log\Test\TestLogger;
+use Beste\Psr\Log\TestLogger;
 
 class MoveJunkListenerTest extends TestCase {
 	private IMailManager $mailManager;
@@ -29,7 +29,7 @@ class MoveJunkListenerTest extends TestCase {
 		parent::setUp();
 
 		$this->mailManager = $this->createMock(IMailManager::class);
-		$this->logger = new TestLogger();
+		$this->logger = TestLogger::create();
 
 		$this->listener = new MoveJunkListener(
 			$this->mailManager,


### PR DESCRIPTION
The `ocp/nextcloud` dependency is pulled in by the ci job on demand and prevents us from upgrading to `psr/log:^2`.

This PR fixes running tests locally.