### PR TITLE
ci: bump mariadb image from 10.11 to 11.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,20 +100,20 @@ jobs:
                   - 143:143
                   - 993:993
                   - 4190:4190
-          mysql-service:
-              image: ghcr.io/nextcloud/continuous-integration-mariadb-10.11:latest
+          mariadb-service:
+              image: ghcr.io/nextcloud/continuous-integration-mariadb-11.4:latest
               env:
-                  MYSQL_ROOT_PASSWORD: my-secret-pw
-                  MYSQL_DATABASE: nextcloud
-                  MYSQL_USER: nextcloud
-                  MYSQL_PASSWORD: nextcloud
+                  MARIADB_ROOT_PASSWORD: my-secret-pw
+                  MARIADB_DATABASE: nextcloud
+                  MARIADB_USER: nextcloud
+                  MARIADB_PASSWORD: nextcloud
               ports:
-                  - 3306:3306
+                  - 3306:3306/tcp
               options: >-
-                  --health-cmd="mysqladmin ping"
-                  --health-interval=10s
-                  --health-timeout=5s
-                  --health-retries=3
+                  --health-cmd="mariadb-admin ping"
+                  --health-interval=5s
+                  --health-timeout=2s
+                  --health-retries=5
           postgres-service:
               image: ghcr.io/nextcloud/continuous-integration-postgres-15:latest
               env:


### PR DESCRIPTION
Renovate doesn't understand this kind of name/version scheme.