### PR TITLE
feat: implement periodic full sync job to repair cache inconsistencies

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -181,6 +181,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'mailboxes#repair',
+			'url' => '/api/mailboxes/{id}/repair',
+			'verb' => 'POST'
+		],
+		[
 			'name' => 'messages#downloadAttachment',
 			'url' => '/api/messages/{id}/attachment/{attachmentId}',
 			'verb' => 'GET'

--- a/lib/BackgroundJob/RepairSyncJob.php
+++ b/lib/BackgroundJob/RepairSyncJob.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\BackgroundJob;
+
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Events\SynchronizationEvent;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Sync\SyncService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\BackgroundJob\TimedJob;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+class RepairSyncJob extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private SyncService $syncService,
+		private AccountService $accountService,
+		private IUserManager $userManager,
+		private MailboxMapper $mailboxMapper,
+		private IJobList $jobList,
+		private LoggerInterface $logger,
+		private IEventDispatcher $dispatcher,
+	) {
+		parent::__construct($time);
+
+		$this->setInterval(3600 * 24 * 7);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+	}
+
+	protected function run($argument): void {
+		$accountId = (int)$argument['accountId'];
+
+		try {
+			$account = $this->accountService->findById($accountId);
+		} catch (DoesNotExistException $e) {
+			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->jobList->remove(self::class, $argument);
+			return;
+		}
+
+		if (!$account->getMailAccount()->canAuthenticateImap()) {
+			$this->logger->debug('No authentication on IMAP possible, skipping background sync job');
+			return;
+		}
+
+		$user = $this->userManager->get($account->getUserId());
+		if ($user === null || !$user->isEnabled()) {
+			$this->logger->debug(sprintf(
+				'Account %d of user %s could not be found or was disabled, skipping background sync',
+				$account->getId(),
+				$account->getUserId()
+			));
+			return;
+		}
+
+		$rebuildThreads = false;
+		$trashMailboxId = $account->getMailAccount()->getTrashMailboxId();
+		$snoozeMailboxId = $account->getMailAccount()->getSnoozeMailboxId();
+		$sentMailboxId = $account->getMailAccount()->getSentMailboxId();
+		$junkMailboxId = $account->getMailAccount()->getJunkMailboxId();
+		foreach ($this->mailboxMapper->findAll($account) as $mailbox) {
+			$isExcluded = [
+				$trashMailboxId === $mailbox->getId(),
+				$snoozeMailboxId === $mailbox->getId(),
+				$sentMailboxId === $mailbox->getId(),
+				$junkMailboxId === $mailbox->getId(),
+			];
+			if (in_array(true, $isExcluded, true)) {
+				continue;
+			}
+
+			if ($this->syncService->repairSync($account, $mailbox) > 0) {
+				$rebuildThreads = true;
+			}
+		}
+
+		$this->dispatcher->dispatchTyped(
+			new SynchronizationEvent($account, $this->logger, $rebuildThreads),
+		);
+	}
+}

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -23,7 +23,9 @@ use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\Sync\SyncService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
@@ -285,5 +287,23 @@ class MailboxesController extends Controller {
 
 		$this->mailManager->clearMailbox($account, $mailbox);
 		return new JSONResponse();
+	}
+
+	/**
+	 * Delete all vanished mails that are still cached.
+	 */
+	#[TrapError]
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 10, period: 600)]
+	public function repair(int $id): JSONResponse {
+		if ($this->currentUserId === null) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
+		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
+
+		$this->syncService->repairSync($account, $mailbox);
+		return new JsonResponse();
 	}
 }

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -112,9 +112,11 @@ class IMAPClientFactory {
 				json_encode($params)
 			]),
 		);
-		$params['cache'] = [
-			'backend' => $this->hordeCacheFactory->newCache($account),
-		];
+		if ($useCache) {
+			$params['cache'] = [
+				'backend' => $this->hordeCacheFactory->newCache($account),
+			];
+		}
 		if ($this->config->getSystemValue('debug', false)) {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
 		}

--- a/lib/Migration/FixBackgroundJobs.php
+++ b/lib/Migration/FixBackgroundJobs.php
@@ -10,6 +10,7 @@ namespace OCA\Mail\Migration;
 
 use OCA\Mail\BackgroundJob\PreviewEnhancementProcessingJob;
 use OCA\Mail\BackgroundJob\QuotaJob;
+use OCA\Mail\BackgroundJob\RepairSyncJob;
 use OCA\Mail\BackgroundJob\SyncJob;
 use OCA\Mail\BackgroundJob\TrainImportanceClassifierJob;
 use OCA\Mail\Db\MailAccount;
@@ -43,6 +44,7 @@ class FixBackgroundJobs implements IRepairStep {
 		$output->startProgress(count($accounts));
 		foreach ($accounts as $account) {
 			$this->jobList->add(SyncJob::class, ['accountId' => $account->getId()]);
+			$this->jobList->add(RepairSyncJob::class, ['accountId' => $account->getId()]);
 			$this->jobList->add(TrainImportanceClassifierJob::class, ['accountId' => $account->getId()]);
 			$this->jobList->add(PreviewEnhancementProcessingJob::class, ['accountId' => $account->getId()]);
 			$this->jobList->add(QuotaJob::class, ['accountId' => $account->getId()]);

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Service\Sync;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Base;
 use Horde_Imap_Client_Exception;
+use Horde_Imap_Client_Ids;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Mailbox;
@@ -495,5 +496,50 @@ class ImapToDbSynchronizer {
 		$perf->end();
 
 		return $newOrVanished;
+	}
+
+	/**
+	 * Run a (rather costly) sync to delete cached messages which are not present on IMAP anymore.
+	 *
+	 * @throws MailboxLockedException
+	 * @throws ServiceException
+	 */
+	public function repairSync(
+		Account $account,
+		Mailbox $mailbox,
+		LoggerInterface  $logger,
+	): void {
+		$this->mailboxMapper->lockForVanishedSync($mailbox);
+
+		$perf = $this->performanceLogger->startWithLogger(
+			'Repair sync for ' . $account->getId() . ':' . $mailbox->getName(),
+			$logger,
+		);
+
+		// Need to use a client without a cache here (to disable QRESYNC entirely)
+		$client = $this->clientFactory->getClient($account, false);
+		try {
+			$knownUids = $this->dbMapper->findAllUids($mailbox);
+			$hordeMailbox = new \Horde_Imap_Client_Mailbox($mailbox->getName());
+			$phantomVanishedUids = $client->vanished($hordeMailbox, 0, [
+				'ids' => new Horde_Imap_Client_Ids($knownUids),
+			])->ids;
+			if (count($phantomVanishedUids) > 0) {
+				$this->dbMapper->deleteByUid($mailbox, ...$phantomVanishedUids);
+			}
+		} catch (Throwable $e) {
+			$message = sprintf(
+				'Repair sync failed for %d:%s: %s',
+				$account->getId(),
+				$mailbox->getName(),
+				$e->getMessage(),
+			);
+			throw new ServiceException($message, 0, $e);
+		} finally {
+			$this->mailboxMapper->unlockFromVanishedSync($mailbox);
+			$client->logout();
+		}
+
+		$perf->end();
 	}
 }

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -86,6 +86,16 @@ class SyncService {
 	}
 
 	/**
+	 * Run a (rather costly) sync to delete cached messages which are not present on IMAP anymore.
+	 *
+	 * @throws MailboxLockedException
+	 * @throws ServiceException
+	 */
+	public function repairSync(Account $account, Mailbox $mailbox): void {
+		$this->synchronizer->repairSync($account, $mailbox, $this->logger);
+	}
+
+	/**
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param int $criteria

--- a/src/service/MailboxService.js
+++ b/src/service/MailboxService.js
@@ -66,3 +66,17 @@ export const clearMailbox = async (id) => {
 
 	await axios.post(url)
 }
+
+/**
+ * Delete all vanished emails that are still cached.
+ *
+ * @param {number} id Mailbox database id
+ * @return {Promise<void>}
+ */
+export const repairMailbox = async (id) => {
+	const url = generateUrl('/apps/mail/api/mailboxes/{id}/repair', {
+		id,
+	})
+
+	await axios.post(url)
+}

--- a/tests/Integration/Sync/ImapToDbSynchronizerTest.php
+++ b/tests/Integration/Sync/ImapToDbSynchronizerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Integration\Sync;
+
+use Horde_Imap_Client;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MessageMapper as DbMessageMapper;
+use OCA\Mail\Service\Sync\ImapToDbSynchronizer;
+use OCA\Mail\Service\Sync\SyncService;
+use OCA\Mail\Tests\Integration\Framework\ImapTest;
+use OCA\Mail\Tests\Integration\Framework\ImapTestAccount;
+use OCA\Mail\Tests\Integration\TestCase;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
+
+class ImapToDbSynchronizerTest extends TestCase {
+	use ImapTest,
+		ImapTestAccount;
+
+	private ImapToDbSynchronizer $synchronizer;
+	private MailAccount $account;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->synchronizer = Server::get(ImapToDbSynchronizer::class);
+		$this->account = $this->createTestAccount();
+	}
+
+	public function testRepairSync(): void {
+		// Create some test messages
+		$mailbox = 'INBOX';
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 1')
+			->finish();
+		$uid1 = $this->saveMessage($mailbox, $message, $this->account);
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 2')
+			->finish();
+		$uid2 = $this->saveMessage($mailbox, $message, $this->account);
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 3')
+			->finish();
+		$uid3 = $this->saveMessage($mailbox, $message, $this->account);
+
+		// Retrieve mailbox object
+		$mailManager = Server::get(IMailManager::class);
+		$mailBoxes = $mailManager->getMailboxes(new Account($this->account));
+		$inbox = null;
+		foreach ($mailBoxes as $mailBox) {
+			if ($mailBox->getName() === 'INBOX') {
+				$inbox = $mailBox;
+				break;
+			}
+		}
+
+		// Do an initial sync to pull in all created messages
+		$syncService = Server::get(SyncService::class);
+		$syncService->syncMailbox(
+			new Account($this->account),
+			$inbox,
+			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			false,
+			null,
+			[],
+		);
+
+		// Assert that there are 3 messages and nothing changes when deleting a message externally
+		$dbMessageMapper = Server::get(DbMessageMapper::class);
+		self::assertCount(3, $dbMessageMapper->findAllUids($inbox));
+		$this->deleteMessagesExternally($mailbox, [$uid3]);
+		self::assertCount(3, $dbMessageMapper->findAllUids($inbox));
+
+		// Do a repair sync to get rid of the vanished message that is still in the cache
+		$this->synchronizer->repairSync(
+			new Account($this->account),
+			$inbox,
+			Server::get(LoggerInterface::class),
+		);
+
+		// Assert that the cached state has been reconciled with IMAP
+		self::assertEquals([$uid1, $uid2], $dbMessageMapper->findAllUids($inbox));
+	}
+
+	public function testRepairSyncNoopIfNoneVanished(): void {
+		// Create some test messages
+		$mailbox = 'INBOX';
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 1')
+			->finish();
+		$uid1 = $this->saveMessage($mailbox, $message, $this->account);
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 2')
+			->finish();
+		$uid2 = $this->saveMessage($mailbox, $message, $this->account);
+		$message = $this->getMessageBuilder()
+			->from('ralph@buffington@domain.tld')
+			->to('user@domain.tld')
+			->subject('Message 3')
+			->finish();
+		$uid3 = $this->saveMessage($mailbox, $message, $this->account);
+
+		// Retrieve mailbox object
+		$mailManager = Server::get(IMailManager::class);
+		$mailBoxes = $mailManager->getMailboxes(new Account($this->account));
+		$inbox = null;
+		foreach ($mailBoxes as $mailBox) {
+			if ($mailBox->getName() === 'INBOX') {
+				$inbox = $mailBox;
+				break;
+			}
+		}
+
+		// Do an initial sync to pull in all created messages
+		$syncService = Server::get(SyncService::class);
+		$syncService->syncMailbox(
+			new Account($this->account),
+			$inbox,
+			Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS,
+			false,
+			null,
+			[],
+		);
+
+		// Assert that there are 3 messages and nothing changes when deleting a message externally
+		$dbMessageMapper = Server::get(DbMessageMapper::class);
+		self::assertCount(3, $dbMessageMapper->findAllUids($inbox));
+
+		// Do a repair sync to get rid of the vanished message that is still in the cache
+		$this->synchronizer->repairSync(
+			new Account($this->account),
+			$inbox,
+			Server::get(LoggerInterface::class),
+		);
+
+		// Assert that the cached state has been reconciled with IMAP
+		self::assertEquals([$uid1, $uid2, $uid3], $dbMessageMapper->findAllUids($inbox));
+	}
+}


### PR DESCRIPTION
Run a background job once a week without any Horde cache to forcibly disable `QRESYNC` support. This should reconcile the UID list in our database.

I also added a button to the mailbox action menu.

![grafik](https://github.com/user-attachments/assets/82a23e6c-dbf1-410b-b50b-0f65e2b18d0d)

Close https://github.com/nextcloud/mail/issues/9168