### PR TITLE
perf: skip message skeleton if it is cached

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -1219,6 +1219,10 @@ export default function mainStoreActions() {
 			})
 		},
 		async fetchMessage(id) {
+			if (this.messages[id]) {
+				return this.messages[id]
+			}
+
 			return handleHttpAuthErrors(async () => {
 				const message = await fetchMessage(id)
 				// Only commit if not undefined (not found)


### PR DESCRIPTION
Resolves #10749

Cache messages in the frontend directly. Only show the skeleton if message is not yet cached.

I also delayed the skeleton animation by 200 milliseconds as we also do HTTP level caching. To prevent flickering in case the message is not cached in the frontend but by the browser.

## Screencasts

### No browser cache + extremely slow connection

https://github.com/user-attachments/assets/d34ef574-f6a3-4344-96b7-e4547c12b08a

### Browser cache + normal connection (localhost)

https://github.com/user-attachments/assets/d8d784b5-bb52-4fdc-9286-ab363f6a44a5