### PR TITLE
Set license for changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-<!--
-  - SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
-  - SPDX-FileCopyrightText: 2016 ownCloud, Inc.
-  - SPDX-License-Identifier: AGPL-3.0-only
--->
 # Changelog
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION
The changelog automation cannot add the spdx tags, unfortunately.