### PR TITLE
ci: update public suffix list only for stable5.0

### DIFF
--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.0', 'stable4.3', 'stable3.7']
+        branches: ['main', 'stable5.0']
 
     name: update-public-suffix-list-${{ matrix.branches }}
 


### PR DESCRIPTION
To prevent https://github.com/nextcloud/mail/pull/11155 and https://github.com/nextcloud/mail/pull/11152