### PR TITLE
[stable5.0] fix(deps): update vulnerable @nextcloud/moment and babel packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@ckeditor/ckeditor5-alignment": "44.3.0",
@@ -422,9 +422,10 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5902,45 +5903,13 @@
       }
     },
     "node_modules/@nextcloud/moment": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.2.tgz",
-      "integrity": "sha512-VfSPnllfciZe1eU4zaHS0fE/4pPWKRUjLFxZSNQec9gkUfbskMsKH2xyPqkYLlYP9FF1uQh2+wZbzkFd6QLc4A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@nextcloud/moment/-/moment-1.3.4.tgz",
+      "integrity": "sha512-ibc1v3HshmI8q1jkfwj5tKgBnOSCpaVp1Nx0uSqnoStUsh5qdf235xA0UFtro+yFuGgfpTbos4gTzfXIoC2enA==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/l10n": "^2.2.0",
-        "moment": "^2.30.1",
-        "node-gettext": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
-      }
-    },
-    "node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-2.2.0.tgz",
-      "integrity": "sha512-UAM2NJcl/NR46MANSF7Gr7q8/Up672zRyGrxLpN3k4URNmWQM9upkbRME+1K3T29wPrUyOIbQu710ZjvZafqFA==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/router": "^2.1.2",
-        "@nextcloud/typings": "^1.7.0",
-        "dompurify": "^3.0.3",
-        "escape-html": "^1.0.3",
-        "node-gettext": "^3.0.0"
-      },
-      "engines": {
-        "node": "^20.0.0",
-        "npm": "^9.0.0"
-      }
-    },
-    "node_modules/@nextcloud/moment/node_modules/@nextcloud/router": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.1.tgz",
-      "integrity": "sha512-ZRc/WI0RaksEJMz08H/6LimIdP+1A1xTHThCYEghs7VgAKNp5917vT2OKSpG0cMRbIwk0ongFVt5FB5qjy/iFg==",
-      "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "@nextcloud/typings": "^1.7.0",
-        "core-js": "^3.6.4"
+        "@nextcloud/l10n": "^3.2.0",
+        "moment": "^2.30.1"
       },
       "engines": {
         "node": "^20.0.0",
@@ -15480,11 +15449,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -17137,14 +17101,6 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
-      }
-    },
-    "node_modules/node-gettext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
-      "integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
-      "dependencies": {
-        "lodash.get": "^4.4.2"
       }
     },
     "node_modules/node-int64": {


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/mail/pull/11109 and https://github.com/nextcloud/mail/pull/11098