### PR TITLE
fix: moving nested mailboxes

### DIFF
--- a/src/components/MoveMailboxModal.vue
+++ b/src/components/MoveMailboxModal.vue
@@ -62,7 +62,7 @@ export default {
 
 					} else {
 						const destMailbox = this.mainStore.getMailbox(this.destMailboxId)
-						const newName = destMailbox.name + this.mailbox.delimiter + this.mailbox.name
+						const newName = destMailbox.name + this.mailbox.delimiter + this.mailbox.displayName
 						await this.mainStore.renameMailbox({
 							account: this.account,
 							mailbox: this.mailbox,


### PR DESCRIPTION
Fix #10548 

**Before:** Move a nested mailbox somewhere else will cause it to become orphaned.
**After:** Moving nested mailboxes works as expected.

More details are available here: https://github.com/nextcloud/mail/issues/10548#issuecomment-2801791854