### PR TITLE
ci: drop stable4.3 and stable3.7 from audit fixes

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.0', 'stable4.3', 'stable3.7']
+        branches: ['main', 'stable5.0']
 
     name: npm-audit-fix-${{ matrix.branches }}
 


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/pull/10978