### PR TITLE
perf: prefetch other mailboxes in the background

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -130,7 +130,7 @@
 			</ActionButton>
 
 			<ActionCheckbox v-if="notVirtual"
-				:checked="isSubscribed"
+				:checked="mailbox.isSubscribed"
 				:disabled="changeSubscription"
 				@update:checked="changeFolderSubscription">
 				{{ t('mail', 'Subscribed') }}
@@ -350,9 +350,6 @@ export default {
 				}
 			}
 			return t('mail', 'Loading …')
-		},
-		isSubscribed() {
-			return this.mailbox.attributes && this.mailbox.attributes.includes('\\subscribed')
 		},
 		isDroppableSpecialMailbox() {
 			if (this.filter === 'starred') {

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -153,6 +153,12 @@ const addMailboxToState = curry((mailboxes, account, mailbox) => {
 	} else {
 		parent.mailboxes.push(mailbox.databaseId)
 	}
+
+	Object.defineProperty(mailbox, 'isSubscribed', {
+		get() {
+			return this.attributes?.includes('\\subscribed') ?? false
+		},
+	})
 })
 
 export default function mainStoreActions() {
@@ -2309,6 +2315,15 @@ export default function mainStoreActions() {
 		},
 		getMailboxes(accountId) {
 			return this.accountsUnmapped[accountId].mailboxes.map((id) => this.mailboxes[id])
+		},
+		* getRecursiveMailboxIterator(accountId) {
+			for (const mailbox of this.getMailboxes(accountId)) {
+				yield mailbox
+
+				for (const subMailboxId of mailbox.mailboxes) {
+					yield this.getMailbox(subMailboxId)
+				}
+			}
 		},
 		getSubMailboxes(id) {
 			const mailbox = this.getMailbox(id)


### PR DESCRIPTION
Resolves https://github.com/nextcloud/mail/issues/10718

This will trigger a request for each subscribed mailbox to cache the first few envelopes in the frontend. Opening a prefetched mailbox will be instant. Otherwise, the usual loading skeleton will be shown.

## Screencast

In this example, the inbox and trash folders are subscribed (and prefetched). The third folder, cache, is not subscribed and will be loaded once opened.

https://github.com/user-attachments/assets/1a82de5c-d327-4564-b258-5e05ff33456c

## TODO

- [ ] Is the trade-off worth it? For each subscribed mailbox there will be a request to fetch at most 20 envelopes from the db (no syncing or IMAP stuff!).