### PR TITLE
fix: reloading recipeint info when you expand and collapse the composer

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -114,7 +114,7 @@
 						@show-toolbar="handleShow" />
 				</div>
 
-				<div v-if="showRecipientPane" class="right-pane">
+				<div v-show="showRecipientPane" class="right-pane">
 					<RecipientInfo />
 				</div>
 			</div>


### PR DESCRIPTION
fix #10814

before
![Screenshot from 2025-03-11 14-18-17](https://github.com/user-attachments/assets/1aae799a-143c-41c9-855d-a1d6dc0abcf6)
after
![Screenshot from 2025-03-11 14-16-49](https://github.com/user-attachments/assets/04ff92c2-e646-41fc-86f2-dbc35296165f)
after
