### PR TITLE
fix(ui): handle error when saving email attachments to Files

### DIFF
--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -186,13 +186,13 @@ export default {
 		humanReadable(size) {
 			return formatFileSize(size)
 		},
-		saveToCloud(dest) {
+		async saveToCloud(dest) {
 			const path = dest[0].path
 			this.savingToCloud = true
 			const id = this.$route.params.threadId
 
 			try {
-				saveAttachmentToFiles(id, this.id, path)
+				await saveAttachmentToFiles(id, this.id, path)
 				Logger.info('saved')
 				showSuccess(t('mail', 'Attachment saved to Files'))
 			} catch (e) {

--- a/src/service/AttachmentService.js
+++ b/src/service/AttachmentService.js
@@ -6,7 +6,7 @@
 import Axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
-export function saveAttachmentToFiles(id, attachmentId, directory) {
+export async function saveAttachmentToFiles(id, attachmentId, directory) {
 	const url = generateUrl(
 		'/apps/mail/api/messages/{id}/attachment/{attachmentId}',
 		{
@@ -15,14 +15,14 @@ export function saveAttachmentToFiles(id, attachmentId, directory) {
 		},
 	)
 
-	return Axios.post(url, {
+	return await Axios.post(url, {
 		targetPath: directory,
 	})
 }
 
-export function saveAttachmentsToFiles(id, directory) {
+export async function saveAttachmentsToFiles(id, directory) {
 	// attachmentId = 0 means 'all attachments' (see MessageController.php::saveAttachement)
-	return saveAttachmentToFiles(id, 0, directory)
+	return await saveAttachmentToFiles(id, 0, directory)
 }
 
 export function downloadAttachment(url) {


### PR DESCRIPTION
Part 1 of https://github.com/nextcloud/mail/issues/10823

Async function calls have to be awaited for an error to be catchable.