### PR TITLE
make accounts reactive

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -23,8 +23,7 @@
 					:aria-label-combobox="t('mail', 'Select account')"
 					:clear-on-select="false"
 					:append-to-body="false"
-					:selectable="(option)=> {
-						return option.selectable}"
+					:selectable="(option)=>option.selectable"
 					@option:selected="onAliasChange">
 					<template #option="option">
 						{{ formatAliases(option) }}
@@ -948,7 +947,7 @@ export default {
 				this.wantsSmimeSign = this.smimeSignAliases.indexOf(aliasEmailAddress) !== -1
 			},
 			immediate: true,
-		}
+		},
 	},
 	async beforeMount() {
 		this.setAlias()

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -30,7 +30,7 @@ import MailboxThread from '../components/MailboxThread.vue'
 import Navigation from '../components/Navigation.vue'
 import Outbox from '../components/Outbox.vue'
 import ComposerSessionIndicator from '../components/ComposerSessionIndicator.vue'
-import { mapStores, mapState } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import useMainStore from '../store/mainStore.js'
 
 export default {
@@ -47,12 +47,14 @@ export default {
 	data() {
 		return {
 			hasComposerSession: false,
-			accounts: null,
 		}
 	},
 	computed: {
 		...mapStores(useMainStore),
 		...mapState(useMainStore, ['composerSessionId']),
+		accounts() {
+			return this.mainStore.getAccounts.filter((a) => !a.isUnified)
+		},
 		activeAccount() {
 			return this.mainStore.getAccount(this.activeMailbox?.accountId)
 		},
@@ -80,12 +82,12 @@ export default {
 		},
 	},
 	async beforeMount() {
-		const accounts = this.mainStore.getAccounts.filter((a) => !a.isUnified)
-		this.accounts = await Promise.all(
-			 accounts.map(async (account) => {
-				return { ...account, connectionStatus: await testAccountConnection(account.id) }
-			}))
-
+		for (const account of this.accounts) {
+			await this.mainStore.patchAccountMutation({
+				account,
+				data: { connectionStatus: await testAccountConnection(account.accountId) },
+			})
+		}
 	},
 	created() {
 		const accounts = this.mainStore.getAccounts


### PR DESCRIPTION
Close #10918 

The reactivity of the accounts property was broken; the most prominent example was that updating the signature required a page refresh to take effect. We are now writing the connectionStatus back to the store and passing along the unmodified accounts property to maintain reactivity.

How to reproduce:

- Have a signature
- Open mail
- Change signature
- New message
- You are still seeing the old signature

