### PR TITLE
fix(imip): process imip messages more frequently

### DIFF
--- a/lib/BackgroundJob/IMipMessageJob.php
+++ b/lib/BackgroundJob/IMipMessageJob.php
@@ -20,8 +20,7 @@ class IMipMessageJob extends TimedJob {
 		IMipService $iMipService) {
 		parent::__construct($time);
 
-		// Run once per hour
-		$this->setInterval(60 * 60);
+		$this->setInterval(300);
 		$this->iMipService = $iMipService;
 	}
 

--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -47,7 +47,7 @@ class IMipService {
 	public function process(): void {
 		$messages = $this->messageMapper->findIMipMessagesAscending();
 		if ($messages === []) {
-			$this->logger->info('No iMIP messages to process.');
+			$this->logger->debug('No iMIP messages to process.');
 			return;
 		}
 

--- a/tests/Unit/Service/IMipServiceTest.php
+++ b/tests/Unit/Service/IMipServiceTest.php
@@ -71,7 +71,7 @@ class IMipServiceTest extends TestCase {
 			->method('findIMipMessagesAscending')
 			->willReturn([]);
 		$this->logger->expects(self::once())
-			->method('info');
+			->method('debug');
 		$this->mailboxMapper->expects(self::never())
 			->method('findById');
 		$this->accountService->expects(self::never())


### PR DESCRIPTION
When a message is flagged as imip, it takes up to one hour until we try to process it. Given that the job processes every message just once, it seems reasonable to run it more often.