### PR TITLE
fix: preview enhancement process job does not process messages

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1611,7 +1611,7 @@ class MessageMapper extends QBMapper {
 		$select = $qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->lte('sent_at', $qb->createNamedParameter($lastRun, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
+				$qb->expr()->gt('sent_at', $qb->createNamedParameter($lastRun, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT),
 				$qb->expr()->eq('structure_analyzed', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
 				$qb->expr()->in('mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY),
 			)->orderBy('sent_at', 'ASC');


### PR DESCRIPTION
The timestamp for sent_at is initialized as now - 2 weeks. The condition lte('sent_at', $timestamp) generates sent_at <= $timestamp, meaning it finds all messages with structure_analyzed = false that are older than two weeks. I assume we actually want to do the opposite.