### PR TITLE
feat: thread list shouldnt reload when searching

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -262,8 +262,7 @@ export default {
 			return 5
 		},
 		showThread() {
-			return (this.mailbox.isPriorityInbox === true || this.hasEnvelopes)
-				&& this.$route.name === 'message'
+			return this.$route.name === 'message'
 				&& this.$route.params.threadId !== 'mailto'
 		},
 		query() {


### PR DESCRIPTION
fixes #10724 

Some finding while debugging why that happens:

In the MailboxThread we show the thread only if hasEnvelopes.
hasEnvelopes checks for the envelopes in the current shown list which:

- Might be empty after filtering
- Is empty during the search query
This means that during the search (and if the result is empty) <MailboxThread> is not rendered. And when there are envelopes, it is rendered again.

The problem here:

hasEnvelopes should not be used for showing or not showing MailboxThread, because it checks the filtered (queries, searched list, not everything). 

To fix the flickering, we should always render Thread when on the thread route, without checking for hasEnvelopes. 