### PR TITLE
chore(psalm): add explicit type annotation for widget items

### DIFF
--- a/lib/Dashboard/MailWidget.php
+++ b/lib/Dashboard/MailWidget.php
@@ -129,6 +129,7 @@ abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOpt
 		$intSince = $since === null ? null : (int)$since;
 		$emails = $this->getEmails($userId, $intSince, $limit);
 
+		/** @var list<WidgetItem> */
 		return array_map(function (Message $email) {
 			$firstFrom = $email->getFrom()->first();
 			return new WidgetItem(


### PR DESCRIPTION
The return type annotation of the inherited function from the interface was changed on master. Let's see if it still runs on stable30 etc. ...