### PR TITLE
ci: use parallelism for cs-fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 require_once './vendor-bin/cs-fixer/vendor/autoload.php';
 
 use Nextcloud\CodingStandard\Config;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $config = new Config();
 $config
+	->setParallelConfig(ParallelConfigFactory::detect())
 	->getFinder()
 	->ignoreVCSIgnored(true)
 	->notPath('build')


### PR DESCRIPTION
> Running analysis on 16 cores with 10 files per process.
> Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!

Let's see