### PR TITLE
feat: adjust background sync on user activity

### DIFF
--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OCA\Mail\BackgroundJob;
 
 use Horde_Imap_Client_Exception;
+use NCU\Config\IUserConfig;
+use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Exception\IncompleteSyncException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\IMAP\MailboxSync;
@@ -33,14 +35,17 @@ class SyncJob extends TimedJob {
 	private LoggerInterface $logger;
 	private IJobList $jobList;
 
-	public function __construct(ITimeFactory $time,
+	public function __construct(
+		ITimeFactory $time,
 		IUserManager $userManager,
 		AccountService $accountService,
 		MailboxSync $mailboxSync,
 		ImapToDbSynchronizer $syncService,
 		LoggerInterface $logger,
 		IJobList $jobList,
-		IConfig $config) {
+		IConfig $config,
+		private IUserConfig $userConfig,
+	) {
 		parent::__construct($time);
 
 		$this->userManager = $userManager;
@@ -75,6 +80,12 @@ class SyncJob extends TimedJob {
 
 		if (!$account->getMailAccount()->canAuthenticateImap()) {
 			$this->logger->debug('No authentication on IMAP possible, skipping background sync job');
+			return;
+		}
+
+		if (($this->userConfig->getValueInt($account->getUserId(), Application::APP_ID, 'ui-hearthbeat') - $this->time->getTime()) > 900) {
+			$this->logger->debug('Detected user activity, skipping background sync job');
+			$this->setInterval(900);
 			return;
 		}
 

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use Horde_Imap_Client;
+use NCU\Config\IUserConfig;
+use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Exception\ClientException;
@@ -28,34 +30,28 @@ use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MailboxesController extends Controller {
 	private AccountService $accountService;
-	private ?string $currentUserId;
 	private IMailManager $mailManager;
 	private SyncService $syncService;
+	private ?string $currentUserId;
 
-	/**
-	 * @param string $appName
-	 * @param IRequest $request
-	 * @param AccountService $accountService
-	 * @param string|null $UserId
-	 * @param IMailManager $mailManager
-	 * @param SyncService $syncService
-	 */
-	public function __construct(string $appName,
+	public function __construct(
 		IRequest $request,
 		AccountService $accountService,
-		?string $UserId,
 		IMailManager $mailManager,
-		SyncService $syncService) {
-		parent::__construct($appName, $request);
-
+		SyncService $syncService,
+		private IUserSession $userSession,
+		private IUserConfig $userConfig,
+	) {
+		parent::__construct(Application::APP_ID, $request);
 		$this->accountService = $accountService;
-		$this->currentUserId = $UserId;
 		$this->mailManager = $mailManager;
 		$this->syncService = $syncService;
+		$this->currentUserId = $userSession->getUser()->getUID();
 	}
 
 	/**
@@ -139,6 +135,8 @@ class MailboxesController extends Controller {
 		$mailbox = $this->mailManager->getMailbox($this->currentUserId, $id);
 		$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 		$order = $sortOrder === 'newest' ? IMailSearch::ORDER_NEWEST_FIRST: IMailSearch::ORDER_OLDEST_FIRST;
+
+		$this->userConfig->setValueInt($this->currentUserId, Application::APP_ID, 'ui-hearthbeat', time());
 
 		try {
 			$syncResponse = $this->syncService->syncMailbox(

--- a/tests/Unit/Controller/MailboxesControllerTest.php
+++ b/tests/Unit/Controller/MailboxesControllerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use NCU\Config\IUserConfig;
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Controller\MailboxesController;
@@ -21,12 +22,12 @@ use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\Sync\SyncService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class MailboxesControllerTest extends TestCase {
-	/** @var string */
-	private $appName = 'mail';
-
+	
 	/** @var IRequest|MockObject */
 	private $request;
 
@@ -45,6 +46,9 @@ class MailboxesControllerTest extends TestCase {
 	/** @var SyncService|MockObject */
 	private $syncService;
 
+	private IUserSession|MockObject $userSession;
+	private IUserConfig|MockObject $userConfig;
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -52,13 +56,22 @@ class MailboxesControllerTest extends TestCase {
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->mailManager = $this->createMock(IMailManager::class);
 		$this->syncService = $this->createMock(SyncService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
+
+		$userObject = $this->createMock(IUser::class);
+		$userObject->method('getUID')
+			->willReturn('john');
+		$this->userSession->method('getUser')
+			->willReturn($userObject);
+
 		$this->controller = new MailboxesController(
-			$this->appName,
 			$this->request,
 			$this->accountService,
-			$this->userId,
 			$this->mailManager,
-			$this->syncService
+			$this->syncService,
+			$this->userSession,
+			$this->userConfig
 		);
 	}
 


### PR DESCRIPTION
### Resolves
https://github.com/nextcloud/mail/issues/10717

### Summery
- added track mail app activity
- added logic to skip back ground job if the user is active in the ui