### PR TITLE
docs(license): Use valid SPDX license identifier AGPL-3.0-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Nextcloud Mail",
   "version": "5.0.0-dev1",
   "author": "Christoph Wurst <christoph@winzerhof-wurst.at>",
-  "license": "agpl",
+  "license": "AGPL-3.0-only",
   "private": true,
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --config webpack.prod.js",


### PR DESCRIPTION
...instead of unspecific "agpl"