### PR TITLE
fix(outbox): outbox do not render

### DIFF
--- a/src/components/OutboxMessageListItem.vue
+++ b/src/components/OutboxMessageListItem.vue
@@ -12,7 +12,7 @@
 		<template #icon>
 			<Avatar :display-name="avatarDisplayName"
 				:email="avatarEmail"
-				:fetch-avatar="data.fetchAvatarFromClient"
+				:fetch-avatar="false"
 				:avatar="message.avatar" />
 		</template>
 		<template #subname>


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/mail/pull/10486

- data is undefined
- fetchAvatarFromClient is (currently) available for messages, but not local messages

