### PR TITLE
fix(ui): show only drafts with draft prefix

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -622,13 +622,16 @@ export default {
 		 */
 		subjectForSubtitle() {
 			const subject = this.data.subject || this.t('mail', 'No subject')
-			return this.t('mail', '{markup-start}Draft:{markup-end} {subject}', {
-				'markup-start': '<em>',
-				'markup-end': '</em>',
-				subject: escapeHtml(subject),
-			}, {
-				escape: false,
-			})
+			if (this.draft) {
+				return this.t('mail', '{markup-start}Draft:{markup-end} {subject}', {
+					'markup-start': '<em>',
+					'markup-end': '</em>',
+					subject: escapeHtml(subject),
+				}, {
+					escape: false,
+				})
+			}
+			return subject
 		},
 		/**
 		 * Link to download the whole message (.eml).


### PR DESCRIPTION
Regression of https://github.com/nextcloud/mail/pull/11338

## How to test

1. Open your drafts
2. See subjects prefixed :heavy_check_mark: 
3. Open your inbox

main: messages are prefixed too
here: messages are not prefixed