### PR TITLE
feat: setup check for mail transport php-mail

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -66,6 +66,7 @@ use OCA\Mail\Service\MailTransmission;
 use OCA\Mail\Service\Search\MailSearch;
 use OCA\Mail\Service\TrustedSenderService;
 use OCA\Mail\Service\UserPreferenceService;
+use OCA\Mail\SetupChecks\MailTransport;
 use OCA\Mail\Vendor\Favicon\Favicon;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -157,6 +158,8 @@ class Application extends App implements IBootstrap {
 		$context->registerMailProvider(MailProvider::class);
 
 		$context->registerNotifierService(Notifier::class);
+
+		$context->registerSetupCheck(MailTransport::class);
 
 		// bypass Horde Translation system
 		Horde_Translation::setHandler('Horde_Imap_Client', new HordeTranslationHandler());

--- a/lib/SetupChecks/MailTransport.php
+++ b/lib/SetupChecks/MailTransport.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class MailTransport implements ISetupCheck {
+	public function __construct(
+		private IConfig $config,
+		private IL10N $l10n,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Mail Transport configuration');
+	}
+
+	public function getCategory(): string {
+		return 'mail';
+	}
+
+	public function run(): SetupResult {
+		$transport = $this->config->getSystemValueString('app.mail.transport', 'smtp');
+
+		if ($transport === 'smtp') {
+			return SetupResult::success();
+		}
+
+		return SetupResult::warning(
+			$this->l10n->t('The app.mail.transport setting is not set to smtp. This configuration can cause issues with modern email security measures such as SPF and DKIM because emails are sent directly from the web server, which is often not properly configured for this purpose. To address this, we have discontinued support for the mail transport. Please remove app.mail.transport from your configuration to use the SMTP transport and hide this message. A properly configured SMTP setup is required to ensure email delivery.')
+		);
+	}
+}

--- a/tests/Unit/SetupChecks/MailTransportTest.php
+++ b/tests/Unit/SetupChecks/MailTransportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace Unit\SetupChecks;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\L10N\L10N;
+use OCA\Mail\SetupChecks\MailTransport;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\SetupCheck\SetupResult;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class MailTransportTest extends TestCase {
+	private IConfig&MockObject $config;
+	private IL10N&MockObject $l10n;
+	private MailTransport $check;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(L10N::class);
+
+		$this->check = new MailTransport($this->config, $this->l10n);
+	}
+
+	public function testSuccess(): void {
+		$this->config->method('getSystemValueString')
+			->willReturn('smtp');
+
+		$result = $this->check->run();
+
+		$this->assertEquals(SetupResult::SUCCESS, $result->getSeverity());
+	}
+
+	public function testWarning(): void {
+		$this->config->method('getSystemValueString')
+			->willReturn('mail');
+
+		$result = $this->check->run();
+
+		$this->assertEquals(SetupResult::WARNING, $result->getSeverity());
+	}
+
+	public function testName(): void {
+		$this->l10n->method('t')
+			->willReturn('Translated Name');
+
+		$this->assertEquals('Translated Name', $this->check->getName());
+	}
+
+	public function testCategory(): void {
+		$this->assertEquals('mail', $this->check->getCategory());
+	}
+}


### PR DESCRIPTION
Setup check from https://github.com/nextcloud/mail/pull/10516

Fix #10066 
Fix #10120 

![image](https://github.com/user-attachments/assets/539f8833-21f6-4349-805e-2ba6613fa2d9)

(Note: The screenshot is old, using error instead of warning)