### PR TITLE
fix: html message alignment

### DIFF
--- a/src/components/PhishingWarning.vue
+++ b/src/components/PhishingWarning.vue
@@ -68,6 +68,8 @@ export default {
     text-align: start;
     padding: 8px;
     margin: calc(var(--default-grid-baseline) * 2);
+	// To match the html message margin
+	margin-inline-start: 50px;
 	&__title {
 		display: flex;
 	}


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="896" alt="image" src="https://github.com/user-attachments/assets/aa1836e1-1d57-4911-ac34-af16ccb95ce0" /> | <img width="896" alt="image" src="https://github.com/user-attachments/assets/d8249c85-39d1-4743-aff5-c4660d77a207" />| 