### PR TITLE
enforce dangling comma / update jsdoc for getSubnameForRecipient

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
 		__webpack_nonce__: true,
 	},
 	rules: {
+		'comma-dangle': 'error',
 		'jsdoc/require-jsdoc': 'off',
 		'perfectionist/sort-enums': 'error',
 		'perfectionist/sort-interfaces': 'error',

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1470,8 +1470,8 @@ export default {
 		 * Empty if label and email are the same or
 		 * if the suggestion is a group.
 		 *
-		 * @param {{email: string, label: string}} option
-		 * @return string
+		 * @param {{email: string, label: string}} option object
+		 * @return {string}
 		 */
 		getSubnameForRecipient(option) {
 			if (option.source && option.source === 'groups') {


### PR DESCRIPTION
The ESLint comma-dangle rule issues warnings but doesn't fail the CI. Running npm run lint:fix adds missing commas automatically. This often leads to committing unrelated changes. Now, the CI enforces the dangling comma rule.