### PR TITLE
perf(imap): avoid double login during mailbox sync

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -13,6 +13,7 @@ use Horde_Imap_Client;
 use Horde_Imap_Client_Data_Namespace;
 use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Namespace_List;
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Db\Mailbox;
@@ -139,13 +140,11 @@ class MailboxSync {
 	/**
 	 * Sync unread and total message statistics.
 	 *
-	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 *
 	 * @throws ServiceException
 	 */
-	public function syncStats(Account $account, Mailbox $mailbox): void {
-		$client = $this->imapClientFactory->getClient($account);
+	public function syncStats(Horde_Imap_Client_Socket $client, Mailbox $mailbox): void {
 		try {
 			$allStats = $this->folderMapper->getFoldersStatusAsObject($client, [$mailbox->getName()]);
 		} catch (Horde_Imap_Client_Exception $e) {
@@ -155,8 +154,6 @@ class MailboxSync {
 				$e->getCode(),
 				$e
 			);
-		} finally {
-			$client->logout();
 		}
 
 		if (!isset($allStats[$mailbox->getName()])) {

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -133,7 +133,7 @@ class SyncService {
 			!$partialOnly
 		);
 
-		$this->mailboxSync->syncStats($account, $mailbox);
+		$this->mailboxSync->syncStats($client, $mailbox);
 
 		$client->logout();
 

--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -213,12 +213,7 @@ class MailboxSyncTest extends TestCase {
 	}
 
 	public function testSyncStats(): void {
-		$account = $this->createMock(Account::class);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
-		$this->imapClientFactory->expects($this->once())
-			->method('getClient')
-			->with($account)
-			->willReturn($client);
 		$stats = new MailboxStats(42, 10, null);
 		$mailbox = new Mailbox();
 		$mailbox->setName('mailbox');
@@ -230,19 +225,14 @@ class MailboxSyncTest extends TestCase {
 			->method('update')
 			->with($mailbox);
 
-		$this->sync->syncStats($account, $mailbox);
+		$this->sync->syncStats($client, $mailbox);
 
 		$this->assertEquals(42, $mailbox->getMessages());
 		$this->assertEquals(10, $mailbox->getUnseen());
 	}
 
 	public function testSyncStatsWithNoStats(): void {
-		$account = $this->createMock(Account::class);
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
-		$this->imapClientFactory->expects($this->once())
-			->method('getClient')
-			->with($account)
-			->willReturn($client);
 		$stats = new MailboxStats(42, 10, null);
 		$mailbox = new Mailbox();
 		$mailbox->setMessages(10);
@@ -255,7 +245,7 @@ class MailboxSyncTest extends TestCase {
 		$this->mailboxMapper->expects(self::never())
 			->method('update');
 
-		$this->sync->syncStats($account, $mailbox);
+		$this->sync->syncStats($client, $mailbox);
 
 		$this->assertEquals(10, $mailbox->getMessages());
 		$this->assertEquals(6, $mailbox->getUnseen());

--- a/tests/Unit/Service/Sync/SyncServiceTest.php
+++ b/tests/Unit/Service/Sync/SyncServiceTest.php
@@ -133,7 +133,7 @@ class SyncServiceTest extends TestCase {
 			);
 		$this->mailboxSync->expects($this->once())
 			->method('syncStats')
-			->with($account, $mailbox);
+			->with($this->client, $mailbox);
 
 		$response = $this->syncService->syncMailbox(
 			$account,

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -732,16 +732,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.13",
+            "version": "9.6.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
                 "shasum": ""
             },
             "require": {
@@ -815,7 +815,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
             },
             "funding": [
                 {
@@ -831,7 +831,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T05:39:22+00:00"
+            "time": "2024-04-05T04:35:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2078,11 +2078,11 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },


### PR DESCRIPTION
Sentry profiles showed that we log in twice within one request. This is easy to avoid.

https://blackfire.io/profiles/compare/182c94b7-a971-471d-b49a-125a54660523/graph