### PR TITLE
fix: recipient label should not contain email address

### DIFF
--- a/lib/Service/AutoCompletion/AutoCompleteService.php
+++ b/lib/Service/AutoCompletion/AutoCompleteService.php
@@ -41,6 +41,7 @@ class AutoCompleteService {
 				'id' => $address->getId(),
 				'label' => $address->getDisplayName(),
 				'email' => $address->getEmail(),
+				'source' => 'collector',
 			];
 		}, $fromCollector);
 

--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -127,9 +127,10 @@ class ContactsIntegration {
 				$receivers[] = [
 					'id' => $id,
 					// Show full name if possible or fall back to email
-					'label' => (empty($fn) ? $e : "$fn ($e)"),
+					'label' => $fn,
 					'email' => $e,
 					'photo' => $photo,
+					'source' => 'contacts',
 				];
 			}
 		}

--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -52,6 +52,7 @@ class GroupsIntegration {
 					'label' => $g['name'] . ' (' . $gs->getNamespace() . ')',
 					'email' => $gid,
 					'photo' => null,
+					'source' => 'groups',
 				];
 			}
 		}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -84,7 +84,7 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subname="showEmailAsSubname(option)"
+								:subname="getSubnameForRecipient(option)"
 								:icon-class="!option.id ? 'icon-user' : null"
 								:url="option.photo" />
 						</div>
@@ -137,7 +137,7 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subname="showEmailAsSubname(option)"
+								:subname="getSubnameForRecipient(option)"
 								:url="option.photo"
 								:icon-class="!option.id ? 'icon-user' : null" />
 						</div>
@@ -190,7 +190,7 @@
 						<div>
 							<ListItemIcon :no-margin="true"
 								:name="option.label"
-								:subname="showEmailAsSubname(option)"
+								:subname="getSubnameForRecipient(option)"
 								:url="option.photo"
 								:icon-class="!option.id ? 'icon-user' : null" />
 						</div>
@@ -1422,15 +1422,24 @@ export default {
 		},
 
 		/**
-		 * Use the email address as subname if we have label
+		 * Return the subname for recipient suggestion.
+		 *
+		 * Empty if label and email are the same or
+		 * if the suggestion is a group.
 		 *
 		 * @param {{email: string, label: string}} option
 		 * @return string
 		 */
-		showEmailAsSubname(option) {
-			return (option.label === option.email)
-				? ''
-				: option.email
+		getSubnameForRecipient(option) {
+			if (option.source && option.source === 'groups') {
+				return ''
+			}
+
+			if (option.label === option.email) {
+				return ''
+			}
+
+			return option.email
 		},
 	},
 }

--- a/tests/Unit/Service/Autocompletion/AutoCompleteServiceTest.php
+++ b/tests/Unit/Service/Autocompletion/AutoCompleteServiceTest.php
@@ -37,8 +37,8 @@ class AutoCompleteServiceTest extends TestCase {
 		$term = 'jo';
 
 		$contactsResult = [
-			['id' => 12, 'label' => '"john doe" <john@doe.cz>', 'email' => 'john@doe.cz'],
-			['id' => 13, 'label' => '"joe doe" <joe@doe.se>', 'email' => 'joe@doe.se'],
+			['id' => 12, 'label' => '"john doe" <john@doe.cz>', 'email' => 'john@doe.cz', 'source' => 'contacts'],
+			['id' => 13, 'label' => '"joe doe" <joe@doe.se>', 'email' => 'joe@doe.se', 'source' => 'contacts'],
 		];
 		$john = new CollectedAddress();
 		$john->setId(1234);
@@ -50,7 +50,7 @@ class AutoCompleteServiceTest extends TestCase {
 		];
 
 		$groupsResult = [
-			['id' => 20, 'label' => 'Journalists', 'email' => 'Journalists']
+			['id' => 20, 'label' => 'Journalists', 'email' => 'Journalists', 'source' => 'groups']
 		];
 
 		$this->contactsIntegration->expects($this->once())
@@ -72,10 +72,10 @@ class AutoCompleteServiceTest extends TestCase {
 		$response = $this->service->findMatches('testuser', $term);
 
 		$expected = [
-			['id' => 12, 'label' => '"john doe" <john@doe.cz>', 'email' => 'john@doe.cz'],
-			['id' => 13, 'label' => '"joe doe" <joe@doe.se>', 'email' => 'joe@doe.se'],
-			['id' => 1234, 'label' => 'John Doe', 'email' => 'john@doe.com'],
-			['id' => 20, 'label' => 'Journalists', 'email' => 'Journalists'],
+			['id' => 12, 'label' => '"john doe" <john@doe.cz>', 'email' => 'john@doe.cz', 'source' => 'contacts'],
+			['id' => 13, 'label' => '"joe doe" <joe@doe.se>', 'email' => 'joe@doe.se', 'source' => 'contacts'],
+			['id' => 1234, 'label' => 'John Doe', 'email' => 'john@doe.com', 'source' => 'collector'],
+			['id' => 20, 'label' => 'Journalists', 'email' => 'Journalists', 'source' => 'groups'],
 		];
 		$this->assertEquals($expected, $response);
 	}

--- a/tests/Unit/Service/ContactsIntegrationTest.php
+++ b/tests/Unit/Service/ContactsIntegrationTest.php
@@ -90,21 +90,24 @@ class ContactsIntegrationTest extends TestCase {
 		$expected = [
 			[
 				'id' => 'jf',
-				'label' => 'Jonathan Frakes (jonathan@frakes.com)',
+				'label' => 'Jonathan Frakes',
 				'email' => 'jonathan@frakes.com',
 				'photo' => null,
+				'source' => 'contacts'
 			],
 			[
 				'id' => 'jd',
-				'label' => 'John Doe (john@doe.info)',
+				'label' => 'John Doe',
 				'email' => 'john@doe.info',
 				'photo' => null,
+				'source' => 'contacts'
 			],
 			[
 				'id' => 'jd',
-				'label' => 'John Doe (doe@john.info)',
+				'label' => 'John Doe',
 				'email' => 'doe@john.info',
 				'photo' => null,
+				'source' => 'contacts'
 			],
 		];
 
@@ -157,21 +160,24 @@ class ContactsIntegrationTest extends TestCase {
 		$expected = [
 			[
 				'id' => 'jd',
-				'label' => 'John Doe (john@doe.info)',
+				'label' => 'John Doe',
 				'email' => 'john@doe.info',
 				'photo' => null,
+				'source' => 'contacts'
 			],
 			[
 				'id' => 'jd',
-				'label' => 'John Doe (doe@john.info)',
+				'label' => 'John Doe',
 				'email' => 'doe@john.info',
 				'photo' => null,
+				'source' => 'contacts',
 			],
 			[
 				'id' => 'js',
-				'label' => 'Johann Strauss II (johann@strauss.com)',
+				'label' => 'Johann Strauss II',
 				'email' => 'johann@strauss.com',
 				'photo' => null,
+				'source' => 'contacts',
 			],
 		];
 
@@ -209,9 +215,10 @@ class ContactsIntegrationTest extends TestCase {
 		$expected = [
 			[
 				'id' => 'jf',
-				'label' => 'Jonathan Frakes (jonathan@frakes.com)',
+				'label' => 'Jonathan Frakes',
 				'email' => 'jonathan@frakes.com',
 				'photo' => null,
+				'source' => 'contacts',
 			],
 		];
 
@@ -249,9 +256,10 @@ class ContactsIntegrationTest extends TestCase {
 		$expected = [
 			[
 				'id' => 'jf',
-				'label' => 'Jonathan Frakes (jonathan@frakes.com)',
+				'label' => 'Jonathan Frakes',
 				'email' => 'jonathan@frakes.com',
 				'photo' => null,
+				'source' => 'contacts',
 			],
 		];
 
@@ -289,9 +297,10 @@ class ContactsIntegrationTest extends TestCase {
 		$expected = [
 			[
 				'id' => 'jf',
-				'label' => 'Jonathan Frakes (jonathan@frakes.com)',
+				'label' => 'Jonathan Frakes',
 				'email' => 'jonathan@frakes.com',
 				'photo' => null,
+				'source' => 'contacts',
 			],
 		];
 

--- a/tests/Unit/Service/GroupsIntegrationTest.php
+++ b/tests/Unit/Service/GroupsIntegrationTest.php
@@ -62,6 +62,7 @@ class GroupsIntegrationTest extends TestCase {
 					'label' => 'first test group (Namespace1)',
 					'email' => 'namespace1:testgroup',
 					'photo' => null,
+					'source' => 'groups',
 				]
 			],
 			$actual


### PR DESCRIPTION
We noticed in #10683 that the recipient label, that is used later in the to/cc/bcc field, contains the email address. This pr removes the email address from the label for suggestions from the contacts integrations and hides the groupid (because it provides no further information currently).

**Example (wrong):**
```
From: Bob <bob@example.org>
To: "Alice (alice@example.org)" <alice@example.org>
```

**B:**

![Screenshot From 2025-02-13 20-48-12](https://github.com/user-attachments/assets/958a3bff-fa1b-4b30-aded-1b3185c344d2)


**A:**

![Screenshot From 2025-02-13 20-42-57](https://github.com/user-attachments/assets/3fff9b3d-149f-42fb-9a5c-66e05fe035d8)
