### PR TITLE
fix(ui): Restore message/thread styling

### DIFF
--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -265,7 +265,6 @@ export default {
 }
 .contact-popover {
 	display: flex;
-	padding: 2px;
 
 	&__email {
 		text-align: center;

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -318,7 +318,7 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 #mail-message {
 	margin-bottom: 30vh;
 
@@ -485,6 +485,12 @@ export default {
 	overflow: hidden;
 	display: flex;
 	align-items: stretch;
+
+	::deep(.v-popper--theme-dropdown.v-popper__popper .v-popper__inner) {
+		height: 300px;
+		width: 250px;
+		overflow: auto;
+	}
 }
 .avatar-more {
 	display: inline;
@@ -499,12 +505,6 @@ export default {
 
 .avatar-hidden {
 	visibility: hidden;
-}
-
-.v-popper--theme-dropdown.v-popper__popper .v-popper__inner {
-	height: 300px;
-	width: 250px;
-	overflow: auto;
 }
 
 .app-content-list-item-star.icon-starred {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/10392

Reverts https://github.com/nextcloud/mail/pull/10268 and adds a more specific fix for the leaked popover styles.

This is still a bodge. Styles should be scoped. We have to move some rules around.