### PR TITLE
chore: accounts controller patch response

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use Horde_Imap_Client;
+use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailTransmission;
@@ -277,7 +278,7 @@ class AccountsController extends Controller {
 			$dbAccount->setSearchBody($searchBody);
 		}
 		return new JSONResponse(
-			$this->accountService->save($dbAccount)
+			new Account($this->accountService->save($dbAccount))
 		);
 	}
 


### PR DESCRIPTION
Does not really change anything because the response is not used anywhere in the frontend (hence a `chore` type commit).

`PATCH https://localhost/index.php/apps/mail/api/accounts/2000`

### Before

```json
{
    "id": 2000
}
```

### After

```json
{
    "id": 2000,
    "accountId": 2000,
    "name": "Alice",
    "order": 5,
    [...]
}
```