### PR TITLE
Fix: Remove extraneous JSON preamble from LLM responses

### DIFF
--- a/lib/Service/AiIntegrations/AiIntegrationsService.php
+++ b/lib/Service/AiIntegrations/AiIntegrationsService.php
@@ -265,7 +265,8 @@ PROMPT;
 			$manager->runTask($task);
 			$replies = $task->getOutput();
 			try {
-				$decoded = json_decode($replies, true, 512, JSON_THROW_ON_ERROR);
+				$cleaned = preg_replace('/^```json\s*|\s*```$/', '', trim($replies));
+                $decoded = json_decode($cleaned, true, 512, JSON_THROW_ON_ERROR);
 				$this->cache->addValue('smartReplies_' . $message->getId(), $replies);
 				return $decoded;
 			} catch (JsonException $e) {


### PR DESCRIPTION
The most of the LLM's return in JSON markdown format, example:
\```json
{
  "reply1": "Received, thanks...",
  "reply2": "Thanks for forwarding this..."
}
\```
Adding additional instructions didn't help. 

This is solution to strip:
\```json
\```
from the answer.