### PR TITLE
fix(iframe): scroll horizontally in case of overflow

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -97,7 +97,11 @@ export default {
 		scout.on('beforeprint', this.onBeforePrint)
 	},
 	mounted() {
-		iframeResizer({ log: false, heightCalculationMethod: 'taggedElement' }, this.$refs.iframe)
+		iframeResizer({
+			log: false,
+			heightCalculationMethod: 'taggedElement',
+			scrolling: true,
+		}, this.$refs.iframe)
 	},
 	beforeDestroy() {
 		scout.off('beforeprint', this.onBeforePrint)

--- a/src/css/html-response.css
+++ b/src/css/html-response.css
@@ -5,3 +5,7 @@
 * {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
+
+html {
+	overflow-y: hidden;
+}


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/10245

Wide HTML emails are not readable on small screens because of the missing horizontal scrollbar.

## Only horizontal scrollbar (single envelope in thread)

If there is only one message, the iframe should grow to its full height and no vertical scrollbar should be visible.

![spectacle_20241014_100745](https://github.com/user-attachments/assets/dc8e1dd9-c6cf-41db-853b-b612d827ee36)

## Both scrollbars (multiple envelopes in thread)

If there are multiple messages, the iframe should not grow to its full height and both scrollbars should be visible.

![spectacle_20241014_100714](https://github.com/user-attachments/assets/d418ea3f-4671-4a12-bce2-df7b98c79fc1)