### PR TITLE
fix: increase default SMTP timeout

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -40,7 +40,7 @@ Depending on your mail host, it may be necessary to increase your IMAP and/or SM
 ```
 #### SMTP timeout
 ```php
-'app.mail.smtp.timeout' => 2
+'app.mail.smtp.timeout' => 20
 ```
 #### Sieve timeout
 ```php

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -60,7 +60,7 @@ class SmtpClientFactory {
 			'port' => $mailAccount->getOutboundPort(),
 			'username' => $mailAccount->getOutboundUser(),
 			'secure' => $security === 'none' ? false : $security,
-			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 5),
+			'timeout' => (int)$this->config->getSystemValue('app.mail.smtp.timeout', 20),
 			'context' => [
 				'ssl' => [
 					'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -70,7 +70,7 @@ class SmtpClientFactoryTest extends TestCase {
 			->willReturnMap([
 				['app.mail.transport', 'smtp', 'smtp'],
 				['debug', false, false],
-				['app.mail.smtp.timeout', 5, 2],
+				['app.mail.smtp.timeout', 20, 2],
 			]);
 		$this->config->expects($this->any())
 			->method('getSystemValueBool')


### PR DESCRIPTION
These are the [RFC](https://www.rfc-editor.org/rfc/rfc5321.html#page-65) recommendations:

```
Recommended Timeout Values:
    Initial Connection: Set the timeout for the initial 220 message to at least 5 minutes.
    Mail Commands: Allocate a minimum of 5 minutes for both the MAIL and RCPT commands.
    Data Initiation: Allow at least 2 minutes for initiating the DATA command.
    Data Block: Set a timeout of at least 3 minutes for sending a data block.
    Data Termination: Provide a generous 10-minute timeout for terminating the DATA command.
    Server Timeout: Configure the server to have a timeout of at least 5 minutes.
```

We have to be cognizant of the PHP timeout, so 5 minutes are out.

20 seconds to start, otherwise we need to see what else we can do and if we need to recommend higher PHP timeouts as well as a higher SMTP timeout for the Mail app.