### PR TITLE
fix(db): Allow long references

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -295,7 +295,7 @@ class MessageMapper extends QBMapper {
 				$qb1->setParameter('message_id', $message->getMessageId(), IQueryBuilder::PARAM_STR);
 				$inReplyTo = self::filterMessageIdLength($message->getInReplyTo());
 				$qb1->setParameter('in_reply_to', $inReplyTo, $inReplyTo === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);
-				$references = self::filterMessageIdLength($message->getReferences());
+				$references = $message->getReferences();
 				$qb1->setParameter('references', $references, $references === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);
 				$threadRootId = self::filterMessageIdLength($message->getThreadRootId());
 				$qb1->setParameter('thread_root_id', $threadRootId, $threadRootId === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR);


### PR DESCRIPTION
oc_mail_messages has 1023-char wide columns message_id, in_reply_to and thread_root_id. But **references** has type *LONGTEXT*. We should't filter that.

Regression of https://github.com/nextcloud/mail/pull/10839