### PR TITLE
fix(rtl): userBubble rtl support

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -318,7 +318,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 #mail-message {
 	margin-bottom: 30vh;
 


### PR DESCRIPTION
| b | a |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7179724d-ffc9-4185-8f08-f4013ed32422) | ![image](https://github.com/user-attachments/assets/92850601-1451-4618-89c3-22cbc91394b6) | 

unwanted styles leaking from `Thread.vue`
part of https://github.com/nextcloud/groupware/issues/84