### PR TITLE
feat: per account imap and smtp debugging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
             run: php -f nextcloud/occ app:enable mail
           - name: Configure Nextcloud for testing
             run: |
-                php -f nextcloud/occ config:system:set debug --type bool --value true
+                php -f nextcloud/occ config:system:set app.mail.debug --type bool --value true
                 php -f nextcloud/occ config:system:set app.mail.verify-tls-peer --type bool --value false
           - name: Enable slow mysql query logs
             if: ${{ matrix.db == 'mysql' }}
@@ -192,7 +192,7 @@ jobs:
             run: echo "SELECT * FROM mysql.slow_log WHERE sql_text LIKE '%oc_mail%' AND sql_text NOT LIKE '%information_schema%'" | mysql -h 127.0.0.1 -u root -pmy-secret-pw
           - name: Print debug logs
             if: ${{ always() }}
-            run: cat nextcloud/data/horde_*.log
+            run: cat nextcloud/data/mail-*-*-imap.log
           - name: Report coverage
             uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
             if: ${{ always() && matrix.db == 'mysql' }}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>5.0.0-dev.1</version>
+	<version>5.0.0-dev.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>
@@ -80,6 +80,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\CleanUp</command>
 		<command>OCA\Mail\Command\CreateAccount</command>
 		<command>OCA\Mail\Command\CreateTagMigrationJobEntry</command>
+		<command>OCA\Mail\Command\DebugAccount</command>
 		<command>OCA\Mail\Command\DeleteAccount</command>
 		<command>OCA\Mail\Command\DiagnoseAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -62,6 +62,13 @@ class Account implements JsonSerializable {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function getDebug(): bool {
+		return $this->account->getDebug();
+	}
+
+	/**
 	 * Set the quota percentage
 	 * @param Quota $quota
 	 * @return void

--- a/lib/Command/DebugAccount.php
+++ b/lib/Command/DebugAccount.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DebugAccount extends Command {
+	protected const ARGUMENT_ACCOUNT_ID = 'account-id';
+	protected const OPTION_DEBUG_ON = 'on';
+	protected const OPTION_DEBUG_OFF = 'off';
+
+	public function __construct(
+		private AccountService $accountService,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function configure(): void {
+		$this->setName('mail:account:debug');
+		$this->setDescription('Enable or Disable IMAP/SMTP debugging for an account');
+		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED);
+		$this->addOption(self::OPTION_DEBUG_ON, null, InputOption::VALUE_NONE);
+		$this->addOption(self::OPTION_DEBUG_OFF, null, InputOption::VALUE_NONE);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
+		$debugOn = $input->getOption(self::OPTION_DEBUG_ON);
+		$debugOff = $input->getOption(self::OPTION_DEBUG_OFF);
+		$debug = false;
+
+		try {
+			$account = $this->accountService->findById($accountId)->getMailAccount();
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Account $accountId does not exist</error>");
+			return 1;
+		}
+
+		if ($debugOn && $debugOff) {
+			$output->writeln('<error>Cannot use both --on and --off at the same time</error>');
+			return 1;
+		}
+
+		if ($debugOn) {
+			$debug = true;
+		}
+
+		$account->setDebug($debug);
+		$this->accountService->save($account);
+
+		return 0;
+	}
+}

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -101,6 +101,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setSearchBody(bool $searchBody)
  * @method bool|null getOooFollowsSystem()
  * @method void setOooFollowsSystem(bool $oooFollowsSystem)
+ * @method bool getDebug()
+ * @method void setDebug(bool $debug)
  */
 class MailAccount extends Entity {
 	public const SIGNATURE_MODE_PLAIN = 0;
@@ -183,6 +185,8 @@ class MailAccount extends Entity {
 	/** @var bool|null */
 	protected $oooFollowsSystem;
 
+	protected bool $debug = false;
+
 	/**
 	 * @param array $params
 	 */
@@ -240,6 +244,9 @@ class MailAccount extends Entity {
 		if (isset($params['outOfOfficeFollowsSystem'])) {
 			$this->setOutOfOfficeFollowsSystem($params['outOfOfficeFollowsSystem']);
 		}
+		if (isset($params['debug'])) {
+			$this->setDebug($params['debug']);
+		}
 
 		$this->addType('inboundPort', 'integer');
 		$this->addType('outboundPort', 'integer');
@@ -263,6 +270,7 @@ class MailAccount extends Entity {
 		$this->addType('junkMailboxId', 'integer');
 		$this->addType('searchBody', 'boolean');
 		$this->addType('oooFollowsSystem', 'boolean');
+		$this->addType('debug', 'boolean');
 	}
 
 	public function getOutOfOfficeFollowsSystem(): bool {
@@ -310,6 +318,7 @@ class MailAccount extends Entity {
 			'junkMailboxId' => $this->getJunkMailboxId(),
 			'searchBody' => $this->getSearchBody(),
 			'outOfOfficeFollowsSystem' => $this->getOutOfOfficeFollowsSystem(),
+			'debug' => $this->getDebug(),
 		];
 
 		if (!is_null($this->getOutboundHost())) {

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -117,8 +117,9 @@ class IMAPClientFactory {
 				'backend' => $this->hordeCacheFactory->newCache($account),
 			];
 		}
-		if ($this->config->getSystemValue('debug', false)) {
-			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_imap.log';
+		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
+			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}
 
 		$client = new HordeImapClient($params);

--- a/lib/Migration/Version5000Date20250405000000.php
+++ b/lib/Migration/Version5000Date20250405000000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version5000Date20250405000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$accountsTable = $schema->getTable('mail_accounts');
+		if (!$accountsTable->hasColumn('debug')) {
+			$accountsTable->addColumn('debug', Types::BOOLEAN, [
+				'notnull' => false,
+				'default' => false,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -72,8 +72,9 @@ class SmtpClientFactory {
 				$decryptedAccessToken,
 			);
 		}
-		if ($this->config->getSystemValue('debug', false)) {
-			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/horde_smtp.log';
+		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-smtp.log';
+			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}
 		return new Horde_Mail_Transport_Smtphorde($params);
 	}

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -54,7 +54,7 @@ class MailAccountTest extends TestCase {
 			'editorMode' => 'html',
 			'provisioningId' => null,
 			'order' => 13,
-			'showSubscribedOnly' => null,
+			'showSubscribedOnly' => false,
 			'personalNamespace' => null,
 			'draftsMailboxId' => null,
 			'sentMailboxId' => null,
@@ -70,6 +70,7 @@ class MailAccountTest extends TestCase {
 			'snoozeMailboxId' => null,
 			'searchBody' => false,
 			'outOfOfficeFollowsSystem' => true,
+			'debug' => false,
 		], $a->toJson());
 	}
 
@@ -107,6 +108,7 @@ class MailAccountTest extends TestCase {
 			'snoozeMailboxId' => null,
 			'searchBody' => false,
 			'outOfOfficeFollowsSystem' => false,
+			'debug' => false,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency

--- a/tests/Integration/Framework/ImapTestAccount.php
+++ b/tests/Integration/Framework/ImapTestAccount.php
@@ -47,6 +47,7 @@ trait ImapTestAccount {
 		$mailAccount->setOutboundUser('user@domain.tld');
 		$mailAccount->setOutboundPassword(OC::$server->getCrypto()->encrypt('mypassword'));
 		$mailAccount->setOutboundSslMode('none');
+		$mailAccount->setDebug(false);
 		$acc = $accountService->save($mailAccount);
 
 		/** @var MailboxSync $mbSync */

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -55,13 +55,14 @@ class SmtpClientFactoryTest extends TestCase {
 			->method('getSystemValue')
 			->willReturnMap([
 				['app.mail.transport', 'smtp', 'smtp'],
-				['debug', false, false],
 				['app.mail.smtp.timeout', 20, 2],
 			]);
 		$this->config->expects($this->any())
 			->method('getSystemValueBool')
-			->with('app.mail.verify-tls-peer', true)
-			->willReturn(true);
+			->willReturnMap([
+				['app.mail.verify-tls-peer', true, true],
+				['app.mail.debug', false, false],
+			]);
 		$this->crypto->expects($this->once())
 			->method('decrypt')
 			->with('obenc')


### PR DESCRIPTION
At the moment there is no ability to debug a single mail account.

This adds the ability to enable debugging from the command line using a occ command on a single account and protocol. This also creates a separate file for each account that is enable instead of logging all accounts to the same log file. ( {data directory}/mail-{user id}-{account id}-imap.log )

// command arguments and options
mail:account:debug [--on] [--off] <account-id>

// enable debugging for imap
mail:account:debug 14 --on

// disable debugging
mail:account:debug 14 --off
mail:account:debug 14

// enable for single run with environmental variable
NC_MAIL_DEBUG=true php occ mail:account:sync 14
