### PR TITLE
fix: go back warning discards the reply text

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -8,70 +8,61 @@
 		:name="modalTitle"
 		:additional-trap-elements="additionalTrapElements"
 		@close="$event.type === 'click' ? onClose() : onMinimize()">
-		<EmptyContent v-if="error"
-			:name="t('mail', 'Error sending your message')"
-			class="empty-content"
-			role="alert">
-			<p>{{ error }}</p>
-			<template #action>
-				<NcButton type="tertiary"
-					:aria-label="t('mail', 'Go back')"
-					@click="error = undefined">
-					{{ t('mail', 'Go back') }}
+		<div class="modal-content">
+			<div class="left-pane">
+				<NcButton class="maximize-button"
+					type="tertiary-no-background"
+					:aria-label="t('mail', 'Maximize composer')"
+					:title="largerModal ? t('mail', 'Collapse composer') : t('mail', 'Maximize composer')"
+					@click="onMaximize">
+					<template #icon>
+						<MaximizeIcon v-if="!largerModal" :size="20" />
+						<DefaultComposerIcon v-else :size="20" />
+					</template>
 				</NcButton>
-				<NcButton type="tertiary"
-					:aria-label="t('mail', 'Retry')"
-					@click="onSend">
-					{{ t('mail', 'Retry') }}
+				<NcButton class="minimize-button"
+					type="tertiary-no-background"
+					:aria-label="t('mail', 'Minimize composer')"
+					:title="t('mail', 'Minimize composer')"
+					@click="onMinimize">
+					<template #icon>
+						<MinimizeIcon :size="20" />
+					</template>
 				</NcButton>
-			</template>
-		</EmptyContent>
-		<Loading v-else-if="uploadingAttachments"
-			:hint="t('mail', 'Uploading attachments …')"
-			role="alert" />
-		<Loading v-else-if="sending" :hint="t('mail', 'Sending …')" role="alert" />
-		<EmptyContent v-else-if="warning"
-			:name="t('mail', 'Warning sending your message')"
-			class="empty-content"
-			role="alert">
-			<template #description>
-				{{ warning }}
-			</template>
-			<template #action>
-				<NcButton type="tertiary"
-					:aria-label="t('mail', 'Go back')"
-					@click="warning = undefined">
-					{{ t('mail', 'Go back') }}
-				</NcButton>
-				<NcButton type="tertiary"
-					:aria-label="t('mail', 'Send anyway')"
-					@click="onForceSend">
-					{{ t('mail', 'Send anyway') }}
-				</NcButton>
-			</template>
-		</EmptyContent>
-		<template v-else>
-			<div :class="['modal-content', { 'with-recipient': composerData.to && composerData.to.length > 0 }]">
-				<div class="left-pane">
-					<NcButton class="maximize-button"
-						type="tertiary-no-background"
-						:aria-label="t('mail', 'Maximize composer')"
-						:title="largerModal ? t('mail', 'Collapse composer') : t('mail', 'Maximize composer')"
-						@click="onMaximize">
-						<template #icon>
-							<MaximizeIcon v-if="!largerModal" :size="20" />
-							<DefaultComposerIcon v-else :size="20" />
+
+				<KeepAlive>
+					<EmptyContent v-if="error"
+						:name="t('mail', 'Error sending your message')"
+						class="empty-content"
+						role="alert">
+						<p>{{ error }}</p>
+						<template #action>
+							<NcButton type="tertiary" :aria-label="t('mail', 'Go back')" @click="error = undefined">
+								{{ t('mail', 'Go back') }}
+							</NcButton>
+							<NcButton type="tertiary" :aria-label="t('mail', 'Retry')" @click="onSend">
+								{{ t('mail', 'Retry') }}
+							</NcButton>
 						</template>
-					</NcButton>
-					<NcButton class="minimize-button"
-						type="tertiary-no-background"
-						:aria-label="t('mail', 'Minimize composer')"
-						:title="t('mail', 'Minimize composer')"
-						@click="onMinimize">
-						<template #icon>
-							<MinimizeIcon :size="20" />
+					</EmptyContent>
+					<Loading v-else-if="uploadingAttachments" :hint="t('mail', 'Uploading attachments …')" role="alert" />
+					<Loading v-else-if="sending" :hint="t('mail', 'Sending …')" role="alert" />
+					<EmptyContent v-else-if="warning"
+						:name="t('mail', 'Warning sending your message')"
+						class="empty-content"
+						role="alert">
+						<template #description>
+							{{ warning }}
 						</template>
-					</NcButton>
+						<template #action>
+							<NcButton type="tertiary" :aria-label="t('mail', 'Go back')" @click="warning = undefined">
+								{{ t('mail', 'Go back') }}
+							</NcButton>
+							<NcButton type="tertiary" :aria-label="t('mail', 'Send anyway')" @click="onForceSend">
+								{{ t('mail', 'Send anyway') }}
+							</NcButton>
+						</template>
+					</EmptyContent>
 
 					<Composer ref="composer"
 						:from-account="composerData.accountId"
@@ -114,13 +105,13 @@
 						@upload-attachment="onAttachmentUploading"
 						@send="onSend"
 						@show-toolbar="handleShow" />
-				</div>
-
-				<div v-show="showRecipientPane" class="right-pane">
-					<RecipientInfo />
-				</div>
+				</KeepAlive>
 			</div>
-		</template>
+
+			<div v-show="showRecipientPane && !warning && !error" class="right-pane">
+				<RecipientInfo />
+			</div>
+		</div>
 	</Modal>
 </template>
 <script>
@@ -516,6 +507,7 @@ export default {
 				}, 500)
 			}
 		},
+
 		async onForceSend() {
 			await this.onSend(this.cookedComposerData, true)
 		},


### PR DESCRIPTION
fixes #10818

this was a nasty one. 
We have 5 states here:
1. error
2. loading for attachment uploading
3. Loading for sending
4. warning
5. composer

When it switches to warning/error/loading and back, it completely destroys modal content because of v-if, including Composer instance.

Restructuring the component, and keeping alive the states plus the composer, fixes the issue. We shouldnt replace the entire modal content with loading/warning but only the composer.