### PR TITLE
perf(ui): Load avatar URLs with low priority

### DIFF
--- a/src/service/AvatarService.js
+++ b/src/service/AvatarService.js
@@ -16,7 +16,7 @@ export const fetchAvatarUrl = (email) => {
 		email,
 	})
 
-	return Axios.get(url)
+	return Axios.get(url, { adapter: 'fetch', fetchOptions: { priority: 'low' } })
 		.then((resp) => resp.data)
 		.then((avatar) => {
 			if (avatar.isExternal) {


### PR DESCRIPTION
When opening a mailbox and performing any operation it can happen at that there are many concurrent requests, and the browser will limit how many it executes at a time. This means that low priority operations like fetching the avatar (URL) blocks something like marking a messages as read. This hurts the UX.

When using `fetch`, we can tell the browser to treat the XHR with low priority, allowing it to run high priority requests first.

Ref https://blog.bitsrc.io/using-the-priority-hints-api-to-prioritize-network-requests-aff7d7676823