### PR TITLE
test: make tests run on every machine

### DIFF
--- a/src/tests/setup.js
+++ b/src/tests/setup.js
@@ -12,6 +12,9 @@ JestFetchMock.enableMocks()
 
 global.appName = 'mail'
 
+global._nc_l10n_locale = 'en'
+global._nc_l10n_language = 'en_US'
+
 global.OC = {
 	getLocale: () => 'en',
 	getLanguage: () => 'en_US',


### PR DESCRIPTION
Frontend unit tests fail on machines with a language/locale other than `en_US`.