### PR TITLE
fix: define appName and app version

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 const path = require('path')
+const webpack = require('webpack')
 const CKEditorWebpackPlugin = require('@ckeditor/ckeditor5-dev-webpack-plugin')
 const { styles } = require('@ckeditor/ckeditor5-dev-utils')
 const { VueLoaderPlugin } = require('vue-loader')
 const BabelLoaderExcludeNodeModulesExcept = require('babel-loader-exclude-node-modules-except')
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 const { IgnorePlugin } = require('webpack')
+
+const appName = 'mail'
+const appVersion = require('./package.json').version
 
 function getPostCssConfig(ckEditorOpts) {
 	// CKEditor is not compatbile with postcss@8 and postcss-loader@4 despite stating so.
@@ -36,6 +40,10 @@ const plugins = [
 	new IgnorePlugin({
 		resourceRegExp: /^\.\/locale$/,
 		contextRegExp: /moment\/min$/,
+	}),
+	new webpack.DefinePlugin({
+		appName: JSON.stringify(appName),
+		appVersion: JSON.stringify(appVersion),
 	}),
 ]
 


### PR DESCRIPTION
on package.js we have this: 
```
"scripts": {
    "build": "NODE_ENV=production webpack --progress --config webpack.prod.js",
```

so i didnt add a new file, i edited the existing common.js webpack