### PR TITLE
fix: prevent invalid return type

### DIFF
--- a/lib/Service/Classification/PersistenceService.php
+++ b/lib/Service/Classification/PersistenceService.php
@@ -205,7 +205,15 @@ class PersistenceService {
 		}
 
 		$serializedData = json_decode($json);
-		return array_map(base64_decode(...), $serializedData);
+		$decodedData = array_map(base64_decode(...), $serializedData);
+		foreach ($decodedData as $decoded) {
+			if ($decoded === false) {
+				// Decoding failed, abort
+				return null;
+			}
+		}
+		/** @var string[] $decodedData */
+		return $decodedData;
 	}
 
 	/**


### PR DESCRIPTION
Discovered by Psalm v6 but fixed manually instead of adjusting the return types. This is a hardening.

Extracted from https://github.com/nextcloud/mail/pull/11224.