### PR TITLE
Fix PGP/MIME sending and viewing

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>4.1.0-alpha.1</version>
+	<version>4.1.0-alpha.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/lib/Controller/DraftsController.php
+++ b/lib/Controller/DraftsController.php
@@ -55,6 +55,7 @@ class DraftsController extends Controller {
 	 * @param string $body
 	 * @param string $editorBody
 	 * @param bool $isHtml
+	 * @param bool $isPgpMime
 	 * @param bool $smimeSign
 	 * @param bool $smimeEncrypt
 	 * @param array<int, string[]> $to i. e. [['label' => 'Linus', 'email' => 'tent@stardewvalley.com'], ['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']]
@@ -89,7 +90,8 @@ class DraftsController extends Controller {
 		?int $smimeCertificateId = null,
 		?int $sendAt = null,
 		?int $draftId = null,
-		bool $requestMdn = false) : JsonResponse {
+		bool $requestMdn = false,
+		bool $isPgpMime = false) : JsonResponse {
 		$account = $this->accountService->find($this->userId, $accountId);
 		if ($draftId !== null) {
 			$this->service->handleDraft($account, $draftId);
@@ -108,6 +110,7 @@ class DraftsController extends Controller {
 		$message->setSmimeSign($smimeSign);
 		$message->setSmimeEncrypt($smimeEncrypt);
 		$message->setRequestMdn($requestMdn);
+		$message->setPgpMime($isPgpMime);
 
 		if (!empty($smimeCertificateId)) {
 			$smimeCertificate = $this->smimeService->findCertificate($smimeCertificateId, $this->userId);
@@ -128,6 +131,7 @@ class DraftsController extends Controller {
 	 * @param string $body
 	 * @param string $editorBody
 	 * @param bool $isHtml
+	 * @param bool $isPgpMime
 	 * @param bool $failed
 	 * @param array<int, string[]> $to i. e. [['label' => 'Linus', 'email' => 'tent@stardewvalley.com'], ['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']]
 	 * @param array<int, string[]> $cc
@@ -156,7 +160,8 @@ class DraftsController extends Controller {
 		?string $inReplyToMessageId = null,
 		?int $smimeCertificateId = null,
 		?int $sendAt = null,
-		bool $requestMdn = false): JsonResponse {
+		bool $requestMdn = false,
+		bool $isPgpMime = false): JsonResponse {
 		$message = $this->service->getMessage($id, $this->userId);
 		$account = $this->accountService->find($this->userId, $accountId);
 
@@ -174,6 +179,7 @@ class DraftsController extends Controller {
 		$message->setSmimeSign($smimeSign);
 		$message->setSmimeEncrypt($smimeEncrypt);
 		$message->setRequestMdn($requestMdn);
+		$message->setPgpMime($isPgpMime);
 
 		if (!empty($smimeCertificateId)) {
 			$smimeCertificate = $this->smimeService->findCertificate($smimeCertificateId, $this->userId);

--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -105,6 +105,7 @@ class OutboxController extends Controller {
 		?int $smimeCertificateId = null,
 		?int $sendAt = null,
 		bool $requestMdn = false,
+		bool $isPgpMime = false,
 	): JsonResponse {
 		$account = $this->accountService->find($this->userId, $accountId);
 
@@ -122,6 +123,7 @@ class OutboxController extends Controller {
 		$message->setHtml($isHtml);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setSendAt($sendAt);
+		$message->setPgpMime($isPgpMime);
 		$message->setSmimeSign($smimeSign);
 		$message->setSmimeEncrypt($smimeEncrypt);
 		$message->setRequestMdn($requestMdn);
@@ -194,6 +196,7 @@ class OutboxController extends Controller {
 		?int $smimeCertificateId = null,
 		?int $sendAt = null,
 		bool $requestMdn = false,
+		bool $isPgpMime = false,
 	): JsonResponse {
 		$message = $this->service->getMessage($id, $this->userId);
 		if ($message->getStatus() === LocalMessage::STATUS_PROCESSED) {
@@ -209,6 +212,7 @@ class OutboxController extends Controller {
 		$message->setHtml($isHtml);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setSendAt($sendAt);
+		$message->setPgpMime($isPgpMime);
 		$message->setSmimeSign($smimeSign);
 		$message->setSmimeEncrypt($smimeEncrypt);
 		$message->setRequestMdn($requestMdn);

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -37,6 +37,8 @@ use function array_filter;
  * @method void setInReplyToMessageId(?string $inReplyToId)
  * @method int|null getUpdatedAt()
  * @method setUpdatedAt(?int $updatedAt)
+ * @method bool|null isPgpMime()
+ * @method setPgpMime(bool $pgpMime)
  * @method bool|null getSmimeSign()
  * @method setSmimeSign(bool $smimeSign)
  * @method int|null getSmimeCertificateId()
@@ -111,6 +113,9 @@ class LocalMessage extends Entity implements JsonSerializable {
 	protected $updatedAt;
 
 	/** @var bool|null */
+	protected $pgpMime;
+
+	/** @var bool|null */
 	protected $smimeSign;
 
 	/** @var int|null */
@@ -139,6 +144,7 @@ class LocalMessage extends Entity implements JsonSerializable {
 		$this->addType('html', 'boolean');
 		$this->addType('failed', 'boolean');
 		$this->addType('updatedAt', 'integer');
+		$this->addType('pgpMime', 'boolean');
 		$this->addType('smimeSign', 'boolean');
 		$this->addType('smimeCertificateId', 'integer');
 		$this->addType('smimeEncrypt', 'boolean');
@@ -160,6 +166,7 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'body' => $this->getBody(),
 			'editorBody' => $this->getEditorBody(),
 			'isHtml' => ($this->isHtml() === true),
+			'isPgpMime' => ($this->isPgpMime() === true),
 			'inReplyToMessageId' => $this->getInReplyToMessageId(),
 			'attachments' => $this->getAttachments(),
 			'from' => array_values(

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -62,6 +62,7 @@ class ImapMessageFetcher {
 	private ?string $unsubscribeUrl = null;
 	private bool $isOneClickUnsubscribe = false;
 	private ?string $unsubscribeMailto = null;
+	private bool $isPgpMimeEncrypted = false;
 
 	public function __construct(
 		int $uid,
@@ -148,6 +149,13 @@ class ImapMessageFetcher {
 
 			// analyse the body part
 			$structure = $fetch->getStructure();
+
+			$this->isPgpMimeEncrypted = ($structure->getType() === 'multipart/encrypted'
+				&& $structure->getContentTypeParameter('protocol') === 'application/pgp-encrypted');
+			if ($this->isPgpMimeEncrypted) {
+				$this->plainMessage = $this->loadBodyData($structure, '2', false);
+				$this->attachmentsToIgnore[] = $structure->getPartByIndex(1)->getName();
+			}
 
 			$this->hasAnyAttachment = $this->hasAttachments($structure);
 
@@ -268,6 +276,7 @@ class ImapMessageFetcher {
 			$isSigned,
 			$signatureIsValid,
 			$this->htmlService, // TODO: drop the html service dependency
+			$this->isPgpMimeEncrypted,
 		);
 	}
 

--- a/lib/Migration/Version4100Date20240916174827.php
+++ b/lib/Migration/Version4100Date20240916174827.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version4100Date20240916174827 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$outboxTable = $schema->getTable('mail_local_messages');
+		if (!$outboxTable->hasColumn('pgp_mime')) {
+			$outboxTable->addColumn('pgp_mime', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -69,6 +69,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	private bool $isEncrypted;
 	private bool $isSigned;
 	private bool $signatureIsValid;
+	private bool $isPgpMimeEncrypted;
 
 	public function __construct(int $uid,
 		string $messageId,
@@ -98,7 +99,8 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		bool $isEncrypted,
 		bool $isSigned,
 		bool $signatureIsValid,
-		Html $htmlService) {
+		Html $htmlService,
+		bool $isPgpMimeEncrypted) {
 		$this->messageId = $uid;
 		$this->realMessageId = $messageId;
 		$this->flags = $flags;
@@ -128,6 +130,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$this->isSigned = $isSigned;
 		$this->signatureIsValid = $signatureIsValid;
 		$this->htmlService = $htmlService;
+		$this->isPgpMimeEncrypted = $isPgpMimeEncrypted;
 	}
 
 	public static function generateMessageId(): string {
@@ -317,6 +320,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'isOneClickUnsubscribe' => $this->isOneClickUnsubscribe,
 			'unsubscribeMailto' => $this->unsubscribeMailto,
 			'scheduling' => $this->scheduling,
+			'isPgpMimeEncrypted' => $this->isPgpMimeEncrypted,
 		];
 	}
 
@@ -457,6 +461,10 @@ class IMAPMessage implements IMessage, JsonSerializable {
 
 	public function isOneClickUnsubscribe(): bool {
 		return $this->isOneClickUnsubscribe;
+	}
+
+	public function isPgpMimeEncrypted(): bool {
+		return $this->isPgpMimeEncrypted;
 	}
 
 	/**

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -124,7 +124,8 @@ class MailTransmission implements IMailTransmission {
 		$mimePart = $mimeMessage->build(
 			$localMessage->isHtml(),
 			$localMessage->getBody(),
-			$attachmentParts
+			$attachmentParts,
+			$localMessage->isPgpMime() === true
 		);
 
 		// TODO: add smimeEncrypt check if implemented

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1097,6 +1097,7 @@ export default {
 				smimeSign: this.shouldSmimeSign,
 				smimeEncrypt: this.shouldSmimeEncrypt,
 				smimeCertificateId: this.smimeCertificateForCurrentAlias?.id,
+				isPgpMime: this.encrypt,
 			}
 		},
 		saveDraft() {

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -30,7 +30,7 @@
 			:message="message"
 			:full-height="fullHeight"
 			@load="$emit('load', $event)" />
-		<MessageEncryptedBody v-else-if="isEncrypted"
+		<MessageEncryptedBody v-else-if="isEncrypted || isPgpMimeEncrypted"
 			:body="message.body"
 			:from="from"
 			:message="message" />
@@ -127,6 +127,9 @@ export default {
 		},
 		isEncrypted() {
 			return isPgpgMessage(this.message.hasHtmlBody ? html(this.message.body) : plain(this.message.body))
+		},
+		isPgpMimeEncrypted() {
+			return this.message.isPgpMimeEncrypted
 		},
 		itineraries() {
 			return this.message.itineraries ?? []

--- a/tests/Unit/Controller/DraftsControllerTest.php
+++ b/tests/Unit/Controller/DraftsControllerTest.php
@@ -202,6 +202,7 @@ class DraftsControllerTest extends TestCase {
 		$message->setSendAt(null);
 		$message->setUpdatedAt(123456);
 		$message->setRequestMdn(false);
+		$message->setPgpMime(false);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
 		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
 
@@ -250,6 +251,7 @@ class DraftsControllerTest extends TestCase {
 		$message->setSendAt(null);
 		$message->setUpdatedAt(123456);
 		$message->setRequestMdn(false);
+		$message->setPgpMime(false);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
 		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
 
@@ -304,6 +306,7 @@ class DraftsControllerTest extends TestCase {
 		$message->setSendAt(null);
 		$message->setUpdatedAt(123456);
 		$message->setRequestMdn(false);
+		$message->setPgpMime(false);
 
 		$account = new Account(new MailAccount());
 		$this->accountService->expects(self::once())

--- a/tests/Unit/Controller/ListControllerTest.php
+++ b/tests/Unit/Controller/ListControllerTest.php
@@ -143,6 +143,7 @@ class ListControllerTest extends TestCase {
 			false,
 			false,
 			$this->createMock(Html::class),
+			false,
 		);
 		$this->serviceMock->getParameter('mailManager')
 			->expects(self::once())
@@ -206,6 +207,7 @@ class ListControllerTest extends TestCase {
 			false,
 			false,
 			$this->createMock(Html::class),
+			false,
 		);
 		$this->serviceMock->getParameter('mailManager')
 			->expects(self::once())

--- a/tests/Unit/Controller/OutboxControllerTest.php
+++ b/tests/Unit/Controller/OutboxControllerTest.php
@@ -267,6 +267,7 @@ class OutboxControllerTest extends TestCase {
 		$message->setInReplyToMessageId('abc');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setRequestMdn(false);
+		$message->setPgpMime(false);
 		$to = [['label' => 'Lewis', 'email' => 'tent@stardewvalley.com']];
 		$cc = [['label' => 'Pierre', 'email' => 'generalstore@stardewvalley.com']];
 

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -81,6 +81,7 @@ class IMAPMessageTest extends TestCase {
 			false,
 			false,
 			$htmlService,
+			false,
 		);
 
 		$actualHtmlBody = $message->getHtmlBody(123);
@@ -123,6 +124,7 @@ class IMAPMessageTest extends TestCase {
 			false,
 			false,
 			$this->htmlService,
+			false,
 		);
 
 		$json = $m->jsonSerialize();
@@ -156,6 +158,7 @@ class IMAPMessageTest extends TestCase {
 			'hasDkimSignature' => false,
 			'phishingDetails' => [],
 			'scheduling' => [],
+			'isPgpMimeEncrypted' => false,
 		], $json);
 		$this->assertEquals(1234, $json['uid']);
 	}


### PR DESCRIPTION
This fixes sending and viewing PGP/MIME encrypted emails (as produced and consumed by Mailvelope in API-mode).

Previously, sent messages were viewable in Mailvelope, too, but all other email programs showed the enclosed mime-headers, because the ciphertext was not properly encapsulated.

Closes #3833 and #9862