### PR TITLE
fix: Reply all inside message thread

### DIFF
--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -15,7 +15,7 @@
 			</ActionButton>
 			<ActionButton v-if="withReply"
 				:close-after-click="true"
-				@click="onReply">
+				@click="onReply(!hasMultipleRecipients)">
 				<template #icon>
 					<ReplyAllIcon v-if="hasMultipleRecipients"
 						:title="t('mail', 'Reply all')"


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/10142

## How to test

1. Write a message to multiple recipients, include yourself
2. Open that message with nextcloud 29 and Mail 3.7.x
3. Open the actions menu of the message in the thread

stable3.7: "simple" reply routine is followed and only the sender is replied to
here: everyone is replied to

cc @StefInP