### PR TITLE
chore: remove legacy iframe-resizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "dompurify": "^3.2.5",
         "html-to-text": "^9.0.5",
         "ical.js": "^2.1.0",
-        "iframe-resizer": "^5.4.6",
         "js-base64": "^3.7.7",
         "jstz": "^2.1.1",
         "lodash": "^4.17.21",
@@ -4788,19 +4787,6 @@
       "license": "GPL-3.0",
       "dependencies": {
         "auto-console-group": "1.2.9"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://iframe-resizer.com/pricing/"
-      }
-    },
-    "node_modules/@iframe-resizer/jquery": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/@iframe-resizer/jquery/-/jquery-5.4.6.tgz",
-      "integrity": "sha512-UsqX1QMzRUDh7SWFpbfKTWkvIqV9C1o5UYXFudtCI8N6pAy30prNnxxCc4CfvRPnxFCLaEnUy1qdLe8tUv+lkw==",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@iframe-resizer/core": "5.4.6"
       },
       "funding": {
         "type": "individual",
@@ -13061,21 +13047,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/iframe-resizer": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-5.4.6.tgz",
-      "integrity": "sha512-eJY9J38okRSOFRmamtlKfkLlNDNRWR052Tr30xscY02lVwZePZKS6USfTYam42crk1KAb9Arm23wexm0xDAUYg==",
-      "license": "GPL-3.0",
-      "dependencies": {
-        "@iframe-resizer/child": "5.4.6",
-        "@iframe-resizer/jquery": "5.4.6",
-        "@iframe-resizer/parent": "5.4.6"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://iframe-resizer.com/pricing/"
-      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "dompurify": "^3.2.5",
     "html-to-text": "^9.0.5",
     "ical.js": "^2.1.0",
-    "iframe-resizer": "^5.4.6",
     "js-base64": "^3.7.7",
     "jstz": "^2.1.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
It looks like a leftover.

The new packages are also included: https://github.com/nextcloud/mail/blob/f9491a6205740e1c2d45621a8c159d4aa631bd00/package.json#L40-L41

Imports are using the new packages:

https://github.com/nextcloud/mail/blob/f9491a6205740e1c2d45621a8c159d4aa631bd00/src/components/MessageHTMLBody.vue#L45

https://github.com/nextcloud/mail/blob/f9491a6205740e1c2d45621a8c159d4aa631bd00/src/html-response.js#L8