### PR TITLE
chore(reuse): move changelog license to reuse.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-<!--
-  - SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
-  - SPDX-FileCopyrightText: 2016 ownCloud, Inc.
-  - SPDX-License-Identifier: AGPL-3.0-only
--->
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -160,3 +160,9 @@ path = [".tx/backport"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = ["CHANGELOG.md"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2016 ownCloud, Inc., 2016-2024 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-only"


### PR DESCRIPTION
Close #10767 

I'm sick of reuse lint failing on each stable branch due to the release automation. (It deletes the copyright information at the top).

Ref https://github.com/nextcloud/mail/actions/runs/13573840201/job/37945182634?pr=10764