### PR TITLE
chore: do not propagate root composer updates to bins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,11 +70,6 @@
 			"\"vendor/bin/mozart\" compose",
 			"composer dump-autoload"
 		],
-		"post-update-cmd": [
-			"@composer bin all update --ansi",
-			"\"vendor/bin/mozart\" compose",
-			"composer dump-autoload"
-		],
 		"rector": "rector process",
 		"test:integration": "phpunit -c tests/phpunit.integration.xml --fail-on-warning",
 		"test:integration:dev": "phpunit -c tests/phpunit.integration.xml --no-coverage --order-by=defects --stop-on-defect --fail-on-warning --stop-on-error --stop-on-failure",


### PR DESCRIPTION
Running `composer update x` in the root directory should not update bins.