### PR TITLE
perf: query search results directly

### DIFF
--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -13,6 +13,8 @@ use OCA\Mail\Account;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\MailboxLockedException;
+use OCA\Mail\Exception\MailboxNotCachedException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\Search\SearchQuery;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -46,6 +48,8 @@ interface IMailSearch {
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException
+	 * @throws MailboxLockedException
+	 * @throws MailboxNotCachedException
 	 */
 	public function findMessages(Account $account,
 		Mailbox $mailbox,

--- a/tests/Unit/Service/Search/MailSearchTest.php
+++ b/tests/Unit/Service/Search/MailSearchTest.php
@@ -139,7 +139,7 @@ class MailSearchTest extends TestCase {
 			->with('my search')
 			->willReturn($query);
 		$this->messageMapper->expects($this->once())
-			->method('findByIds')
+			->method('findByQuery')
 			->willReturn([
 				$this->createMock(Message::class),
 				$this->createMock(Message::class),
@@ -185,7 +185,7 @@ class MailSearchTest extends TestCase {
 			->with($account, $mailbox, $query)
 			->willReturn([2, 3]);
 		$this->messageMapper->expects($this->once())
-			->method('findByIds')
+			->method('findByQuery')
 			->willReturn([
 				$this->createMock(Message::class),
 				$this->createMock(Message::class),


### PR DESCRIPTION
Query the search results (messages) directly instead of querying their ids first by the search query and then doing another query for the actual messages.