### PR TITLE
fix enabeling sieve

### DIFF
--- a/lib/Controller/SieveController.php
+++ b/lib/Controller/SieveController.php
@@ -141,26 +141,25 @@ class SieveController extends Controller {
 			$mailAccount->setSieveEnabled(false);
 			$mailAccount->setSieveHost(null);
 			$mailAccount->setSievePort(null);
+			$mailAccount->setSieveSslMode(null);
 			$mailAccount->setSieveUser(null);
 			$mailAccount->setSievePassword(null);
-			$mailAccount->setSieveSslMode(null);
 
 			$this->mailAccountMapper->save($mailAccount);
 			return new JSONResponse(['sieveEnabled' => $mailAccount->isSieveEnabled()]);
 		}
 
-		if (empty($sieveUser)) {
+		if (empty($sieveUser) && empty($sievePassword)) {
+			$useImapCredentials = true;
 			$sieveUser = $mailAccount->getInboundUser();
-		}
-
-		if (empty($sievePassword)) {
-			$sievePassword = $mailAccount->getInboundPassword();
+			/** @psalm-suppress PossiblyNullArgument */
+			$sievePassword = $this->crypto->decrypt($mailAccount->getInboundPassword());
 		} else {
-			$sievePassword = $this->crypto->encrypt($sievePassword);
+			$useImapCredentials = false;
 		}
 
 		try {
-			$this->sieveClientFactory->createClient($sieveHost, $sievePort, $sieveUser, $sievePassword, $sieveSslMode);
+			$this->sieveClientFactory->createClient($sieveHost, $sievePort, $sieveUser, $sievePassword, $sieveSslMode, null);
 		} catch (ManagesieveException $e) {
 			throw new CouldNotConnectException($e, 'ManageSieve', $sieveHost, $sievePort);
 		}
@@ -168,9 +167,14 @@ class SieveController extends Controller {
 		$mailAccount->setSieveEnabled(true);
 		$mailAccount->setSieveHost($sieveHost);
 		$mailAccount->setSievePort($sievePort);
-		$mailAccount->setSieveUser($mailAccount->getInboundUser() === $sieveUser ? null : $sieveUser);
-		$mailAccount->setSievePassword($mailAccount->getInboundPassword() === $sievePassword ? null : $sievePassword);
 		$mailAccount->setSieveSslMode($sieveSslMode);
+		if ($useImapCredentials) {
+			$mailAccount->setSieveUser(null);
+			$mailAccount->setSievePassword(null);
+		} else {
+			$mailAccount->setSieveUser($sieveUser);
+			$mailAccount->setSievePassword($this->crypto->encrypt($sievePassword));
+		}
 
 		$this->mailAccountMapper->save($mailAccount);
 		return new JSONResponse(['sieveEnabled' => $mailAccount->isSieveEnabled()]);

--- a/lib/Controller/SieveController.php
+++ b/lib/Controller/SieveController.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use Horde\ManageSieve\Exception as ManagesieveException;
-use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Exception\ClientException;
@@ -161,7 +160,7 @@ class SieveController extends Controller {
 		}
 
 		try {
-			$this->sieveClientFactory->getClient(new Account($mailAccount));
+			$this->sieveClientFactory->createClient($sieveHost, $sievePort, $sieveUser, $sievePassword, $sieveSslMode);
 		} catch (ManagesieveException $e) {
 			throw new CouldNotConnectException($e, 'ManageSieve', $sieveHost, $sievePort);
 		}

--- a/lib/Sieve/SieveClientFactory.php
+++ b/lib/Sieve/SieveClientFactory.php
@@ -33,6 +33,8 @@ class SieveClientFactory {
 	}
 
 	/**
+	 * @param Account $account
+	 * @return ManageSieve
 	 * @throws ManageSieve\Exception
 	 */
 	public function getClient(Account $account): ManageSieve {
@@ -41,43 +43,59 @@ class SieveClientFactory {
 			if (empty($user)) {
 				$user = $account->getMailAccount()->getInboundUser();
 			}
-
 			$password = $account->getMailAccount()->getSievePassword();
 			if (empty($password)) {
 				$password = $account->getMailAccount()->getInboundPassword();
 			}
 
-			$sslMode = $account->getMailAccount()->getSieveSslMode();
-			if (empty($sslMode)) {
-				$sslMode = true;
-			} elseif ($sslMode === 'none') {
-				$sslMode = false;
-			}
-
-			$params = [
-				'host' => $account->getMailAccount()->getSieveHost(),
-				'port' => $account->getMailAccount()->getSievePort(),
-				'user' => $user,
-				'password' => $this->crypto->decrypt($password),
-				'secure' => $sslMode,
-				'timeout' => $this->config->getSystemValueInt('app.mail.sieve.timeout', 5),
-				'context' => [
-					'ssl' => [
-						'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-						'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-					]
-				],
-			];
-
-			if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
-				$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-sieve.log';
-				$params['logger'] = new SieveLogger($this->config->getSystemValue('datadirectory') . '/' . $fn);
-			}
-
-			$this->cache[$account->getId()] = new ManageSieve($params);
+			$this->cache[$account->getId()] = $this->createClient(
+				$account->getMailAccount()->getSieveHost(),
+				$account->getMailAccount()->getSievePort(),
+				$user,
+				$password,
+				$account->getMailAccount()->getSieveSslMode()
+			);
 		}
 
 		return $this->cache[$account->getId()];
 	}
 
+	/**
+	 * @param string $host
+	 * @param int $port
+	 * @param string $user
+	 * @param string $password
+	 * @param string $sslMode
+	 * @return ManageSieve
+	 * @throws ManageSieve\Exception
+	 */
+	public function createClient(string $host, int $port, string $user, string $password, string $sslMode): ManageSieve {
+		if (empty($sslMode)) {
+			$sslMode = true;
+		} elseif ($sslMode === 'none') {
+			$sslMode = false;
+		}
+
+		$params = [
+			'host' => $host,
+			'port' => $port,
+			'user' => $user,
+			'password' => $this->crypto->decrypt($password),
+			'secure' => $sslMode,
+			'timeout' => (int)$this->config->getSystemValue('app.mail.sieve.timeout', 5),
+			'context' => [
+				'ssl' => [
+					'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+					'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+
+				]
+			],
+		];
+
+		if ($this->config->getSystemValue('debug', false)) {
+			$params['logger'] = new SieveLogger($this->config->getSystemValue('datadirectory') . '/horde_sieve.log');
+		}
+
+		return new ManageSieve($params);
+	}
 }

--- a/tests/Integration/Sieve/SieveClientFactoryTest.php
+++ b/tests/Integration/Sieve/SieveClientFactoryTest.php
@@ -35,20 +35,16 @@ class SieveClientFactoryTest extends TestCase {
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->config = $this->createMock(IConfig::class);
 
-		$this->config->method('getSystemValue')
-			->willReturnCallback(static function ($key, $default) {
-				if ($key === 'app.mail.sieve.timeout') {
-					return 5;
-				}
-				if ($key === 'debug') {
-					return false;
-				}
-				return null;
-			});
+		$this->config->method('getSystemValueInt')
+			->willReturnMap([
+				['app.mail.sieve.timeout', 5, 5],
+			]);
 
 		$this->config->method('getSystemValueBool')
-			->with('app.mail.verify-tls-peer', true)
-			->willReturn(false);
+			->willReturnMap([
+				['app.mail.verify-tls-peer', true, false],
+				['app.mail.debug', false, false],
+			]);
 
 		$this->factory = new SieveClientFactory($this->crypto, $this->config);
 	}

--- a/tests/Integration/Sieve/SieveClientFactoryTest.php
+++ b/tests/Integration/Sieve/SieveClientFactoryTest.php
@@ -35,16 +35,20 @@ class SieveClientFactoryTest extends TestCase {
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->config = $this->createMock(IConfig::class);
 
-		$this->config->method('getSystemValueInt')
-			->willReturnMap([
-				['app.mail.sieve.timeout', 5, 5],
-			]);
+		$this->config->method('getSystemValue')
+			->willReturnCallback(static function ($key, $default) {
+				if ($key === 'app.mail.sieve.timeout') {
+					return 5;
+				}
+				if ($key === 'debug') {
+					return false;
+				}
+				return null;
+			});
 
 		$this->config->method('getSystemValueBool')
-			->willReturnMap([
-				['app.mail.verify-tls-peer', true, false],
-				['app.mail.debug', false, false],
-			]);
+			->with('app.mail.verify-tls-peer', true)
+			->willReturn(false);
 
 		$this->factory = new SieveClientFactory($this->crypto, $this->config);
 	}

--- a/tests/Unit/Controller/SieveControllerTest.php
+++ b/tests/Unit/Controller/SieveControllerTest.php
@@ -107,7 +107,7 @@ class SieveControllerTest extends TestCase {
 
 		$sieveClientFactory = $this->serviceMock->getParameter('sieveClientFactory');
 		$sieveClientFactory->expects($this->once())
-			->method('getClient')
+			->method('createClient')
 			->willThrowException(new Exception('Computer says no'));
 
 		$response = $this->sieveController->updateAccount(2, true, 'localhost', 4190, 'user', 'password', '');


### PR DESCRIPTION
https://github.com/nextcloud/mail/pull/11011 broke enabling sieve for an account.

SieveClientFactory.createClient was used when updating the configuration to validate if the credentials work before updating the account object. 