### PR TITLE
fix(smime): handle encoding properly when signing and encrypting

### DIFF
--- a/lib/Service/SmimeService.php
+++ b/lib/Service/SmimeService.php
@@ -585,6 +585,7 @@ class SmimeService {
 		file_put_contents($inPath, $part->toString([
 			'canonical' => true,
 			'headers' => true,
+			'encode' => Horde_Mime_Part::ENCODE_8BIT,
 		]));
 
 		/**

--- a/tests/data/mime-html-unicode.txt
+++ b/tests/data/mime-html-unicode.txt
@@ -1,0 +1,27 @@
+From: user@imap.localhost
+To: user@domain.tld
+Subject: Teszt =?utf-8?b?bGV2w6ls?=
+Message-ID: <20250514132452.Horde.JRGbr8cAk7ysMOeEx0jMBn0>
+Date: Wed, 14 May 2025 13:24:52 +0000
+Content-Type: multipart/alternative; boundary="=_shItsjsi03fQs0CAoN2y-EA"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+This message is in MIME format.
+
+--=_shItsjsi03fQs0CAoN2y-EA
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+Teszt levél
+--=_shItsjsi03fQs0CAoN2y-EA
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+<!DOCTYPE html>
+<html><meta http-equiv="content-type" content="text/html; charset=UTF-8"><body>
+<p style="margin:0;">Teszt levél</p>
+</body></html>
+
+--=_shItsjsi03fQs0CAoN2y-EA--
+

--- a/tests/data/mime-html-unicode.txt.license
+++ b/tests/data/mime-html-unicode.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/11128

This fix is analogous to #11118 just for the encryption part.

Again, I added a unit test that fails without my fix. I tested that locally.