### PR TITLE
feat: make thread elements have the same space around them

### DIFF
--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -429,7 +429,7 @@ export default {
 	--list-item-padding: calc(var(--default-grid-baseline) * 2);
 	// The content are two lines of text and respect the 1.5 line height
 	--list-item-border-radius: var(--border-radius-element, 32px);
-	--list-item-height: calc(4 * var(--default-line-height));
+	--list-item-height: 4.5lh;
 	height: var(--list-item-height);
 
 	// General styles
@@ -484,6 +484,8 @@ export default {
 			&__main {
 				flex: 0 1 auto;
 				min-width: 0;
+				line-height: var(--default-line-height);
+				min-height: var(--default-line-height);
 			}
 
 			&__subname {
@@ -511,12 +513,12 @@ export default {
 				justify-content: start;
 				align-items: end;
 				white-space: nowrap;
-				margin-inline-start: calc(var(--default-grid-baseline) * 2);
+				gap: 4px;
 				// to align details on top instead of in the center. The right way to do it would be to change the template, but that breaks one-line layout
 				margin-top: -22px;
 
 				&__details {
-					margin: 0 9px !important;
+					margin: 0 4px !important;
 					color: var(--color-text-maxcontrast);
 					height: var(--default-line-height);
 					font-weight: normal;
@@ -529,7 +531,7 @@ export default {
 					align-items: center;
 
 					&__indicator {
-						margin: 0 5px;
+						margin: 0 4px;
 					}
 				}
 			}

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -178,7 +178,7 @@ export default {
 }
 
 .reply-buttons {
-	margin: 0 30px 0 50px;
+	margin: 26px 30px 0 50px;
 	display: flex;
 	flex-wrap: wrap;
 	gap: 5px;
@@ -203,6 +203,7 @@ export default {
 
 	&__notsuggested {
 		margin-inline-start: auto;
+		margin-inline-end: -12px;
 	}
 }
 @media screen and (max-width: 600px) {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -579,17 +579,27 @@ export default {
 	position: -webkit-sticky; // ios/safari fallback
 	position: sticky;
 	top: 0;
-	background: -webkit-linear-gradient(var(--color-main-background), var(--color-main-background) 80%, rgba(255,255,255,0));
-	background: -o-linear-gradient(var(--color-main-background), var(--color-main-background)  80%, rgba(255,255,255,0));
-	background: -moz-linear-gradient(var(--color-main-background), var(--color-main-background)  80%, rgba(255,255,255,0));
-	background: linear-gradient(var(--color-main-background), var(--color-main-background)  80%, rgba(255,255,255,0));
+	margin-bottom: 5px;
+
+	&::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		inset-inline-start: 50%;
+		transform: translateX(-50%);
+		width: 100vw;
+		height: 100%;
+		background: var(--color-main-background);
+		border-bottom: var(--border-width-input-focused) solid var(--color-border);
+		z-index: -1;
+	}
 }
 
 #mail-thread-header-fields {
 	// initial width
 	width: 0;
 	// while scrolling, the back button overlaps with subject on small screen
-	padding-inline-start: calc(var(--default-grid-baseline) * 21);
+	padding-inline-start: calc(var(--border-radius-container-large) + var(--header-height));
 	// grow and try to fill 100%
 	flex: 1 1 auto;
 	h2,
@@ -605,7 +615,6 @@ export default {
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
-
 	.transparency {
 		opacity: 0.6;
 		a {
@@ -669,7 +678,7 @@ export default {
 	display: flex;
 	align-items: stretch;
 
-	::deep(.v-popper--theme-dropdown.v-popper__popper .v-popper__inner) {
+	:deep(.v-popper--theme-dropdown.v-popper__popper .v-popper__inner) {
 		height: 300px;
 		width: 250px;
 		overflow: auto;


### PR DESCRIPTION
fixes #11316 

Only worked on these points as added by Jan on the ticket:

- The mail heading & participants should be aligned to the content box.
- and the "Reply" button as well as the action buttons on the top right
- When scrolling the content, the container / top divider line vanishes and gets overlapped partly by the heading, making it look strange
- Now with the message list having more content, horizontal divider lines could make sense to have some nicer separation.
- Mails have different heights in the message list if there’s shorter ones – but all should have the same consistent height
- Whitespace is sometimes not the same across the board, for example the space left and right in the message list is much less (half?) than in the left navigation.



before
<img width="546" height="112" alt="Screenshot from 2025-07-24 18-34-16" src="https://github.com/user-attachments/assets/06bc13b3-1048-4e80-a63d-87090b0ea3aa" />
after

<img width="558" height="143" alt="Screenshot from 2025-07-24 18-30-27" src="https://github.com/user-attachments/assets/4158dee3-8c70-44de-ac56-a2798fea2ae8" />

after(reply button aligned with the action menu)
<img width="703" height="215" alt="Screenshot from 2025-07-24 18-29-59" src="https://github.com/user-attachments/assets/3c51289d-68b9-4d4b-9c6e-22cfdc57fe08" />

Subject and recipient aligned with the recipient in the message header. plus added the line to split subject from the message
<img width="909" height="401" alt="Screenshot from 2025-08-11 13-12-19" src="https://github.com/user-attachments/assets/a3d33e08-1884-42a3-acef-c12c36679a87" />

more space for the preview, but this is a bit tricky to add more space for the preview because the details, the unread and the action menu wouldnt allow it to go further.
before
<img width="546" height="112" alt="Screenshot from 2025-07-24 18-37-18" src="https://github.com/user-attachments/assets/2d02669c-cc6c-4ca9-9c67-3d381a442b0c" />


after
<img width="601" height="117" alt="Screenshot from 2025-07-24 17-27-46" src="https://github.com/user-attachments/assets/f1dafb82-5a1f-4480-8ad2-defe29b12e59" />
