### PR TITLE
fix: don't show important or unread emails in trash

### DIFF
--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -14,6 +14,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Service\Search\SearchQuery;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IUser;
 
@@ -50,14 +51,12 @@ interface IMailSearch {
 		?int $limit): array;
 
 	/**
-	 * @param IUser $user
-	 * @param string|null $filter
-	 * @param int|null $cursor
+	 * Run a search through all mailboxes of a user.
 	 *
 	 * @return Message[]
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function findMessagesGlobally(IUser $user, ?string $filter, ?int $cursor, ?int $limit): array;
+	public function findMessagesGlobally(IUser $user, SearchQuery $query, ?int $limit): array;
 }

--- a/lib/Dashboard/ImportantMailWidget.php
+++ b/lib/Dashboard/ImportantMailWidget.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Dashboard;
 
+use OCA\Mail\Service\Search\Flag;
+use OCA\Mail\Service\Search\GlobalSearchQuery;
+use OCA\Mail\Service\Search\SearchQuery;
+
 class ImportantMailWidget extends MailWidget {
 	/**
 	 * @inheritDoc
@@ -24,10 +28,10 @@ class ImportantMailWidget extends MailWidget {
 		return $this->l10n->t('Important mail');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function getSearchFilter(): string {
-		return 'is:important';
+	public function getSearchQuery(string $userId): SearchQuery {
+		$query = new GlobalSearchQuery();
+		$query->addFlag(Flag::is(Flag::IMPORTANT));
+		$query->setExcludeMailboxIds($this->getMailboxIdsToExclude($userId));
+		return $query;
 	}
 }

--- a/lib/Dashboard/UnreadMailWidget.php
+++ b/lib/Dashboard/UnreadMailWidget.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Dashboard;
 
+use OCA\Mail\Service\Search\Flag;
+use OCA\Mail\Service\Search\GlobalSearchQuery;
+use OCA\Mail\Service\Search\SearchQuery;
+
 class UnreadMailWidget extends MailWidget {
 	/**
 	 * @inheritDoc
@@ -24,10 +28,10 @@ class UnreadMailWidget extends MailWidget {
 		return $this->l10n->t('Unread mail');
 	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function getSearchFilter(): string {
-		return 'is:unread';
+	public function getSearchQuery(string $userId): SearchQuery {
+		$query = new GlobalSearchQuery();
+		$query->addFlag(Flag::not(Flag::SEEN));
+		$query->setExcludeMailboxIds($this->getMailboxIdsToExclude($userId));
+		return $query;
 	}
 }

--- a/lib/Service/Search/GlobalSearchQuery.php
+++ b/lib/Service/Search/GlobalSearchQuery.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Service\Search;
+
+class GlobalSearchQuery extends SearchQuery {
+	/** @var int[] */
+	private array $excludeMailboxIds = [];
+
+	/**
+	 * @return int[]
+	 */
+	public function getExcludeMailboxIds(): array {
+		return $this->excludeMailboxIds;
+	}
+
+	/**
+	 * @param int[] $mailboxIds
+	 */
+	public function setExcludeMailboxIds(array $mailboxIds): void {
+		$this->excludeMailboxIds = $mailboxIds;
+	}
+}

--- a/lib/Service/Search/MailSearch.php
+++ b/lib/Service/Search/MailSearch.php
@@ -123,24 +123,16 @@ class MailSearch implements IMailSearch {
 	}
 
 	/**
-	 * @param IUser $user
-	 * @param string|null $filter
-	 * @param int|null $cursor
+	 * Find messages across all mailboxes for a user
 	 *
 	 * @return Message[]
 	 *
-	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function findMessagesGlobally(IUser $user,
-		?string $filter,
-		?int $cursor,
+	public function findMessagesGlobally(
+		IUser $user,
+		SearchQuery $query,
 		?int $limit): array {
-		$query = $this->filterStringParser->parse($filter);
-		if ($cursor !== null) {
-			$query->setCursor($cursor);
-		}
-
 		return $this->messageMapper->findByIds($user->getUID(),
 			$this->getIdsGlobally($user, $query, $limit),
 			'DESC'

--- a/tests/Unit/Dashboard/ImportantMailWidgetTest.php
+++ b/tests/Unit/Dashboard/ImportantMailWidgetTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\Dashboard;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Dashboard\ImportantMailWidget;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Search\GlobalSearchQuery;
+use OCA\Mail\Service\Search\MailSearch;
+use OCA\Mail\Service\Search\SearchQuery as MailSearchQuery;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ImportantMailWidgetTest extends TestCase {
+
+	private IL10N&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IUserManager&MockObject $userManager;
+	private AccountService&MockObject $accountService;
+	private MailSearch&MockObject $mailSearch;
+	private IInitialState&MockObject $initialState;
+	private ImportantMailWidget $widget;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->mailSearch = $this->createMock(MailSearch::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+
+		$this->widget = new ImportantMailWidget(
+			$this->l10n,
+			$this->urlGenerator,
+			$this->userManager,
+			$this->accountService,
+			$this->mailSearch,
+			$this->initialState,
+			'bob'
+		);
+	}
+
+	public function testGetItems(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+		$message1 = new Message();
+		$message1->setSubject('Important');
+		$message1->setMailboxId(1);
+		$message2 = new Message();
+		$message2->setSubject('Also important');
+		$message2->setMailboxId(2);
+		$this->mailSearch->expects($this->once())
+			->method('findMessagesGlobally')
+			->with($user, $this->callback(function (GlobalSearchQuery $query) {
+				self::assertCount(1, $query->getFlags());
+				self::assertNull($query->getStart());
+				return true;
+			}))
+			->willReturn([$message1, $message2]);
+		$mailAccount = new MailAccount();
+		$account = new Account($mailAccount);
+		$this->accountService->expects($this->once())
+			->method('findByUserId')
+			->willReturn([$account]);
+
+		$items = $this->widget->getItems('bob', null, 7);
+
+		$this->assertCount(2, $items);
+	}
+
+	public function testGetItemsWithSince(): void {
+		$user = $this->createMock(IUser::class);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+		$message1 = new Message();
+		$message1->setSubject('Important');
+		$message1->setMailboxId(1);
+		$message2 = new Message();
+		$message2->setSubject('Also important');
+		$message2->setMailboxId(2);
+		$this->mailSearch->expects($this->once())
+			->method('findMessagesGlobally')
+			->with($user, $this->callback(function (MailSearchQuery $query) {
+				self::assertCount(1, $query->getFlags());
+				self::assertNotNull($query->getStart());
+				return true;
+			}))
+			->willReturn([$message1, $message2]);
+		$mailAccount = new MailAccount();
+		$account = new Account($mailAccount);
+		$this->accountService->expects($this->once())
+			->method('findByUserId')
+			->willReturn([$account]);
+
+		$items = $this->widget->getItems('bob', '1745340000', 7);
+
+		$this->assertCount(2, $items);
+	}
+}

--- a/tests/Unit/Search/FilteringProviderTest.php
+++ b/tests/Unit/Search/FilteringProviderTest.php
@@ -9,126 +9,197 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Tests\Unit\Search;
 
-use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\DateTimeFormatter;
+use OC\Search\Filter\DateTimeFilter;
+use OC\Search\Filter\StringFilter;
+use OC\Search\Filter\UserFilter;
+use OC\Search\FilterCollection;
+use OC\Search\SearchQuery;
 use OCA\Mail\AddressList;
+use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Search\FilteringProvider;
+use OCA\Mail\Service\Search\FilterStringParser;
+use OCA\Mail\Service\Search\SearchQuery as MailSearchQuery;
+use OCP\IDateTimeFormatter;
+use OCP\IL10N;
+use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Search\IFilter;
-use OCP\Search\IFilteringProvider;
-use OCP\Search\ISearchQuery;
-use function interface_exists;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @covers \OCA\Mail\Search\FilteringProvider
  */
 class FilteringProviderTest extends TestCase {
-	private ServiceMockObject $serviceMock;
+	private IMailSearch&MockObject $mailSearch;
+	private IL10N&MockObject $l10n;
+	private IDateTimeFormatter $dateTimeFormatter;
+	private IURLGenerator&MockObject $urlGenerator;
+	private FilterStringParser $filterStringParser;
+	private IUserManager&MockObject $userManager;
 	private FilteringProvider $provider;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		if (!interface_exists(IFilteringProvider::class)) {
-			$this->markTestSkipped('Base class missing');
-		}
+		$this->mailSearch = $this->createMock(IMailSearch::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->dateTimeFormatter = new DateTimeFormatter(new \DateTimeZone('Europe/Berlin'), $this->l10n);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->filterStringParser = new FilterStringParser();
+		$this->userManager = $this->createMock(IUserManager::class);
 
-		$this->serviceMock = $this->createServiceMock(FilteringProvider::class);
-		$this->provider = $this->serviceMock->getService();
+		$this->provider = new FilteringProvider(
+			$this->mailSearch,
+			$this->l10n,
+			$this->dateTimeFormatter,
+			$this->urlGenerator,
+			$this->filterStringParser
+		);
 	}
 
 	public function testSearchForTerm(): void {
 		$term = 'spam';
 		$user = $this->createMock(IUser::class);
-		$query = $this->createMock(ISearchQuery::class);
-		$termFilter = $this->createMock(IFilter::class);
-		$termFilter->method('get')->willReturn($term);
-		$query->method('getFilter')->willReturnCallback(function ($filter) use ($termFilter) {
-			return match ($filter) {
-				'term' => $termFilter,
-				default => null,
-			};
-		});
+		$filters = [
+			IFilter::BUILTIN_TERM => new StringFilter($term),
+		];
+		$filterCollection = new FilterCollection(... $filters);
+		$searchQuery = new SearchQuery($filterCollection);
 		$message1 = new Message();
 		$message1->setSubject('This is not spam');
 		$message1->setFrom(AddressList::parse('Sender <sender@domain.tld>'));
-		$this->serviceMock->getParameter('mailSearch')
-			->expects(self::once())
+		$this->mailSearch->expects($this->once())
 			->method('findMessagesGlobally')
-			->with(
-				$user,
-				'subject:spam'
-			)
-			->willReturn([
-				$message1,
-			]);
+			->with($user, $this->callback(function (MailSearchQuery $query) {
+				self::assertCount(1, $query->getSubjects());
+				self::assertEquals('spam', $query->getSubjects()[0]);
+				return true;
+			}))
+			->willReturn([$message1]);
 
 		$result = $this->provider->search(
 			$user,
-			$query,
+			$searchQuery
 		);
+		$entries = $result->jsonSerialize()['entries'] ?? [];
 
-		self::assertNotEmpty($result->jsonSerialize()['entries'] ?? []);
+		self::assertNotEmpty($entries);
 	}
 
 	public function testSearchForUserNoEmail(): void {
 		$user = $this->createMock(IUser::class);
 		$otherUser = $this->createMock(IUser::class);
-		$query = $this->createMock(ISearchQuery::class);
-		$termFilter = $this->createMock(IFilter::class);
-		$termFilter->method('get')->willReturn($otherUser);
-		$query->method('getFilter')->willReturnCallback(function ($filter) use ($termFilter) {
-			return match ($filter) {
-				'person' => $termFilter,
-				default => null,
-			};
-		});
-		$this->serviceMock->getParameter('mailSearch')
-			->expects(self::never())
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('bob')
+			->willReturn($otherUser);
+		$filters = [
+			IFilter::BUILTIN_PERSON => new UserFilter('bob', $this->userManager),
+		];
+		$filterCollection = new FilterCollection(... $filters);
+		$searchQuery = new SearchQuery($filterCollection);
+		$this->mailSearch->expects($this->never())
 			->method('findMessagesGlobally');
 
 		$result = $this->provider->search(
 			$user,
-			$query,
+			$searchQuery,
 		);
+		$entries = $result->jsonSerialize()['entries'] ?? [];
 
-		self::assertEmpty($result->jsonSerialize()['entries'] ?? []);
+		self::assertEmpty($entries);
 	}
 
 	public function testSearchForUser(): void {
 		$user = $this->createMock(IUser::class);
 		$otherUser = $this->createMock(IUser::class);
-		$otherUser->method('getEMailAddress')->willReturn('other@domain.tld');
-		$query = $this->createMock(ISearchQuery::class);
-		$userFilter = $this->createMock(IFilter::class);
-		$userFilter->method('get')->willReturn($otherUser);
-		$query->method('getFilter')->willReturnCallback(function ($filter) use ($userFilter) {
-			return match ($filter) {
-				'person' => $userFilter,
-				default => null,
-			};
-		});
+		$otherUser->method('getEMailAddress')
+			->willReturn('other@domain.tld');
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('bob')
+			->willReturn($otherUser);
+		$filters = [
+			IFilter::BUILTIN_PERSON => new UserFilter('bob', $this->userManager),
+		];
+		$filterCollection = new FilterCollection(... $filters);
+		$searchQuery = new SearchQuery($filterCollection);
 		$message1 = new Message();
 		$message1->setSubject('This is not spam');
 		$message1->setFrom(AddressList::parse('Other <other@domain.tld>'));
-		$this->serviceMock->getParameter('mailSearch')
-			->expects(self::once())
+		$this->mailSearch->expects($this->once())
 			->method('findMessagesGlobally')
-			->with(
-				$user,
-				'from:other@domain.tld to:other@domain.tld cc:other@domain.tld'
-			)
-			->willReturn([
-				$message1,
-			]);
+			->with($user, $this->callback(function (MailSearchQuery $query) {
+				self::assertCount(1, $query->getFrom());
+				self::assertCount(1, $query->getTo());
+				self::assertCount(1, $query->getCc());
+				return true;
+			}))
+			->willReturn([$message1]);
 
 		$result = $this->provider->search(
 			$user,
-			$query,
+			$searchQuery,
 		);
+		$entries = $result->jsonSerialize()['entries'] ?? [];
 
-		self::assertNotEmpty($result->jsonSerialize()['entries'] ?? []);
+		self::assertNotEmpty($entries);
 	}
 
+	public function testSearchSinceAndUntil(): void {
+		$user = $this->createMock(IUser::class);
+		$otherUser = $this->createMock(IUser::class);
+		$otherUser->method('getEMailAddress')
+			->willReturn('other@domain.tld');
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('bob')
+			->willReturn($otherUser);
+		$filters = [
+			IFilter::BUILTIN_PERSON => new UserFilter('bob', $this->userManager),
+			IFilter::BUILTIN_SINCE => new DateTimeFilter('2025-04-25T15:30:00'),
+			IFilter::BUILTIN_UNTIL => new DateTimeFilter('2025-05-25T15:30:00'),
+		];
+		$filterCollection = new FilterCollection(... $filters);
+		$searchQuery = new SearchQuery($filterCollection);
+		$message1 = new Message();
+		$message1->setSubject('This is not spam');
+		$message1->setFrom(AddressList::parse('Other <other@domain.tld>'));
+		$this->mailSearch->expects($this->once())
+			->method('findMessagesGlobally')
+			->with($user, $this->callback(function (MailSearchQuery $query) {
+				self::assertCount(1, $query->getFrom());
+				self::assertCount(1, $query->getTo());
+				self::assertCount(1, $query->getCc());
+				self::assertNotNull($query->getStart());
+				self::assertNotNull($query->getEnd());
+				return true;
+			}))
+			->willReturn([$message1]);
+
+		$result = $this->provider->search(
+			$user,
+			$searchQuery,
+		);
+		$entries = $result->jsonSerialize()['entries'] ?? [];
+
+		self::assertNotEmpty($entries);
+	}
+
+	public function testGetSupportedFilters(): void {
+		$filters = $this->provider->getSupportedFilters();
+		self::assertCount(4, $filters);
+	}
+
+	public function testGetAlternateIds(): void {
+		self::assertCount(0, $this->provider->getAlternateIds());
+	}
+
+	public function testGetCustomFilters(): void {
+		self::assertCount(0, $this->provider->getCustomFilters());
+	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/7475
Fix https://github.com/nextcloud/mail/issues/8849


To exclude messages in the trash or junk, we need to pass the IDs of those mailboxes to the search. Previously, MailSearch.findMessagesGlobally expected a filter string like "is:unread" and fed it through a parser to create a SearchQuery object. I've changed the API to expect a SearchQuery object directly. The parsing is now handled a step earlier when processing the incoming search request.

The SearchQuery is used for searching across all mailboxes and for a given mailbox. To distinguish these cases more clearly, we now have GlobalSearchQuery. For example excluding certain mailbox IDs doesn't make sense when searching within a specific mailbox anyway. The MailSearch API still feels a bit unfinished, but this PR is already large enough, and the current state looks good to me.

Note: The special_use (e.g., trash or junk) is stored as a JSON string in the database. It might also work to select those rows using LIKE and toggle a flag like ignoreJunk for the SearchQuery object instead of using the actual mailbox ID. 