### PR TITLE
fix(db): Do not JOIN recipients when fetching the latest messages

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1479,9 +1479,7 @@ class MessageMapper extends QBMapper {
 		$select = $qb
 			->select('m.*')
 			->from($this->getTableName(), 'm')
-			->join('m', 'mail_recipients', 'r', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
 			->where(
-				$qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
 				$qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
 			)
 			->orderBy('sent_at', 'desc')


### PR DESCRIPTION
As discussed with @st3iny, there seems no reason to JOIN because we don't filter on the data.

## MariaDB analyze

### Before

```json
{
  "query_optimization": {
    "r_total_time_ms": 0.295886183
  },
  "query_block": {
    "select_id": 1,
    "cost": 17.2639218,
    "r_loops": 1,
    "r_total_time_ms": 7.380777476,
    "nested_loop": [
      {
        "read_sorted_file": {
          "r_rows": 300,
          "filesort": {
            "sort_key": "m.sent_at desc",
            "r_loops": 1,
            "r_total_time_ms": 5.414184066,
            "r_used_priority_queue": false,
            "r_output_rows": 4544,
            "r_buffer_size": "1817Kb",
            "r_sort_mode": "sort_key,rowid",
            "table": {
              "table_name": "m",
              "access_type": "range",
              "possible_keys": [
                "PRIMARY",
                "mail_messages_mb_id_uid_uidx",
                "mail_messages_id_flags",
                "mail_messages_id_flags2",
                "mail_msg_thrd_root_snt_idx"
              ],
              "key": "mail_messages_mb_id_uid_uidx",
              "key_length": "4",
              "used_key_parts": ["mailbox_id"],
              "loops": 1,
              "r_loops": 1,
              "rows": 4560,
              "r_index_rows": 4544,
              "r_rows": 4544,
              "cost": 1.0139296,
              "r_table_time_ms": 5.357798992,
              "r_other_time_ms": 0.370584295,
              "r_engine_stats": {
                "pages_accessed": 9741
              },
              "filtered": 100,
              "r_total_filtered": 100,
              "index_condition": "m.mailbox_id in (696,708,703,706,705,712,707,695,711,702,700,697,693,704,701,698,692)",
              "r_icp_filtered": 100,
              "r_filtered": 100
            }
          }
        }
      },
      {
        "table": {
          "table_name": "r",
          "access_type": "ref",
          "possible_keys": ["mail_recipient_msg_id_idx", "20250325_test_mr_type"],
          "key": "mail_recipient_msg_id_idx",
          "key_length": "5",
          "used_key_parts": ["message_id"],
          "ref": ["nextcloud.m.id"],
          "rowid_filter": {
            "range": {
              "key": "20250325_test_mr_type",
              "used_key_parts": ["type"]
            },
            "rows": 9598,
            "selectivity_pct": 61.68776914,
            "r_rows": 4768,
            "r_lookups": 984,
            "r_selectivity_pct": 30.48780488,
            "r_buffer_size": 4768,
            "r_filling_time_ms": 0.875788622
          },
          "loops": 4560,
          "r_loops": 300,
          "rows": 3,
          "r_index_rows": 3.28,
          "r_rows": 1,
          "cost": 16.2499922,
          "r_table_time_ms": 1.459849695,
          "r_other_time_ms": 0.054745228,
          "r_engine_stats": {
            "pages_accessed": 1216
          },
          "filtered": 61.68777084,
          "r_total_filtered": 30.48780488,
          "index_condition": "m.`id` = r.message_id",
          "r_icp_filtered": 100,
          "attached_condition": "r.`type` = 0",
          "r_filtered": 100
        }
      }
    ]
  }
}
```

### After

```json
{
  "query_optimization": {
    "r_total_time_ms": 0.516227237
  },
  "query_block": {
    "select_id": 1,
    "cost": 1.0139296,
    "r_loops": 1,
    "r_total_time_ms": 6.236020586,
    "nested_loop": [
      {
        "read_sorted_file": {
          "r_rows": 300,
          "filesort": {
            "sort_key": "m.sent_at desc",
            "r_loops": 1,
            "r_total_time_ms": 5.889989475,
            "r_limit": 300,
            "r_used_priority_queue": true,
            "r_output_rows": 301,
            "r_sort_mode": "sort_key,rowid",
            "table": {
              "table_name": "m",
              "access_type": "range",
              "possible_keys": [
                "mail_messages_mb_id_uid_uidx",
                "mail_messages_id_flags",
                "mail_messages_id_flags2",
                "mail_msg_thrd_root_snt_idx"
              ],
              "key": "mail_messages_mb_id_uid_uidx",
              "key_length": "4",
              "used_key_parts": ["mailbox_id"],
              "loops": 1,
              "r_loops": 1,
              "rows": 4560,
              "r_index_rows": 4544,
              "r_rows": 4544,
              "cost": 1.0139296,
              "r_table_time_ms": 5.489310666,
              "r_other_time_ms": 0.715012756,
              "r_engine_stats": {
                "pages_accessed": 9741
              },
              "filtered": 100,
              "r_total_filtered": 6.624119718,
              "index_condition": "m.mailbox_id in (696,708,703,706,705,712,707,695,711,702,700,697,693,704,701,698,692)",
              "r_icp_filtered": 100,
              "r_filtered": 100
            }
          }
        }
      }
    ]
  }
}
```