### PR TITLE
fix(contactsintegration): Limit number of matches

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -58,7 +58,15 @@ class ContactsIntegration {
 		$shareeEnumerationFullMatchUserId = $shareeEnumerationFullMatch && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_userid', 'yes') === 'yes';
 		$shareeEnumerationFullMatchEmail = $shareeEnumerationFullMatch && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_email', 'yes') === 'yes';
 
-		$result = $this->contactsManager->search($term, ['UID', 'FN', 'EMAIL'], ['enumeration' => $shareeEnumeration, 'fullmatch' => $shareeEnumerationFullMatch]);
+		$result = $this->contactsManager->search(
+			$term,
+			['UID', 'FN', 'EMAIL'],
+			[
+				'enumeration' => $shareeEnumeration,
+				'fullmatch' => $shareeEnumerationFullMatch,
+				'limit' => 20,
+			],
+		);
 		if (empty($result)) {
 			return [];
 		}

--- a/tests/Unit/Service/ContactsIntegrationTest.php
+++ b/tests/Unit/Service/ContactsIntegrationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2015-2016 ownCloud, Inc.
@@ -353,7 +355,14 @@ class ContactsIntegrationTest extends TestCase {
 			->will($this->returnValue(true));
 		$this->contactsManager->expects($this->once())
 			->method('search')
-			->with($term, ['UID', 'FN', 'EMAIL'], ['enumeration' => $allowSystemUsers, 'fullmatch' => $shareeEnumerationFullMatch])
+			->with(
+				$term,
+				['UID', 'FN', 'EMAIL'],
+				[
+					'enumeration' => $allowSystemUsers,
+					'fullmatch' => $shareeEnumerationFullMatch,
+					'limit' => 20,
+				])
 			->will($this->returnValue($searchResult));
 	}
 


### PR DESCRIPTION
Prevents the composer autocompletion from listing *all* matches. For large address books or system address books this can slow down the browser significantly.