### PR TITLE
fix: accept avatars with image/vnd.microsoft.icon mime types

### DIFF
--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -78,6 +78,7 @@ class AvatarService implements IAvatarService {
 					'image/jpeg',
 					'image/png',
 					'image/x-icon',
+					'image/vnd.microsoft.icon',
 				]);
 		} else {
 			// We trust internal URLs by default


### PR DESCRIPTION
Avatars sourced from favicons won't render if they are provided as .ico files. 

The mime type `image/x-icon` is not registered with the IANA. Instead, `image/vnd.microsoft.icon` is the preferred mime type for .ico files.

The unofficial type `image/x-icon` is mostly used by Microsoft software (ironically).