### PR TITLE
fix: quota spacing

### DIFF
--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -21,12 +21,12 @@
 					</ActionText>
 				</template>
 				<template v-else>
-					<ActionText v-if="!account.isUnified" :name="t('mail', 'Quota')">
+					<ActionButton v-if="!account.isUnified" :name="t('mail', 'Quota')">
 						<template #icon>
 							<IconInfo :size="16" />
 						</template>
 						{{ quotaText }}
-					</ActionText>
+					</ActionButton>
 					<ActionButton :close-after-click="true"
 						@click="showAccountSettings(true)">
 						<template #icon>


### PR DESCRIPTION
The problem:
`NcActionText` has a [br](https://github.com/nextcloud-libraries/nextcloud-vue/blob/31d28c228f6d8dbc09d875f8053e50d49824ec84/src/components/NcActionText/NcActionText.vue#L25) to split action name from action_long text, which breaks our quota and quota text on our action menu as seen below on the screenshot. 
NcActionButton has a section for long text that doesnt break: https://github.com/nextcloud-libraries/nextcloud-vue/blob/ae1b3c2ef908985a4052ac03d9a6310593030545/src/components/NcActionButton/NcActionButton.vue#L346-L364

so i used that to fix our problem. Another solution would be if we remove the `br` and add description prop, but im not sure if that works on every scenario.

before
![Screenshot from 2025-07-02 12-35-21](https://github.com/user-attachments/assets/16ca2175-42e1-4db6-9432-30019d04434e)
after
![Screenshot from 2025-07-02 12-35-41](https://github.com/user-attachments/assets/87b312e4-a502-4a53-ab7c-83f7d84c13df)

