### PR TITLE
feat: save the composer state per account

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -13,7 +13,7 @@
 				<NcButton class="maximize-button"
 					type="tertiary-no-background"
 					:aria-label="t('mail', 'Maximize composer')"
-					:title="largerModal ? t('mail', 'Collapse composer') : t('mail', 'Maximize composer')"
+					:title="largerModal ? t('mail', 'Show recipient details') : t('mail', 'Hide recipient details')"
 					@click="onMaximize">
 					<template #icon>
 						<MaximizeIcon v-if="!largerModal" :size="20" />
@@ -212,7 +212,7 @@ export default {
 			return this.hasContactDetailsApi
 				&& this.composerData.to
 				&& this.composerData.to.length > 0
-				&& !this.isMaximized
+				&& !this.largerModal
 		},
 		composerMessage() {
 			return this.mainStore.composerMessage


### PR DESCRIPTION
This is a bit tricky because those 2 buttons were supposed to maximize and collapse the composer modal. But now with the recipient details, its about showing or hiding the details. I believe this pr makes it more intuitive what those buttons do.



https://github.com/user-attachments/assets/6e510fd8-6e6d-4d24-945d-5b180eba1555


fixes #10627 


