### PR TITLE
fix: Version of psr/log incompatible with the same version at 3rdpart…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 		"nextcloud/kitinerary-flatpak": "^1.0",
 		"nextcloud/kitinerary-sys": "^1.0.1",
 		"phpmailer/dkimvalidator": "^0.3.0",
-		"psr/log": "^3.0.2",
+		"psr/log": "^2.0",
 		"rubix/ml": "2.5.2",
 		"sabberworm/php-css-parser": "^8.7.0",
 		"youthweb/urllinker": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1101c2dd1b2758767154826ada8b67b4",
+    "content-hash": "4c18ac1b1c6819dd048979e97e77711f",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2272,16 +2272,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/ef29f6d262798707a9edd554e2b82517ef3a9376",
+                "reference": "ef29f6d262798707a9edd554e2b82517ef3a9376",
                 "shasum": ""
             },
             "require": {
@@ -2290,7 +2290,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -2316,9 +2316,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
+                "source": "https://github.com/php-fig/log/tree/2.0.0"
             },
-            "time": "2024-09-11T13:17:53+00:00"
+            "time": "2021-07-14T16:41:46+00:00"
         },
         {
             "name": "rubix/ml",


### PR DESCRIPTION
### What's I made
Downgrade `psr/log` from 3 to 2 reverting the PR: https://github.com/nextcloud/mail/pull/10237

### Explaining

The file `appinfo/info.xml` of app Mail is using a range of stable versions:
```xml
<nextcloud min-version="30" max-version="32" />
```

At branch `stable30` of `3rdparty` folder of server, is using the versoin 2.0 of `psr/log`

https://github.com/nextcloud/3rdparty/blob/stable30/composer.lock#L3296-L3297
```json
            "name": "psr/log",
            "version": "2.0.0",
```

that haven't the :void at interface:

https://github.com/nextcloud/3rdparty/blob/stable30/psr/log/src/LoggerAwareTrait.php#L22
```php
    public function setLogger(LoggerInterface $logger)
```
Look the code at `psr/log` repository:

https://github.com/php-fig/log/blob/2.0.0/src/LoggerAwareTrait.php#L22
```php
    public function setLogger(LoggerInterface $logger)
```

But at `composer.json` and at `composer-lock` file of mail, the used version is `3.0.2`:

`composer.json`
https://github.com/nextcloud/mail/blob/main/composer.json#L41
```json
		"psr/log": "^3.0.2",
```
`composer-lock`
https://github.com/nextcloud/mail/blob/main/composer.lock#L2274-L2275
```json
            "name": "psr/log",
            "version": "3.0.2",
```
And the signature of method setLogger at version 3.0.2 is: https://github.com/php-fig/log/blob/3.0.2/src/LoggerAwareTrait.php#L18
```php
    public function setLogger(LoggerInterface $logger): void
```

The different signature of this interface between `3rdparty` and mail generate error about inconsistent declaration of `Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger)`.

Only is possible upgrade the version of psr/log when the `min-version` at `info.xml` file is equals to 31 because the version 3.x of `psr/log` only was bumped at stable31 of 3rdparty.

ref: https://github.com/LibreSign/libresign/issues/4376