### PR TITLE
feat(composer): suggest recipients from own identities

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1216,6 +1216,20 @@ export default {
 			this.loadingIndicatorCc = addressType === 'cc'
 			this.loadingIndicatorBcc = addressType === 'bcc'
 			this.recipientSearchTerms[addressType] = term
+
+			// Autocomplete from own identifies (useful for testing)
+			const accounts = this.accounts.filter((a) => !a.isUnified)
+			const selfRecipients = accounts
+				.filter(
+					account => account.emailAddress.toLowerCase().indexOf(term.toLowerCase()) !== -1
+					|| account.name.toLowerCase().indexOf(term.toLowerCase()) !== -1,
+				)
+				.map(account => ({
+					email: account.emailAddress,
+					label: account.name,
+				}))
+			this.autocompleteRecipients = uniqBy('email')(this.autocompleteRecipients.concat(selfRecipients))
+
 			debouncedSearch(term).then((results) => {
 				if (addressType === 'to') {
 					this.loadingIndicatorTo = false


### PR DESCRIPTION
I'm an impatient tester. This allows me to go through smoke tests faster.

For regular users this could also make the autocomplete feel a bit faster because there are early results.

## How to test

1. Open the app
2. Open the composer
3. Type in one letter of your name or email address

main: you have to wait
here: you get an instant result