### PR TITLE
fix(uid): use outline erasor icon for clear mailbox action

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -148,7 +148,7 @@
 				:close-after-click="true"
 				@click="clearMailbox">
 				<template #icon>
-					<EraserVariant :size="16" />
+					<EraserIcon :size="16" />
 				</template>
 				{{ t('mail', 'Clear folder') }}
 			</ActionButton>
@@ -201,7 +201,7 @@ import IconArchive from 'vue-material-design-icons/PackageDown.vue'
 import IconInbox from 'vue-material-design-icons/HomeOutline.vue'
 import IconJunk from 'vue-material-design-icons/Fire.vue'
 import IconAllInboxes from 'vue-material-design-icons/InboxMultipleOutline.vue'
-import EraserVariant from 'vue-material-design-icons/EraserVariant.vue'
+import EraserIcon from 'vue-material-design-icons/Eraser.vue'
 import ImportantIcon from './icons/ImportantIcon.vue'
 import IconSend from 'vue-material-design-icons/SendOutline.vue'
 import IconWrench from 'vue-material-design-icons/Wrench.vue'
@@ -246,7 +246,7 @@ export default {
 		IconJunk,
 		IconInbox,
 		IconWrench,
-		EraserVariant,
+		EraserIcon,
 		ImportantIcon,
 		IconLoading,
 		MoveMailboxModal,


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/mail/issues/11370

| Before | After |
|--------|--------|
| <img width="573" height="248" alt="Bildschirmfoto vom 2025-07-17 18-56-35" src="https://github.com/user-attachments/assets/145c2f6f-4aa6-4b7a-a9a0-77adf9457590" /> | <img width="573" height="248" alt="Bildschirmfoto vom 2025-07-17 18-55-17" src="https://github.com/user-attachments/assets/0fcd660a-4a3d-4716-aff8-1444510afb96" /> | 
