### PR TITLE
Fix toggle seen/unseen via shortcut 

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -386,17 +386,23 @@ export default {
 
 				break
 			case 'unseen':
-				if (this.hasSeenAcl()) {
+				logger.debug('marking as seen/unseen via shortcut')
+
+				if (!this.hasSeenAcl()) {
+					showWarning(t('mail', 'Your IMAP server does not support storing the seen/unseen state.'))
 					return
 				}
-				logger.debug('marking message as seen/unseen via shortkey', { env })
-				this.mainStore.toggleEnvelopeSeen({ envelope: env }).catch((error) =>
+
+				logger.debug('marking as seen/unseen', { env })
+				try {
+					await this.mainStore.toggleEnvelopeSeen({ envelope: env })
+				} catch (error) {
 					logger.error('could not mark envelope as seen/unseen via shortkey', {
 						env,
 						error,
-					}),
-				)
-
+					})
+					showError(t('mail', 'Could not mark message as seen/unseen'))
+				}
 				break
 			default:
 				logger.warn('shortcut ' + e.srcKey + ' is unknown. ignoring.')


### PR DESCRIPTION
Toggling seen/unseen via shortcut was broken due to a mixed up check if storing the state is allowed.

How to test:

- Open mailbox
- Select message
- Press `u`

Main: nothing happens
Here: seen/unseen toggles

Thanks to @crtvrmn for reporting it in https://github.com/nextcloud/mail/issues/11040. 