### PR TITLE
ci: Simplify release and packaging workflows

### DIFF
--- a/.github/workflows/appstore-conventional-build-publish.yml
+++ b/.github/workflows/appstore-conventional-build-publish.yml
@@ -3,22 +3,22 @@
 # https://github.com/nextcloud/.github
 # https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
 #
-# SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-FileCopyrightText: 2021-2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 
 name: Build and publish app release conventionally
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    branches: stable*
 
 env:
   PHP_VERSION: 8.2
 
 jobs:
   build_and_publish:
-    runs-on: ubuntu-latest
-
-    # Only allowed to be run on nextcloud-releases repositories
-    if: ${{ github.repository_owner == 'nextcloud-releases' }}
+    runs-on: [ubuntu-latest, self-hosted]
+    environment: release
 
     steps:
       - name: Check actor permission
@@ -33,14 +33,14 @@ jobs:
           echo "APP_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          path: ${{ env.APP_NAME }}
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
 
       - name: Conventional Changelog Action
         id: changelog
-        uses: TriPSs/conventional-changelog-action@b7f32a8347e86c26ea2f4823cc7c160b9014c6a0 # v3
-        working-directory: ${{ env.APP_NAME }}
+        uses: TriPSs/conventional-changelog-action@v3
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           git-user-email: nextcloud-command@users.noreply.github.com
@@ -50,112 +50,20 @@ jobs:
           release-count: 0
           version-file: "package.json, package-lock.json"
 
-      - name: Get appinfo data
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        id: appinfo
-        uses: skjnldsv/xpath-action@7e6a7c379d0e9abc8acaef43df403ab4fc4f770c # master
-        with:
-          filename: ${{ env.APP_NAME }}/appinfo/info.xml
-          expression: "//info//dependencies//nextcloud/@min-version"
-
-      - name: Read package.json node and npm engines version
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: skjnldsv/read-package-engines-version-actions@8205673bab74a63eb9b8093402fd9e0e018663a1 # v2.2
-        id: versions
-        # Continue if no package.json
-        continue-on-error: true
-        with:
-          path: ${{ env.APP_NAME }}
-          fallbackNode: '^20'
-          fallbackNpm: '^9'
-
-      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
-        with:
-          node-version: ${{ steps.versions.outputs.nodeVersion }}
-
-      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        run: npm i -g npm@"${{ steps.versions.outputs.npmVersion }}"
-
-      - name: Set up php ${{ env.PHP_VERSION }}
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2
-        with:
-          php-version: ${{ env.PHP_VERSION }}
-          coverage: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Krankerl
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        run: |
-          wget https://github.com/ChristophWurst/krankerl/releases/download/v0.14.0/krankerl_0.14.0_amd64.deb
-          sudo dpkg -i krankerl_0.14.0_amd64.deb
-
-      - name: Package ${{ env.APP_NAME }} ${{ env.APP_VERSION }} with krankerl
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        run: |
-          cd ${{ env.APP_NAME }}
-          krankerl package
-
-      - name: Checkout server ${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        continue-on-error: true
-        id: server-checkout
-        run: |
-          NCVERSION=${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
-          wget --quiet https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip
-          unzip latest-$NCVERSION.zip
-
-      - name: Checkout server master fallback
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: ${{ steps.changelog.outputs.skipped == 'false' && steps.server-checkout.outcome != 'success' }}
-        with:
-          submodules: true
-          repository: nextcloud/server
-          path: nextcloud
-
-      - name: Sign app
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        run: |
-          # Extracting release
-          cd ${{ env.APP_NAME }}/build/artifacts
-          tar -xvf ${{ env.APP_NAME }}.tar.gz
-          cd ../../../
-          # Setting up keys
-          echo "${{ secrets.APP_PRIVATE_KEY }}" > ${{ env.APP_NAME }}.key
-          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/${{ env.APP_NAME }}/${{ env.APP_NAME }}.crt"
-          # Signing
-          php nextcloud/occ integrity:sign-app --privateKey=../${{ env.APP_NAME }}.key --certificate=../${{ env.APP_NAME }}.crt --path=../${{ env.APP_NAME }}/build/artifacts/${{ env.APP_NAME }}
-          # Rebuilding archive
-          cd ${{ env.APP_NAME }}/build/artifacts
-          tar -zcvf ${{ env.APP_NAME }}.tar.gz ${{ env.APP_NAME }}
-
       - name: Push tag to releases organization
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
         run: |
           git remote add release https://github.com/nextcloud-releases/${{ env.APP_NAME }}.git
           git push release ${{ steps.changelog.outputs.tag }}
 
-      - name: Attach tarball to github release
+      - name: Create Release
         if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd # v2
-        id: attach_to_release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         with:
-          repo_token: ${{ secrets.RELEASE_PAT }}
-          repo_name: nextcloud-releases/${{ env.APP_NAME }}
-          file: ${{ env.APP_NAME }}/build/artifacts/${{ env.APP_NAME }}.tar.gz
-          asset_name: ${{ env.APP_NAME }}-${{ env.APP_VERSION }}.tar.gz
-          tag: ${{ steps.changelog.outputs.tag }}
-          overwrite: true
-
-      - name: Upload app to Nextcloud appstore
-        if: ${{ steps.changelog.outputs.skipped == 'false' }}
-        uses: nextcloud-releases/nextcloud-appstore-push-action@a011fe619bcf6e77ddebc96f9908e1af4071b9c1 # v1
-        with:
-          app_name: ${{ env.APP_NAME }}
-          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
-          download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
-          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          repo: nextcloud-releases/${{ env.APP_NAME }}
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
We currently have two release workflows
1. One for manual builds for pre-releases and the vx.y.0
2. An automated one for further patch releases

This blew up recently at https://github.com/nextcloud/contacts/issues/4372 where both workflows ran.

This PR simplifies the process.

1. We can either tag a release manually and push it over to the releases or **or** use `appstore-conventional-build-publish.yml` for patch releases, which now does nothing more than a human would do
2. The `appstore-bulid-publish.yml` will react on the github release, build and push to the app store

This mean we no longer have to delete the second workflow when going from .0 to .1.