### PR TITLE
fix(ui): resize action icons from 16px to 20px

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -305,11 +305,11 @@
 
 				<Actions :open.sync="isAddAttachmentsOpen">
 					<template #icon>
-						<Paperclip :size="16" />
+						<Paperclip :size="20" />
 					</template>
 					<ActionButton :close-after-click="true" @click="onAddLocalAttachment">
 						<template #icon>
-							<IconUpload :size="16" />
+							<IconUpload :size="20" />
 						</template>
 						{{
 							t('mail', 'Upload attachment')
@@ -317,7 +317,7 @@
 					</ActionButton>
 					<ActionButton :close-after-click="true" @click="onAddCloudAttachment">
 						<template #icon>
-							<IconFolder :size="16" />
+							<IconFolder :size="20" />
 						</template>
 						{{
 							t('mail', 'Add attachment from Files')
@@ -325,7 +325,7 @@
 					</ActionButton>
 					<ActionButton :close-after-click="true" :disabled="encrypt" @click="onAddCloudAttachmentLink">
 						<template #icon>
-							<IconPublic :size="16" />
+							<IconPublic :size="20" />
 						</template>
 						{{
 							t('mail', 'Add share link from Files')
@@ -338,7 +338,7 @@
 					<template v-if="!isMoreActionsOpen">
 						<ActionButton v-if="isPickerAvailable" :close-after-click="true" @click="openPicker">
 							<template #icon>
-								<IconLinkPicker :size="16" />
+								<IconLinkPicker :size="20" />
 							</template>
 							{{
 								t('mail', 'Smart picker')
@@ -346,7 +346,7 @@
 						</ActionButton>
 						<ActionButton :close-after-click="true" @click="openTextBlockPicker">
 							<template #icon>
-								<NcIconSvgWrapper :size="16"
+								<NcIconSvgWrapper :size="20"
 									:title="t('mail', 'Text blocks')"
 									:svg="textBlockSvg" />
 							</template>
@@ -358,7 +358,7 @@
 							:close-after-click="false"
 							@click="isMoreActionsOpen=true">
 							<template #icon>
-								<SendClock :size="16" :title="t('mail', 'Send later')" />
+								<SendClock :size="20" :title="t('mail', 'Send later')" />
 							</template>
 							{{
 								t('mail', 'Send later')
@@ -396,7 +396,7 @@
 							@click="isMoreActionsOpen=false">
 							<template #icon>
 								<ChevronLeft :title="t('mail', 'Send later')"
-									:size="16" />
+									:size="20" />
 								{{ t('mail', 'Send later') }}
 							</template>
 						</ActionButton>

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -179,7 +179,7 @@
 					@click="onUnSnooze">
 					<template #icon>
 						<AlarmIcon :title="t('mail', 'Unsnooze')"
-							:size="16" />
+							:size="20" />
 					</template>
 					{{ t('mail', 'Unsnooze') }}
 				</ActionButton>
@@ -187,7 +187,7 @@
 					:close-after-click="true"
 					@click.prevent="onOpenMoveModal">
 					<template #icon>
-						<OpenInNewIcon :size="16" />
+						<OpenInNewIcon :size="20" />
 					</template>
 					<template v-if="layoutMessageViewThreaded">
 						{{ t('mail', 'Move thread') }}


### PR DESCRIPTION
A few leftovers from https://github.com/nextcloud/mail/pull/11455 for https://github.com/nextcloud/mail/issues/11438

| Before | After |
|--------|--------|
| <img width="398" height="283" alt="Bildschirmfoto vom 2025-08-08 13-25-55" src="https://github.com/user-attachments/assets/3bcba202-5e93-4384-b8b1-2bfeb140d0b5" /> | <img width="398" height="283" alt="Bildschirmfoto vom 2025-08-08 13-26-06" src="https://github.com/user-attachments/assets/7d37cee4-e65d-4662-80c6-16817b220275" /> | 

