### PR TITLE
chore(deps): remove eslint-plugin-standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,6 @@
         "eslint": "^8.57.1",
         "eslint-config-standard": "^17.1.0",
         "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-standard": "^4.1.0",
         "eslint-plugin-vue": "^9.33.0",
         "file-loader": "^6.2.0",
         "jest": "^29.7.0",
@@ -11488,29 +11487,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
-      "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-vue": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "eslint": "^8.57.1",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-vue": "^9.33.0",
     "file-loader": "^6.2.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
> standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316