### PR TITLE
[stable3.7] ci(psalm-matrix): don't run on stable30

### DIFF
--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -18,7 +18,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        ocp-version: [ 'dev-stable30', 'dev-stable29', 'dev-stable28', 'dev-stable27' ]
+        ocp-version: [ 'dev-stable29', 'dev-stable28', 'dev-stable27' ]
 
     name: static-psalm-analysis ${{ matrix.ocp-version }}
     steps:


### PR DESCRIPTION
Mail `stable4.0` supersedes `stable3.7` on Nextcloud `stable30` so we don't really need to include `stable30` in the matrix.

![image](https://github.com/user-attachments/assets/406d69f5-2e3a-4dc4-a939-7cebf05ea1b6)