### PR TITLE
fix: remove photo property from groups integration

### DIFF
--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -51,7 +51,6 @@ class GroupsIntegration {
 					'id' => $gid,
 					'label' => $g['name'] . ' (' . $gs->getNamespace() . ')',
 					'email' => $gid,
-					'photo' => null,
 					'source' => 'groups',
 				];
 			}

--- a/tests/Unit/Service/GroupsIntegrationTest.php
+++ b/tests/Unit/Service/GroupsIntegrationTest.php
@@ -61,7 +61,6 @@ class GroupsIntegrationTest extends TestCase {
 					'id' => 'namespace1:testgroup',
 					'label' => 'first test group (Namespace1)',
 					'email' => 'namespace1:testgroup',
-					'photo' => null,
 					'source' => 'groups',
 				]
 			],


### PR DESCRIPTION
I've run into some requests like:

![Screenshot From 2025-02-28 16-40-56](https://github.com/user-attachments/assets/cf3abfa0-e484-46c7-a64a-815199431299)

Caused by the groups integration, returning null as photo.

![Screenshot From 2025-02-28 16-41-24](https://github.com/user-attachments/assets/fb897d3c-c58c-4c91-8ae7-40a09fffc3c8)

That's forwarded as url to NcAvatar and used to fetch an image. 
If there's no avatar url the component expects undefined instead of null. 


