### PR TITLE
fix: always show email address for suggestions from address collector

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -84,10 +84,9 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subtitle="option.email"
+								:subname="showEmailAsSubname(option)"
 								:icon-class="!option.id ? 'icon-user' : null"
-								:url="option.photo"
-								:avatar-size="24" />
+								:url="option.photo" />
 						</div>
 					</template>
 				</NcSelect>
@@ -138,10 +137,9 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subtitle="option.email"
+								:subname="showEmailAsSubname(option)"
 								:url="option.photo"
-								:icon-class="!option.id ? 'icon-user' : null"
-								:avatar-size="24" />
+								:icon-class="!option.id ? 'icon-user' : null" />
 						</div>
 					</template>
 				</NcSelect>
@@ -192,10 +190,9 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subtitle="option.email"
+								:subname="showEmailAsSubname(option)"
 								:url="option.photo"
-								:icon-class="!option.id ? 'icon-user' : null"
-								:avatar-size="24" />
+								:icon-class="!option.id ? 'icon-user' : null" />
 						</div>
 					</template>
 				</NcSelect>
@@ -1422,6 +1419,18 @@ export default {
 		 */
 		createRecipientOption(value) {
 			return { email: value, label: value }
+		},
+
+		/**
+		 * Use the email address as subname if we have label
+		 *
+		 * @param {{email: string, label: string}} option
+		 * @return string
+		 */
+		showEmailAsSubname(option) {
+			return (option.label === option.email)
+				? ''
+				: option.email
 		},
 	},
 }


### PR DESCRIPTION
Have `oc_mail_coll_addresses` with:

| user_id | email | display_name |
|--------|--------|--------|
| admin | bob@example.org | Bob |
| admin | bob+test@example.org | Bob |

**B**

![Screenshot From 2025-02-12 12-43-43](https://github.com/user-attachments/assets/99ba311c-0051-44e6-a317-32dc73f02e25)


**A**

![image](https://github.com/user-attachments/assets/b67182f9-2993-4a10-ad4d-b1c0b8316734)
