### PR TITLE
test: fix redis not being used properly in imapClientFactoryTest

### DIFF
--- a/tests/Integration/Framework/Caching.php
+++ b/tests/Integration/Framework/Caching.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Integration\Framework;
+
+use OC\Memcache\Factory;
+use OCA\Mail\Cache\HordeCacheFactory;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\Profiler\IProfiler;
+use OCP\Security\ICrypto;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
+
+class Caching {
+	/**
+	 * Force usage of a real cache as configured in system config. The original ICacheFactory
+	 * service closure is hard-coded to always return an instance of ArrayCache when the global
+	 * PHPUNIT_RUN is defined.
+	 */
+	public static function getImapClientFactoryAndConfiguredCacheFactory(?ICrypto $crypto = null): array {
+		$config = Server::get(IConfig::class);
+		$cacheFactory = new Factory(
+			static fn () => 'mail-integration-tests',
+			Server::get(LoggerInterface::class),
+			Server::get(IProfiler::class),
+			$config->getSystemValue('memcache.local', null),
+			$config->getSystemValue('memcache.distributed', null),
+			$config->getSystemValue('memcache.locking', null),
+			$config->getSystemValueString('redis_log_file')
+		);
+		$imapClient = new IMAPClientFactory(
+			$crypto ?? Server::get(ICrypto::class),
+			$config,
+			$cacheFactory,
+			Server::get(IEventDispatcher::class),
+			Server::get(ITimeFactory::class),
+			Server::get(HordeCacheFactory::class),
+		);
+		return [$imapClient, $cacheFactory];
+	}
+}


### PR DESCRIPTION
Noticed while developing https://github.com/nextcloud/mail/pull/10036.

The injected cache factory from OCP will always inject an `ArrayCache` instance when `PHPUNIT_RUN` is defined.

https://github.com/nextcloud/server/blob/606241caebda2e01702c0d08adbc35ace8d01f13/lib/private/Server.php#L600-L638

Force to use the configured cache and also assert that it is an instance of Redis in the affected test.