### PR TITLE
[stable4.1] fix(dns): Update public suffix list

### DIFF
--- a/resources/public_suffix_list.dat
+++ b/resources/public_suffix_list.dat
@@ -5,8 +5,8 @@
 // Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
 // rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
 
-// VERSION: 2024-12-12_15-28-46_UTC
-// COMMIT: 54119e116bb0dc5be5b1c0f4218eaa057db17d92
+// VERSION: 2024-12-15_19-58-11_UTC
+// COMMIT: 0660ae7ec652fc051b3968c1cb36f03accd2a48c
 
 // Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
@@ -13676,10 +13676,6 @@ homesklep.pl
 *.kin.one
 *.id.pub
 *.kin.pub
-
-// Hong Kong Productivity Council: https://www.hkpc.org/
-// Submitted by SECaaS Team <summchan@hkpc.org>
-secaas.hk
 
 // Hoplix : https://www.hoplix.com
 // Submitted by Danilo De Franco<info@hoplix.shop>


### PR DESCRIPTION
Auto-generated update of https://publicsuffix.org/