### PR TITLE
fix(ui): replace deprecated iframe resizer attribute

### DIFF
--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -71,6 +71,6 @@ class HtmlResponse extends Response {
 			return $this->content;
 		}
 
-		return '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script></head><body>' . $this->content . '<div data-iframe-height></div></body></html>';
+		return '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><script nonce="' . $this->nonce . '" src="' . $this->scriptUrl . '"></script></head><body>' . $this->content . '<div data-iframe-size></div></body></html>';
 	}
 }


### PR DESCRIPTION
Fixes

>  Deprecated Attributes
>          
> The data-iframe-height and data-iframe-width attributes have been deprecated and replaced with the single data-iframe-size attribute. Use of the old attributes will be removed in a future version of iframe-resizer.

Ref https://iframe-resizer.com/setup/advanced/#data-iframe-size

Discovered while testing https://github.com/nextcloud/mail/issues/11001.