### PR TITLE
feat:support darkmode in html messages

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -114,6 +114,7 @@ export default {
 		},
 		onMessageFrameLoad() {
 			const iframeDoc = this.getIframeDoc()
+			this.styleIframe(iframeDoc)
 			this.hasBlockedContent
 				= iframeDoc.querySelectorAll('[data-original-src]').length > 0
 				|| iframeDoc.querySelectorAll('[data-original-style]').length > 0
@@ -143,6 +144,10 @@ export default {
 					node.innerHTML = node.getAttribute('data-original-content')
 				})
 			this.hasBlockedContent = false
+		},
+		styleIframe(iframeDoc) {
+			iframeDoc.body.style.backgroundColor = getComputedStyle(document.body).getPropertyValue('--color-main-background')
+			iframeDoc.body.style.color = getComputedStyle(document.body).getPropertyValue('--color-main-text')
 		},
 		async onShowBlockedContent() {
 			this.displayIframe()


### PR DESCRIPTION
| b | a |
|--------|--------|
| <img width="649" alt="image" src="https://github.com/user-attachments/assets/6e2ae891-d650-4bc6-b2b4-91872fd2b0f1" /> | <img width="649" alt="image" src="https://github.com/user-attachments/assets/86235cb4-c410-47c8-b763-2420eb80960d" /> | 