### PR TITLE
fix(imap): Log MessageMapper not finding full text

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -492,6 +492,7 @@ class MessageMapper {
 		}
 
 		if (($message = $result->first()) === null) {
+			\OCP\Log\logger('mail')->info('Found ' . $result->count() . ' results');
 			return null;
 		}
 


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/9729

cc @Sjoerd001