### PR TITLE
fix: show warning when creating a folder fails

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -98,7 +98,7 @@ import IconFolderAdd from 'vue-material-design-icons/Folder.vue'
 import MenuDown from 'vue-material-design-icons/ChevronDown.vue'
 import MenuUp from 'vue-material-design-icons/ChevronUp.vue'
 import IconDelete from 'vue-material-design-icons/Delete.vue'
-import { DialogBuilder } from '@nextcloud/dialogs'
+import { DialogBuilder, showError } from '@nextcloud/dialogs'
 import { mapStores } from 'pinia'
 import useMainStore from '../store/mainStore.js'
 
@@ -195,6 +195,7 @@ export default {
 					account: this.account, name,
 				})
 			} catch (error) {
+				showError(t('mail', 'Unable to create mailbox. The name likely contains invalid characters. Please try another name.'))
 				logger.error('could not create mailbox', { error })
 				throw error
 			} finally {


### PR DESCRIPTION
How to reproduce:

Try adding a mailbox with "Test 1/1" as name.

Before:

The input closes, but not folder is created.

After:

Warning is shown.

[Screencast From 2025-05-06 19-50-48.webm](https://github.com/user-attachments/assets/180b9499-5a11-4a41-81c4-52c7071ad0c2)
