### PR TITLE
fix: don't propagate click event on reply

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -52,7 +52,7 @@
 			</div>
 			<NcButton type="primary"
 				class="reply-buttons__notsuggested"
-				@click="onReply">
+				@click="onReply('')">
 				<template #icon>
 					<ReplyIcon />
 				</template>
@@ -142,7 +142,7 @@ export default {
 		},
 	},
 	methods: {
-		onReply(replyBody = '') {
+		onReply(replyBody) {
 			this.$emit('reply', replyBody)
 		},
 	},

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -186,7 +186,7 @@
 							:with-select="false"
 							:with-show-source="true"
 							:more-actions-open.sync="moreActionsOpen"
-							@reply="onReply"
+							@reply="onReply('', false, false)"
 							@delete="$emit('delete',envelope.databaseId)"
 							@show-source-modal="onShowSourceModal"
 							@open-tag-modal="onOpenTagModal"


### PR DESCRIPTION
Make sure we don't propagate the click event when replying with no preset message body (currently only done when using smart replies) 