### PR TITLE
ci(test): use low runner to run summary step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,7 +228,7 @@ jobs:
           CI: true
 
   summary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-low
     needs:
       - unit-tests
       - integration-tests


### PR DESCRIPTION
No need to block a full runner.