### PR TITLE
fix: Junk/NotJunk flags

### DIFF
--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -48,17 +48,15 @@ use function array_values;
 
 class MailManager implements IMailManager {
 	/**
-	 * https://tools.ietf.org/html/rfc3501#section-2.3.2
+	 * https://datatracker.ietf.org/doc/html/rfc9051#name-flags-message-attribute
 	 */
-	private const ALLOWED_FLAGS = [
+	private const SYSTEM_FLAGS = [
 		'seen' => [Horde_Imap_Client::FLAG_SEEN],
 		'answered' => [Horde_Imap_Client::FLAG_ANSWERED],
 		'flagged' => [Horde_Imap_Client::FLAG_FLAGGED],
 		'deleted' => [Horde_Imap_Client::FLAG_DELETED],
 		'draft' => [Horde_Imap_Client::FLAG_DRAFT],
 		'recent' => [Horde_Imap_Client::FLAG_RECENT],
-		'junk' => [Horde_Imap_Client::FLAG_JUNK, 'junk'],
-		'mdnsent' => [Horde_Imap_Client::FLAG_MDNSENT],
 	];
 
 	/** @var IMAPClientFactory */
@@ -766,16 +764,29 @@ class MailManager implements IMailManager {
 	 * @return array
 	 */
 	public function filterFlags(Horde_Imap_Client_Socket $client, Account $account, string $flag, string $mailbox): array {
-		// check for RFC server flags
-		if (array_key_exists($flag, self::ALLOWED_FLAGS) === true) {
-			return self::ALLOWED_FLAGS[$flag];
+		// check if flag is RFC defined system flag
+		if (array_key_exists($flag, self::SYSTEM_FLAGS) === true) {
+			return self::SYSTEM_FLAGS[$flag];
 		}
-
-		// Only allow flag setting if IMAP supports Permaflags
-		// @TODO check if there are length & char limits on permflags
-		if ($this->isPermflagsEnabled($client, $account, $mailbox) === true) {
+		// check if server supports custom keywords / this specific keyword
+		try {
+			$capabilities = $client->status($mailbox, Horde_Imap_Client::STATUS_PERMFLAGS);
+		} catch (Horde_Imap_Client_Exception $e) {
+			throw new ServiceException(
+				'Could not get message flag options from IMAP: ' . $e->getMessage(),
+				$e->getCode(),
+				$e
+			);
+		}
+		// check if server returned supported flags
+		if (!isset($capabilities['permflags'])) {
+			return [];
+		}
+		// check if server supports custom flags or specific flag
+		if (in_array("\*", $capabilities['permflags']) || in_array($flag, $capabilities['permflags'])) {
 			return [$flag];
 		}
+		
 		return [];
 	}
 

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -326,7 +326,7 @@ class MailManagerTest extends TestCase {
 		$this->manager->flagMessage($account, 'INBOX', 123, Tag::LABEL_IMPORTANT, false);
 	}
 
-	public function testFilterFlagStandard(): void {
+	public function testFilterFlagsWithSystemFlags(): void {
 		$account = $this->createMock(Account::class);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$flags = [
@@ -336,32 +336,50 @@ class MailManagerTest extends TestCase {
 			'deleted' => [\Horde_Imap_Client::FLAG_DELETED],
 			'draft' => [\Horde_Imap_Client::FLAG_DRAFT],
 			'recent' => [\Horde_Imap_Client::FLAG_RECENT],
-			'junk' => [\Horde_Imap_Client::FLAG_JUNK, 'junk'],
-			'mdnsent' => [\Horde_Imap_Client::FLAG_MDNSENT],
 		];
 
-		//standard flags
+		// test all system flags
 		foreach ($flags as $k => $flag) {
 			$this->assertEquals($this->manager->filterFlags($client, $account, $k, 'INBOX'), $flags[$k]);
 		}
 	}
 
-	public function testSetFilterFlagsNoCapabilities() {
+	public function testFilterFlagsWithDefinedKeyword() {
+		$account = $this->createMock(Account::class);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
+		$client->expects($this->exactly(2))
+			->method('status')
+			->willReturn(['permflags' => ['\seen', '$junk', '$notjunk']]);
+		
+		// test keyword supported
+		$this->assertEquals(['$junk'], $this->manager->filterFlags($client, $account, '$junk', 'INBOX'));
+		// test keyword unsupported
+		$this->assertEquals([], $this->manager->filterFlags($client, $account, '$autojunk', 'INBOX'));
+	}
+
+	public function testFilterFlagsWithCustomKeyword() {
+		$account = $this->createMock(Account::class);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
+		$client->expects($this->exactly(2))
+			->method('status')
+			->willReturnOnConsecutiveCalls(
+				['permflags' => ['\seen', '$junk', '$notjunk', '\*']],
+				['permflags' => ['\seen', '$junk', '$notjunk']],
+			);
+		
+		// test custom keyword supported
+		$this->assertEquals([Tag::LABEL_IMPORTANT], $this->manager->filterFlags($client, $account, Tag::LABEL_IMPORTANT, 'INBOX'));
+		// test custom keyword unsupported
+		$this->assertEquals([], $this->manager->filterFlags($client, $account, Tag::LABEL_IMPORTANT, 'INBOX'));
+	}
+
+	public function testFilterFlagsNoCapabilities() {
 		$account = $this->createMock(Account::class);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->assertEquals([], $this->manager->filterFlags($client, $account, Tag::LABEL_IMPORTANT, 'INBOX'));
-	}
-
-	public function testSetFilterFlagsImportant() {
-		$account = $this->createMock(Account::class);
-		$client = $this->createMock(Horde_Imap_Client_Socket::class);
-
-		$client->expects($this->once())
-			->method('status')
-			->willReturn(['permflags' => [ '11' => "\*" ]]);
-
-		$this->assertEquals([Tag::LABEL_IMPORTANT], $this->manager->filterFlags($client, $account, Tag::LABEL_IMPORTANT, 'INBOX'));
 	}
 
 	public function testIsPermflagsEnabledTrue(): void {


### PR DESCRIPTION
### Issue

Junk and NotJunk flags where not being set due to a invalid comparison. UI was sending "$junk" but it was being compared to "junk".
 
![Screenshot 2024-11-05 181610](https://github.com/user-attachments/assets/31a8af26-4dd1-48b1-ab36-126c30a4452c)

Allowed flags was also missing "notjunk"

![image](https://github.com/user-attachments/assets/85b2ec51-b119-4394-8bda-0fbac4cd68be)
