### PR TITLE
fix(notifications): Notifier::prepare() threw \InvalidArgumentExcepti…

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -14,6 +14,7 @@ use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	private IFactory $factory;
@@ -41,7 +42,7 @@ class Notifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
 			// Not my app => throw
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -69,7 +70,7 @@ class Notifier implements INotifier {
 					]);
 				break;
 			default:
-				throw  new \InvalidArgumentException();
+				throw  new UnknownNotificationException();
 		}
 
 		return $notification;


### PR DESCRIPTION
…on which is deprecated


If a user has any notifications this log is generated all the time:

> OCA\Mail\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself

