### PR TITLE
fix: wrong attendance status for imip events

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,6 +48,7 @@ export default {
 		this.sync()
 		await this.$store.dispatch('fetchCurrentUserPrincipal')
 		await this.$store.dispatch('loadCollections')
+		this.$store.commit('hasCurrentUserPrincipalAndCollections', true)
 	},
 	methods: {
 		reload() {

--- a/src/components/Imip.vue
+++ b/src/components/Imip.vue
@@ -191,7 +191,7 @@ export default {
 	computed: {
 		...mapGetters({
 			currentUserPrincipalEmail: 'getCurrentUserPrincipalEmail',
-			clonedCalendars: 'getClonedCalendars',
+			clonedWriteableCalendars: 'getClonedWriteableCalendars',
 		}),
 
 		/**
@@ -362,7 +362,7 @@ export default {
 				}
 			}
 
-			return this.clonedCalendars
+			return this.clonedWriteableCalendars
 				.map(getCalendarData)
 				.filter(props => props.components.vevent && props.writable === true)
 		},
@@ -470,7 +470,7 @@ export default {
 
 			// TODO: can this query be reduced to a single request?
 			const limit = pLimit(5)
-			const promises = this.clonedCalendars.map(async (calendar) => {
+			const promises = this.clonedWriteableCalendars.map(async (calendar) => {
 				// Query adapted from https://datatracker.ietf.org/doc/html/rfc4791#section-7.8.6
 				return limit(() => calendar.calendarQuery([{
 					name: [NS.IETF_CALDAV, 'comp-filter'],

--- a/src/components/Imip.vue
+++ b/src/components/Imip.vue
@@ -374,12 +374,6 @@ export default {
 				await this.fetchExistingEvent(this.attachedVEvent.uid)
 			},
 		},
-		clonedCalendars: {
-			immediate: true,
-			async handler() {
-				await this.fetchExistingEvent(this.attachedVEvent.uid)
-			},
-		},
 		calendarsForPicker: {
 			immediate: true,
 			handler(calendarsForPicker) {

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -20,7 +20,7 @@
 		<div v-if="itineraries.length > 0" class="message-itinerary">
 			<Itinerary :entries="itineraries" :message-id="message.messageId" />
 		</div>
-		<div v-if="message.scheduling.length > 0" class="message-imip">
+		<div v-if="hasCurrentUserPrincipalAndCollections && message.scheduling.length > 0" class="message-imip">
 			<Imip v-for="scheduling in message.scheduling"
 				:key="scheduling.id"
 				:scheduling="scheduling" />
@@ -129,6 +129,9 @@ export default {
 		},
 		itineraries() {
 			return this.message.itineraries ?? []
+		},
+		hasCurrentUserPrincipalAndCollections() {
+			return this.$store.getters.hasCurrentUserPrincipalAndCollections
 		},
 	},
 	methods: {

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -120,7 +120,9 @@ export const getters = {
 	getCurrentUserPrincipal: (state) => state.currentUserPrincipal,
 	getCurrentUserPrincipalEmail: (state) => state.currentUserPrincipal?.email,
 	getCalendars: (state) => state.calendars,
-	getClonedCalendars: (state) => state.calendars.map(calendar => {
+	getClonedWriteableCalendars: (state) => state.calendars.filter(calendar => {
+		return calendar.isWriteable()
+	}).map(calendar => {
 		// Hack: We need to clone all calendars because some methods (e.g. calendarQuery) are
 		// unnecessarily mutating the object and causing vue warnings (if used outside of
 		// mutations).

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -156,4 +156,5 @@ export const getters = {
 	hasFetchedInitialEnvelopes: (state) => state.hasFetchedInitialEnvelopes,
 	isFollowUpFeatureAvailable: (state) => state.followUpFeatureAvailable,
 	getInternalAddresses: (state) => state.internalAddress?.filter(internalAddress => internalAddress !== undefined),
+	hasCurrentUserPrincipalAndCollections: (state) => state.hasCurrentUserPrincipalAndCollections,
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -107,6 +107,7 @@ export default new Store({
 				hasFetchedInitialEnvelopes: false,
 				followUpFeatureAvailable: false,
 				internalAddress: [],
+				hasCurrentUserPrincipalAndCollections: false,
 			},
 			getters,
 			mutations,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -513,4 +513,7 @@ export default {
 	setFollowUpFeatureAvailable(state, followUpFeatureAvailable) {
 		state.followUpFeatureAvailable = followUpFeatureAvailable
 	},
+	hasCurrentUserPrincipalAndCollections(state, hasCurrentUserPrincipalAndCollections) {
+		state.hasCurrentUserPrincipalAndCollections = hasCurrentUserPrincipalAndCollections
+	},
 }


### PR DESCRIPTION
- [x] Needs/Based on https://github.com/nextcloud/mail/pull/9992

### Problem

 The attendence status for an imip event might be wrong. 

### Before

[Screencast from 2024-08-20 13-53-29.webm](https://github.com/user-attachments/assets/513c24df-4849-441c-b571-1d3e9364c1d7)

### After

[Screencast from 2024-08-20 13-52-35.webm](https://github.com/user-attachments/assets/b65c22ef-11ad-47e2-8a35-f97ec43eaaa2)


Commit a1ecb2e15a4ea848e171919bd50b42888eb593da

One may have imported an event, but the attendance status is not properly fetched when rendering the email.
The reason is a timing / state problem.

- Loading the user principal and collections is initialized in https://github.com/nextcloud/mail/blob/6fc45eb0630b9065f9ccb4c1da5cc9557f7df834/src/App.vue#L49-L50
- If the backend request for the message body is faster, than loading the principal and collections, then Imip.fetchExistingEvent runs without having calendars and changes existingEventFetched to true that prevents the method from running again.
- Solution: Render the imip component when principal and collections are fetched.


Commit d677ce7af6dae7deb33bf0b471fa8c5a3aa96edc

Accepting a calendar invitation should always go to a writable calendar, and therefore we can skip the check if the event exists in a read-only calendar.