### PR TITLE
chore(ui): remove EmptyContent icon size

### DIFF
--- a/src/components/EmptyMailbox.vue
+++ b/src/components/EmptyMailbox.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcEmptyContent :name="t('mail', 'No messages in this folder')">
 		<template #icon>
-			<IconMail :size="65" />
+			<IconMail />
 		</template>
 	</NcEmptyContent>
 </template>

--- a/src/components/EmptyMailboxSection.vue
+++ b/src/components/EmptyMailboxSection.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcEmptyContent class="empty-content" :name="t('mail', 'No messages')">
 		<template #icon>
-			<IconMail :size="65" />
+			<IconMail />
 		</template>
 	</NcEmptyContent>
 </template>

--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -9,7 +9,7 @@
 		class="mail-error"
 		:class="{ 'mail-error--auto-margin': autoMargin }">
 		<template #icon>
-			<AlertCircleIcon :size="24" />
+			<AlertCircleIcon />
 		</template>
 		<template v-if="data && data.debug" #action>
 			<NcButton :aria-label="t('mail', 'Report this bug')"

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -8,7 +8,7 @@
 			class="empty-content"
 			:name="hint">
 			<template #icon>
-				<IconLoading :size="16" />
+				<IconLoading />
 			</template>
 			<transition name="fade">
 				<em v-if="slowHint && slow">{{ slowHint }}</em>

--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -9,7 +9,7 @@
 			:name="t('mail', 'Welcome to {productName} Mail', { productName }, null, {escape: false})"
 			:description="t('mail', 'Start writing a message by clicking below or select an existing message to display its contents')">
 			<template #icon>
-				<IconMail :size="65" />
+				<IconMail />
 			</template>
 			<template #action>
 				<NewMessageButtonHeader />

--- a/src/components/OutboxMessageContent.vue
+++ b/src/components/OutboxMessageContent.vue
@@ -5,7 +5,7 @@
 <template>
 	<NcEmptyContent :name="t('mail', 'Pending or not sent messages will show up here')" class="empty-content">
 		<template #icon>
-			<IconMail :size="65" />
+			<IconMail />
 		</template>
 	</NcEmptyContent>
 </template>

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -9,7 +9,7 @@
 			<div v-if="allowNewMailAccounts">
 				<EmptyContent :name="t('mail', 'Connect your mail account')">
 					<template #icon>
-						<IconMail :size="65" />
+						<IconMail />
 					</template>
 				</EmptyContent>
 				<AccountForm :display-name="displayName"
@@ -19,7 +19,7 @@
 			</div>
 			<EmptyContent v-else :name="t('mail', 'To add a mail account, please contact your administrator.')">
 				<template #icon>
-					<IconMail :size="65" />
+					<IconMail />
 				</template>
 			</EmptyContent>
 		</AppContent>


### PR DESCRIPTION
Noticed while working on https://github.com/nextcloud/mail/issues/11438. Our icon size does not take effect, because `@nextcloud/vue` forces a size of 64px:

<img width="449" height="137" alt="Bildschirmfoto vom 2025-08-11 14-33-24" src="https://github.com/user-attachments/assets/473226d9-c18b-4e8f-a984-4754e584919e" />
