### PR TITLE
fix: outbox message not being cleared after retry

### DIFF
--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -143,6 +143,7 @@ class MailTransmission implements IMailTransmission {
 		try {
 			$mail->send($transport, false, false);
 			$localMessage->setRaw($mail->getRaw(false));
+			$localMessage->setStatus(LocalMessage::STATUS_RAW);
 		} catch (Horde_Mime_Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);
 			if (in_array($e->getCode(), self::RETRIABLE_CODES, true)) {


### PR DESCRIPTION
## Issue
Messages that original fail to send but succeed on resend are not clear from outbox.

## Cause
After a failed send operation the local message status is set to int > 0 but never reset to 0 after a successful send operation. Causing send process to abort, leaving the message in the outbox and not moving it to sent items.

## Resolution
Reset message status to 0 (STATUS_RAW) after successful send operation.