### PR TITLE
fix(autoresponder): enable immediately on an OutOfOfficeStartedEvent

### DIFF
--- a/lib/Listener/OutOfOfficeListener.php
+++ b/lib/Listener/OutOfOfficeListener.php
@@ -53,7 +53,9 @@ class OutOfOfficeListener implements IEventListener {
 		// check inside the sieve script acts as a redundancy.
 		$now = $this->timeFactory->getTime();
 		$enabled = $now >= $eventData->getStartDate() && $now < $eventData->getEndDate();
-		if (($event instanceof OutOfOfficeClearedEvent) || ($event instanceof OutOfOfficeEndedEvent)) {
+		if ($event instanceof OutOfOfficeStartedEvent) {
+			$enabled = true;
+		} elseif (($event instanceof OutOfOfficeClearedEvent) || ($event instanceof OutOfOfficeEndedEvent)) {
 			$enabled = false;
 		}
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/9984

~Conflicts with https://github.com/nextcloud/server/pull/47183~

> I'd propose to skip this condition if the event is an instance of OutOfOfficeStartedEvent and force enable the responder instead. Otherwise, the date check makes sense, e.g. in the case of the OutOfOfficeChangedEvent event.

See https://github.com/nextcloud/mail/issues/9984#issuecomment-2285480874