### PR TITLE
perf: reuse a single imap client for the whole send chain

### DIFF
--- a/lib/Send/AHandler.php
+++ b/lib/Send/AHandler.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCA\Mail\Send;
 
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 
@@ -18,11 +19,19 @@ abstract class AHandler {
 		return $next;
 	}
 
-	abstract public function process(Account $account, LocalMessage $localMessage): LocalMessage;
+	abstract public function process(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage;
 
-	protected function processNext(Account $account, LocalMessage $localMessage): LocalMessage {
+	protected function processNext(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage {
 		if ($this->next !== null) {
-			return $this->next->process($account, $localMessage);
+			return $this->next->process($account, $localMessage, $client);
 		}
 		return $localMessage;
 	}

--- a/lib/Send/AntiAbuseHandler.php
+++ b/lib/Send/AntiAbuseHandler.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCA\Mail\Send;
 
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Service\AntiAbuseService;
@@ -21,10 +22,15 @@ class AntiAbuseHandler extends AHandler {
 		private LoggerInterface $logger,
 	) {
 	}
-	public function process(Account $account, LocalMessage $localMessage): LocalMessage {
+
+	public function process(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage {
 		if ($localMessage->getStatus() === LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL
 			|| $localMessage->getStatus() === LocalMessage::STATUS_PROCESSED) {
-			return $this->processNext($account, $localMessage);
+			return $this->processNext($account, $localMessage, $client);
 		}
 
 		$user = $this->userManager->get($account->getUserId());
@@ -45,6 +51,6 @@ class AntiAbuseHandler extends AHandler {
 		// at this point.
 		// Any future improvement from https://github.com/nextcloud/mail/issues/6461
 		// should refactor the chain to stop at this point unless the force send option is true
-		return $this->processNext($account, $localMessage);
+		return $this->processNext($account, $localMessage, $client);
 	}
 }

--- a/lib/Send/FlagRepliedMessageHandler.php
+++ b/lib/Send/FlagRepliedMessageHandler.php
@@ -9,18 +9,17 @@ namespace OCA\Mail\Send;
 
 use Horde_Imap_Client;
 use Horde_Imap_Client_Exception;
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\MessageMapper as DbMessageMapper;
-use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 
 class FlagRepliedMessageHandler extends AHandler {
 	public function __construct(
-		private IMAPClientFactory $imapClientFactory,
 		private MailboxMapper $mailboxMapper,
 		private LoggerInterface $logger,
 		private MessageMapper $messageMapper,
@@ -28,53 +27,51 @@ class FlagRepliedMessageHandler extends AHandler {
 	) {
 	}
 
-	public function process(Account $account, LocalMessage $localMessage): LocalMessage {
+	public function process(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage {
 		if ($localMessage->getStatus() !== LocalMessage::STATUS_PROCESSED) {
 			return $localMessage;
 		}
 
 		if ($localMessage->getInReplyToMessageId() === null) {
-			return $this->processNext($account, $localMessage);
+			return $this->processNext($account, $localMessage, $client);
 		}
 
 		$messages = $this->dbMessageMapper->findByMessageId($account, $localMessage->getInReplyToMessageId());
 		if ($messages === []) {
-			return $this->processNext($account, $localMessage);
+			return $this->processNext($account, $localMessage, $client);
 		}
 
-		try {
-			$client = $this->imapClientFactory->getClient($account);
-			foreach ($messages as $message) {
-				try {
-					$mailbox = $this->mailboxMapper->findById($message->getMailboxId());
-					//ignore read-only mailboxes
-					if ($mailbox->getMyAcls() !== null && !strpos($mailbox->getMyAcls(), 'w')) {
-						continue;
-					}
-					// ignore drafts and sent
-					if ($mailbox->isSpecialUse('sent') || $mailbox->isSpecialUse('drafts')) {
-						continue;
-					}
-					// Mark all other mailboxes that contain the message with the same imap message id as replied
-					$this->messageMapper->addFlag(
-						$client,
-						$mailbox,
-						[$message->getUid()],
-						Horde_Imap_Client::FLAG_ANSWERED
-					);
-					$message->setFlagAnswered(true);
-					$this->dbMessageMapper->update($message);
-				} catch (DoesNotExistException|Horde_Imap_Client_Exception $e) {
-					$this->logger->warning('Could not flag replied message: ' . $e, [
-						'exception' => $e,
-					]);
+		foreach ($messages as $message) {
+			try {
+				$mailbox = $this->mailboxMapper->findById($message->getMailboxId());
+				//ignore read-only mailboxes
+				if ($mailbox->getMyAcls() !== null && !strpos($mailbox->getMyAcls(), 'w')) {
+					continue;
 				}
-
+				// ignore drafts and sent
+				if ($mailbox->isSpecialUse('sent') || $mailbox->isSpecialUse('drafts')) {
+					continue;
+				}
+				// Mark all other mailboxes that contain the message with the same imap message id as replied
+				$this->messageMapper->addFlag(
+					$client,
+					$mailbox,
+					[$message->getUid()],
+					Horde_Imap_Client::FLAG_ANSWERED
+				);
+				$message->setFlagAnswered(true);
+				$this->dbMessageMapper->update($message);
+			} catch (DoesNotExistException|Horde_Imap_Client_Exception $e) {
+				$this->logger->warning('Could not flag replied message: ' . $e, [
+					'exception' => $e,
+				]);
 			}
-		} finally {
-			$client->logout();
 		}
 
-		return $this->processNext($account, $localMessage);
+		return $this->processNext($account, $localMessage, $client);
 	}
 }

--- a/lib/Send/SendHandler.php
+++ b/lib/Send/SendHandler.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCA\Mail\Send;
 
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\LocalMessage;
@@ -17,16 +18,20 @@ class SendHandler extends AHandler {
 	) {
 	}
 
-	public function process(Account $account, LocalMessage $localMessage): LocalMessage {
+	public function process(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage {
 		if ($localMessage->getStatus() === LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL
 			|| $localMessage->getStatus() === LocalMessage::STATUS_PROCESSED) {
-			return $this->processNext($account, $localMessage);
+			return $this->processNext($account, $localMessage, $client);
 		}
 
 		$this->transmission->sendMessage($account, $localMessage);
 
 		if ($localMessage->getStatus() === LocalMessage::STATUS_RAW || $localMessage->getStatus() === null) {
-			return $this->processNext($account, $localMessage);
+			return $this->processNext($account, $localMessage, $client);
 		}
 		// Something went wrong during the sending
 		return $localMessage;

--- a/lib/Send/SentMailboxHandler.php
+++ b/lib/Send/SentMailboxHandler.php
@@ -7,15 +7,20 @@ declare(strict_types=1);
  */
 namespace OCA\Mail\Send;
 
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 
 class SentMailboxHandler extends AHandler {
-	public function process(Account $account, LocalMessage $localMessage): LocalMessage {
+	public function process(
+		Account $account,
+		LocalMessage $localMessage,
+		Horde_Imap_Client_Socket $client,
+	): LocalMessage {
 		if ($account->getMailAccount()->getSentMailboxId() === null) {
 			$localMessage->setStatus(LocalMessage::STATUS_NO_SENT_MAILBOX);
 			return $localMessage;
 		}
-		return $this->processNext($account, $localMessage);
+		return $this->processNext($account, $localMessage, $client);
 	}
 }

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -128,6 +128,7 @@ class MailTransmissionIntegrationTest extends TestCase {
 			Server::get(FlagRepliedMessageHandler::class),
 			$this->attachmentService,
 			$this->localMessageMapper,
+			Server::get(IMAPClientFactory::class),
 		);
 
 		$this->transmission = new MailTransmission(Server::get(IMAPClientFactory::class),

--- a/tests/Unit/Send/AntiAbuseHandlerTest.php
+++ b/tests/Unit/Send/AntiAbuseHandlerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Unit\Send;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Db\MailAccount;
@@ -45,6 +46,7 @@ class AntiAbuseHandlerTest extends TestCase {
 		$account = new Account($mailAccount);
 		$localMessage = new LocalMessage();
 		$localMessage->setStatus(LocalMessage::STATUS_RAW);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->userManager->expects(self::once())
 			->method('get')
@@ -56,7 +58,7 @@ class AntiAbuseHandlerTest extends TestCase {
 		$this->sendHandler->expects(self::once())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 
 	public function testProcessNoUser(): void {
@@ -66,6 +68,7 @@ class AntiAbuseHandlerTest extends TestCase {
 		$account = new Account($mailAccount);
 		$localMessage = new LocalMessage();
 		$localMessage->setStatus(LocalMessage::STATUS_RAW);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->userManager->expects(self::once())
 			->method('get')
@@ -77,7 +80,7 @@ class AntiAbuseHandlerTest extends TestCase {
 		$this->sendHandler->expects(self::never())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 
 	public function testProcessAlreadyProcessed(): void {
@@ -87,6 +90,7 @@ class AntiAbuseHandlerTest extends TestCase {
 		$account = new Account($mailAccount);
 		$localMessage = new LocalMessage();
 		$localMessage->setStatus(LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->userManager->expects(self::never())
 			->method('get');
@@ -97,6 +101,6 @@ class AntiAbuseHandlerTest extends TestCase {
 		$this->sendHandler->expects(self::once())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 }

--- a/tests/Unit/Send/SendHandlerTest.php
+++ b/tests/Unit/Send/SendHandlerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Unit\Send;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\LocalMessage;
@@ -40,6 +41,7 @@ class SendHandlerTest extends TestCase {
 		$localMessage = new LocalMessage();
 		$localMessage->setId(100);
 		$localMessage->setStatus(LocalMessage::STATUS_RAW);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->transmission->expects(self::once())
 			->method('sendMessage')
@@ -47,7 +49,7 @@ class SendHandlerTest extends TestCase {
 		$this->copySentMessageHandler->expects(self::once())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 
 	public function testProcessAlreadyProcessed(): void {
@@ -58,13 +60,14 @@ class SendHandlerTest extends TestCase {
 		$localMessage = new LocalMessage();
 		$localMessage->setId(100);
 		$localMessage->setStatus(LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->transmission->expects(self::never())
 			->method('sendMessage');
 		$this->copySentMessageHandler->expects(self::once())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 
 	public function testProcessError(): void {
@@ -79,11 +82,13 @@ class SendHandlerTest extends TestCase {
 		$mock->expects(self::any())
 			->method('getStatus')
 			->willReturn(LocalMessage::STATUS_SMPT_SEND_FAIL);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
 		$this->transmission->expects(self::once())
 			->method('sendMessage');
 		$this->copySentMessageHandler->expects(self::never())
 			->method('process');
 
-		$this->handler->process($account, $mock);
+		$this->handler->process($account, $mock, $client);
 	}
 }

--- a/tests/Unit/Send/SentMailboxHandlerTest.php
+++ b/tests/Unit/Send/SentMailboxHandlerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace Unit\Send;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Db\MailAccount;
@@ -32,11 +33,12 @@ class SentMailboxHandlerTest extends TestCase {
 		$account = new Account($mailAccount);
 		$localMessage = new LocalMessage();
 		$localMessage->setStatus(LocalMessage::STATUS_RAW);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$this->antiAbuseHandler->expects(self::once())
 			->method('process');
 
-		$this->handler->process($account, $localMessage);
+		$this->handler->process($account, $localMessage, $client);
 	}
 
 	public function testNoSentMailbox(): void {
@@ -47,6 +49,7 @@ class SentMailboxHandlerTest extends TestCase {
 		$localMessage = $this->getMockBuilder(LocalMessage::class);
 		$localMessage->addMethods(['setStatus']);
 		$mock = $localMessage->getMock();
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 
 		$mock->expects(self::once())
 			->method('setStatus')
@@ -54,6 +57,6 @@ class SentMailboxHandlerTest extends TestCase {
 		$this->antiAbuseHandler->expects(self::never())
 			->method('process');
 
-		$this->handler->process($account, $mock);
+		$this->handler->process($account, $mock, $client);
 	}
 }


### PR DESCRIPTION
I spotted and fixed another double IMAP login in the send chain.

The PR consists of mostly white space and test changes.