### PR TITLE
fix: case insensitive comparison for contact emails

### DIFF
--- a/lib/Service/PhishingDetection/ContactCheck.php
+++ b/lib/Service/PhishingDetection/ContactCheck.php
@@ -20,20 +20,20 @@ class ContactCheck {
 	}
 
 	public function run(string $fn, string $email): PhishingDetectionResult {
-		$emailInContacts = false;
-		$emails = "";
+		$emails = [];
 		$contacts = $this->contactIntegration->getContactsWithName($fn, true);
 		foreach ($contacts as $contact) {
 			foreach ($contact['email'] as $contactEmail) {
-				$emailInContacts = true;
-				$emails .= $contactEmail.",";
-				if ($contactEmail === $email) {
+				$emails[] = $contactEmail;
+				if (strcasecmp($contactEmail, $email) == 0) {
 					return new PhishingDetectionResult(PhishingDetectionResult::CONTACTS_CHECK, false);
 				}
 			}
 		}
-		if ($emailInContacts) {
-			return new PhishingDetectionResult(PhishingDetectionResult::CONTACTS_CHECK, true, $this->l10n->t('Sender email: %1$s is not in the address book, but the sender name: %2$s is in the address book with the following emails: %3$s', [$email, $fn, $emails]));
+		if (count($emails) == 1) {
+			return new PhishingDetectionResult(PhishingDetectionResult::CONTACTS_CHECK, true, $this->l10n->t('Sender email: %1$s is not in the address book, but the sender name: %2$s is in the address book with the following email: %3$s', [$email, $fn, $emails[0]]));
+		} elseif (count($emails) > 1) {
+			return new PhishingDetectionResult(PhishingDetectionResult::CONTACTS_CHECK, true, $this->l10n->t('Sender email: %1$s is not in the address book, but the sender name: %2$s is in the address book with the following emails: %3$s', [$email, $fn, implode(', ', $emails)]));
 		}
 
 		return new PhishingDetectionResult(PhishingDetectionResult::CONTACTS_CHECK, false);

--- a/tests/Unit/Service/Phishing/ContactCheckTest.php
+++ b/tests/Unit/Service/Phishing/ContactCheckTest.php
@@ -28,7 +28,6 @@ class ContactCheckTest extends TestCase {
 	}
 
 	public function testContactInABCorrectEmail(): void {
-		
 		$fn = "John Doe";
 		$email = "jhon@example.com" ;
 		$contacts = [
@@ -39,12 +38,24 @@ class ContactCheckTest extends TestCase {
 		$this->contactsIntegration->method('getContactsWithName')->willReturn($contacts);
 		$result = $this->service->run($fn, $email);
 
+		$this->assertFalse($result->isPhishing());
+	}
+
+	public function testCaseInsensitiveEmail(): void {
+		$fn = "John Doe";
+		$email = "jhondoe@example.com" ;
+		$contacts = [
+			[
+				"email" => ["JhonDoe@example.com"]
+			]
+		];
+		$this->contactsIntegration->method('getContactsWithName')->willReturn($contacts);
+		$result = $this->service->run($fn, $email);
 
 		$this->assertFalse($result->isPhishing());
 	}
 
 	public function testContactInABWrongEmail(): void {
-		
 		$fn = "John Doe";
 		$email = "jhon@example.com" ;
 		$contacts = [
@@ -54,7 +65,6 @@ class ContactCheckTest extends TestCase {
 		];
 		$this->contactsIntegration->method('getContactsWithName')->willReturn($contacts);
 		$result = $this->service->run($fn, $email);
-
 
 		$this->assertTrue($result->isPhishing());
 	}


### PR DESCRIPTION
- Make email comparison case insensitive 
- refactor to use singular form and remove trailing comma in case of one mail address in the address book 