### PR TITLE
fix(message-summary): respect admin config

### DIFF
--- a/lib/Listener/NewMessagesSummarizeListener.php
+++ b/lib/Listener/NewMessagesSummarizeListener.php
@@ -14,6 +14,7 @@ use OCA\Mail\Events\NewMessagesSynchronized;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use Psr\Log\LoggerInterface;
@@ -28,11 +29,14 @@ class NewMessagesSummarizeListener implements IEventListener {
 		private IMAPClientFactory $imapFactory,
 		private AiIntegrationsService $aiService,
 		private IMailManager $mailManager,
+		private IAppConfig $appConfig,
 	) {
 	}
 
 	public function handle(Event $event): void {
-
+		if ($this->appConfig->getAppValue('llm_processing', 'no') !== 'yes') {
+			return;
+		}
 		if (!($event instanceof NewMessagesSynchronized)) {
 			return;
 		}

--- a/tests/Unit/Listener/NewMessagesSummarizeListenerTest.php
+++ b/tests/Unit/Listener/NewMessagesSummarizeListenerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Events\NewMessagesSynchronized;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\Listener\NewMessagesSummarizeListener;
+use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
+use OCP\AppFramework\Services\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger;
+
+class NewMessagesSummarizeListenerTest extends TestCase {
+	private LoggerInterface $logger;
+	private NewMessagesSummarizeListener $listener;
+	private IMAPClientFactory|MockObject $imapFactory;
+	private AiIntegrationsService|MockObject $aiService;
+	private IMailManager|MockObject $mailManager;
+	private IAppConfig|MockObject $appConfig;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->logger = new TestLogger();
+		$this->imapFactory = $this->createMock(IMAPClientFactory::class);
+		$this->aiService = $this->createMock(AiIntegrationsService::class);
+		$this->mailManager = $this->createMock(IMailManager::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->listener = new NewMessagesSummarizeListener(
+			$this->logger,
+			$this->imapFactory,
+			$this->aiService,
+			$this->mailManager,
+			$this->appConfig
+		);
+	}
+
+	public function testLlmEnabled(): void {
+		$event = $this->createMock(NewMessagesSynchronized::class);
+		$account = new Account(new MailAccount());
+		$event->expects($this->once())
+			->method('getAccount')
+			->willReturn($account);
+		$event->expects($this->once())
+			->method('getMessages')
+			->willReturn([]);
+		$this->appConfig->expects($this->once())
+			->method('getAppValue')
+			->with('llm_processing', 'no')
+			->willReturn('yes');
+		$this->aiService->expects($this->once())
+			->method('summarizeMessages')
+			->with($account, []);
+		$this->listener->handle($event);
+	}
+
+	public function testLlmDisabled(): void {
+		$event = $this->createMock(NewMessagesSynchronized::class);
+		$this->appConfig->expects($this->once())
+			->method('getAppValue')
+			->with('llm_processing', 'no')
+			->willReturn('no');
+		$this->aiService->expects($this->never())
+			->method('summarizeMessages');
+		$this->listener->handle($event);
+	}
+
+
+}


### PR DESCRIPTION
`summarizeMessages`feature is enabled by default, and not checking the admin config https://github.com/nextcloud/mail/pull/10465#issuecomment-2616014729