### PR TITLE
fix(imap): Avoid OOM when syncing sparse mailboxes

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -146,6 +146,7 @@ class MessageMapper {
 		} else {
 			$max = ((int)$metaResults['max']);
 		}
+		unset($metaResults);
 
 		// The inclusive range of UIDs
 		$totalRange = $max - $min + 1;
@@ -161,7 +162,8 @@ class MessageMapper {
 		// Determine max UID to fetch, but don't exceed the known maximum
 		$upper = min(
 			$max,
-			$lower + $estimatedPageSize
+			$lower + $estimatedPageSize,
+			$lower + 1_000_000, // Somewhat sensible number of UIDs that fit into memory (Horde_Imap_ClientId bloat)
 		);
 		if ($lower > $upper) {
 			$logger->debug("Range for findAll did not find any (not already known) messages and all messages of mailbox $mailbox have been fetched.");
@@ -172,7 +174,22 @@ class MessageMapper {
 			];
 		}
 
-		$logger->debug("Built range for findAll: min=$min max=$max total=$total totalRange=$totalRange estimatedPageSize=$estimatedPageSize lower=$lower upper=$upper highestKnownUid=$highestKnownUid");
+		$idsToFetch = new Horde_Imap_Client_Ids($lower . ':' . $upper);
+		$actualPageSize = $this->getPageSize($client, $mailbox, $idsToFetch);
+		$logger->debug("Built range for findAll: min=$min max=$max total=$total totalRange=$totalRange estimatedPageSize=$estimatedPageSize actualPageSize=$actualPageSize lower=$lower upper=$upper highestKnownUid=$highestKnownUid");
+		while ($actualPageSize > $maxResults) {
+			$logger->debug("Range for findAll matches too many messages: min=$min max=$max total=$total estimatedPageSize=$estimatedPageSize actualPageSize=$actualPageSize");
+
+			$estimatedPageSize = (int)($estimatedPageSize / 2);
+
+			$upper = min(
+				$max,
+				$lower + $estimatedPageSize,
+				$lower + 1_000_000, // Somewhat sensible number of UIDs that fit into memory (Horde_Imap_ClientId bloat)
+			);
+			$idsToFetch = new Horde_Imap_Client_Ids($lower . ':' . $upper);
+			$actualPageSize = $this->getPageSize($client, $mailbox, $idsToFetch);
+		}
 
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
@@ -180,7 +197,7 @@ class MessageMapper {
 			$mailbox,
 			$query,
 			[
-				'ids' => new Horde_Imap_Client_Ids($lower . ':' . $upper)
+				'ids' => $idsToFetch
 			]
 		);
 		$perf->step('fetch UIDs');
@@ -194,6 +211,9 @@ class MessageMapper {
 			 * there is nothing to fetch in $highestKnownUid:$upper
 			 */
 			$logger->debug('Range for findAll did not find any messages. Trying again with a succeeding range');
+			// Clean up some unused variables before recursion
+			unset($fetchResult, $idsToFetch, $query);
+			$perf->step('free memory before recursion');
 			return $this->findAll($client, $mailbox, $maxResults, $upper, $logger, $perf, $userId);
 		}
 		$uidCandidates = array_filter(
@@ -1009,5 +1029,22 @@ class MessageMapper {
 			}
 		}
 		return false;
+	}
+
+	private function getPageSize(Horde_Imap_Client_Socket $client,
+		string $mailbox,
+		Horde_Imap_Client_Ids $idsToFetch): int {
+		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
+		$rangeSearchQuery->ids($idsToFetch);
+		$rangeSearchResult = $client->search(
+			$mailbox,
+			$rangeSearchQuery,
+			[
+				'results' => [
+					Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+				],
+			]
+		);
+		return (int)$rangeSearchResult['count'];
 	}
 }

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -15,6 +15,7 @@ use Horde_Imap_Client_Data_Fetch;
 use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Fetch_Results;
 use Horde_Imap_Client_Ids;
+use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\IMAP\Charset\Converter;
@@ -289,24 +290,42 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$client->expects(self::once())
+		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
+		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('123:321'));
+		$client->expects(self::exactly(2))
 			->method('search')
-			->with(
-				$mailbox,
-				null,
+			->withConsecutive(
 				[
-					'results' => [
-						Horde_Imap_Client::SEARCH_RESULTS_MIN,
-						Horde_Imap_Client::SEARCH_RESULTS_MAX,
-						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+					$mailbox,
+					null,
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_MIN,
+							Horde_Imap_Client::SEARCH_RESULTS_MAX,
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						]
 					]
-				]
+				],
+				[
+					$mailbox,
+					($rangeSearchQuery),
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						]
+					],
+				],
 			)
-			->willReturn([
-				'min' => 123,
-				'max' => 321,
-				'count' => 50,
-			]);
+			->willReturnOnConsecutiveCalls(
+				[
+					'min' => 123,
+					'max' => 321,
+					'count' => 50,
+				],
+				[
+					'count' => 50,
+				],
+			);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
 		$uidResults = new Horde_Imap_Client_Fetch_Results();
@@ -354,24 +373,42 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$client->expects(self::once())
+		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
+		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('301:321'));
+		$client->expects(self::exactly(2))
 			->method('search')
-			->with(
-				$mailbox,
-				null,
+			->withConsecutive(
 				[
-					'results' => [
-						Horde_Imap_Client::SEARCH_RESULTS_MIN,
-						Horde_Imap_Client::SEARCH_RESULTS_MAX,
-						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-					]
-				]
+					$mailbox,
+					null,
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_MIN,
+							Horde_Imap_Client::SEARCH_RESULTS_MAX,
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						],
+					],
+				],
+				[
+					$mailbox,
+					$rangeSearchQuery,
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						],
+					],
+				],
 			)
-			->willReturn([
-				'min' => 123,
-				'max' => 321,
-				'count' => 50,
-			]);
+			->willReturnOnConsecutiveCalls(
+				[
+					'min' => 123,
+					'max' => 321,
+					'count' => 50,
+				],
+				[
+					'count' => 50,
+				],
+			);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
 		$uidResults = new Horde_Imap_Client_Fetch_Results();
@@ -426,24 +463,42 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$client->expects(self::once())
+		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
+		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('92001:99999'));
+		$client->expects(self::exactly(2))
 			->method('search')
-			->with(
-				$mailbox,
-				null,
+			->withConsecutive(
 				[
-					'results' => [
-						Horde_Imap_Client::SEARCH_RESULTS_MIN,
-						Horde_Imap_Client::SEARCH_RESULTS_MAX,
-						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-					]
-				]
+					$mailbox,
+					null,
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_MIN,
+							Horde_Imap_Client::SEARCH_RESULTS_MAX,
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						],
+					],
+				],
+				[
+					$mailbox,
+					$rangeSearchQuery,
+					[
+						'results' => [
+							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
+						],
+					],
+				],
 			)
-			->willReturn([
-				'min' => 10000,
-				'max' => 99999,
-				'count' => 50000,
-			]);
+			->willReturnOnConsecutiveCalls(
+				[
+					'min' => 10000,
+					'max' => 99999,
+					'count' => 50000,
+				],
+				[
+					'count' => 50,
+				],
+			);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
 		$uidResults = new Horde_Imap_Client_Fetch_Results();


### PR DESCRIPTION
UIDs of a mailbox can be fragmented. In that case we overfetch when building chunk pages. Before doing the actual FETCH this does a test on the number of results. If the result is too big, the range will be halved. That is repeated until a reasonable page is built. 
See https://github.com/nextcloud/mail/pull/10696#issuecomment-2735653743 for a production run and data.