### PR TITLE
fix(mime): ignore HTML parsing errors consistently

### DIFF
--- a/lib/Html/Parser.php
+++ b/lib/Html/Parser.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Mail\Html;
+
+use DOMDocument;
+use function libxml_clear_errors;
+use function libxml_use_internal_errors;
+
+class Parser {
+
+	/**
+	 * Parse a DOM document from a string
+	 *
+	 * @psalm-param non-empty-string $html
+	 *
+	 * DOMDocument uses libxml to parse HTML and that expects HTML4. It
+	 * is likely that some markup cause an error, which is otherwise
+	 * logged. Therefore, we ignore any error here.
+	 * @todo Migrate to \Dom\HTMLDocument::createFromString when this app uses PHP8.4+
+	 */
+	public static function parseToDomDocument(string $html): DOMDocument {
+		$document = new DOMDocument();
+		$previousLibxmlErrorsState = libxml_use_internal_errors(true);
+		$document->loadHTML($html, LIBXML_NONET | LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
+		libxml_clear_errors();
+		libxml_use_internal_errors($previousLibxmlErrorsState);
+		return $document;
+	}
+
+}

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\IMAP;
 
-use DOMDocument;
 use Horde_Imap_Client;
 use Horde_Imap_Client_Base;
 use Horde_Imap_Client_Data_Fetch;
@@ -28,6 +27,7 @@ use Html2Text\Html2Text;
 use OCA\Mail\Attachment;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Html\Parser;
 use OCA\Mail\IMAP\Charset\Converter;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\SmimeService;
@@ -41,7 +41,6 @@ use function fclose;
 use function in_array;
 use function is_array;
 use function iterator_to_array;
-use function libxml_clear_errors;
 use function max;
 use function min;
 use function OCA\Mail\array_flat_map;
@@ -1019,17 +1018,7 @@ class MessageMapper {
 		if (empty($body)) {
 			return false;
 		}
-		/**
-		 * DOMDocument uses libxml to parse HTML and that expects HTML4. It
-		 * is likely that some markup cause an error, which is otherwise
-		 * logged. Therefore, we ignore any error here.
-		 * @todo Migrate to \Dom\HTMLDocument::createFromString when this app uses PHP8.4+
-		 */
-		$dom = new DOMDocument();
-		$previousLibxmlErrorsState = libxml_use_internal_errors(true);
-		$dom->loadHTML($body, LIBXML_NONET | LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
-		libxml_clear_errors();
-		libxml_use_internal_errors($previousLibxmlErrorsState);
+		$dom = Parser::parseToDomDocument($body);
 		$anchors = $dom->getElementsByTagName('a');
 		foreach ($anchors as $anchor) {
 			$href = $anchor->getAttribute('href');

--- a/lib/Service/PhishingDetection/LinkCheck.php
+++ b/lib/Service/PhishingDetection/LinkCheck.php
@@ -9,11 +9,10 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service\PhishingDetection;
 
-use DOMDocument;
+use OCA\Mail\Html\Parser;
 use OCA\Mail\PhishingDetectionResult;
 use OCP\IL10N;
 use URL\Normalizer;
-use function libxml_clear_errors;
 
 class LinkCheck {
 	protected IL10N $l10n;
@@ -54,17 +53,7 @@ class LinkCheck {
 		$results = [];
 		$zippedArray = [];
 
-		/**
-		 * DOMDocument uses libxml to parse HTML and that expects HTML4. It
-		 * is likely that some markup cause an error, which is otherwise
-		 * logged. Therefore, we ignore any error here.
-		 * @todo Migrate to \Dom\HTMLDocument::createFromString when this app uses PHP8.4+
-		 */
-		$dom = new DOMDocument();
-		$previousLibxmlErrorsState = libxml_use_internal_errors(true);
-		$dom->loadHTML($htmlMessage, LIBXML_NONET | LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
-		libxml_clear_errors();
-		libxml_use_internal_errors($previousLibxmlErrorsState);
+		$dom = Parser::parseToDomDocument($htmlMessage);
 		$anchors = $dom->getElementsByTagName('a');
 		foreach ($anchors as $anchor) {
 			$href = $anchor->getAttribute('href');


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/11112

While ignoring XML errors in MimeMessage I noticed that we use the same trick in other places already. Added a comment with the learning that PHP8.4 handles this better, and unified resetting the XML error handling to its previous value and the parsing options.