### PR TITLE
fix: handle utf-8 strings correctly in the link detection

### DIFF
--- a/lib/Service/PhishingDetection/LinkCheck.php
+++ b/lib/Service/PhishingDetection/LinkCheck.php
@@ -63,12 +63,11 @@ class LinkCheck {
 			if ($href === '' || $linkText === '') {
 				continue;
 			}
-			// handle links that are wrapped in brackets, quotes, etc.
-			$firstChar = $linkText[0];
-			$lastChar = $linkText[strlen($linkText) - 1];
 
-			if (!ctype_alpha($firstChar) && !ctype_alpha($lastChar)) {
-				$linkText = substr($linkText, 1, -1);
+			// Handle links that are wrapped in brackets, quotes, etc.
+			// Need to use preg_match with the u(nicode) flag to properly match multibyte chars.
+			if (preg_match('/^(?![[:alnum:]]).*(?![[:alnum:]])$/u', $linkText)) {
+				$linkText = mb_substr($linkText, 1, -2);
 			}
 
 			$zippedArray[] = [

--- a/tests/Unit/Service/Phishing/LinkCheckTest.php
+++ b/tests/Unit/Service/Phishing/LinkCheckTest.php
@@ -65,4 +65,17 @@ class LinkCheckTest extends TestCase {
 
 		$this->assertFalse($result->isPhishing());
 	}
+
+	public function testRunWithUtf8(): void {
+		$htmlMessage = '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body><a href="https://iplookup.flagfox.net/">Öffne iplookup.flagfox.net ↗</a></body></html>';
+
+		$result = $this->service->run($htmlMessage);
+		$actualJson = $result->jsonSerialize();
+		$this->assertTrue($result->isPhishing());
+		$this->assertEquals([[
+			'linkText' => 'Öffne iplookup.flagfox.net ↗',
+			'href' => 'https://iplookup.flagfox.net/',
+		]], $actualJson['additionalData']);
+		$this->assertTrue(is_string(json_encode($actualJson, JSON_THROW_ON_ERROR)));
+	}
 }


### PR DESCRIPTION
More hardening regarding multibyte (utf-8) characters.

Regex proof: https://regex101.com/r/zPv0vh/1 (is covered by unit tests)