### PR TITLE
fix: wrong path for itinerary executable

### DIFF
--- a/lib/Migration/MakeItineraryExtractorExecutable.php
+++ b/lib/Migration/MakeItineraryExtractorExecutable.php
@@ -27,7 +27,7 @@ class MakeItineraryExtractorExecutable implements IRepairStep {
 
 	public function __construct(LoggerInterface $logger,
 		?string $file = null) {
-		$this->file = $file ?? __DIR__ . '/../../vendor/christophwurst/kitinerary-bin/bin/kitinerary-extractor';
+		$this->file = $file ?? (__DIR__ . '/../../vendor/nextcloud/kitinerary-bin/bin/kitinerary-extractor');
 		$this->logger = $logger;
 	}
 


### PR DESCRIPTION
Resolve #10504 

We moved the packages to the nextcloud namespace. 

How to test:

Run occ maintenance:repair and look for "Make Mail itinerary extractor executable"

| B | A |
|--------|--------|
| itinerary file doesn\'t exist | :heavy_check_mark:  | 
