### PR TITLE
test(integration): ignore uid order in sync tests

### DIFF
--- a/tests/Integration/Sync/ImapToDbSynchronizerTest.php
+++ b/tests/Integration/Sync/ImapToDbSynchronizerTest.php
@@ -94,7 +94,7 @@ class ImapToDbSynchronizerTest extends TestCase {
 		);
 
 		// Assert that the cached state has been reconciled with IMAP
-		self::assertEquals([$uid1, $uid2], $dbMessageMapper->findAllUids($inbox));
+		self::assertEqualsCanonicalizing([$uid1, $uid2], $dbMessageMapper->findAllUids($inbox));
 	}
 
 	public function testRepairSyncNoopIfNoneVanished(): void {
@@ -153,6 +153,6 @@ class ImapToDbSynchronizerTest extends TestCase {
 		);
 
 		// Assert that the cached state has been reconciled with IMAP
-		self::assertEquals([$uid1, $uid2, $uid3], $dbMessageMapper->findAllUids($inbox));
+		self::assertEqualsCanonicalizing([$uid1, $uid2, $uid3], $dbMessageMapper->findAllUids($inbox));
 	}
 }


### PR DESCRIPTION
To make the tests a bit more robust. The order doesn't matter. The test is about checking if all emails have been synced.

Ref https://github.com/nextcloud/mail/actions/runs/13369653729/job/37335154778?pr=10710