### PR TITLE
[stable4.0] ci: fix wget output file flag

### DIFF
--- a/.github/workflows/appstore-conventional-build-publish.yml
+++ b/.github/workflows/appstore-conventional-build-publish.yml
@@ -104,7 +104,7 @@ jobs:
         id: server-checkout
         run: |
           NCVERSION=${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
-          wget --quiet https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip -o build/nextcloud.zip
+          wget --quiet https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip -O build/nextcloud.zip
           unzip build/nextcloud.zip build/nextcloud
 
       - name: Checkout server master fallback
@@ -124,7 +124,7 @@ jobs:
           cd ../../
           # Setting up keys
           echo "${{ secrets.APP_PRIVATE_KEY }}" > build/${{ env.APP_NAME }}.key
-          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt" -o build/${{ env.APP_NAME }}.crt
+          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt" -O build/${{ env.APP_NAME }}.crt
           pwd
           ls -l
           ls -l build


### PR DESCRIPTION
It should be -O not -o. The flag -o will redirect the log instead of writing the downloaded output file.

Fixes a missing certificate causing an invalid signature.