### PR TITLE
fix(avatar): handle null bodies

### DIFF
--- a/lib/Service/Avatar/GravatarSource.php
+++ b/lib/Service/Avatar/GravatarSource.php
@@ -56,7 +56,7 @@ class GravatarSource implements IAvatarSource {
 		if (is_resource($body)) {
 			$body = stream_get_contents($body);
 		}
-		if (strlen($body) === 0) {
+		if ($body === null || strlen($body) === 0) {
 			return null;
 		}
 


### PR DESCRIPTION
Fixes 

```
Warning: "findUnusedBaselineEntry" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedBaselineEntry" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Warning: "findUnusedCode" will default to "true" in Psalm 6. You should explicitly enable or disable this setting.
Target PHP version: 8.1 (inferred from composer.json).
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  60 / 453 (13%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 120 / 453 (26%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 180 / 453 (39%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 240 / 453 (52%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 300 / 453 (66%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 360 / 453 (79%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ 420 / 453 (92%)
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
Error: lib/Service/Avatar/GravatarSource.php:59:14: PossiblyNullArgument: Argument 1 of strlen cannot be null, possibly null value provided (see https://psalm.dev/078)
------------------------------
1 errors found
------------------------------
791 other issues found.
You can display them with --show-info=true
------------------------------
Psalm can automatically fix 25 of these issues.
Run Psalm again with 
--alter --issues=MissingReturnType,LessSpecificReturnType,MissingParamType --dry-run
to see what it can fix.
------------------------------

Checks took 30.33 seconds and used 808.685MB of memory
Psalm was able to infer types for 96.5159% of the codebase
Script psalm.phar handling the psalm event returned with error code 2
Error: Process completed with exit code 2.
```