### PR TITLE
fix: make filter routes available for normal users

### DIFF
--- a/lib/Controller/FilterController.php
+++ b/lib/Controller/FilterController.php
@@ -12,13 +12,14 @@ namespace OCA\Mail\Controller;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\FilterService;
+use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\Route;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\AppFramework\OCSController;
 use OCP\IRequest;
 
-class FilterController extends OCSController {
+class FilterController extends Controller {
 	private string $currentUserId;
 
 	public function __construct(
@@ -31,7 +32,9 @@ class FilterController extends OCSController {
 		$this->currentUserId = $userId;
 	}
 
+
 	#[Route(Route::TYPE_FRONTPAGE, verb: 'GET', url: '/api/filter/{accountId}', requirements: ['accountId' => '[\d]+'])]
+	#[NoAdminRequired]
 	public function getFilters(int $accountId) {
 		$account = $this->accountService->findById($accountId);
 
@@ -45,6 +48,7 @@ class FilterController extends OCSController {
 	}
 
 	#[Route(Route::TYPE_FRONTPAGE, verb: 'PUT', url: '/api/filter/{accountId}', requirements: ['accountId' => '[\d]+'])]
+	#[NoAdminRequired]
 	public function updateFilters(int $accountId, array $filters) {
 		$account = $this->accountService->findById($accountId);
 


### PR DESCRIPTION
**Summary**

1) The NoAdminRequired attribute is required to make the route available for non-admins.
2) Changing OCSController to Controller to respond with a proper error code on a failing request.

**How to test**

1) Login with a normal user account
2) Add an email account with sieve support
3) Try to create a filter

| B | A |
|--------|--------|
| Success state, but it failed | Success state, it works | 