### PR TITLE
fix(threading): Handle threads with duplicate send times

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -792,7 +792,13 @@ class MessageMapper extends QBMapper {
 		$selfJoin = $select->expr()->andX(
 			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
 			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
-			$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+			$select->expr()->orX(
+				$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+				$select->expr()->andX(
+					$select->expr()->eq('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+					$select->expr()->lt('m.message_id', 'm2.message_id', IQueryBuilder::PARAM_STR),
+				),
+			),
 		);
 
 		$select->from($this->getTableName(), 'm')
@@ -1016,7 +1022,13 @@ class MessageMapper extends QBMapper {
 		$selfJoin = $select->expr()->andX(
 			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
 			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
-			$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+			$select->expr()->orX(
+				$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+				$select->expr()->andX(
+					$select->expr()->eq('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+					$select->expr()->lt('m.message_id', 'm2.message_id', IQueryBuilder::PARAM_STR),
+				),
+			),
 		);
 
 		$select->from($this->getTableName(), 'm')
@@ -1373,9 +1385,15 @@ class MessageMapper extends QBMapper {
 		$selfJoin = $select->expr()->andX(
 			$select->expr()->eq('m.mailbox_id', 'm2.mailbox_id', IQueryBuilder::PARAM_INT),
 			$select->expr()->eq('m.thread_root_id', 'm2.thread_root_id', IQueryBuilder::PARAM_INT),
-			$sortOrder === IMailSearch::ORDER_NEWEST_FIRST ?
-				$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT) :
-				$select->expr()->gt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT)
+			$select->expr()->orX(
+				$sortOrder === IMailSearch::ORDER_NEWEST_FIRST ?
+					$select->expr()->lt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT) :
+					$select->expr()->gt('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+				$select->expr()->andX(
+					$select->expr()->eq('m.sent_at', 'm2.sent_at', IQueryBuilder::PARAM_INT),
+					$select->expr()->lt('m.message_id', 'm2.message_id', IQueryBuilder::PARAM_STR),
+				),
+			),
 		);
 		$wheres = [$select->expr()->eq('m.mailbox_id', $select->createNamedParameter($mailbox->getId(), IQueryBuilder::PARAM_INT)),
 			$select->expr()->andX($subSelect->expr()->notIn('m.id', $select->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY)),


### PR DESCRIPTION
A thread with two messages with identical sent_at result in a problematic situation. The backend will return *both* messages when listing the inbox. The front-end will de-duplicate and only show one of the two. At every browser-server sync, the picked duplicate will be replaced by the other message. At the next sync they are replaced again. Etc. This causes endless notifications.

I ran into this with a thread for an outgoing message that was replied to by the mail server. This seems to be the rare case where two messages in a thread have an identical send time because they were processed in the same second.

## How to test

1. Create a thread with two messages
2. Go into the database, find the thread and change send_at to be identical for both messages
3. Reload the app
4. Wait for the sync

main: the two messages toggle.
here: only one of the messages is loaded and never replaced.

---

Note: I can't come up with a good way to find out which of the messages with identical send time are "newer". I just sort them by message id. It's a bit "random" semantically but keeps the sorting stable.