### PR TITLE
fix: ckeditor dropdown overlaping

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -658,7 +658,7 @@ export default {
 }
 
 .right-pane {
-	flex: 0 0 400px;
+	flex: 0 0 370px;
 	overflow-y: auto;
 	padding-inline-start: 5px;
 	border-inline-start: 1px solid #ccc;

--- a/src/components/RecipientInfo.vue
+++ b/src/components/RecipientInfo.vue
@@ -105,7 +105,7 @@ export default {
 	width: 100%;
 
 	&__single {
-		width: 400px;
+		width: 370px;
 		display: inline-block;
 	}
 

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -617,10 +617,6 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	font-weight: normal;
 }
 
-.ck.ck-dropdown.ck-list-styles-dropdown {
-	width: 55px;
-}
-
 .ck-source-editing-area {
 	height: 97%;
 	overflow: scroll;


### PR DESCRIPTION
The problem:
<img width="679" height="228" alt="Screenshot from 2025-08-18 15-21-35" src="https://github.com/user-attachments/assets/892b73a3-6ec3-4d37-84b3-7cc7c114f068" />

The solution i propose in this pr is to make the recipient info column smaller by 30px. Since the problem only occurs when the right pane is shown. 
My initial solution was to do it like we do it on the signature section, that when the width is reached, the elements start creating a third row. Here that will not work because it will be cut on the bottom(same problem we have now on the left) and it glitches. The recipient info doesnt need that much space anyway(in my opinion)

after
<img width="926" height="742" alt="Screenshot from 2025-08-18 15-27-13" src="https://github.com/user-attachments/assets/1a365023-4f10-41af-93db-e8305030ccd1" />
