### PR TITLE
fix(mailto): Handle BCC recipients only

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -411,7 +411,10 @@ class PageController extends Controller {
 	 */
 	public function compose(string $uri): RedirectResponse {
 		$parts = parse_url($uri);
-		$params = ['to' => $parts['path']];
+		$params = [];
+		if (isset($parts['path'])) {
+			$params['to'] = $parts['path'];
+		}
 		if (isset($parts['query'])) {
 			$parts = explode('&', $parts['query']);
 			foreach ($parts as $part) {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -362,6 +362,7 @@ export default {
 						accountId,
 						to: this.stringToRecipients(this.$route.query.to),
 						cc: this.stringToRecipients(this.$route.query.cc),
+						bcc: this.stringToRecipients(this.$route.query.bcc),
 						subject: this.$route.query.subject || '',
 						body: this.$route.query.body ? detect(this.$route.query.body) : html(''),
 					},

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -40,6 +40,7 @@ use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use function urlencode;
 
 class PageControllerTest extends TestCase {
 	/** @var string */
@@ -374,6 +375,17 @@ class PageControllerTest extends TestCase {
 
 		$expected = new RedirectResponse('?to=' . urlencode($address)
 			. '&cc=' . urlencode($cc));
+
+		$response = $this->controller->compose($uri);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testComposeBcc() {
+		$bcc = 'blind@example.com';
+		$uri = "mailto:?bcc=$bcc";
+
+		$expected = new RedirectResponse('?bcc=' . urlencode($bcc));
 
 		$response = $this->controller->compose($uri);
 


### PR DESCRIPTION
When using the *Send email as BCC* feature in Contacts, Mail failed at two steps:
* The PHP redirect that always assumed a ordinary recipient (to)
* The frontend that didn't pass BCC information to the composer modal