### PR TITLE
fix(ui): give file pickers a name

### DIFF
--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -34,12 +34,12 @@
 			style="display: none;"
 			@change="onLocalAttachmentSelected">
 		<FilePicker v-if="isAttachementPickerOpen"
-			:title="t('mail','Choose a file to add as attachment')"
+			:name="t('mail','Choose a file to add as attachment')"
 			:buttons="attachementPickerButtons"
 			:filter-fn="filterAttachements"
 			@close="()=>isAttachementPickerOpen = false" />
 		<FilePicker v-if="isLinkPickerOpen"
-			:title="t('mail','Choose a file to share as a link')"
+			:name="t('mail','Choose a file to share as a link')"
 			:multiselect="false"
 			:buttons="linkPickerButtons"
 			:filter-fn="filterAttachements"

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -18,7 +18,7 @@
 			<span class="attachment-size">{{ humanReadable(size) }}</span>
 		</div>
 		<FilePicker v-if="isFilePickerOpen"
-			:title="t('mail', 'Choose a folder to store the attachment in')"
+			:name="t('mail', 'Choose a folder to store the attachment in')"
 			:buttons="saveAttachementButtons"
 			:allow-pick-directory="true"
 			:multiselect="false"

--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -36,7 +36,7 @@
 		</div>
 		<p v-if="moreThanOne" class="attachments-button-wrapper">
 			<FilePicker v-if="isFilePickerOpen"
-				:title="t('mail', 'Choose a folder to store the attachments in')"
+				:name="t('mail', 'Choose a folder to store the attachments in')"
 				:buttons="saveAttachementButtons"
 				:allow-pick-directory="true"
 				:multiselect="false"


### PR DESCRIPTION
Fixes 

```
13:49:10.042 [Vue warn]: Invalid prop: type check failed for prop "name". Expected String, got Undefined 

found in

---> <NcDialog>
       <FilePicker>
         <ComposerAttachments> at src/components/ComposerAttachments.vue
           <Composer> at src/components/Composer.vue
             <NcModal>
               <NewMessageModal> at src/components/NewMessageModal.vue
                 <NcContent>
                   <Home> at src/views/Home.vue
                     <App> at src/App.vue
                       <Root> vue.runtime.esm.js:4625
```

and similar that pop up when the dev console is open.

This is also noticeable visually:

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2025-07-02 13-49-12](https://github.com/user-attachments/assets/43b3d8a6-f64b-4ed3-b597-3c3076fcc478) | ![Bildschirmfoto vom 2025-07-02 13-48-37](https://github.com/user-attachments/assets/3a3610fa-5179-4c24-a7f1-de523930a9f7) | 

Unsure how we ended up here. The Vue file picker never had a `title` prop: https://github.com/nextcloud-libraries/nextcloud-dialogs/commit/4bdb0efcdb1f2f175131911a5901da6b8461314f