### PR TITLE
fix(ui): Restore account quota fetching

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -9,7 +9,7 @@
 			:id="id"
 			:key="id"
 			:name="account.emailAddress"
-			@update:menuOpen="onMenuToggle">
+			@update:open="onMenuToggle">
 			<!-- Actions -->
 			<template #actions>
 				<template v-if="isDisabled">


### PR DESCRIPTION
It's triggered when the menu opens. NcAppNavigationItem and NcAppNavigationCaption use different prop names for the menu state.

Regression of https://github.com/nextcloud/mail/pull/9719

Fixes https://github.com/nextcloud/mail/issues/10441

## How to test

* Configure an account, doesn't matter if it support quota or not
* Open the app
* Open the account actions menu

main/stable4.x: Infinite *Loading …* while nothing is actually loaded.
here: quota loads, or shows that the server doesn't support it.