### PR TITLE
chore: update Github security issue links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
-    - name: Support and Help
-      url: https://help.nextcloud.com/c/apps/mail/35
-      about: Ask a question or seek for help
-    - name: Security issue
-      url: https://hackerone.com/nextcloud
-      about: Report a security issue
+  - name: 🚨 Report a security or privacy issue
+    url: https://hackerone.com/nextcloud
+    about: Report security and privacy related issues privately to the Nextcloud team, so we can coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
+  - name: 🚨 报告安全或隐私问题
+    url: https://hackerone.com/nextcloud
+    about: 请以私密方式向 Nextcloud 团队报告安全和隐私相关问题，以便我们能够协调修复工作并安排发布计划，避免在此期间可能暴露所有 Nextcloud 服务器和用户的风险。
+  - name: Support and Help
+    url: https://help.nextcloud.com/c/apps/mail/35
+    about: Ask a question or seek for help


### PR DESCRIPTION
This copies https://github.com/nextcloud/.github/blob/dba4a6decff4ce019d5019eed252d425c8dd519c/.github/ISSUE_TEMPLATE/config.yml#L4-L9. This app has it's own config, so the organization config is not applied.