### PR TITLE
fix: disable async vue components

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "NODE_ENV=production NODE_OPTIONS='--max-old-space-size=4096' vite --mode=production build",
-    "dev": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=4096' vite --mode=development build",
+    "build": "NODE_ENV=production NODE_OPTIONS='--max-old-space-size=8192' vite --mode=production build",
+    "dev": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8192' vite --mode=development build",
     "watch": "NODE_ENV=development NODE_OPTIONS='--max-old-space-size=8192' vite build --mode=development --watch",
     "lint": "eslint --ext .js,.vue --ignore-pattern tests src",
     "lint:fix": "eslint --ext .js,.vue --ignore-pattern tests src --fix",

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -98,6 +98,7 @@ import IconFolderAdd from 'vue-material-design-icons/Folder.vue'
 import MenuDown from 'vue-material-design-icons/ChevronDown.vue'
 import MenuUp from 'vue-material-design-icons/ChevronUp.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
+import AccountSettings from './AccountSettings.vue'
 import { DialogBuilder } from '@nextcloud/dialogs'
 export default {
 	name: 'NavigationAccount',
@@ -108,7 +109,7 @@ export default {
 		ActionCheckbox,
 		ActionInput,
 		ActionText,
-		AccountSettings: () => import(/* webpackChunkName: "account-settings" */ './AccountSettings.vue'),
+		AccountSettings,
 		IconInfo,
 		IconSettings,
 		IconFolderAdd,

--- a/src/router.js
+++ b/src/router.js
@@ -7,8 +7,8 @@ import Vue from 'vue'
 import Router from 'vue-router'
 import { generateUrl } from '@nextcloud/router'
 
-const Home = () => import('./views/Home.vue')
-const Setup = () => import('./views/Setup.vue')
+import Home from './views/Home.vue'
+import Setup from './views/Setup.vue'
 
 Vue.use(Router)
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -30,6 +30,7 @@ import MailboxThread from '../components/MailboxThread.vue'
 import Navigation from '../components/Navigation.vue'
 import Outbox from '../components/Outbox.vue'
 import ComposerSessionIndicator from '../components/ComposerSessionIndicator.vue'
+import NewMessageModal from '../components/NewMessageModal.vue'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -38,7 +39,7 @@ export default {
 		NcContent,
 		MailboxThread,
 		Navigation,
-		NewMessageModal: () => import(/* webpackChunkName: "new-message-modal" */ '../components/NewMessageModal.vue'),
+		NewMessageModal,
 		Outbox,
 		ComposerSessionIndicator,
 	},


### PR DESCRIPTION
![Screenshot From 2024-11-23 22-18-48](https://github.com/user-attachments/assets/3daba347-b387-41a8-aa34-fddc0689d307)

I'm seeing the famous "can't redefine non-configurable property $router" on my dev setup (main) and on c.nc.c (stable4.1).

Downside is that mail-main.js is now 9,803.38 kB :fearful: 

Before: 
```
./js/Upload-CiIThrPS.chunk.mjs                              1.56 kB │ gzip:   0.84 kB │ map:     1.30 kB
./js/Setup-B65pp2sL.chunk.mjs                               2.78 kB │ gzip:   1.21 kB │ map:     2.79 kB
./js/randomId-BnxyHsj7.chunk.mjs                            5.99 kB │ gzip:   1.78 kB │ map:    14.04 kB
./js/NcCheckboxRadioSwitch-l-6YVD9V-DzPQuco_.chunk.mjs     31.13 kB │ gzip:   6.20 kB │ map:    50.59 kB
./js/AccountForm-BmpEnP8z.chunk.mjs                        32.84 kB │ gzip:   6.75 kB │ map:    48.36 kB
./js/FilePicker-ajWx2Snh-mBxkLcb8.chunk.mjs                90.94 kB │ gzip:  20.73 kB │ map: 3,063.28 kB
./js/NewMessageModal-D4XCzgv-.chunk.mjs                   121.14 kB │ gzip:  26.76 kB │ map:   187.80 kB
./js/AccountSettings-CDiuapQM.chunk.mjs                   228.25 kB │ gzip:  40.23 kB │ map:   330.50 kB
./js/Nextcloud-COIclUaX.chunk.mjs                         315.16 kB │ gzip:  79.50 kB │ map:   690.04 kB
./js/index-BvQHV1fZ.chunk.mjs                           1,370.16 kB │ gzip: 231.08 kB │ map: 2,976.78 kB
./js/mail-main.mjs                                      1,536.75 kB │ gzip: 343.43 kB │ map: 3,134.61 kB
./js/Home-pbw81Vm5.chunk.mjs                            1,553.83 kB │ gzip: 293.28 kB │ map: 2,621.17 kB
./js/TextEditor-n_Vsblu4.chunk.mjs                      2,021.52 kB │ gzip: 401.91 kB │ map: 4,356.37 kB
./js/Navigation-C6biF-u5.chunk.mjs                      4,276.88 kB │ gzip: 724.46 kB │ map: 5,887.16 kB
```

After:
```
./js/FilePicker-ajWx2Snh-Dm0EJAwb.chunk.mjs             90.86 kB │ gzip:    20.71 kB │ map:  3,063.28 kB
./js/Nextcloud-DbAgo5M9.chunk.mjs                      315.16 kB │ gzip:    79.49 kB │ map:    690.04 kB
./js/Upload-DEdpxAeZ.chunk.mjs                       1,402.34 kB │ gzip:   236.92 kB │ map:  3,028.48 kB
./js/mail-main.mjs                                   9,803.38 kB │ gzip: 1,837.67 kB │ map: 16,611.15 kB
```

(Note: I removed some unrelated chunks for better readability, for the language related chunks which did not change).