### PR TITLE
fix: invitation title on small screen

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -614,8 +614,7 @@ export default {
 	}
 }
 @media only screen and (max-width: 1024px) {
-	#mail-thread-header-fields,
-	h2 {
+	#mail-thread-header-fields {
 		margin-top: -20px;
 	}
 }


### PR DESCRIPTION
we only need the margin top for the subject of the mail not for all` <h2> ` in the small screen

before
![Screenshot from 2025-06-18 14-27-04](https://github.com/user-attachments/assets/742ae32e-d1f5-4d6c-aa36-15ca99382e68)


after
![Screenshot from 2025-06-18 14-24-54](https://github.com/user-attachments/assets/bf4f43ea-38ab-4c45-9dea-d97dea4f6beb)