### PR TITLE
EnvelopeSkeleton: make oneline envelopes actually one line and not two

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -70,7 +70,9 @@
 					</span>
 					<span class="envelope__subtitle__subject"
 						:class="{'one-line': oneLineLayout }">
-						{{ subjectForSubtitle }}
+						<span class="envelope__subtitle__subject__text" :class="{'one-line': oneLineLayout }">
+							{{ subjectForSubtitle }}
+						</span>
 					</span>
 				</div>
 				<div v-if="data.encrypted || data.previewText"
@@ -1091,10 +1093,22 @@ export default {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
+
 .envelope__subtitle__subject.one-line {
+	display: flex;
+	align-items: center;
+	height: calc(var(--default-font-size) * var(--default-line-height));
+
 	&::after {
 		content: '\00B7';
 		margin: 12px;
 	}
+}
+
+.envelope__subtitle__subject__text.one-line {
+	max-width: 300px;
+	display: inline-block;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 </style>

--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -552,24 +552,47 @@ export default {
 		--list-item-border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
 		padding-block: calc(var(--list-item-padding) * 2);
 		--list-item-padding: 2px;
+		height: unset;
 
-		.list-item-content__inner__main {
-			display: flex;
-			justify-content: start;
-			gap: 12px;
-			min-width: 0;
-		}
-		.list-item-content__inner__details {
+		.list-item-content {
 			flex-direction: row;
-			align-items: unset;
-			justify-content: end;
-		}
-		.list-item-content__name {
-			align-self: center;
+			align-content: center;
+			align-items: center;
+
+			&__name {
+				align-self: center;
+				min-width: 300px;
+				padding-right: calc(var(--default-grid-baseline) * 2);
+			}
+
+			&__inner {
+				overflow-y: hidden;
+			}
+
+			&__inner__main {
+				display: flex;
+				justify-content: start;
+				min-width: 0;
+			}
+
+			&__inner__details {
+				flex-direction: row;
+				align-items: unset;
+				justify-content: end;
+				margin-top: 0;
+				margin-left: 0;
+			}
 		}
 
 		a {
 			margin: 0;
+			align-items: center;
+			height: unset;
+		}
+
+		.list-item__actions {
+			align-self: center;
+			margin-top: 0;
 		}
 	}
 
@@ -616,10 +639,6 @@ export default {
 :deep(.app-content-list-item-icon), :deep(.avatardiv), :deep(.avatardiv__initials-wrapper) {
 	height: calc(var(--header-menu-item-height) - 4px);
 	width: calc(var(--header-menu-item-height) - 4px);
-}
-
-:deep(.avatardiv__initials){
-	line-height: 2.5;
 }
 
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/10043

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/f6059da5-2929-4cc6-afef-434621149469) | ![Screenshot from 2024-08-23 14-46-35](https://github.com/user-attachments/assets/510e942f-6957-4aa3-b89c-32d995a01699) |