### PR TITLE
feat: improve the height and width of threads

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -191,7 +191,6 @@ export default {
 	// TODO: collapse quoted text and remove inner scrollbar
 	@media only screen {
 		&.scroll {
-			max-height: 50vh;
 			overflow-y: auto;
 		}
 	}

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -1077,7 +1077,7 @@ export default {
 			position: relative;
 			display: flex;
 			align-items: center;
-			padding: calc(var(--default-grid-baseline) * 2);
+			padding: var(--border-radius-element) var(--border-radius-container) var(--border-radius-container) var(--border-radius-container);
 			border-radius: var(--border-radius);
 			min-height: 68px; /* prevents jumping between open/collapsed */
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -195,7 +195,6 @@ export default {
 
 :deep(.app-content-details) {
 	margin: 0 auto;
-	max-width: 900px;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 100%;


### PR DESCRIPTION
ref #11328 

fixed in this pr:

- Full width boxes
- Only 2 states: one collapsed fully, one expanded fully, no max-height for each message
- Avatar: Space on the top and left should be equal


before
<img width="1293" height="937" alt="Screenshot from 2025-08-14 17-27-20" src="https://github.com/user-attachments/assets/760dd95b-3fab-41e2-a67b-49e198e8aaed" />


after
<img width="1293" height="937" alt="Screenshot from 2025-08-14 17-23-53" src="https://github.com/user-attachments/assets/0c487896-c026-4937-925f-3ee0e52db63a" />

