### PR TITLE
fix: recipient length is undefined

### DIFF
--- a/src/components/RecipientInfo.vue
+++ b/src/components/RecipientInfo.vue
@@ -1,12 +1,12 @@
 /**
- * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
+* SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+* SPDX-License-Identifier: AGPL-3.0-or-later
+*/
 
 <template>
 	<div class="recipient-info">
 		<!-- For a single recipient -->
-		<div v-if="recipients.length === 1" class="recipient-info__single">
+		<div v-if="recipients && recipients.length === 1" class="recipient-info__single">
 			<div class="recipient-info__header">
 				<div class="recipient-info__avatar">
 					<Avatar :display-name="recipients[0].label"
@@ -22,7 +22,7 @@
 		</div>
 
 		<!-- For multiple recipients -->
-		<div v-else class="recipient-info__multiple">
+		<div v-else-if="recipients && recipients.length > 1" class="recipient-info__multiple">
 			<div v-for="(recipient, index) in recipients" :key="recipient.email" class="recipient-info__item">
 				<div class="recipient-info__header">
 					<div class="recipient-info__avatar">
@@ -79,7 +79,7 @@ export default {
 	computed: {
 		...mapGetters(useMainStore, ['composerMessage']),
 		recipients() {
-			return this.composerMessage.data.to
+			return Array.isArray(this.composerMessage.data.to) ? this.composerMessage.data.to : []
 		},
 	},
 	watch: {


### PR DESCRIPTION
the error: `[Vue warn]: Error in render: "TypeError: can't access property "length", _vm.recipients is undefined"
found in
---> <RecipientInfo> at src/components/RecipientInfo.vue
       <NcModal>
         <NewMessageModal> at src/components/NewMessageModal.vue
           <NcContent>
             <Home> at src/views/Home.vue
               <App> at src/App.vue
                 <Root> vue.runtime.esm.js:4625`

this pr:
This PR ensures the recipients computed property always returns an array, even if composerMessage.data.to is undefined. This prevents errors when accessing .length or using .map() in the template and watchers. 