### PR TITLE
fix(contactsintegration): Limit number of search results

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -227,7 +227,8 @@ class ContactsIntegration {
 		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
 
 		$result = $this->contactsManager->search($term, $fields, [
-			'strict_search' => $strictSearch
+			'strict_search' => $strictSearch,
+			'limit' => 20,
 		]);
 		$matches = [];
 		foreach ($result as $r) {


### PR DESCRIPTION
Searching with few characters in large address books or system address books can yield lots of results. This can exhaust the memory and a user likely will search more specifically anyway.

Fixes ```Allowed memory size of 1073741824 bytes exhausted (tried to allocate 4096 bytes) at /var/www/html/nextcloud/apps/dav/lib/CardDAV/CardDavBackend.php```