### PR TITLE
fix: harden phishing detection against missing and malformed headers

### DIFF
--- a/lib/Service/PhishingDetection/DateCheck.php
+++ b/lib/Service/PhishingDetection/DateCheck.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service\PhishingDetection;
 
-use DateException;
 use OCA\Mail\PhishingDetectionResult;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IL10N;
@@ -27,7 +26,7 @@ class DateCheck {
 		$now = $this->timeFactory->getDateTime('now');
 		try {
 			$dt = $this->timeFactory->getDateTime($date);
-		} catch (DateException $e) {
+		} catch (\Exception $e) {
 			return new PhishingDetectionResult(PhishingDetectionResult::DATE_CHECK, false);
 		}
 		if ($dt > $now) {

--- a/lib/Service/PhishingDetection/PhishingDetectionService.php
+++ b/lib/Service/PhishingDetection/PhishingDetectionService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\PhishingDetection;
 
 use Horde_Mime_Headers;
+use Horde_Mime_Headers_Element_Address;
 use OCA\Mail\AddressList;
 use OCA\Mail\PhishingDetectionList;
 
@@ -30,21 +31,47 @@ class PhishingDetectionService {
 
 
 	public function checkHeadersForPhishing(Horde_Mime_Headers $headers, bool $hasHtmlMessage, string $htmlMessage = ''): array {
+		/** @var string|null $fromFN */
+		$fromFN = null;
+		/** @var string|null $fromEmail */
+		$fromEmail = null;
+		/** @var string|null $customEmail */
+		$customEmail = null;
+		$fromHeader = $headers->getHeader('From');
+		if ($fromHeader instanceof Horde_Mime_Headers_Element_Address) {
+			$firstAddr = AddressList::fromHorde($fromHeader->getAddressList(true))?->first();
+			$fromFN = $firstAddr?->getLabel();
+			$fromEmail = $firstAddr?->getEmail();
+			$customEmail = $firstAddr?->getCustomEmail();
+		}
+
+		/** @var string|null $replyToEmail */
+		$replyToEmail = null;
+		$replyToHeader = $headers->getHeader('Reply-To');
+		if ($replyToHeader instanceof Horde_Mime_Headers_Element_Address) {
+			$replyToAddrs = $replyToHeader->getAddressList(true);
+			if (isset($replyToAddrs)) {
+				$replyToEmail = AddressList::fromHorde($replyToAddrs)->first()?->getEmail();
+			}
+		}
+
+		$date = $headers->getHeader('Date')?->value;
+
 		$list = new PhishingDetectionList();
-		/** @psalm-suppress UndefinedMethod */
-		$fromFN = AddressList::fromHorde($headers->getHeader('From')->getAddressList(true))->first()->getLabel();
-		/** @psalm-suppress UndefinedMethod */
-		$fromEmail = AddressList::fromHorde($headers->getHeader('From')->getAddressList(true))->first()->getEmail();
-		/** @psalm-suppress UndefinedMethod */
-		$replyToEmailHeader = $headers->getHeader('Reply-To')?->getAddressList(true);
-		$replyToEmail = isset($replyToEmailHeader)? AddressList::fromHorde($replyToEmailHeader)->first()->getEmail() : null ;
-		$date = $headers->getHeader('Date')->__get('value');
-		/** @psalm-suppress UndefinedMethod */
-		$customEmail = AddressList::fromHorde($headers->getHeader('From')->getAddressList(true))->first()->getCustomEmail();
-		$list->addCheck($this->replyToCheck->run($fromEmail, $replyToEmail));
-		$list->addCheck($this->contactCheck->run($fromFN, $fromEmail));
-		$list->addCheck($this->dateCheck->run($date));
-		$list->addCheck($this->customEmailCheck->run($fromEmail, $customEmail));
+		if ($fromEmail !== null) {
+			if ($replyToEmail !== null) {
+				$list->addCheck($this->replyToCheck->run($fromEmail, $replyToEmail));
+			}
+			if ($fromFN !== null) {
+				$list->addCheck($this->contactCheck->run($fromFN, $fromEmail));
+			}
+			if ($customEmail !== null) {
+				$list->addCheck($this->customEmailCheck->run($fromEmail, $customEmail));
+			}
+		}
+		if ($date !== null) {
+			$list->addCheck($this->dateCheck->run($date));
+		}
 		if ($hasHtmlMessage) {
 			$list->addCheck($this->linkCheck->run($htmlMessage));
 		}

--- a/tests/data/phishing-mail-headers.malformed-date.txt
+++ b/tests/data/phishing-mail-headers.malformed-date.txt
@@ -1,0 +1,36 @@
+MIME-Version: 1.0
+Received: from DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18)
+ by HE1P189MB0380.EURP189.PROD.OUTLOOK.COM with HTTPS; Tue, 28 May 2024
+ 11:02:30 +0000
+Received: from BYAPR03CA0019.namprd03.prod.outlook.com (2603:10b6:a02:a8::32)
+ by DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7611.29; Tue, 28 May
+ 2024 11:02:29 +0000
+Received: from MWH0EPF000971E4.namprd02.prod.outlook.com
+ (2603:10b6:a02:a8:cafe::b6) by BYAPR03CA0019.outlook.office365.com
+ (2603:10b6:a02:a8::32) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7633.17 via Frontend
+ Transport; Tue, 28 May 2024 11:02:27 +0000
+Authentication-Results: spf=pass (sender IP is 209.85.218.45)
+ smtp.mailfrom=example.com; dkim=pass (signature was verified)
+ header.d=example.com;dmarc=pass action=none header.from=example.com;compauth=pass
+ reason=100
+Received-SPF: Pass (protection.outlook.com: domain of example.com designates
+ 209.85.218.45 as permitted sender) receiver=protection.outlook.com;
+ client-ip=209.85.218.45; helo=mail-ej1-f45.google.com; pr=C
+Received: from mail-ej1-f45.google.com (209.85.218.45) by
+ MWH0EPF000971E4.mail.protection.outlook.com (10.167.243.72) with Microsoft
+ SMTP Server (version=TLS1_3, cipher=TLS_AES_256_GCM_SHA384) id 15.20.7633.15
+ via Frontend Transport; Tue, 28 May 2024 11:02:27 +0000
+Received: by mail-ej1-f45.google.com with SMTP id a640c23a62f3a-a626777f74eso85431166b.3
+        for <bob@example.com>; Tue, 28 May 2024 04:02:27 -0700 (PDT)
+From: Jhon Doe <jhondoe@example.com>
+Date: Wed, 26 Feb 2025 12:09:28 +0100 (GMT+01:00)
+Message-ID: <CAOFMF9F1cMTJz=cSEk13i=3xDQ4fbrb5G-z1GWntYFrg+A__Vg@mail.example.com>
+Subject: Smells Phishy 🎣
+To: bobby bob <bob@example.com>
+Content-Type: multipart/alternative; boundary="000000000000b4c1d1061981915d"
+X-IncomingHeaderCount: 13
+Return-Path: jhondoe@example.com
+Reply-To: Jhon Doe <batman@example.com>

--- a/tests/data/phishing-mail-headers.malformed-date.txt.license
+++ b/tests/data/phishing-mail-headers.malformed-date.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/data/phishing-mail-headers.no-date.txt
+++ b/tests/data/phishing-mail-headers.no-date.txt
@@ -1,0 +1,35 @@
+MIME-Version: 1.0
+Received: from DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18)
+ by HE1P189MB0380.EURP189.PROD.OUTLOOK.COM with HTTPS; Tue, 28 May 2024
+ 11:02:30 +0000
+Received: from BYAPR03CA0019.namprd03.prod.outlook.com (2603:10b6:a02:a8::32)
+ by DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7611.29; Tue, 28 May
+ 2024 11:02:29 +0000
+Received: from MWH0EPF000971E4.namprd02.prod.outlook.com
+ (2603:10b6:a02:a8:cafe::b6) by BYAPR03CA0019.outlook.office365.com
+ (2603:10b6:a02:a8::32) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7633.17 via Frontend
+ Transport; Tue, 28 May 2024 11:02:27 +0000
+Authentication-Results: spf=pass (sender IP is 209.85.218.45)
+ smtp.mailfrom=example.com; dkim=pass (signature was verified)
+ header.d=example.com;dmarc=pass action=none header.from=example.com;compauth=pass
+ reason=100
+Received-SPF: Pass (protection.outlook.com: domain of example.com designates
+ 209.85.218.45 as permitted sender) receiver=protection.outlook.com;
+ client-ip=209.85.218.45; helo=mail-ej1-f45.google.com; pr=C
+Received: from mail-ej1-f45.google.com (209.85.218.45) by
+ MWH0EPF000971E4.mail.protection.outlook.com (10.167.243.72) with Microsoft
+ SMTP Server (version=TLS1_3, cipher=TLS_AES_256_GCM_SHA384) id 15.20.7633.15
+ via Frontend Transport; Tue, 28 May 2024 11:02:27 +0000
+Received: by mail-ej1-f45.google.com with SMTP id a640c23a62f3a-a626777f74eso85431166b.3
+        for <bob@example.com>; Tue, 28 May 2024 04:02:27 -0700 (PDT)
+From: Jhon Doe <jhondoe@example.com>
+Message-ID: <CAOFMF9F1cMTJz=cSEk13i=3xDQ4fbrb5G-z1GWntYFrg+A__Vg@mail.example.com>
+Subject: Smells Phishy 🎣
+To: bobby bob <bob@example.com>
+Content-Type: multipart/alternative; boundary="000000000000b4c1d1061981915d"
+X-IncomingHeaderCount: 13
+Return-Path: jhondoe@example.com
+Reply-To: Jhon Doe <batman@example.com>

--- a/tests/data/phishing-mail-headers.no-date.txt.license
+++ b/tests/data/phishing-mail-headers.no-date.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/data/phishing-mail-headers.no-from.txt
+++ b/tests/data/phishing-mail-headers.no-from.txt
@@ -1,0 +1,35 @@
+MIME-Version: 1.0
+Received: from DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18)
+ by HE1P189MB0380.EURP189.PROD.OUTLOOK.COM with HTTPS; Tue, 28 May 2024
+ 11:02:30 +0000
+Received: from BYAPR03CA0019.namprd03.prod.outlook.com (2603:10b6:a02:a8::32)
+ by DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7611.29; Tue, 28 May
+ 2024 11:02:29 +0000
+Received: from MWH0EPF000971E4.namprd02.prod.outlook.com
+ (2603:10b6:a02:a8:cafe::b6) by BYAPR03CA0019.outlook.office365.com
+ (2603:10b6:a02:a8::32) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7633.17 via Frontend
+ Transport; Tue, 28 May 2024 11:02:27 +0000
+Authentication-Results: spf=pass (sender IP is 209.85.218.45)
+ smtp.mailfrom=example.com; dkim=pass (signature was verified)
+ header.d=example.com;dmarc=pass action=none header.from=example.com;compauth=pass
+ reason=100
+Received-SPF: Pass (protection.outlook.com: domain of example.com designates
+ 209.85.218.45 as permitted sender) receiver=protection.outlook.com;
+ client-ip=209.85.218.45; helo=mail-ej1-f45.google.com; pr=C
+Received: from mail-ej1-f45.google.com (209.85.218.45) by
+ MWH0EPF000971E4.mail.protection.outlook.com (10.167.243.72) with Microsoft
+ SMTP Server (version=TLS1_3, cipher=TLS_AES_256_GCM_SHA384) id 15.20.7633.15
+ via Frontend Transport; Tue, 28 May 2024 11:02:27 +0000
+Received: by mail-ej1-f45.google.com with SMTP id a640c23a62f3a-a626777f74eso85431166b.3
+        for <bob@example.com>; Tue, 28 May 2024 04:02:27 -0700 (PDT)
+Date: Tue, 28 May 3024 13:02:15 +0200
+Message-ID: <CAOFMF9F1cMTJz=cSEk13i=3xDQ4fbrb5G-z1GWntYFrg+A__Vg@mail.example.com>
+Subject: Smells Phishy 🎣
+To: bobby bob <bob@example.com>
+Content-Type: multipart/alternative; boundary="000000000000b4c1d1061981915d"
+X-IncomingHeaderCount: 13
+Return-Path: jhondoe@example.com
+Reply-To: Jhon Doe <batman@example.com>

--- a/tests/data/phishing-mail-headers.no-from.txt.license
+++ b/tests/data/phishing-mail-headers.no-from.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/data/phishing-mail-headers.no-reply-to.txt
+++ b/tests/data/phishing-mail-headers.no-reply-to.txt
@@ -1,0 +1,35 @@
+MIME-Version: 1.0
+Received: from DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18)
+ by HE1P189MB0380.EURP189.PROD.OUTLOOK.COM with HTTPS; Tue, 28 May 2024
+ 11:02:30 +0000
+Received: from BYAPR03CA0019.namprd03.prod.outlook.com (2603:10b6:a02:a8::32)
+ by DB3P189MB2377.EURP189.PROD.OUTLOOK.COM (2603:10a6:10:434::18) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7611.29; Tue, 28 May
+ 2024 11:02:29 +0000
+Received: from MWH0EPF000971E4.namprd02.prod.outlook.com
+ (2603:10b6:a02:a8:cafe::b6) by BYAPR03CA0019.outlook.office365.com
+ (2603:10b6:a02:a8::32) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.7633.17 via Frontend
+ Transport; Tue, 28 May 2024 11:02:27 +0000
+Authentication-Results: spf=pass (sender IP is 209.85.218.45)
+ smtp.mailfrom=example.com; dkim=pass (signature was verified)
+ header.d=example.com;dmarc=pass action=none header.from=example.com;compauth=pass
+ reason=100
+Received-SPF: Pass (protection.outlook.com: domain of example.com designates
+ 209.85.218.45 as permitted sender) receiver=protection.outlook.com;
+ client-ip=209.85.218.45; helo=mail-ej1-f45.google.com; pr=C
+Received: from mail-ej1-f45.google.com (209.85.218.45) by
+ MWH0EPF000971E4.mail.protection.outlook.com (10.167.243.72) with Microsoft
+ SMTP Server (version=TLS1_3, cipher=TLS_AES_256_GCM_SHA384) id 15.20.7633.15
+ via Frontend Transport; Tue, 28 May 2024 11:02:27 +0000
+Received: by mail-ej1-f45.google.com with SMTP id a640c23a62f3a-a626777f74eso85431166b.3
+        for <bob@example.com>; Tue, 28 May 2024 04:02:27 -0700 (PDT)
+From: Jhon Doe <jhondoe@example.com>
+Date: Tue, 28 May 3024 13:02:15 +0200
+Message-ID: <CAOFMF9F1cMTJz=cSEk13i=3xDQ4fbrb5G-z1GWntYFrg+A__Vg@mail.example.com>
+Subject: Smells Phishy 🎣
+To: bobby bob <bob@example.com>
+Content-Type: multipart/alternative; boundary="000000000000b4c1d1061981915d"
+X-IncomingHeaderCount: 13
+Return-Path: jhondoe@example.com

--- a/tests/data/phishing-mail-headers.no-reply-to.txt.license
+++ b/tests/data/phishing-mail-headers.no-reply-to.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/10753
Fix https://github.com/nextcloud/mail/issues/10361

Ref https://github.com/nextcloud/mail/issues/10602

Closes https://github.com/nextcloud/mail/pull/10371 (alternative to)

**Before:** Emails with missing headers can't be opened, for example, the date header.
**After:** Emails can be opened again.

(See the referenced tickets for some example EML files to test this with).