### PR TITLE
ci: Only update public suffix list twice a month

### DIFF
--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -5,7 +5,7 @@ name: Update public suffix list
 on:
   workflow_dispatch:
   schedule:
-    - cron: "5 2 * * *"
+    - cron: "0 6 1,15 * *"
 
 jobs:
   update-public-suffix-list:


### PR DESCRIPTION
The job currently runs nightly and there are constant changes.