### PR TITLE
fix: add ability to send alternet text (html and plain)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>4.2.0-beta.1</version>
+	<version>4.2.0-beta.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/lib/Controller/DraftsController.php
+++ b/lib/Controller/DraftsController.php
@@ -76,8 +76,9 @@ class DraftsController extends Controller {
 	public function create(
 		int $accountId,
 		string $subject,
-		string $body,
-		string $editorBody,
+		?string $bodyPlain,
+		?string $bodyHtml,
+		?string $editorBody,
 		bool $isHtml,
 		?bool $smimeSign,
 		?bool $smimeEncrypt,
@@ -101,9 +102,10 @@ class DraftsController extends Controller {
 		$message->setAccountId($accountId);
 		$message->setAliasId($aliasId);
 		$message->setSubject($subject);
-		$message->setBody($body);
-		$message->setEditorBody($editorBody);
+		$message->setBodyPlain($bodyPlain);
+		$message->setBodyHtml($bodyHtml);
 		$message->setHtml($isHtml);
+		$message->setEditorBody($editorBody);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setUpdatedAt($this->timeFactory->getTime());
 		$message->setSendAt($sendAt);
@@ -146,8 +148,9 @@ class DraftsController extends Controller {
 	public function update(int $id,
 		int $accountId,
 		string $subject,
-		string $body,
-		string $editorBody,
+		?string $bodyPlain,
+		?string $bodyHtml,
+		?string $editorBody,
 		bool $isHtml,
 		?bool $smimeSign,
 		?bool $smimeEncrypt,
@@ -169,9 +172,10 @@ class DraftsController extends Controller {
 		$message->setAccountId($accountId);
 		$message->setAliasId($aliasId);
 		$message->setSubject($subject);
-		$message->setBody($body);
-		$message->setEditorBody($editorBody);
+		$message->setBodyPlain($bodyPlain);
+		$message->setBodyHtml($bodyHtml);
 		$message->setHtml($isHtml);
+		$message->setEditorBody($editorBody);
 		$message->setFailed($failed);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setSendAt($sendAt);

--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -151,9 +151,16 @@ class MessageApiController extends OCSController {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($accountId);
 		$message->setSubject($subject);
-		$message->setBody($body);
+		if ($isHtml) {
+			$message->setBodyPlain(null);
+			$message->setBodyHtml($body);
+			$message->setHtml(true);
+		} else {
+			$message->setBodyPlain($body);
+			$message->setBodyHtml(null);
+			$message->setHtml(false);
+		}
 		$message->setEditorBody($body);
-		$message->setHtml($isHtml);
 		$message->setSendAt($this->time->getTime());
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 

--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -90,8 +90,9 @@ class OutboxController extends Controller {
 	public function create(
 		int $accountId,
 		string $subject,
-		string $body,
-		string $editorBody,
+		?string $bodyPlain,
+		?string $bodyHtml,
+		?string $editorBody,
 		bool $isHtml,
 		bool $smimeSign,
 		bool $smimeEncrypt,
@@ -118,9 +119,10 @@ class OutboxController extends Controller {
 		$message->setAccountId($accountId);
 		$message->setAliasId($aliasId);
 		$message->setSubject($subject);
-		$message->setBody($body);
-		$message->setEditorBody($editorBody);
+		$message->setBodyPlain($bodyPlain);
+		$message->setBodyHtml($bodyHtml);
 		$message->setHtml($isHtml);
+		$message->setEditorBody($editorBody);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setSendAt($sendAt);
 		$message->setPgpMime($isPgpMime);
@@ -181,7 +183,8 @@ class OutboxController extends Controller {
 		int $id,
 		int $accountId,
 		string $subject,
-		string $body,
+		?string $bodyPlain,
+		?string $bodyHtml,
 		?string $editorBody,
 		bool $isHtml,
 		bool $smimeSign,
@@ -207,9 +210,10 @@ class OutboxController extends Controller {
 		$message->setAccountId($accountId);
 		$message->setAliasId($aliasId);
 		$message->setSubject($subject);
-		$message->setBody($body);
-		$message->setEditorBody($editorBody);
+		$message->setBodyPlain($bodyPlain);
+		$message->setBodyHtml($bodyHtml);
 		$message->setHtml($isHtml);
+		$message->setEditorBody($editorBody);
 		$message->setInReplyToMessageId($inReplyToMessageId);
 		$message->setSendAt($sendAt);
 		$message->setPgpMime($isPgpMime);

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -25,10 +25,12 @@ use function array_filter;
  * @method void setSendAt(?int $sendAt)
  * @method string getSubject()
  * @method void setSubject(string $subject)
- * @method string getBody()
- * @method void setBody(?string $body)
+ * @method string getBodyPlain()
+ * @method void setBodyPlain(?string $bodyPlain)
+ * @method string getBodyHtml()
+ * @method void setBodyHtml(?string $bodyHtml)
  * @method string|null getEditorBody()
- * @method void setEditorBody(string $body)
+ * @method void setEditorBody(?string $body)
  * @method bool isHtml()
  * @method void setHtml(bool $html)
  * @method bool|null isFailed()
@@ -88,8 +90,11 @@ class LocalMessage extends Entity implements JsonSerializable {
 	/** @var string */
 	protected $subject;
 
-	/** @var string */
-	protected $body;
+	/** @var string|null */
+	protected $bodyPlain;
+	
+	/** @var string|null */
+	protected $bodyHtml;
 
 	/** @var string|null */
 	protected $editorBody;
@@ -163,7 +168,8 @@ class LocalMessage extends Entity implements JsonSerializable {
 			'sendAt' => $this->getSendAt(),
 			'updatedAt' => $this->getUpdatedAt(),
 			'subject' => $this->getSubject(),
-			'body' => $this->getBody(),
+			'bodyPlain' => $this->getBodyPlain(),
+			'bodyHtml' => $this->getBodyHtml(),
 			'editorBody' => $this->getEditorBody(),
 			'isHtml' => ($this->isHtml() === true),
 			'isPgpMime' => ($this->isPgpMime() === true),

--- a/lib/Migration/Version4200Date20241210000000.php
+++ b/lib/Migration/Version4200Date20241210000000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version4200Date20241210000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$outboxTable = $schema->getTable('mail_local_messages');
+		if (!$outboxTable->hasColumn('body_plain')) {
+			$outboxTable->addColumn('body_plain', Types::TEXT, [
+				'notnull' => false,
+			]);
+		}
+		if (!$outboxTable->hasColumn('body_html')) {
+			$outboxTable->addColumn('body_html', Types::TEXT, [
+				'notnull' => false,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/Migration/Version4200Date20241210000001.php
+++ b/lib/Migration/Version4200Date20241210000001.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version4200Date20241210000001 extends SimpleMigrationStep {
+
+	/**
+	 * Version4200Date20241210000000 constructor.
+	 *
+	 * @param IDBConnection $connection
+	 */
+	public function __construct(
+		private IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @psalm-param Closure():ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options) {
+		$schema = $schemaClosure();
+
+		$outboxTable = $schema->getTable('mail_local_messages');
+		if ($outboxTable->hasColumn('body') && $outboxTable->hasColumn('body_plain') && $outboxTable->hasColumn('body_html')) {
+			// copy plain type content to proper column
+			$qb = $this->db->getQueryBuilder();
+			$qb->update('mail_local_messages')
+				->set('body_plain', 'body')
+				->where($qb->expr()->eq('html', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)))
+				->executeStatement();
+			// copy html type content to proper column
+			$qb = $this->db->getQueryBuilder();
+			$qb->update('mail_local_messages')
+				->set('body_html', 'body')
+				->where($qb->expr()->eq('html', $qb->createNamedParameter(1, IQueryBuilder::PARAM_INT)))
+				->executeStatement();
+		} else {
+			throw new Exception('Can not perform migration step, one of the following columns is missing body, body_plain, body_html', 1);
+		}
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$outboxTable = $schema->getTable('mail_local_messages');
+		if ($outboxTable->hasColumn('body')) {
+			$outboxTable->dropColumn('body');
+		}
+		return $schema;
+	}
+}

--- a/lib/Provider/Command/MessageSend.php
+++ b/lib/Provider/Command/MessageSend.php
@@ -75,10 +75,13 @@ class MessageSend {
 		$localMessage->setType($localMessage::TYPE_OUTGOING);
 		$localMessage->setAccountId($account->getId());
 		$localMessage->setSubject((string)$message->getSubject());
-		$localMessage->setBody((string)$message->getBody());
-		// disabled due to issues caused by opening these messages in gui
-		//$localMessage->setEditorBody($message->getBody());
-		$localMessage->setHtml(true);
+		$localMessage->setBodyPlain($message->getBodyPlain());
+		$localMessage->setBodyHtml($message->getBodyHtml());
+		if (!empty($message->getBodyHtml())) {
+			$localMessage->setHtml(true);
+		} else {
+			$localMessage->setHtml(false);
+		}
 		$localMessage->setSendAt($this->time->getTime());
 		// convert mail provider addresses to recipient addresses
 		$to = $this->convertAddressArray($message->getTo());

--- a/lib/Service/AntiSpamService.php
+++ b/lib/Service/AntiSpamService.php
@@ -158,7 +158,7 @@ class AntiSpamService {
 			new DataUriParser()
 		);
 		$mimePart = $mimeMessage->build(
-			true,
+			null,
 			$message->getContent(),
 			$message->getAttachments()
 		);

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -122,8 +122,8 @@ class MailTransmission implements IMailTransmission {
 			new DataUriParser()
 		);
 		$mimePart = $mimeMessage->build(
-			$localMessage->isHtml(),
-			$localMessage->getBody(),
+			$localMessage->getBodyPlain(),
+			$localMessage->getBodyHtml(),
 			$attachmentParts,
 			$localMessage->isPgpMime() === true
 		);
@@ -183,7 +183,11 @@ class MailTransmission implements IMailTransmission {
 		$imapMessage->setFrom($from);
 		$imapMessage->setCC($cc);
 		$imapMessage->setBcc($bcc);
-		$imapMessage->setContent($message->getBody());
+		if ($message->isHtml() === true) {
+			$imapMessage->setContent($message->getBodyHtml());
+		} else {
+			$imapMessage->setContent($message->getBodyPlain());
+		}
 
 		foreach ($attachments as $attachment) {
 			$this->transmissionService->handleAttachment($account, $attachment);

--- a/lib/Service/MimeMessage.php
+++ b/lib/Service/MimeMessage.php
@@ -25,151 +25,181 @@ class MimeMessage {
 	}
 
 	/**
-	 * @param bool $isHtml
-	 * @param string $content
+	 * generates mime message
+	 *
+	 * @param string $contentPlain
+	 * @param string $contentHtml
 	 * @param Horde_Mime_Part[] $attachments
+	 *
 	 * @return Horde_Mime_Part
 	 */
-	public function build(bool $isHtml, string $content, array $attachments, bool $isPgpMime = false): Horde_Mime_Part {
-		if ($isHtml) {
-			$imageParts = [];
-			if (empty($content)) {
-				$htmlContent = $textContent = $content;
-			} else {
-				$source = '<html><meta http-equiv="content-type" content="text/html; charset=UTF-8"><body>' . $content . '</body>';
+	public function build(?string $contentPlain, ?string $contentHtml, array $attachments, bool $isPgpEncrypted = false): Horde_Mime_Part {
 
-				$doc = new DOMDocument();
-				$doc->loadHTML($source, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
-
-				$images = $doc->getElementsByTagName('img');
-
-				for ($i = 0; $i < $images->count(); $i++) {
-					$image = $images->item($i);
-					if (!($image instanceof DOMElement)) {
-						continue;
-					}
-
-					$src = $image->getAttribute('src');
-					if ($src === '') {
-						continue;
-					}
-
-					try {
-						$dataUri = $this->uriParser->parse($src);
-					} catch (InvalidDataUriException $e) {
-						continue;
-					}
-
-					$part = new Horde_Mime_Part();
-					$part->setType($dataUri->getMediaType());
-					$part->setCharset($dataUri->getParameters()['charset']);
-					$part->setName('embedded_image_' . $i);
-					$part->setDisposition('inline');
-					if ($dataUri->isBase64()) {
-						$part->setTransferEncoding('base64');
-					}
-					$part->setContents($dataUri->getData());
-
-					$cid = $part->setContentId();
-					$imageParts[] = $part;
-
-					$image->setAttribute('src', 'cid:' . $cid);
-				}
-
-				$htmlContent = $doc->saveHTML();
-				$textContent = Horde_Text_Filter::filter($htmlContent, 'Html2text', ['callback' => [$this, 'htmlToTextCallback']]);
-			}
-
-			$alternativePart = new Horde_Mime_Part();
-			$alternativePart->setType('multipart/alternative');
-
-			$htmlPart = new Horde_Mime_Part();
-			$htmlPart->setType('text/html');
-			$htmlPart->setCharset('UTF-8');
-			$htmlPart->setContents($htmlContent);
-			$htmlPart->setDescription('HTML Version of Message');
-
-			$textPart = new Horde_Mime_Part();
-			$textPart->setType('text/plain');
-			$textPart->setCharset('UTF-8');
-			$textPart->setContents($textContent);
-			$textPart->setDescription('Plaintext Version of Message');
-
+		if ($isPgpEncrypted === true && isset($contentPlain)) {
+			$basePart = $this->buildPgpPart($contentPlain);
+		} elseif (count($attachments) > 0) {
 			/*
-			 * RFC1341: In general, user agents that compose multipart/alternative entities should place the
-			 * body parts in increasing order of preference, that is, with the preferred format last.
-			 */
-			$alternativePart[] = $textPart;
-			$alternativePart[] = $htmlPart;
-
-			/*
-			 * Wrap the multipart/alternative parts in multipart/related when inline images are found.
-			 */
-			if (count($imageParts) > 0) {
-				$bodyPart = new Horde_Mime_Part();
-				$bodyPart->setType('multipart/related');
-				$bodyPart[] = $alternativePart;
-				foreach ($imageParts as $imagePart) {
-					$bodyPart[] = $imagePart;
-				}
-			} else {
-				$bodyPart = $alternativePart;
-			}
-		} elseif ($isPgpMime) {
-			$contentPart = new Horde_Mime_Part();
-			$contentPart->setType('application/octet-stream');
-			$contentPart->setContentTypeParameter('name', 'encrypted.asc');
-			$contentPart->setTransferEncoding('7bit');
-			$contentPart->setDisposition('inline');
-			$contentPart->setDispositionParameter('filename', 'encrypted.asc');
-			$contentPart->setDescription('OpenPGP encrypted message');
-			$contentPart->setContents($content);
-
-			$pgpIdentPart = new Horde_Mime_Part();
-			$pgpIdentPart->setType('application/pgp-encrypted');
-			$pgpIdentPart->setTransferEncoding('7bit');
-			$pgpIdentPart->setDescription('PGP/MIME Versions Identification');
-			$pgpIdentPart->setContents('Version: 1');
-
-			$bodyPart = new Horde_Mime_Part();
-			$bodyPart->setType('multipart/encrypted');
-			$bodyPart->setContentTypeParameter('protocol', 'application/pgp-encrypted');
-			$bodyPart[] = $pgpIdentPart;
-			$bodyPart[] = $contentPart;
-		} else {
-			$bodyPart = new Horde_Mime_Part();
-			$bodyPart->setType('text/plain');
-			$bodyPart->setCharset('UTF-8');
-			$bodyPart->setContents($content);
-		}
-
-		/*
-		 * For attachments wrap the body (multipart/related, multipart/alternative or text/plain) in
-		 * a multipart/mixed part.
-		 */
-		if (count($attachments) > 0) {
+			* Messages with non embedded attachments need to be wrap in a multipart/mixed part
+			*/
 			$basePart = new Horde_Mime_Part();
 			$basePart->setType('multipart/mixed');
-			$basePart[] = $bodyPart;
+			$basePart[] = $this->buildMessagePart($contentPlain, $contentHtml);
 			foreach ($attachments as $attachment) {
 				$basePart[] = $attachment;
 			}
 		} else {
-			$basePart = $bodyPart;
+			$basePart = $this->buildMessagePart($contentPlain, $contentHtml);
 		}
 
-		/*
-		 * To add the Mime-Version-Header
-		 */
 		$basePart->isBasePart(true);
 
 		return $basePart;
 	}
 
 	/**
+	 * generates html/plain message part
+	 *
+	 * @return Horde_Mime_Part
+	 */
+	private function buildMessagePart(?string $contentPlain, ?string $contentHtml): Horde_Mime_Part {
+
+		if (isset($contentHtml)) {
+			
+			// determine if content is wrapped properly in a html tag, otherwise we need to wrap it properly
+			if (mb_strpos($contentHtml, '<html') === false) {
+				$source = '<html><meta http-equiv="content-type" content="text/html; charset=UTF-8"><body>' . $contentHtml . '</body>';
+			} else {
+				$source = ' ' . $contentHtml;
+			}
+			
+			$doc = new DOMDocument();
+			$doc->loadHTML($source, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
+			// determine if content has any embedded images
+			$embeddedParts = [];
+			foreach ($doc->getElementsByTagName('img') as $id => $image) {
+				if (!($image instanceof DOMElement)) {
+					continue;
+				}
+
+				$src = $image->getAttribute('src');
+				if ($src === '') {
+					continue;
+				}
+				try {
+					$dataUri = $this->uriParser->parse($src);
+				} catch (InvalidDataUriException $e) {
+					continue;
+				}
+
+				$part = new Horde_Mime_Part();
+				$part->setType($dataUri->getMediaType());
+				$part->setCharset($dataUri->getParameters()['charset']);
+				$part->setName('embedded_image_' . $id);
+				$part->setDisposition('inline');
+				if ($dataUri->isBase64()) {
+					$part->setTransferEncoding('base64');
+				}
+				$part->setContents($dataUri->getData());
+
+				$cid = $part->setContentId();
+				$embeddedParts[] = $part;
+
+				$image->setAttribute('src', 'cid:' . $cid);
+			}
+			$htmlContent = $doc->saveHTML();
+
+			$htmlPart = new Horde_Mime_Part();
+			$htmlPart->setType('text/html');
+			$htmlPart->setCharset('UTF-8');
+			$htmlPart->setContents($htmlContent);
+		}
+		
+		if (isset($contentPlain)) {
+			$plainPart = new Horde_Mime_Part();
+			$plainPart->setType('text/plain');
+			$plainPart->setCharset('UTF-8');
+			$plainPart->setContents($contentPlain);
+		} elseif (!isset($contentPlain) && isset($contentHtml)) {
+			$plainPart = new Horde_Mime_Part();
+			$plainPart->setType('text/plain');
+			$plainPart->setCharset('UTF-8');
+			$plainPart->setContents(
+				Horde_Text_Filter::filter($contentHtml, 'Html2text', ['callback' => [$this, 'htmlToTextCallback']])
+			);
+		}
+
+		if (isset($plainPart, $htmlPart)) {
+			/*
+			* RFC1341: Multipart/alternative entities should place the body parts in
+			* increasing order of preference, that is, with the preferred format last.
+			*/
+			$messagePart = new Horde_Mime_Part();
+			$messagePart->setType('multipart/alternative');
+			$messagePart[] = $plainPart;
+			$messagePart[] = $htmlPart;
+		} elseif (isset($htmlPart)) {
+			$messagePart = $htmlPart;
+		} elseif (isset($plainPart)) {
+			$messagePart = $plainPart;
+		} else {
+			$messagePart = new Horde_Mime_Part();
+		}
+
+		if (isset($embeddedParts) && count($embeddedParts) > 0) {
+			/*
+			 * Text parts with embedded content (e.g. inline images, etc) need be wrapped in multipart/related part
+			 */
+			$basePart = new Horde_Mime_Part();
+			$basePart->setType('multipart/related');
+			$basePart[] = $messagePart;
+			foreach ($embeddedParts as $part) {
+				$basePart[] = $part;
+			}
+		} else {
+			$basePart = $messagePart;
+		}
+
+		return $basePart;
+	}
+
+	/**
+	 * generates pgp encrypted message part
+	 *
+	 * @param string $content
+	 *
+	 * @return Horde_Mime_Part
+	 */
+	private function buildPgpPart(string $content): Horde_Mime_Part {
+
+		$contentPart = new Horde_Mime_Part();
+		$contentPart->setType('application/octet-stream');
+		$contentPart->setContentTypeParameter('name', 'encrypted.asc');
+		$contentPart->setTransferEncoding('7bit');
+		$contentPart->setDisposition('inline');
+		$contentPart->setDispositionParameter('filename', 'encrypted.asc');
+		$contentPart->setDescription('OpenPGP encrypted message');
+		$contentPart->setContents($content);
+
+		$pgpIdentPart = new Horde_Mime_Part();
+		$pgpIdentPart->setType('application/pgp-encrypted');
+		$pgpIdentPart->setTransferEncoding('7bit');
+		$pgpIdentPart->setDescription('PGP/MIME Versions Identification');
+		$pgpIdentPart->setContents('Version: 1');
+		
+		$basePart = new Horde_Mime_Part();
+		$basePart->setType('multipart/encrypted');
+		$basePart->setContentTypeParameter('protocol', 'application/pgp-encrypted');
+		$basePart[] = $pgpIdentPart;
+		$basePart[] = $contentPart;
+
+		return $basePart;
+
+	}
+
+	/**
 	 * A callback for Horde_Text_Filter.
 	 *
-	 * The purpose of this callback is to overwrite the default behaviour
+	 * The purpose of this callback is to overwrite the default behavior
 	 * of html2text filter to convert <p>Hello</p> => Hello\n\n with
 	 * <p>Hello</p> => Hello\n.
 	 *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "4.2.0-beta1",
+  "version": "4.2.0-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "4.2.0-beta1",
+      "version": "4.2.0-beta2",
       "license": "agpl",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "37.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nextcloud-mail",
   "description": "Nextcloud Mail",
-  "version": "4.2.0-beta1",
+  "version": "4.2.0-beta2",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
   "license": "agpl",
   "private": true,

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -363,11 +363,10 @@ export default {
 			return this.draftsPromise
 		},
 		getDataForServer(data) {
-			return {
+			const dataForServer = {
 				...data,
 				id: data.id,
 				accountId: data.accountId,
-				body: data.isHtml ? data.body.value : toPlain(data.body).value,
 				editorBody: data.body.value,
 				to: data.to,
 				cc: data.cc,
@@ -378,6 +377,12 @@ export default {
 				sendAt: data.sendAt,
 				draftId: this.composerData?.draftId,
 			}
+			if (data.isHtml) {
+				dataForServer.bodyHtml = data.body.value
+			} else {
+				dataForServer.bodyPlain = toPlain(data.body).value
+			}
+			return dataForServer
 		},
 		onAttachmentUploading(done, data) {
 			this.attachmentsPromise = this.attachmentsPromise

--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -173,11 +173,17 @@ export default {
 			if (this.message.editorBody === null) {
 				return
 			}
+			const bodyData = {}
+			if (this.message.isHtml) {
+				bodyData.bodyHtml = html(this.message.body)
+			} else {
+				bodyData.bodyPlain = plain(this.message.body)
+			}
 			await this.mainStore.startComposerSession({
 				type: 'outbox',
 				data: {
 					...this.message,
-					body: this.message.isHtml ? html(this.message.body) : plain(this.message.body),
+					...bodyData,
 				},
 			})
 		},

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -555,9 +555,11 @@ export default function mainStoreActions() {
 				let originalSendAt
 				if (type === 'outbox' && data.id && data.sendAt) {
 					originalSendAt = data.sendAt
-					const message = {
-						...data,
-						body: data.isHtml ? data.body.value : toPlain(data.body).value,
+					const message = { ...data }
+					if (data.isHtml) {
+						message.bodyHtml = data.body.value
+					} else {
+						message.bodyPlain = toPlain(data.body).value
 					}
 					const outboxStore = useOutboxStore()
 					await outboxStore.stopMessage({ message })
@@ -588,7 +590,11 @@ export default function mainStoreActions() {
 				const message = this.composerMessage
 				if (restoreOriginalSendAt && message.type === 'outbox' && message.options?.originalSendAt) {
 					const body = message.data.body
-					message.body = message.data.isHtml ? body.value : toPlain(body).value
+					if (message.data.isHtml) {
+						message.bodyHtml = body.value
+					} else {
+						message.bodyPlain = toPlain(body).value
+					}
 					message.sendAt = message.options.originalSendAt
 					updateDraft(message)
 				}

--- a/src/store/outboxStore.js
+++ b/src/store/outboxStore.js
@@ -184,12 +184,18 @@ export default defineStore('outbox', {
 						logger.info('Attempting to stop sending message ' + message.id)
 						const stopped = await this.stopMessage({ message })
 						logger.info('Message ' + message.id + ' stopped', { message: stopped })
+						// The composer expects rich body data and not just a string
+						const bodyData = {}
+						if (message.isHtml) {
+							bodyData.bodyHtml = html(message.body)
+						} else {
+							bodyData.bodyPlain = plain(message.body)
+						}
 						await this.mainStore.startComposerSession({
 							type: 'outbox',
 							data: {
 								...message,
-								// The composer expects rich body data and not just a string
-								body: message.isHtml ? html(message.body) : plain(message.body),
+								...bodyData,
 							},
 						}, { root: true })
 					}, {

--- a/tests/Integration/Db/LocalAttachmentMapperTest.php
+++ b/tests/Integration/Db/LocalAttachmentMapperTest.php
@@ -97,7 +97,7 @@ class LocalAttachmentMapperTest extends TestCase {
 		$message1->setAliasId(3);
 		$message1->setSendAt(3);
 		$message1->setSubject('testSaveLocalAttachments');
-		$message1->setBody('message');
+		$message1->setBodyHtml('message');
 		$message1->setHtml(true);
 		$message1->setInReplyToMessageId('abcdefg');
 		$message1 = $this->localMessageMapper->insert($message1);
@@ -107,7 +107,7 @@ class LocalAttachmentMapperTest extends TestCase {
 		$message2->setAliasId(3);
 		$message2->setSendAt(3);
 		$message2->setSubject('testSaveLocalAttachments');
-		$message2->setBody('message');
+		$message2->setBodyHtml('message');
 		$message2->setHtml(true);
 		$message2->setInReplyToMessageId('abcdefg');
 		$message2 = $this->localMessageMapper->insert($message2);

--- a/tests/Integration/Db/LocalMessageMapperTest.php
+++ b/tests/Integration/Db/LocalMessageMapperTest.php
@@ -67,7 +67,7 @@ class LocalMessageMapperTest extends TestCase {
 		$message->setAliasId(2);
 		$message->setSendAt(123);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
 		$this->entity = $this->mapper->insert($message);
@@ -82,7 +82,7 @@ class LocalMessageMapperTest extends TestCase {
 		$this->assertEquals(2, $row->getAliasId());
 		$this->assertEquals($this->account->getId(), $row->getAccountId());
 		$this->assertEquals('subject', $row->getSubject());
-		$this->assertEquals('message', $row->getBody());
+		$this->assertEquals('message', $row->getBodyHtml());
 		$this->assertEquals('abc', $row->getInReplyToMessageId());
 		$this->assertTrue($row->isHtml());
 		$this->assertEmpty($row->getAttachments());
@@ -99,7 +99,7 @@ class LocalMessageMapperTest extends TestCase {
 		$this->assertEquals(2, $row->getAliasId());
 		$this->assertEquals($this->account->getId(), $row->getAccountId());
 		$this->assertEquals('subject', $row->getSubject());
-		$this->assertEquals('message', $row->getBody());
+		$this->assertEquals('message', $row->getBodyHtml());
 		$this->assertEquals('abc', $row->getInReplyToMessageId());
 		$this->assertTrue($row->isHtml());
 		$this->assertEmpty($row->getAttachments());
@@ -134,7 +134,7 @@ class LocalMessageMapperTest extends TestCase {
 		$message->setAliasId(3);
 		$message->setSendAt(3);
 		$message->setSubject('savedWithRelated');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcdefg');
 		$recipient = new Recipient();
@@ -151,7 +151,7 @@ class LocalMessageMapperTest extends TestCase {
 		$this->assertEquals(3, $row->getAliasId());
 		$this->assertEquals($this->account->getId(), $row->getAccountId());
 		$this->assertEquals('savedWithRelated', $row->getSubject());
-		$this->assertEquals('message', $row->getBody());
+		$this->assertEquals('message', $row->getBodyHtml());
 		$this->assertEquals('abcdefg', $row->getInReplyToMessageId());
 		$this->assertTrue($row->isHtml());
 		$this->assertEmpty($row->getAttachments());
@@ -185,7 +185,7 @@ class LocalMessageMapperTest extends TestCase {
 		$message->setAliasId(3);
 		$message->setSendAt(3);
 		$message->setSubject('savedWithRelated');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcdefg');
 		$recipient = new Recipient();

--- a/tests/Integration/Db/LocalMessageTest.php
+++ b/tests/Integration/Db/LocalMessageTest.php
@@ -31,7 +31,7 @@ class LocalMessageTest extends TestCase {
 		$message->setAliasId(2);
 		$message->setSendAt($time);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('<abcdefg@12345678.com>');
 
@@ -40,7 +40,7 @@ class LocalMessageTest extends TestCase {
 		$this->assertEquals(2, $message->getAliasId());
 		$this->assertEquals($time, $message->getSendAt());
 		$this->assertEquals('subject', $message->getSubject());
-		$this->assertEquals('message', $message->getBody());
+		$this->assertEquals('message', $message->getBodyHtml());
 		$this->assertTrue($message->isHtml());
 		$this->assertEquals('<abcdefg@12345678.com>', $message->getInReplyToMessageId());
 		$this->assertNull($message->getAttachments());

--- a/tests/Integration/Db/RecipientMapperTest.php
+++ b/tests/Integration/Db/RecipientMapperTest.php
@@ -74,7 +74,7 @@ class RecipientMapperTest extends TestCase {
 		$message->setAliasId(2);
 		$message->setSendAt(123);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$this->message = $this->localMessageMapper->insert($message);
@@ -134,7 +134,7 @@ class RecipientMapperTest extends TestCase {
 		$message->setAliasId(2);
 		$message->setSendAt(123);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message = $this->localMessageMapper->insert($message);
@@ -163,7 +163,7 @@ class RecipientMapperTest extends TestCase {
 		$message->setAccountId($this->account->getId());
 		$message->setSendAt(123);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message = $this->localMessageMapper->insert($message);

--- a/tests/Integration/Service/DraftServiceIntegrationTest.php
+++ b/tests/Integration/Service/DraftServiceIntegrationTest.php
@@ -129,7 +129,7 @@ class DraftServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_DRAFT);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -153,7 +153,7 @@ class DraftServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_DRAFT);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -176,7 +176,7 @@ class DraftServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_DRAFT);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -205,7 +205,7 @@ class DraftServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_DRAFT);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -239,7 +239,7 @@ class DraftServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_DRAFT);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -109,7 +109,7 @@ class MailTransmissionIntegrationTest extends TestCase {
 		$this->message = new LocalMessage();
 		$this->message->setAccountId($this->account->getId());
 		$this->message->setSubject('greetings');
-		$this->message->setBody('hello there');
+		$this->message->setBodyHtml('hello there');
 		$this->message->setType(LocalMessage::TYPE_OUTGOING);
 		$this->message->setHtml(false);
 		$this->message->setRecipients([$recipient]);

--- a/tests/Integration/Service/OutboxServiceIntegrationTest.php
+++ b/tests/Integration/Service/OutboxServiceIntegrationTest.php
@@ -135,7 +135,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -159,7 +159,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$saved = $this->outbox->saveMessage(new Account($this->account), $message, [], [], []);
@@ -170,7 +170,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$saved = $this->outbox->saveMessage(new Account($this->account), $message, [], [], []);
@@ -186,7 +186,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		/** @var \Horde_Imap_Client_Mailbox[] $mailBoxes */
@@ -249,7 +249,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$this->userFolder->newFile('/test.txt', file_get_contents(__DIR__ . '/../../data/test.txt'));
 		$attachments = [
@@ -281,7 +281,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -304,7 +304,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -334,7 +334,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 
 		$to = [[
@@ -358,7 +358,7 @@ class OutboxServiceIntegrationTest extends TestCase {
 		$message->setType(LocalMessage::TYPE_OUTGOING);
 		$message->setAccountId($this->account->getId());
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('message');
 		$message->setHtml(true);
 		$message->setSendAt(100);
 

--- a/tests/Unit/Controller/DraftsControllerTest.php
+++ b/tests/Unit/Controller/DraftsControllerTest.php
@@ -194,7 +194,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -222,7 +223,8 @@ class DraftsControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -243,7 +245,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -273,7 +276,8 @@ class DraftsControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -298,7 +302,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -324,7 +329,8 @@ class DraftsControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -345,7 +351,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -365,7 +372,8 @@ class DraftsControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -384,7 +392,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -403,7 +412,8 @@ class DraftsControllerTest extends TestCase {
 		$this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -423,7 +433,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -451,7 +462,8 @@ class DraftsControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -474,7 +486,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -503,7 +516,8 @@ class DraftsControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -528,7 +542,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -551,7 +566,8 @@ class DraftsControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,
@@ -574,7 +590,8 @@ class DraftsControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abc');
@@ -602,7 +619,8 @@ class DraftsControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			null,

--- a/tests/Unit/Controller/MessageApiControllerTest.php
+++ b/tests/Unit/Controller/MessageApiControllerTest.php
@@ -109,7 +109,7 @@ class MessageApiControllerTest extends TestCase {
 		$this->message = new LocalMessage();
 		$this->message->setAccountId($this->accountId);
 		$this->message->setSubject('');
-		$this->message->setBody('');
+		$this->message->setBodyHtml('');
 		$this->message->setHtml(true);
 		$this->message->setType(LocalMessage::TYPE_OUTGOING);
 	}

--- a/tests/Unit/Controller/OutboxControllerTest.php
+++ b/tests/Unit/Controller/OutboxControllerTest.php
@@ -259,7 +259,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -284,7 +285,8 @@ class OutboxControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -306,7 +308,7 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -327,7 +329,8 @@ class OutboxControllerTest extends TestCase {
 		$actual = $this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -347,7 +350,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -368,7 +372,8 @@ class OutboxControllerTest extends TestCase {
 		$this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -389,7 +394,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -419,7 +425,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -442,7 +449,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -467,7 +475,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -490,7 +499,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -520,7 +530,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -540,7 +551,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -564,7 +576,8 @@ class OutboxControllerTest extends TestCase {
 		$this->controller->create(
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),
@@ -586,7 +599,8 @@ class OutboxControllerTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setAliasId(2);
 		$message->setSubject('subject');
-		$message->setBody('message');
+		$message->setBodyPlain(null);
+		$message->setBodyHtml('<p>message</p>');
 		$message->setEditorBody('<p>message</p>');
 		$message->setHtml(true);
 		$message->setSmimeSign(false);
@@ -616,7 +630,8 @@ class OutboxControllerTest extends TestCase {
 			$message->getId(),
 			$message->getAccountId(),
 			$message->getSubject(),
-			$message->getBody(),
+			$message->getBodyPlain(),
+			$message->getBodyHtml(),
 			'<p>message</p>',
 			$message->isHtml(),
 			$message->getSmimeSign(),

--- a/tests/Unit/Provider/Command/MessageSendTest.php
+++ b/tests/Unit/Provider/Command/MessageSendTest.php
@@ -80,8 +80,8 @@ class MessageSendTest extends TestCase {
 			'type' => 0,
 			'accountId' => 100,
 			'subject' => 'World domination',
-			'body' => 'I have the most brilliant plan. Let me tell you all about it. What we do is, we',
-			'html' => true
+			'bodyPlain' => 'I have the most brilliant plan. Let me tell you all about it. What we do is, we',
+			'html' => false
 		];
 		// construct mail app attachment object
 		$this->localAttachmentData = [

--- a/tests/Unit/Service/DraftsServiceTest.php
+++ b/tests/Unit/Service/DraftsServiceTest.php
@@ -101,7 +101,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setSendAt(null);
 		$message->setUpdatedAt(123456);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 
@@ -129,7 +129,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt(null);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 
@@ -148,7 +148,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt(null);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_DRAFT);
@@ -199,7 +199,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt(null);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_DRAFT);
@@ -246,7 +246,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt(null);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_DRAFT);
@@ -304,7 +304,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_OUTGOING);
@@ -362,7 +362,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt(null);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_DRAFT);
@@ -412,7 +412,7 @@ class DraftsServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('laskdjhsakjh33233928@startdewvalley.com');
 		$message->setType(LocalMessage::TYPE_OUTGOING);

--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -86,7 +86,7 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getEMailAddress')->willReturn('test@user');
 		$localMessage = new LocalMessage();
 		$localMessage->setSubject('Test');
-		$localMessage->setBody('Test');
+		$localMessage->setBodyPlain('Test');
 		$localMessage->setHtml(false);
 		$transport = $this->createMock(Horde_Mail_Transport::class);
 
@@ -115,7 +115,7 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getEMailAddress')->willReturn('test@user');
 		$localMessage = new LocalMessage();
 		$localMessage->setSubject('Test');
-		$localMessage->setBody('Test');
+		$localMessage->setBodyPlain('Test');
 		$localMessage->setHtml(false);
 		$transport = $this->createMock(Horde_Mail_Transport::class);
 
@@ -147,7 +147,7 @@ class MailTransmissionTest extends TestCase {
 		$alias->setAlias('a@d.com');
 		$localMessage = new LocalMessage();
 		$localMessage->setSubject('Test');
-		$localMessage->setBody('Test');
+		$localMessage->setBodyPlain('Test');
 		$localMessage->setHtml(false);
 		$localMessage->setAliasId(1);
 		$transport = $this->createMock(Horde_Mail_Transport::class);
@@ -186,7 +186,7 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getUserId')->willReturn($userId);
 		$localMessage = new LocalMessage();
 		$localMessage->setSubject('Test');
-		$localMessage->setBody('Test');
+		$localMessage->setBodyPlain('Test');
 		$localMessage->setHtml(false);
 		$attachment = new LocalAttachment();
 		$attachment->setId(1);
@@ -236,7 +236,7 @@ class MailTransmissionTest extends TestCase {
 		$account->method('getEMailAddress')->willReturn('test@user');
 		$localMessage = new LocalMessage();
 		$localMessage->setSubject('Test');
-		$localMessage->setBody('Test');
+		$localMessage->setBodyPlain('Test');
 		$localMessage->setHtml(false);
 		$localMessage->setInReplyToMessageId('321');
 		$repliedMessageUid = 321;
@@ -306,7 +306,7 @@ class MailTransmissionTest extends TestCase {
 		$localMessage->setAliasId(2);
 		$localMessage->setSendAt(123);
 		$localMessage->setSubject('subject');
-		$localMessage->setBody('message');
+		$localMessage->setBodyHtml('message');
 		$localMessage->setHtml(true);
 		$localMessage->setInReplyToMessageId('abc');
 		$localMessage->setAttachments([]);

--- a/tests/Unit/Service/MimeMessageTest.php
+++ b/tests/Unit/Service/MimeMessageTest.php
@@ -45,8 +45,8 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
 			$messageData->getBody(),
+			null,
 			[],
 		);
 
@@ -67,7 +67,7 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
+			$messageData->getBody(),
 			$messageData->getBody(),
 			[],
 		);
@@ -95,7 +95,7 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
+			$messageData->getBody(),
 			$messageData->getBody(),
 			[],
 		);
@@ -129,7 +129,7 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
+			$messageData->getBody(),
 			$messageData->getBody(),
 			[$attachment1],
 		);
@@ -180,7 +180,7 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
+			$messageData->getBody(),
 			$messageData->getBody(),
 			[$attachment1, $attachment2],
 		);
@@ -238,7 +238,7 @@ class MimeMessageTest extends TestCase {
 		);
 
 		$part = $this->mimeMessage->build(
-			$messageData->isHtml(),
+			null,
 			$messageData->getBody(),
 			[],
 		);

--- a/tests/Unit/Service/OutboxServiceTest.php
+++ b/tests/Unit/Service/OutboxServiceTest.php
@@ -146,7 +146,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 
@@ -174,7 +174,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 
@@ -193,7 +193,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$to = [
@@ -243,7 +243,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$to = [
@@ -289,7 +289,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$old = Recipient::fromParams([
@@ -346,7 +346,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$old = Recipient::fromParams([
@@ -397,7 +397,7 @@ class OutboxServiceTest extends TestCase {
 		$message->setAccountId(1);
 		$message->setSendAt($this->time->getTime());
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('laskdjhsakjh33233928@startdewvalley.com');
 		$to = [
@@ -514,7 +514,7 @@ class OutboxServiceTest extends TestCase {
 		$sentAt = $this->time->getTime();
 		$message->setSendAt($sentAt);
 		$message->setSubject('Test');
-		$message->setBody('Test Test Test');
+		$message->setBodyHtml('<p>message</p>');
 		$message->setHtml(true);
 		$message->setInReplyToMessageId('abcd');
 		$message->setType(LocalMessage::TYPE_DRAFT);


### PR DESCRIPTION
Resolves #10415

### Summary
This modifies the local_message table and mail transmission service to support alternative text for automated messages.
