### PR TITLE
fix: import for getTimezoneManager

### DIFF
--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -64,7 +64,8 @@
 </template>
 
 <script>
-import { createEvent, getTimezoneManager, DateTimeValue, TextProperty } from '@nextcloud/calendar-js'
+import { createEvent, DateTimeValue, TextProperty } from '@nextcloud/calendar-js'
+import { getTimezoneManager } from '@nextcloud/timezones'
 import { NcDateTimePicker as DatetimePicker, NcModal as Modal, NcSelect } from '@nextcloud/vue'
 import jstz from 'jstz'
 


### PR DESCRIPTION
Fix: Creating an event from an email fails with a type error

Regression from https://github.com/nextcloud/mail/pull/10797

Found while testing the backport for stable4.2 (https://github.com/nextcloud/mail/pull/10853/) and cherry-picked the commit right away. 