### PR TITLE
fix(imip): hide warning about email mismatch for imip replies

### DIFF
--- a/src/components/Imip.vue
+++ b/src/components/Imip.vue
@@ -148,7 +148,7 @@ function findAttendee(vEvent, email) {
 	}
 
 	email = removeMailtoPrefix(email)
-	for (const attendee of vEvent.getAttendeeIterator()) {
+	for (const attendee of [...vEvent.getPropertyIterator('ORGANIZER'), ...vEvent.getAttendeeIterator()]) {
 		if (removeMailtoPrefix(attendee.email) === email) {
 			return attendee
 		}


### PR DESCRIPTION
| B | A |
| --- | --- |
| ![Screenshot From 2025-07-01 15-25-10](https://github.com/user-attachments/assets/62bbf2c1-31bd-4023-aea7-ae17d16950e3) | ![Screenshot From 2025-07-01 15-27-49](https://github.com/user-attachments/assets/cc72ea32-fed2-46e4-822c-1e1daf7cff88) |

How to reproduce:

1) Invite an external attendee
2) External attendee accepts invitation
3) Open response in mail app,
4) Be confused about the mismatch warning :confused: 



