### PR TITLE
fix(composer): allow attaching shared files again

### DIFF
--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -194,7 +194,7 @@ export default {
 	methods: {
 		filterAttachements(node) {
 			const downloadShareAttribute = node.attributes['share-attributes'] ? JSON.parse(node.attributes['share-attributes'])?.find((shareAttribute) => shareAttribute.key === 'download') : undefined
-			const downloadPermissions = downloadShareAttribute !== undefined ? downloadShareAttribute.enabled : true
+			const downloadPermissions = downloadShareAttribute !== undefined ? downloadShareAttribute.value : true
 			return (node.permissions & OC.PERMISSION_READ) && downloadPermissions
 		},
 		openAttachementPicker() {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/11329

Breaking change of https://github.com/nextcloud/server/pull/46007 that was not addressed in this app.

> IAttributes enabled key have bee renamed to value and supports more than boolean.

https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_30.html#id1