### PR TITLE
refactor: drop fallback for availability coordinator

### DIFF
--- a/lib/Service/OutOfOfficeService.php
+++ b/lib/Service/OutOfOfficeService.php
@@ -25,12 +25,9 @@ use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUser;
 use OCP\User\IAvailabilityCoordinator;
-use Psr\Container\ContainerExceptionInterface;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class OutOfOfficeService {
-	private ?IAvailabilityCoordinator $availabilityCoordinator;
 
 	public function __construct(
 		private OutOfOfficeParser $outOfOfficeParser,
@@ -38,14 +35,8 @@ class OutOfOfficeService {
 		private LoggerInterface $logger,
 		private AliasesService $aliasesService,
 		private ITimeFactory $timeFactory,
-		ContainerInterface $container,
+		private IAvailabilityCoordinator $availabilityCoordinator,
 	) {
-		// TODO: inject directly if we only support Nextcloud >= 28
-		try {
-			$this->availabilityCoordinator = $container->get(IAvailabilityCoordinator::class);
-		} catch (ContainerExceptionInterface $e) {
-			$this->availabilityCoordinator = null;
-		}
 	}
 
 	/**
@@ -102,10 +93,6 @@ class OutOfOfficeService {
 	 * @throws InvalidArgumentException If the given mail account doesn't follow out-of-office settings
 	 */
 	public function updateFromSystem(MailAccount $mailAccount, IUser $user): ?OutOfOfficeState {
-		if ($this->availabilityCoordinator === null) {
-			throw new ServiceException('System out-of-office data is only available in Nextcloud >= 28');
-		}
-
 		if (!$mailAccount->getOutOfOfficeFollowsSystem()) {
 			throw new InvalidArgumentException('The mail account does not follow system out-of-office settings');
 		}

--- a/tests/Unit/Service/OutOfOfficeServiceTest.php
+++ b/tests/Unit/Service/OutOfOfficeServiceTest.php
@@ -19,40 +19,16 @@ use OCA\Mail\Service\OutOfOffice\OutOfOfficeState;
 use OCA\Mail\Service\OutOfOfficeService;
 use OCA\Mail\Sieve\NamedSieveScript;
 use OCP\IUser;
-use OCP\User\IAvailabilityCoordinator;
 use OCP\User\IOutOfOfficeData;
-use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Container\ContainerInterface;
 
 class OutOfOfficeServiceTest extends TestCase {
 	private ServiceMockObject $serviceMock;
 	private OutOfOfficeService $outOfOfficeService;
 
-	/** @var ContainerInterface|MockObject */
-	private $container;
-
-	/** @var IAvailabilityCoordinator|MockObject */
-	private $availabilityCoordinator;
-
 	protected function setUp(): void {
 		parent::setUp();
 
-		if (!interface_exists(IAvailabilityCoordinator::class)
-			|| !interface_exists(IOutOfOfficeData::class)) {
-			$this->markTestSkipped('Out-of-office feature is not available');
-		}
-
-		$this->container = $this->createMock(ContainerInterface::class);
-		$this->availabilityCoordinator = $this->createMock(IAvailabilityCoordinator::class);
-
-		$this->container->expects(self::once())
-			->method('get')
-			->with(IAvailabilityCoordinator::class)
-			->willReturn($this->availabilityCoordinator);
-
-		$this->serviceMock = $this->createServiceMock(OutOfOfficeService::class, [
-			'container' => $this->container,
-		]);
+		$this->serviceMock = $this->createServiceMock(OutOfOfficeService::class);
 		$this->outOfOfficeService = $this->serviceMock->getService();
 	}
 
@@ -64,10 +40,6 @@ class OutOfOfficeServiceTest extends TestCase {
 		string $subject,
 		string $message,
 	): ?IOutOfOfficeData {
-		if (!interface_exists(IOutOfOfficeData::class)) {
-			return null;
-		}
-
 		$data = $this->createMock(IOutOfOfficeData::class);
 		$data->method('getId')->willReturn($id);
 		$data->method('getUser')->willReturn($user);
@@ -119,7 +91,8 @@ class OutOfOfficeServiceTest extends TestCase {
 		$timeFactory->expects(self::once())
 			->method('getTime')
 			->willReturn(1500);
-		$this->availabilityCoordinator->expects(self::once())
+		$availabilityCoordinator = $this->serviceMock->getParameter('availabilityCoordinator');
+		$availabilityCoordinator->expects(self::once())
 			->method('getCurrentOutOfOfficeData')
 			->with($user)
 			->willReturn($data);
@@ -196,7 +169,8 @@ class OutOfOfficeServiceTest extends TestCase {
 		$timeFactory->expects(self::once())
 			->method('getTime')
 			->willReturn(1500);
-		$this->availabilityCoordinator->expects(self::once())
+		$availabilityCoordinator = $this->serviceMock->getParameter('availabilityCoordinator');
+		$availabilityCoordinator->expects(self::once())
 			->method('getCurrentOutOfOfficeData')
 			->with($user)
 			->willReturn($data);


### PR DESCRIPTION
Fallback can go because Mail 4.0 requires at least Nextcloud 30.