### PR TITLE
fix: handle 204 response

### DIFF
--- a/src/service/AvatarService.js
+++ b/src/service/AvatarService.js
@@ -17,22 +17,18 @@ export const fetchAvatarUrl = (email) => {
 	})
 
 	return Axios.get(url, { adapter: 'fetch', fetchOptions: { priority: 'low' } })
-		.then((resp) => resp.data)
-		.then((avatar) => {
-			if (avatar.isExternal) {
-				return generateUrl('/apps/mail/api/avatars/image/{email}', {
-					email,
-				})
-			} else {
-				return avatar.url
-			}
-		})
-		.catch((err) => {
-			if (err.response.status === 404) {
+		.then(res => {
+			if (res.status === 204) {
 				return undefined
 			}
 
-			return Promise.reject(err)
+			if (res.data.isExternal) {
+				return generateUrl('/apps/mail/api/avatars/image/{email}', {
+					email,
+				})
+			}
+
+			return res.data.url
 		})
 }
 


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/mail/pull/10694

- A 404 is no longer an expected response, so the special handling has been removed.
- A 204 response has an empty body, which means avatar.url would return undefined. This update makes it more explicit what is happening and what’s expected, though the behavior itself remains unchanged.