### PR TITLE
fix: migrate preferences to initial state

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -205,19 +205,19 @@ class PageController extends Controller {
 		);
 
 		$user = $this->userSession->getUser();
-		$response = new TemplateResponse($this->appName, 'index',
-			[
-				'attachment-size-limit' => $this->config->getSystemValue('app.mail.attachment-size-limit', 0),
-				'app-version' => $this->config->getAppValue('mail', 'installed_version'),
-				'external-avatars' => $this->preferences->getPreference($this->currentUserId, 'external-avatars', 'true'),
-				'layout-mode' => $this->preferences->getPreference($this->currentUserId, 'layout-mode', 'vertical-split'),
-				'reply-mode' => $this->preferences->getPreference($this->currentUserId, 'reply-mode', 'top'),
-				'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
-				'search-priority-body' => $this->preferences->getPreference($this->currentUserId, 'search-priority-body', 'false'),
-				'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
-				'tag-classified-messages' => $this->classificationSettingsService->isClassificationEnabled($this->currentUserId) ? 'true' : 'false',
-				'follow-up-reminders' => $this->preferences->getPreference($this->currentUserId, 'follow-up-reminders', 'true'),
-			]);
+		$response = new TemplateResponse($this->appName, 'index');
+		$this->initialStateService->provideInitialState('preferences', [
+			'attachment-size-limit' => $this->config->getSystemValue('app.mail.attachment-size-limit', 0),
+			'app-version' => $this->config->getAppValue('mail', 'installed_version'),
+			'external-avatars' => $this->preferences->getPreference($this->currentUserId, 'external-avatars', 'true'),
+			'layout-mode' => $this->preferences->getPreference($this->currentUserId, 'layout-mode', 'vertical-split'),
+			'reply-mode' => $this->preferences->getPreference($this->currentUserId, 'reply-mode', 'top'),
+			'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
+			'search-priority-body' => $this->preferences->getPreference($this->currentUserId, 'search-priority-body', 'false'),
+			'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
+			'tag-classified-messages' => $this->classificationSettingsService->isClassificationEnabled($this->currentUserId) ? 'true' : 'false',
+			'follow-up-reminders' => $this->preferences->getPreference($this->currentUserId, 'follow-up-reminders', 'true'),
+		]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',
 			$this->userManager->getDisplayName($this->currentUserId),

--- a/src/init.js
+++ b/src/init.js
@@ -9,17 +9,11 @@ import { fetchAvailableLanguages } from './service/translationService.js'
 import useOutboxStore from './store/outboxStore.js'
 import useMainStore from './store/mainStore.js'
 
-const getPreferenceFromPage = (key) => {
-	const elem = document.getElementById(key)
-	if (!elem) {
-		return
-	}
-	return elem.value
-}
-
 export default function initAfterAppCreation() {
 	console.debug('Init after app creation')
 	const mainStore = useMainStore()
+
+	const preferences = loadState('mail', 'preferences', [])
 
 	mainStore.savePreferenceMutation({
 		key: 'debug',
@@ -37,32 +31,32 @@ export default function initAfterAppCreation() {
 
 	mainStore.savePreferenceMutation({
 		key: 'attachment-size-limit',
-		value: Number.parseInt(getPreferenceFromPage('attachment-size-limit'), 10),
+		value: Number.parseInt(preferences['attachment-size-limit'], 10),
 	})
 	mainStore.savePreferenceMutation({
 		key: 'version',
-		value: getPreferenceFromPage('config-installed-version'),
+		value: preferences['config-installed-version'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'external-avatars',
-		value: getPreferenceFromPage('external-avatars'),
+		value: preferences['external-avatars'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'collect-data',
-		value: getPreferenceFromPage('collect-data'),
+		value: preferences['collect-data'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'search-priority-body',
-		value: getPreferenceFromPage('search-priority-body'),
+		value: preferences['search-priority-body'],
 	})
-	const startMailboxId = getPreferenceFromPage('start-mailbox-id')
+	const startMailboxId = preferences['start-mailbox-id']
 	mainStore.savePreferenceMutation({
 		key: 'start-mailbox-id',
 		value: startMailboxId ? parseInt(startMailboxId, 10) : null,
 	})
 	mainStore.savePreferenceMutation({
 		key: 'tag-classified-messages',
-		value: getPreferenceFromPage('tag-classified-messages'),
+		value: preferences['tag-classified-messages'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'allow-new-accounts',
@@ -74,11 +68,11 @@ export default function initAfterAppCreation() {
 	})
 	mainStore.savePreferenceMutation({
 		key: 'layout-mode',
-		value: getPreferenceFromPage('layout-mode'),
+		value: preferences['layout-mode'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'follow-up-reminders',
-		value: getPreferenceFromPage('follow-up-reminders'),
+		value: preferences['follow-up-reminders'],
 	})
 	mainStore.savePreferenceMutation({
 		key: 'internal-addresses',

--- a/templates/index.php
+++ b/templates/index.php
@@ -5,15 +5,3 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 script('mail', 'mail');
-?>
-
-<input type="hidden" id="attachment-size-limit" value="<?php p($_['attachment-size-limit']); ?>">
-<input type="hidden" id="config-installed-version" value="<?php p($_['app-version']); ?>">
-<input type="hidden" id="external-avatars" value="<?php p($_['external-avatars']); ?>">
-<input type="hidden" id="collect-data" value="<?php p($_['collect-data']); ?>">
-<input type="hidden" id="start-mailbox-id" value="<?php p($_['start-mailbox-id']); ?>">
-<input type="hidden" id="tag-classified-messages" value="<?php p($_['tag-classified-messages']); ?>">
-<input type="hidden" id="search-priority-body" value="<?php p($_['search-priority-body']); ?>">
-<input type="hidden" id="layout-mode" value="<?php p($_['layout-mode']); ?>">
-<input type="hidden" id="follow-up-reminders" value="<?php p($_['follow-up-reminders']); ?>">
-

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -299,7 +299,7 @@ class PageControllerTest extends TestCase {
 			->method('getLoginCredentials')
 			->willReturn($loginCredentials);
 
-		$this->initialState->expects($this->exactly(20))
+		$this->initialState->expects($this->exactly(21))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
@@ -311,6 +311,18 @@ class PageControllerTest extends TestCase {
 				['internal-addresses', false],
 				['sort-order', 'newest'],
 				['password-is-unavailable', true],
+				['preferences', [
+					'attachment-size-limit' => 123,
+					'external-avatars' => 'true',
+					'reply-mode' => 'bottom',
+					'app-version' => '1.2.3',
+					'collect-data' => 'true',
+					'start-mailbox-id' => '123',
+					'tag-classified-messages' => 'false',
+					'search-priority-body' => 'false',
+					'layout-mode' => 'vertical-split',
+					'follow-up-reminders' => 'true',
+				]],
 				['prefill_displayName', 'Jane Doe'],
 				['prefill_email', 'jane@doe.cz'],
 				['outbox-messages', []],
@@ -324,18 +336,7 @@ class PageControllerTest extends TestCase {
 				['smime-certificates', []],
 			);
 
-		$expected = new TemplateResponse($this->appName, 'index', [
-			'attachment-size-limit' => 123,
-			'external-avatars' => 'true',
-			'reply-mode' => 'bottom',
-			'app-version' => '1.2.3',
-			'collect-data' => 'true',
-			'start-mailbox-id' => '123',
-			'tag-classified-messages' => 'false',
-			'search-priority-body' => 'false',
-			'layout-mode' => 'vertical-split',
-			'follow-up-reminders' => 'true',
-		]);
+		$expected = new TemplateResponse($this->appName, 'index');
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expected->setContentSecurityPolicy($csp);


### PR DESCRIPTION
Resolves https://github.com/nextcloud/mail/issues/10556
Regression from #10138 

The preferences could not be parsed because they are overwritten when mounting the Vue app. Inspect the source of the index page and see that the preference elements are injected into the main container whose content is overwritten on mount. Hence, all values were lost and no preferences were actually loaded.

**Before:** Preferences are not parsed on the frontend due to missing elements.
**After:** Preferences are parsed correctly again.