### PR TITLE
ci: put stable5.0 into EOL

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.1', 'stable5.0']
+        branches: ['main', 'stable5.1']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.1', 'stable5.0']
+        branches: ['main', 'stable5.1']
 
     name: update-public-suffix-list-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,2 +1,1 @@
 stable5.1
-stable5.0

--- a/renovate.json
+++ b/renovate.json
@@ -23,8 +23,7 @@
 	"ignoreUnstable": false,
 	"baseBranches": [
 		"main",
-		"stable5.1",
-		"stable5.0"
+		"stable5.1"
 	],
 	"enabledManagers": [
 		"composer",


### PR DESCRIPTION
v5.1.0 was released today. This obsoletes 5.0.x.