### PR TITLE
fix(imap): Consider charset for preview text decoding

### DIFF
--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -17,6 +17,7 @@ use Horde_Imap_Client_Fetch_Results;
 use Horde_Imap_Client_Ids;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Db\Mailbox;
+use OCA\Mail\IMAP\Charset\Converter;
 use OCA\Mail\IMAP\ImapMessageFetcher;
 use OCA\Mail\IMAP\ImapMessageFetcherFactory;
 use OCA\Mail\IMAP\MessageMapper;
@@ -40,17 +41,21 @@ class MessageMapperTest extends TestCase {
 	/** @var ImapMessageFetcherFactory|MockObject */
 	private $imapMessageFactory;
 
+	private Converter|MockObject $converter;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->sMimeService = $this->createMock(SmimeService::class);
 		$this->imapMessageFactory = $this->createMock(ImapMessageFetcherFactory::class);
+		$this->converter = $this->createMock(Converter::class);
 
 		$this->mapper = new MessageMapper(
 			$this->logger,
 			$this->sMimeService,
 			$this->imapMessageFactory,
+			$this->converter,
 		);
 	}
 


### PR DESCRIPTION
~~@alexanderdd I'd appreciate if you could give this a test. Please not that existing messages will not be changed/fixed. Only newly arriving messages will have the correctly decoded characters.~~ Not possible due to time constraints.

## How to test

Import the eml with Evolution/Thunderbird:

```
Return-Path: <user@domain.tld>
From: Jan Doe <user@domain.tld>
To: "Jan Doe (user@domain.tld)"
 <user@domain.tld>
Subject: ISO-88591 charset test
Message-ID: <20241205074113.Horde.Ut2Mt73MCILSvZ6gOTiFbNE@localhost>
User-Agent: Horde Application Framework 5
Date: Thu, 05 Dec 2024 07:41:13 +0000
MIME-Version: 1.0
Content-Type: text/plain; charset="iso-8859-1"
Content-Transfer-Encoding: quoted-printable

Wir k=F6nnen ja
```

and open Mail with the same account.

Before: 
![image](https://github.com/user-attachments/assets/1441e909-2650-4136-94f3-10d4d0873d8d)
After: 
![image](https://github.com/user-attachments/assets/ecabe5d3-02e5-4c02-ac39-21e64f7779ca)
