### PR TITLE
fix: overlapping text on small screens

### DIFF
--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -630,7 +630,7 @@ export default {
 		flex: 0 0 auto;
 		justify-content: center;
 		align-self: start;
-		margin-top: -4px;
+		margin-top: 0;
 	}
 
 }

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -170,12 +170,16 @@ export default {
 .reply-buttons {
 	margin: 0 10px 0 50px;
 	display: flex;
+	flex-wrap: wrap;
+	gap: 5px;
 	justify-content: space-between;
 	align-items: center;
 
 	&__suggested {
-		display: flex;
 		justify-content: flex-start;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 5px;
 		&__button {
 			margin-right: 5px;
 			border-radius: 12px;
@@ -187,6 +191,23 @@ export default {
 
 	&__notsuggested {
 		margin-left: auto;
+	}
+}
+@media screen and (max-width: 600px) {
+	.reply-buttons {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 5px;
+
+		&__suggested {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 5px;
+		}
+
+		&__notsuggested {
+			margin-left: 0;
+		}
 	}
 }
 </style>

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -64,15 +64,17 @@
 							{{ isEncrypted ? t('mail', 'Encrypted message') : envelope.previewText }}
 						</span>
 					</div>
-					<div v-for="tag in tags"
-						:key="tag.id"
-						class="tag-group">
-						<div class="tag-group__bg"
-							:style="{'background-color': tag.color}" />
-						<span class="tag-group__label"
-							:style="{color: tag.color}">
-							{{ translateTagDisplayName(tag) }}
-						</span>
+					<div class="tagline">
+						<div v-for="tag in tags"
+							:key="tag.id"
+							class="tag-group">
+							<div class="tag-group__bg"
+								:style="{'background-color': tag.color}" />
+							<span class="tag-group__label"
+								:style="{color: tag.color}">
+								{{ translateTagDisplayName(tag) }}
+							</span>
+						</div>
 					</div>
 				</div>
 				<div class="envelope__header__left__unsubscribe">
@@ -887,9 +889,10 @@ export default {
 <style lang="scss" scoped>
 	.sender {
 		margin-left: 8px;
-
 		&__email{
 			color: var(--color-text-maxcontrast);
+			text-overflow: ellipsis;
+			overflow: hidden;
 		}
 
 		&__external{
@@ -1038,8 +1041,6 @@ export default {
 				color: var(--color-text-maxcontrast);
 			}
 			&__left__sender-subject-tags {
-				text-overflow: ellipsis;
-				overflow: hidden;
 				white-space: nowrap;
 				width: 100%;
 			}
@@ -1088,6 +1089,11 @@ export default {
 		left: 0;
 		opacity: 15%;
 	}
+	.tagline {
+		display: flex;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
 	.tag-group {
 		display: inline-block;
 		border: 1px solid transparent;
@@ -1095,6 +1101,7 @@ export default {
 		position: relative;
 		margin: 0 1px;
 		overflow: hidden;
+		text-overflow: ellipsis;
 		left: 4px;
 	}
 	.smime-text {
@@ -1105,5 +1112,12 @@ export default {
 		font-weight: normal;
 		display: inline;
 		align-items: center;
+	}
+	@media only screen and (max-width: 400px) {
+		.sender {
+			text-overflow: ellipsis;
+			overflow: hidden;
+			width: 180px;
+		}
 	}
 </style>


### PR DESCRIPTION
fixes #https://github.com/nextcloud/mail/issues/9752 

and some other small stuff like the action menu on envelope
before ( see sender/header and smart replies)
![Screenshot from 2024-08-28 14-17-10](https://github.com/user-attachments/assets/d825136b-aa14-46a4-b5ae-d3e1ffd2a091)


after
![Screenshot from 2024-08-28 14-12-20](https://github.com/user-attachments/assets/77381994-25ec-4216-a799-2b3de3ae37cb)
![Screenshot from 2024-08-28 14-01-12](https://github.com/user-attachments/assets/09525350-2606-4ad1-a185-78f63fb9e578)
