### PR TITLE
fix: text block wording / spelling

### DIFF
--- a/lib/Controller/TextBlockController.php
+++ b/lib/Controller/TextBlockController.php
@@ -81,7 +81,7 @@ class TextBlockController extends Controller {
 		$textBlock = $this->textBlockService->find($id, $this->uid);
 
 		if ($textBlock === null) {
-			return JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 
 		$textBlock = $this->textBlockService->update($textBlock, $this->uid, $title, $content);
@@ -97,7 +97,7 @@ class TextBlockController extends Controller {
 			$this->textBlockService->delete($id, $this->uid);
 			return JsonResponse::success();
 		} catch (DoesNotExistException $e) {
-			return JsonResponse::fail('TextBlock not found', Http::STATUS_NOT_FOUND);
+			return JsonResponse::fail('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 	}
 

--- a/lib/Controller/TextBlockSharesController.php
+++ b/lib/Controller/TextBlockSharesController.php
@@ -60,7 +60,7 @@ class TextBlockSharesController extends Controller {
 		try {
 			$this->textBlockService->find($textBlockId, $this->uid);
 		} catch (DoesNotExistException $e) {
-			return JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 
 		switch ($type) {
@@ -84,7 +84,7 @@ class TextBlockSharesController extends Controller {
 		try {
 			$this->textBlockService->find($id, $this->uid);
 		} catch (DoesNotExistException $e) {
-			return JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 
 		$this->textBlockService->unshare($id, $shareWith);
@@ -100,7 +100,7 @@ class TextBlockSharesController extends Controller {
 		try {
 			$this->textBlockService->find($id, $this->uid);
 		} catch (DoesNotExistException $e) {
-			return JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 
 		$shares = $this->textBlockService->getShares($id);

--- a/src/components/textBlocks/ListItem.vue
+++ b/src/components/textBlocks/ListItem.vue
@@ -34,12 +34,12 @@
 			<p v-if="shared">
 				{{ localTextBlock.title }}
 			</p>
-			<NcInputField v-else :value.sync="localTextBlock.title" :label="t('mail','Title of the textBlock')" />
+			<NcInputField v-else :value.sync="localTextBlock.title" :label="t('mail','Title of the text block')" />
 			<TextEditor v-model="localTextBlock.content"
 				:is-bordered="!shared"
 				:html="true"
 				:read-only="shared"
-				:placeholder="t('mail','Content of the textBlock')"
+				:placeholder="t('mail','Content of the text block')"
 				:bus="bus" />
 			<template v-if="!shared">
 				<h3>
@@ -194,19 +194,19 @@ export default {
 	methods: {
 		async deleteTextBlock() {
 			await this.mainStore.deleteTextBlock({ id: this.textBlock.id }).then(() => {
-				showSuccess(t('mail', 'TextBlock deleted'))
+				showSuccess(t('mail', 'Text block deleted'))
 			}).catch(() => {
-				showError(t('mail', 'Failed to delete textBlock'))
+				showError(t('mail', 'Failed to delete text block'))
 			})
 		},
 		async shareTextBlock(sharee) {
 			try {
 				await shareTextBlock(this.textBlock.id, sharee.shareWith, sharee.shareType === ShareType.User ? 'user' : 'group')
 				this.shares.push({ shareWith: sharee.shareWith, type: sharee.isNoUser ? 'group' : 'user', displayName: sharee.displayName })
-				showSuccess(t('mail', 'TextBlock shared with {sharee}', { sharee: sharee.shareWith }))
+				showSuccess(t('mail', 'Text block shared with {sharee}', { sharee: sharee.shareWith }))
 				this.share = null
 			} catch (error) {
-				showError(t('mail', 'Failed to share textBlock with {sharee}', { sharee: sharee.shareWith }))
+				showError(t('mail', 'Failed to share text block with {sharee}', { sharee: sharee.shareWith }))
 			}
 		},
 		async removeShare(sharee) {
@@ -356,8 +356,8 @@ export default {
 				this.saveLoading = false
 				this.editModalOpen = false
 			} catch (error) {
-				showError(t('mail', 'Failed to save textBlock'))
-				logger.error('Failed to save textBlock', error)
+				showError(t('mail', 'Failed to save text block'))
+				logger.error('Failed to save text block', error)
 			}
 		},
 	},

--- a/tests/Unit/Controller/TextBlockControllerTest.php
+++ b/tests/Unit/Controller/TextBlockControllerTest.php
@@ -67,7 +67,7 @@ class TextBlockControllerTest extends TestCase {
 	public function testCreateTextBlockNoUser(): void {
 		$controller = new TextBlockController($this->request, null, $this->textBlockService);
 
-		$response = $controller->create('New TextBlock', 'New Content');
+		$response = $controller->create('New Text Block', 'New Content');
 		$expectedResponse = JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		$this->assertEquals($expectedResponse, $response);
 	}
@@ -77,12 +77,12 @@ class TextBlockControllerTest extends TestCase {
 
 		$this->textBlockService->expects($this->once())
 			->method('create')
-			->with($this->userId, 'New TextBlock', 'New Content')
+			->with($this->userId, 'New Text Block', 'New Content')
 			->willReturn($newTextBlock);
 
 		$controller = new TextBlockController($this->request, $this->userId, $this->textBlockService);
 
-		$response = $controller->create('New TextBlock', 'New Content');
+		$response = $controller->create('New Text Block', 'New Content');
 		$expectedResponse = JsonResponse::success($newTextBlock, Http::STATUS_CREATED);
 		$this->assertEquals($expectedResponse, $response);
 	}
@@ -90,7 +90,7 @@ class TextBlockControllerTest extends TestCase {
 	public function testUpdateNoUser(): void {
 		$controller = new TextBlockController($this->request, null, $this->textBlockService);
 
-		$response = $controller->update(1, 'Updated TextBlock', 'Updated Content');
+		$response = $controller->update(1, 'Updated Text Block', 'Updated Content');
 		$expectedResponse = JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		$this->assertEquals($expectedResponse, $response);
 	}
@@ -103,8 +103,8 @@ class TextBlockControllerTest extends TestCase {
 
 		$controller = new TextBlockController($this->request, $this->userId, $this->textBlockService);
 
-		$response = $controller->update(1, 'Updated TextBlock', 'Updated Content');
-		$expectedResponse = JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+		$response = $controller->update(1, 'Updated Text Block', 'Updated Content');
+		$expectedResponse = JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -119,12 +119,12 @@ class TextBlockControllerTest extends TestCase {
 
 		$this->textBlockService->expects($this->once())
 			->method('update')
-			->with($textBlock, $this->userId, 'Updated TextBlock', 'Updated Content')
+			->with($textBlock, $this->userId, 'Updated Text Block', 'Updated Content')
 			->willReturn($updatedTextBlock);
 
 		$controller = new TextBlockController($this->request, $this->userId, $this->textBlockService);
 
-		$response = $controller->update(1, 'Updated TextBlock', 'Updated Content');
+		$response = $controller->update(1, 'Updated Text Block', 'Updated Content');
 		$expectedResponse = JsonResponse::success($updatedTextBlock, Http::STATUS_OK);
 		$this->assertEquals($expectedResponse, $response);
 	}
@@ -146,7 +146,7 @@ class TextBlockControllerTest extends TestCase {
 		$controller = new TextBlockController($this->request, $this->userId, $this->textBlockService);
 
 		$response = $controller->destroy(1);
-		$expectedResponse = JsonResponse::fail('TextBlock not found', Http::STATUS_NOT_FOUND);
+		$expectedResponse = JsonResponse::fail('Text block not found', Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 

--- a/tests/Unit/Controller/TextBlockSharesControllerTest.php
+++ b/tests/Unit/Controller/TextBlockSharesControllerTest.php
@@ -95,7 +95,7 @@ class TextBlockSharesControllerTest extends TestCase {
 		$controller = new TextBlockSharesController($this->request, $this->userId, $this->textBlockService);
 
 		$response = $controller->create(1, 'alice', 'user');
-		$expectedResponse = JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+		$expectedResponse = JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -154,12 +154,12 @@ class TextBlockSharesControllerTest extends TestCase {
 		$this->textBlockService->expects($this->once())
 			->method('find')
 			->with(1, $this->userId)
-			->willThrowException(new DoesNotExistException('TextBlock not found'));
+			->willThrowException(new DoesNotExistException('Text block not found'));
 
 		$controller = new TextBlockSharesController($this->request, $this->userId, $this->textBlockService);
 
 		$response = $controller->destroy(1, 'alice');
-		$expectedResponse = JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+		$expectedResponse = JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 
@@ -183,12 +183,12 @@ class TextBlockSharesControllerTest extends TestCase {
 		$this->textBlockService->expects($this->once())
 			->method('find')
 			->with(1, $this->userId)
-			->willThrowException(new DoesNotExistException('TextBlock not found'));
+			->willThrowException(new DoesNotExistException('Text block not found'));
 
 		$controller = new TextBlockSharesController($this->request, $this->userId, $this->textBlockService);
 
 		$response = $controller->getTextBlockShares(1);
-		$expectedResponse = JsonResponse::error('TextBlock not found', Http::STATUS_NOT_FOUND);
+		$expectedResponse = JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expectedResponse, $response);
 	}
 

--- a/tests/Unit/Service/TextBlockServiceTest.php
+++ b/tests/Unit/Service/TextBlockServiceTest.php
@@ -65,7 +65,7 @@ class TextBlockServiceTest extends TestCase {
 
 	public function testCreate(): void {
 		$userId = 'bob';
-		$title = 'Test TextBlock';
+		$title = 'Test Text Block';
 		$content = '<p>This is content</p>';
 		$textBlock = new TextBlock();
 
@@ -133,10 +133,10 @@ class TextBlockServiceTest extends TestCase {
 		$this->textBlockMapper->expects($this->once())
 			->method('find')
 			->with($textBlockId, $userId)
-			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('TextBlock does not exist'));
+			->willThrowException(new \OCP\AppFramework\Db\DoesNotExistException('Text block does not exist'));
 
 		$this->expectException(\OCP\AppFramework\Db\DoesNotExistException::class);
-		$this->expectExceptionMessage('TextBlock does not exist');
+		$this->expectExceptionMessage('Text block does not exist');
 
 		$this->textBlockService->delete($textBlockId, $userId);
 	}


### PR DESCRIPTION
### Summary
- Changed the user facing wording of 'TextBlock' to 'Text block'