### PR TITLE
fix: white space between section titles

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -563,7 +563,7 @@ div {
 	justify-content: center;
 	background-color: var(--color-main-background-translucent);
 	position: sticky;
-	top: 0px;
+	top: 0;
 	height: 48px;
 	z-index: 100;
 	.action-buttons {
@@ -572,8 +572,6 @@ div {
 }
 
 #load-more-mail-messages {
-	margin: 10px auto;
-	padding: 10px;
 	background-position: 9px center;
 }
 
@@ -589,7 +587,7 @@ div {
 .list-enter,
 .list-leave-to {
 	opacity: 0;
-	height: 0px;
+	height: 0;
 	transform: scaleY(0);
 }
 

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -580,7 +580,6 @@ export default {
 .nameimportant {
 	:deep(#load-more-mail-messages) {
 		margin-top: 0;
-		margin-bottom: 8px;
 	}
 }
 


### PR DESCRIPTION
before
<img width="498" height="183" alt="Screenshot from 2025-08-18 16-58-21" src="https://github.com/user-attachments/assets/1f92f812-74fa-4f90-ab2b-95a8adfeb73c" />

after
<img width="490" height="150" alt="Screenshot from 2025-08-18 16-56-51" src="https://github.com/user-attachments/assets/0c66a455-1a05-46a9-b76d-aa7dc16e35c9" />
