### PR TITLE
fix: avoid invalid false return type

### DIFF
--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -504,7 +504,12 @@ class ImapMessageFetcher {
 		if ($utf8 !== false) {
 			return $utf8;
 		}
-		return iconv('UTF-8', 'UTF-8//IGNORE', $subject);
+		$utf8Ignored = iconv('UTF-8', 'UTF-8//IGNORE', $subject);
+		if ($utf8Ignored === false) {
+			// Give up
+			return $subject;
+		}
+		return $utf8Ignored;
 	}
 
 	private function parseHeaders(Horde_Imap_Client_Data_Fetch $fetch): void {

--- a/lib/Service/Avatar/Downloader.php
+++ b/lib/Service/Avatar/Downloader.php
@@ -22,11 +22,7 @@ class Downloader {
 		$this->clientService = $clientService;
 	}
 
-	/**
-	 * @param string $url
-	 * @return string|null
-	 */
-	public function download(string $url) {
+	public function download(string $url): ?string {
 		$client = $this->clientService->newClient();
 
 		try {
@@ -37,7 +33,7 @@ class Downloader {
 
 		$body = $resp->getBody();
 		if (is_resource($body)) {
-			return stream_get_contents($body);
+			return stream_get_contents($body) ?: null;
 		}
 		return $body;
 	}


### PR DESCRIPTION
`iconv` and `stream_get_contents` can return `false` on error. This adds a fallback handling.

Discovered by Psalm v6.

Extracted from https://github.com/nextcloud/mail/pull/11224.