### PR TITLE
fix(ui): make composer link attachments icon size wider

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -442,9 +442,6 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	color: var(--color-main-text) !important;
 	margin-left: var(--default-grid-baseline) !important;
  }
- .link-icon {
-	width: 16px !important;
- }
  .custom-item {
 	width : 100% !important;
 	border-radius : 8px !important;
@@ -461,6 +458,10 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	display : block;
 	width : 100% !important;
 	background:var(--color-main-background)!important;
+	img.link-icon {
+		width: 16px;
+		height: 16px;
+	}
  }
  .link-container:hover {
 	background:var(--color-primary-element-light)!important;


### PR DESCRIPTION
Regression of https://github.com/nextcloud/mail/pull/9889

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2025-07-02 09-38-19](https://github.com/user-attachments/assets/33bcf1be-a544-4974-aadd-3693ce38d487) | ![Bildschirmfoto vom 2025-07-02 09-47-32](https://github.com/user-attachments/assets/10aa244a-f4a9-4226-94a1-a3b1b543faa2) |
| ![Bildschirmfoto vom 2025-07-02 09-38-30](https://github.com/user-attachments/assets/fff18dbe-5195-463d-b850-1ad09f4a6a74) | ![Bildschirmfoto vom 2025-07-02 09-47-38](https://github.com/user-attachments/assets/dd86ff33-c8dd-411b-a62d-6281d12ca49f) | 


