### PR TITLE
ci: update stable branches for stable5.3

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.2', 'stable5.1']
+        branches: ['main', 'stable5.3', 'stable5.2']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.2', 'stable5.1']
+        branches: ['main', 'stable5.3', 'stable5.2']
 
     name: update-public-suffix-list-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,2 +1,2 @@
+stable5.3
 stable5.2
-stable5.1

--- a/renovate.json
+++ b/renovate.json
@@ -23,8 +23,8 @@
 	"ignoreUnstable": false,
 	"baseBranches": [
 		"main",
-		"stable5.2",
-		"stable5.1"
+		"stable5.3",
+		"stable5.2"
 	],
 	"enabledManagers": [
 		"composer",


### PR DESCRIPTION
5.2 is stable, so 5.1 is no longer maintained. 5.3 is the next pre-release.