### PR TITLE
fix: reset filter does not work

### DIFF
--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -539,7 +539,6 @@ export default {
 			})
 		},
 		resetFilter() {
-			const prevQuery = this.query
 			this.match = 'allof'
 			this.query = ''
 			this.selectedTags = []
@@ -554,10 +553,7 @@ export default {
 			this.startDate = null
 			this.endDate = null
 			this.mentionsMe = false
-			// Need if there is only tag filter or recipients filter
-			if (prevQuery === '') {
-				this.sendQueryEvent()
-			}
+			this.sendQueryEvent()
 		},
 		addTag(tag, type) {
 			if (typeof tag === 'string') {


### PR DESCRIPTION
**Steps to reproduce:**

1. Open a folder
2. Type something into the search field
3. Click "X" to reset the filter
4. Notice the message list does not reset

**B**

https://github.com/user-attachments/assets/27fb7f54-a372-4046-af43-749dd960490c

**A**

https://github.com/user-attachments/assets/4199ee02-ea27-4c08-9b66-c1717547983a

