### PR TITLE
fix(imap): Sync mailboxes without a status

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -285,9 +285,11 @@ class MailboxSync {
 			return $mailbox->getName();
 		}, $syncStatus));
 		foreach ($syncStatus as $mailbox) {
-			$status = $statuses[$mailbox->getName()];
-			$mailbox->setMessages($status->getTotal());
-			$mailbox->setUnseen($status->getUnread());
+			$status = $statuses[$mailbox->getName()] ?? null;
+			if ($status !== null) {
+				$mailbox->setMessages($status->getTotal());
+				$mailbox->setUnseen($status->getUnread());
+			}
 		}
 		$this->atomic(function () use ($syncStatus) {
 			foreach ($syncStatus as $mailbox) {

--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -108,6 +108,7 @@ class MailboxSyncTest extends TestCase {
 		$folders = [
 			$this->createMock(Folder::class),
 			$this->createMock(Folder::class),
+			$this->createMock(Folder::class),
 		];
 		$status = [
 			'unseen' => 10,
@@ -117,24 +118,27 @@ class MailboxSyncTest extends TestCase {
 		$folders[0]->method('getMailbox')->willReturn('mb1');
 		$folders[1]->method('getStatus')->willReturn($status);
 		$folders[1]->method('getMailbox')->willReturn('mb2');
+		$folders[2]->method('getStatus')->willReturn($status);
+		$folders[2]->method('getMailbox')->willReturn('mb3');
 		$this->folderMapper->expects($this->once())
 			->method('getFolders')
 			->with($account, $client)
 			->willReturn($folders);
 		$this->folderMapper->expects($this->once())
 			->method('getFoldersStatusAsObject')
-			->with($client, self::equalToCanonicalizing(['mb1', 'mb2',]))
+			->with($client, self::equalToCanonicalizing(['mb1', 'mb2', 'mb3',]))
 			->willReturn([
 				'mb1' => new MailboxStats(1, 2),
 				'mb2' => new MailboxStats(1, 2),
+				/* no status for mb3 */
 			]);
 		$this->folderMapper->expects($this->once())
 			->method('detectFolderSpecialUse')
 			->with($folders);
-		$this->mailboxMapper->expects(self::exactly(2))
+		$this->mailboxMapper->expects(self::exactly(3))
 			->method('insert')
 			->willReturnArgument(0);
-		$this->mailboxMapper->expects(self::exactly(2))
+		$this->mailboxMapper->expects(self::exactly(3))
 			->method('update')
 			->willReturnArgument(0);
 		$this->dispatcher


### PR DESCRIPTION
From Sentry

> ErrorExceptionWarning: Undefined array key "INBOX.xyz"

I can only explain this as a missing STATUS response by the IMAP server. We can handle this more gracefully.