### PR TITLE
fix: change status code from 404 to 204 for missing avatars

### DIFF
--- a/lib/Controller/AvatarsController.php
+++ b/lib/Controller/AvatarsController.php
@@ -54,7 +54,7 @@ class AvatarsController extends Controller {
 		$avatar = $this->avatarService->getAvatar($email, $this->uid);
 		if (is_null($avatar)) {
 			// No avatar found
-			$response = new JSONResponse([], Http::STATUS_NOT_FOUND);
+			$response = new JSONResponse([], Http::STATUS_NO_CONTENT);
 
 			// Debounce this a bit
 			// (cache for one day)

--- a/tests/Unit/Controller/AvatarControllerTest.php
+++ b/tests/Unit/Controller/AvatarControllerTest.php
@@ -78,7 +78,7 @@ class AvatarControllerTest extends TestCase {
 
 		$resp = $this->controller->url($email);
 
-		$expected = new JSONResponse([], Http::STATUS_NOT_FOUND);
+		$expected = new JSONResponse([], Http::STATUS_NO_CONTENT);
 		$expected->cacheFor(24 * 60 * 60, false, true);
 		$this->assertEquals($expected, $resp);
 	}


### PR DESCRIPTION
Similar to https://github.com/nextcloud/contacts/issues/3021 and https://github.com/nextcloud/server/pull/49839.

Switching the response code from 404 to 204 improves compatibility with security appliances like CrowdSec.
Since avatar lookups (including external sources) can validly result in a non-existing avatar.

Bonus: This will not trigger the debug log for missing avatars anylonger. 

https://github.com/nextcloud/mail/blob/bcd523917605779f84e4944d1455bee505e28ef1/src/components/Avatar.vue#L62

There's another action in the controller also using 404. 
I'm not sure where we are using it and therefore left it unchanged: https://github.com/nextcloud/mail/blob/bcd523917605779f84e4944d1455bee505e28ef1/lib/Controller/AvatarsController.php#L106