### PR TITLE
fix(filters): Use contains operator for from and to header

### DIFF
--- a/src/components/mailFilter/MailFilterFromEnvelope.vue
+++ b/src/components/mailFilter/MailFilterFromEnvelope.vue
@@ -82,12 +82,12 @@ export default {
 
 			const fromTest = new MailFilterCondition()
 			fromTest.field = MailFilterConditionField.From
-			fromTest.operator = MailFilterConditionOperator.Is
+			fromTest.operator = MailFilterConditionOperator.Contains
 			fromTest.values = []
 
 			const toTest = new MailFilterCondition()
 			toTest.field = MailFilterConditionField.To
-			toTest.operator = MailFilterConditionOperator.Is
+			toTest.operator = MailFilterConditionOperator.Contains
 			toTest.values = []
 
 			for (const header of headers) {


### PR DESCRIPTION
Follow-up for https://github.com/nextcloud/mail/pull/11210

Contains is the better default as it would also work with an header like

From: Example <info@example.org>