### PR TITLE
fix: reply buttons spacing

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -177,7 +177,7 @@ export default {
 	}
 }
 .reply-buttons {
-	margin: 0 30px 0 50px;
+	margin: 0 calc(var(--default-grid-baseline) * 2) 0 50px;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 5px;

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -558,7 +558,7 @@ export default {
 
 .mail-message-body {
 	flex: 1;
-	margin-bottom: calc(var(--default-grid-baseline) * 7);
+	margin-bottom: calc(var(--default-grid-baseline) * 2);
 	position: relative;
 }
 


### PR DESCRIPTION
fix [#11353](https://github.com/nextcloud/mail/issues/11353)

| b | a |
|--------|--------|
|<img width="915" alt="image" src="https://github.com/user-attachments/assets/a2226ddf-5a9e-49a4-a999-e7eebf9720bf" /> |<img width="915" alt="image" src="https://github.com/user-attachments/assets/c2b15791-74c3-4206-bf39-e549cb6bd967" /> | 