### PR TITLE
ci: Fix public suffix data file path

### DIFF
--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: true
 
       - name: Download public suffix list
-        run: curl --output resources/resources/public_suffix_list.dat https://publicsuffix.org/list/public_suffix_list.dat
+        run: curl --output resources/public_suffix_list.dat https://publicsuffix.org/list/public_suffix_list.dat
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@7920c48d6af627948130adb390df5809c471ae3b


### PR DESCRIPTION
Previous cron action runs failed with

```
Run curl --output resources/resources/public_suffix_list.dat https://publicsuffix.org/list/public_suffix_list.dat
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0Warning: Failed to open the file resources/resources/public_suffix_list.dat: 
Warning: No such file or directory

  0  309k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (23) Failure writing output to destination
Error: Process completed with exit code 23.
```