### PR TITLE
fix: load-more button alignment

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -547,13 +547,13 @@ div {
 	text-align: center;
 	margin-top: 10px;
 	cursor: pointer;
+	margin-inline-start: 28px;
 	color: var(--color-text-maxcontrast);
 	display: inline-flex;
-	gap: 15px;
-}
-
-.plus-icon {
-	margin-inline-start: 20px;
+	gap: 12px;
+	.plus-icon{
+		transform: translateX(-8px);
+	}
 }
 
 .multiselect-header {


### PR DESCRIPTION
fix [#11358](https://github.com/nextcloud/mail/issues/11358)
| b | a |
|--------|--------|
|<img width="495" alt="image" src="https://github.com/user-attachments/assets/b755feb1-740e-4c63-a35a-1cec0fd014f8" /> |<img width="985" height="258" alt="image" src="https://github.com/user-attachments/assets/f6e67867-298d-4078-a2f2-2d6bac7ef9b9" /> | 