### PR TITLE
feat: store envelopes as list of threads

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -112,7 +112,7 @@ interface IMailManager {
 	 *
 	 * @return Message[]
 	 */
-	public function getThread(Account $account, string $threadRootId): array;
+	public function getThread(Account $account, string $threadRootId, string $sortOrder = IMailSearch::ORDER_NEWEST_FIRST): array;
 
 	/**
 	 * @param Account $sourceAccount

--- a/lib/Contracts/IMailSearch.php
+++ b/lib/Contracts/IMailSearch.php
@@ -42,7 +42,7 @@ interface IMailSearch {
 	 * @param string|null $userId
 	 * @param string|null $view
 	 *
-	 * @return Message[]
+	 * @return Message[][]
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -755,10 +755,11 @@ class MessageMapper extends QBMapper {
 	/**
 	 * @param Account $account
 	 * @param string $threadRootId
+	 * @param string $sortOrder
 	 *
 	 * @return Message[]
 	 */
-	public function findThread(Account $account, string $threadRootId): array {
+	public function findThread(Account $account, string $threadRootId, string $sortOrder): array {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('messages.*')
 			->from($this->getTableName(), 'messages')
@@ -767,7 +768,7 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->eq('mailboxes.account_id', $qb->createNamedParameter($account->getId(), IQueryBuilder::PARAM_INT)),
 				$qb->expr()->eq('messages.thread_root_id', $qb->createNamedParameter($threadRootId, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR)
 			)
-			->orderBy('messages.sent_at', 'desc');
+			->orderBy('messages.sent_at', $sortOrder);
 
 		return $this->findRelatedData($this->findEntities($qb), $account->getUserId());
 	}
@@ -1228,10 +1229,11 @@ class MessageMapper extends QBMapper {
 	 * @param Mailbox $mailbox
 	 * @param string $userId
 	 * @param int[] $ids
+	 * @param string $sortOrder
 	 *
 	 * @return Message[]
 	 */
-	public function findByMailboxAndIds(Mailbox $mailbox, string $userId, array $ids): array {
+	public function findByMailboxAndIds(Mailbox $mailbox, string $userId, array $ids, string $sortOrder): array {
 		if ($ids === []) {
 			return [];
 		}
@@ -1243,7 +1245,7 @@ class MessageMapper extends QBMapper {
 				$qb->expr()->eq('mailbox_id', $qb->createNamedParameter($mailbox->getId()), IQueryBuilder::PARAM_INT),
 				$qb->expr()->in('id', $qb->createParameter('ids'))
 			)
-			->orderBy('sent_at', 'desc');
+			->orderBy('sent_at', $sortOrder);
 
 		$results = [];
 		foreach (array_chunk($ids, 1000) as $chunk) {
@@ -1251,6 +1253,92 @@ class MessageMapper extends QBMapper {
 			$results[] = $this->findRelatedData($this->findEntities($qb), $userId);
 		}
 		return array_merge([], ...$results);
+	}
+
+	/**
+	 * @param Account $account
+	 * @param Mailbox $mailbox
+	 * @param string $userId
+	 * @param int[] $ids
+	 * @param string $sortOrder
+	 * @param bool $threadingEnabled
+	 *
+	 * @return Message[][]
+	 */
+	public function findMessageListsByMailboxAndIds(Account $account, Mailbox $mailbox, string $userId, array $ids, string $sortOrder, bool $threadingEnabled = false): array {
+		if ($ids === []) {
+			return [];
+		}
+
+		$base = $this->findByMailboxAndIds($mailbox, $userId, $ids, $sortOrder);
+		if ($threadingEnabled === false) {
+			return array_map(static fn (Message $m) => [$m], $base);
+		}
+
+		return $this->groupThreadsForRepresentatives($account, $base, $ids, $userId, $sortOrder);
+	}
+
+	/**
+	 * Expand a list of per-thread representative messages into full thread
+	 * groups by fetching all sibling messages (same thread_root_id) across the
+	 * account's mailboxes, preserving the order of $representatives.
+	 *
+	 * @param Message[] $representatives one ordered representative per thread
+	 * @param int[] $representativeIds ids already loaded in $representatives
+	 *
+	 * @return Message[][]
+	 */
+	private function groupThreadsForRepresentatives(Account $account, array $representatives, array $representativeIds, string $userId, string $sortOrder): array {
+		if ($representatives === []) {
+			return [];
+		}
+
+		// A null thread_root_id means the message is not threaded, so it must
+		// stay its own group. Casting null to '' would collapse every unthreaded
+		// representative into a single shared key, merging unrelated messages.
+		$keyOf = static fn (Message $m) => $m->getThreadRootId() ?? 'id:' . $m->getId();
+
+		// Only messages with an actual thread root can have siblings to fetch.
+		$threadRoots = array_values(array_unique(array_filter(
+			array_map(static fn (Message $m) => $m->getThreadRootId(), $representatives),
+			static fn (?string $root) => $root !== null
+		)));
+
+		$messages = [$representatives];
+		if ($threadRoots !== []) {
+			$qb = $this->db->getQueryBuilder();
+			$qb->select('m.*')
+				->from($this->getTableName(), 'm')
+				->join('m', 'mail_mailboxes', 'mb', $qb->expr()->eq('m.mailbox_id', 'mb.id', IQueryBuilder::PARAM_INT))
+				->where(
+					$qb->expr()->eq('mb.account_id', $qb->createNamedParameter($account->getId(), IQueryBuilder::PARAM_INT)),
+					$qb->expr()->in('m.thread_root_id', $qb->createParameter('roots')),
+					$qb->expr()->notIn('m.id', $qb->createNamedParameter($representativeIds, IQueryBuilder::PARAM_INT_ARRAY))
+				)
+				->orderBy('m.sent_at', $sortOrder);
+			foreach (array_chunk($threadRoots, 1000) as $chunk) {
+				$qb->setParameter('roots', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
+				$messages[] = $this->findEntities($qb);
+			}
+		}
+
+		$enriched = $this->findRelatedData(array_merge(...$messages), $userId);
+
+		$groups = [];
+		foreach ($enriched as $m) {
+			$groups[$keyOf($m)][] = $m;
+		}
+
+		$out = [];
+		$seen = [];
+		foreach ($representatives as $rep) {
+			$key = $keyOf($rep);
+			if (isset($groups[$key]) && !isset($seen[$key])) {
+				$out[] = $groups[$key];
+				$seen[$key] = true;
+			}
+		}
+		return $out;
 	}
 
 	/**
@@ -1278,6 +1366,29 @@ class MessageMapper extends QBMapper {
 			$results[] = $this->findRelatedData($this->findEntities($qb), $userId);
 		}
 		return array_merge([], ...$results);
+	}
+
+
+	/**
+	 * @param Account $account
+	 * @param string $userId
+	 * @param int[] $ids
+	 * @param string $sortOrder
+	 *
+	 * @return Message[][]
+	 */
+	public function findMessageListsByIds(Account $account, string $userId, array $ids, string $sortOrder, bool $threadingEnabled = false): array {
+		if ($ids === []) {
+			return [];
+		}
+
+		$base = $this->findByIds($userId, $ids, $sortOrder);
+
+		if ($threadingEnabled === false) {
+			return array_map(static fn (Message $m) => [$m], $base);
+		}
+
+		return $this->groupThreadsForRepresentatives($account, $base, $ids, $userId, $sortOrder);
 	}
 
 	/**

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -12,12 +12,14 @@ namespace OCA\Mail\IMAP;
 use Horde_Imap_Client_Exception;
 use OCA\Mail\Account;
 use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMapper;
 use OCA\Mail\IMAP\MessageMapper as ImapMapper;
 use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\Avatar\Avatar;
 use OCA\Mail\Service\AvatarService;
+use OCP\AppFramework\Db\DoesNotExistException;
 use Psr\Log\LoggerInterface;
 use function array_key_exists;
 use function array_map;
@@ -32,7 +34,35 @@ class PreviewEnhancer {
 		private LoggerInterface $logger,
 		private AvatarService $avatarService,
 		private AttachmentService $attachmentService,
+		private MailboxMapper $mailboxMapper,
 	) {
+	}
+
+	/**
+	 * Enhance messages that may belong to different mailboxes (e.g. thread
+	 * members spanning INBOX and Sent). Each mailbox's messages are processed
+	 * against their own IMAP folder, otherwise attachments and preview data
+	 * are fetched from the wrong folder and silently come back empty.
+	 *
+	 * @param Message[] $messages
+	 *
+	 * @return Message[]
+	 */
+	public function processMany(Account $account, array $messages, bool $preLoadAvatars = false, ?string $userId = null): array {
+		$byMailbox = [];
+		foreach ($messages as $message) {
+			$byMailbox[$message->getMailboxId()][] = $message;
+		}
+		foreach ($byMailbox as $mailboxId => $mailboxMessages) {
+			try {
+				$mailbox = $this->mailboxMapper->findById($mailboxId);
+			} catch (DoesNotExistException $e) {
+				$this->logger->warning('Could not enhance previews, mailbox ' . $mailboxId . ' not found: ' . $e->getMessage(), ['exception' => $e]);
+				continue;
+			}
+			$this->process($account, $mailbox, $mailboxMessages, $preLoadAvatars, $userId);
+		}
+		return $messages;
 	}
 
 	/**

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -17,6 +17,7 @@ use Horde_Mime_Exception;
 use OCA\Mail\Account;
 use OCA\Mail\Attachment;
 use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
@@ -176,8 +177,8 @@ class MailManager implements IMailManager {
 	}
 
 	#[\Override]
-	public function getThread(Account $account, string $threadRootId): array {
-		return $this->dbMessageMapper->findThread($account, $threadRootId);
+	public function getThread(Account $account, string $threadRootId, string $sortOrder = IMailSearch::ORDER_NEWEST_FIRST): array {
+		return $this->dbMessageMapper->findThread($account, $threadRootId, $sortOrder);
 	}
 
 	#[\Override]

--- a/lib/Service/Search/MailSearch.php
+++ b/lib/Service/Search/MailSearch.php
@@ -63,7 +63,7 @@ class MailSearch implements IMailSearch {
 	 * @param int|null $limit
 	 * @param string|null $view
 	 *
-	 * @return Message[]
+	 * @return Message[][]
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException
@@ -88,8 +88,9 @@ class MailSearch implements IMailSearch {
 		if ($cursor !== null) {
 			$query->setCursor($cursor);
 		}
+		$threadingEnabled = $view === self::VIEW_THREADED;
 		if ($view !== null) {
-			$query->setThreaded($view === self::VIEW_THREADED);
+			$query->setThreaded($threadingEnabled);
 		}
 		// In flagged we don't want anything but flagged messages
 		if ($mailbox->isSpecialUse(Horde_Imap_Client::SPECIALUSE_FLAGGED)) {
@@ -99,17 +100,23 @@ class MailSearch implements IMailSearch {
 		if (!$mailbox->isSpecialUse(Horde_Imap_Client::SPECIALUSE_TRASH)) {
 			$query->addFlag(Flag::not(Flag::DELETED));
 		}
+		$messages = $this->messageMapper->findMessageListsByIds($account, $account->getUserId(),
+			$this->getIdsLocally($account, $mailbox, $query, $sortOrder, $limit),
+			$sortOrder,
+			$threadingEnabled
+		);
 
-		return $this->previewEnhancer->process(
+		// Enhance previews for the whole page, grouping by mailbox so thread
+		// members in other folders (e.g. Sent) are enhanced against their own
+		// folder.
+		$this->previewEnhancer->processMany(
 			$account,
-			$mailbox,
-			$this->messageMapper->findByIds($account->getUserId(),
-				$this->getIdsLocally($account, $mailbox, $query, $sortOrder, $limit),
-				$sortOrder,
-			),
+			array_merge([], ...$messages),
 			true,
 			$userId
 		);
+
+		return $messages;
 	}
 
 	/**

--- a/lib/Service/SnoozeService.php
+++ b/lib/Service/SnoozeService.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Service;
 
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
@@ -213,7 +214,7 @@ class SnoozeService {
 			}
 		}
 
-		$messages = $this->messageMapper->findThread($srcAccount, $selectedMessage->getThreadRootId());
+		$messages = $this->messageMapper->findThread($srcAccount, $selectedMessage->getThreadRootId(), IMailSearch::ORDER_NEWEST_FIRST);
 
 		foreach ($messages as $message) {
 			$this->mailManager->moveMessage(

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Service\Sync;
 
 use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailSearch;
+use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
@@ -24,6 +25,7 @@ use OCA\Mail\IMAP\PreviewEnhancer;
 use OCA\Mail\IMAP\Sync\Response;
 use OCA\Mail\Service\Search\FilterStringParser;
 use OCA\Mail\Service\Search\SearchQuery;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use function array_diff;
 use function array_map;
@@ -38,6 +40,8 @@ class SyncService {
 		private PreviewEnhancer $previewEnhancer,
 		private LoggerInterface $logger,
 		private MailboxSync $mailboxSync,
+		private IAppConfig $config,
+		private IUserPreferences $preferences,
 	) {
 	}
 
@@ -102,7 +106,8 @@ class SyncService {
 		);
 
 		$this->mailboxSync->syncStats($client, $mailbox);
-
+		$userId = $account->getUserId();
+		$threadingEnabled = $this->preferences->getPreference($userId, 'layout-message-view', $this->config->getValueString('mail', 'layout_message_view', 'threaded')) === 'threaded';
 		$client->logout();
 
 		$query = $filter === null ? null : $this->filterStringParser->parse($filter);
@@ -112,7 +117,8 @@ class SyncService {
 			$knownIds ?? [],
 			$lastMessageTimestamp,
 			$sortOrder,
-			$query
+			$query,
+			$threadingEnabled
 		);
 	}
 
@@ -121,6 +127,7 @@ class SyncService {
 	 * @param Mailbox $mailbox
 	 * @param int[] $knownIds
 	 * @param SearchQuery $query
+	 * @param bool $threadingEnabled
 	 *
 	 * @return Response
 	 * @todo does not work with text token search queries
@@ -131,7 +138,8 @@ class SyncService {
 		array $knownIds,
 		?int $lastMessageTimestamp,
 		string $sortOrder,
-		?SearchQuery $query): Response {
+		?SearchQuery $query,
+		bool $threadingEnabled): Response {
 		if ($knownIds === []) {
 			$newIds = $this->messageMapper->findAllIds($mailbox);
 		} else {
@@ -143,7 +151,13 @@ class SyncService {
 			$newUids = $this->messageMapper->findUidsForIds($mailbox, $newIds);
 			$newIds = $this->messageMapper->findIdsByQuery($mailbox, $query, $order, null, $newUids);
 		}
-		$new = $this->messageMapper->findByMailboxAndIds($mailbox, $account->getUserId(), $newIds);
+
+		$new = $this->messageMapper->findMessageListsByMailboxAndIds($account, $mailbox, $account->getUserId(), $newIds, $sortOrder, $threadingEnabled);
+
+		// Enhance previews for all new messages, grouping by mailbox so thread
+		// members in other folders are enhanced against their own folder. The
+		// Message objects are mutated in place, so the grouping stays intact.
+		$this->previewEnhancer->processMany($account, array_merge([], ...$new));
 
 		// TODO: $changed = $this->messageMapper->findChanged($account, $mailbox, $uids);
 		if ($query !== null) {
@@ -152,13 +166,13 @@ class SyncService {
 		} else {
 			$changedIds = $knownIds;
 		}
-		$changed = $this->messageMapper->findByMailboxAndIds($mailbox, $account->getUserId(), $changedIds);
+		$changed = $this->messageMapper->findByMailboxAndIds($mailbox, $account->getUserId(), $changedIds, $sortOrder);
 
 		$stillKnownIds = array_map(static fn (Message $msg) => $msg->getId(), $changed);
 		$vanished = array_values(array_diff($knownIds, $stillKnownIds));
 
 		return new Response(
-			$this->previewEnhancer->process($account, $mailbox, $new),
+			$new,
 			$changed,
 			$vanished,
 			$mailbox->getStats()

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -820,12 +820,20 @@ export default {
 			return tags
 		},
 
+		threadAttachments() {
+			const envelopes = this.layoutMessageViewThreaded
+				? this.mainStore.getEnvelopesByThreadRootId(this.data)
+				: [this.data]
+			return envelopes
+				.flatMap((envelope) => envelope.attachments ?? [])
+		},
+
 		attachments() {
-			return this.data.attachments.filter((e) => e.fileName && e.fileName.length > 0).slice(0, this.possibleAttachmentsCount)
+			return this.threadAttachments.filter((e) => e.fileName && e.fileName.length > 0).slice(0, this.possibleAttachmentsCount)
 		},
 
 		remainingAttachements() {
-			return this.data.attachments.length - this.attachments.length
+			return this.threadAttachments.length - this.attachments.length
 		},
 
 		draggableLabel() {
@@ -1096,7 +1104,7 @@ export default {
 		async setTag(tagId) {
 			const tag = this.mainStore.getTag(tagId)
 			const threadEnvelopes = this.layoutMessageViewThreaded
-				? this.mainStore.getEnvelopesByThreadRootId(this.data.accountId, this.data.threadRootId)
+				? this.mainStore.getEnvelopesByThreadRootId(this.data)
 				: [this.data]
 			if (!tag) {
 				showWarning(t('mail', 'Could not apply tag, configured tag not found'))
@@ -1139,7 +1147,7 @@ export default {
 
 		onToggleImportantThread() {
 			const threadEnvelopes = this.layoutMessageViewThreaded
-				? this.mainStore.getEnvelopesByThreadRootId(this.data.accountId, this.data.threadRootId)
+				? this.mainStore.getEnvelopesByThreadRootId(this.data)
 				: [this.data]
 			threadEnvelopes.forEach((envelope) => {
 				this.mainStore.toggleEnvelopeImportant(envelope)
@@ -1152,7 +1160,7 @@ export default {
 
 		onToggleFlaggedThread() {
 			const threadEnvelopes = this.layoutMessageViewThreaded
-				? this.mainStore.getEnvelopesByThreadRootId(this.data.accountId, this.data.threadRootId)
+				? this.mainStore.getEnvelopesByThreadRootId(this.data)
 				: [this.data]
 			threadEnvelopes.forEach((envelope) => {
 				this.mainStore.toggleEnvelopeFlagged(envelope)
@@ -1162,7 +1170,7 @@ export default {
 		onToggleSeen() {
 			if (this.layoutMessageViewThreaded) {
 				const threadEnvelopes = this.layoutMessageViewThreaded
-					? this.mainStore.getEnvelopesByThreadRootId(this.data.accountId, this.data.threadRootId)
+					? this.mainStore.getEnvelopesByThreadRootId(this.data)
 					: [this.data]
 				threadEnvelopes.forEach((envelope) => {
 					this.mainStore.toggleEnvelopeSeen({ envelope })
@@ -1176,7 +1184,7 @@ export default {
 			const removeEnvelope = await this.mainStore.moveEnvelopeToJunk(this.data)
 
 			const threadEnvelopes = this.layoutMessageViewThreaded
-				? this.mainStore.getEnvelopesByThreadRootId(this.data.accountId, this.data.threadRootId)
+				? this.mainStore.getEnvelopesByThreadRootId(this.data)
 				: [this.data]
 			threadEnvelopes.forEach(async (envelope) => {
 				if (this.isImportant) {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -93,7 +93,7 @@ export default {
 				return [envelope]
 			}
 
-			const envelopes = this.mainStore.getEnvelopesByThreadRootId(envelope.accountId, envelope.threadRootId)
+			const envelopes = this.mainStore.getEnvelopesByThreadRootId(envelope)
 			if (envelopes.length === 0) {
 				return []
 			}

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -61,7 +61,7 @@ export function fetchEnvelopes(accountId, mailboxId, query, cursor, limit, sort,
 			params,
 		})
 		.then((resp) => resp.data)
-		.then((envelopes) => envelopes.map(amendEnvelopeWithIds(accountId)))
+		.then((data) => data.map((envelopes) => envelopes.map(amendEnvelopeWithIds(accountId))))
 		.catch((error) => {
 			throw convertAxiosError(error)
 		})
@@ -94,7 +94,7 @@ export async function syncEnvelopes(accountId, id, ids, lastMessageTimestamp, qu
 
 		const amend = amendEnvelopeWithIds(accountId)
 		return {
-			newMessages: response.data.newMessages.map(amend),
+			newMessages: response.data.newMessages.map((envelopes) => envelopes.map(amend)),
 			changedMessages: response.data.changedMessages.map(amend),
 			vanishedMessages: response.data.vanishedMessages,
 			stats: response.data.stats,

--- a/src/store/mainStore.js
+++ b/src/store/mainStore.js
@@ -80,6 +80,8 @@ export default defineStore('main', {
 				},
 			},
 			envelopes: {},
+			threads: {},
+			messageToThreadDictionnary: {},
 			messages: {},
 			newMessage: undefined,
 			showMessageComposer: false,

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -725,12 +725,10 @@ export default function mainStoreActions() {
 					const fetchUnifiedEnvelopes = pipe(
 						findIndividualMailboxes(this.getMailboxes, mailbox.specialRole),
 						fetchIndividualLists,
-						andThen(combineEnvelopeLists(this.getPreference('sort-order'))),
-						andThen(sliceToPage),
-						andThen(tap((envelopes) => this.addEnvelopesMutation({
-							envelopes,
+						andThen(tap((threadlist) => threadlist.forEach((threads) => this.addThreadsMutation({
+							threads,
 							query,
-						}))),
+						})))),
 					)
 
 					return fetchUnifiedEnvelopes(this.getAccounts)
@@ -738,9 +736,9 @@ export default function mainStoreActions() {
 
 				return pipe(
 					fetchEnvelopes,
-					andThen(tap((envelopes) => this.addEnvelopesMutation({
+					andThen(tap((threads) => this.addThreadsMutation({
 						query,
-						envelopes,
+						threads,
 						addToUnifiedMailboxes,
 					}))),
 				)(mailbox.accountId, mailboxId, query, undefined, PAGE_SIZE, this.getPreference('sort-order'), this.getPreference('layout-message-view'), includeCacheBuster ? mailbox.cacheBuster : undefined)
@@ -857,25 +855,17 @@ export default function mainStoreActions() {
 					return Promise.reject(new Error('Cannot find last envelope. Required for the mailbox cursor'))
 				}
 
-				return fetchEnvelopes(
-					mailbox.accountId,
-					mailboxId,
-					query,
-					lastEnvelope.dateInt,
-					quantity,
-					this.getPreference('sort-order'),
-					this.getPreference('layout-message-view'),
-				).then((envelopes) => {
-					logger.debug(`fetched ${envelopes.length} messages for mailbox ${mailboxId}`, {
-						envelopes,
+				return fetchEnvelopes(mailbox.accountId, mailboxId, query, lastEnvelope.dateInt, quantity, this.getPreference('sort-order'), this.getPreference('layout-message-view')).then((threads) => {
+					logger.debug(`fetched ${threads.length} messages for mailbox ${mailboxId}`, {
+						threads,
 						addToUnifiedMailboxes,
 					})
-					this.addEnvelopesMutation({
+					this.addThreadsMutation({
 						query,
-						envelopes,
+						threads,
 						addToUnifiedMailboxes,
 					})
-					return envelopes
+					return threads
 				})
 			})
 		},
@@ -928,16 +918,16 @@ export default function mainStoreActions() {
 
 						const unifiedMailbox = this.getUnifiedMailbox(mailbox.specialRole)
 
-						this.addEnvelopesMutation({
-							envelopes: syncData.newMessages,
+						this.addThreadsMutation({
+							threads: syncData.newMessages,
 							query,
 						})
 
-						syncData.newMessages.forEach((envelope) => {
+						syncData.newMessages.forEach((thread) => {
 							if (unifiedMailbox) {
-								this.updateEnvelopeMutation({
+								thread.forEach((envelope) => this.updateEnvelopeMutation({
 									envelope,
-								})
+								}))
 							}
 						})
 						syncData.changedMessages.forEach((envelope) => {
@@ -1874,7 +1864,7 @@ export default function mainStoreActions() {
 			if (this.getPreference('layout-message-view') === 'singleton') {
 				existing.push(envelope.databaseId)
 			} else {
-				const index = existing.findIndex((id) => this.envelopes[id].threadRootId === envelope.threadRootId)
+				const index = existing.findIndex((id) => this.getThreadKey(this.getEnvelope(id)) === this.getThreadKey(envelope))
 				if (index === -1) {
 					existing.push(envelope.databaseId)
 				} else {
@@ -2060,6 +2050,58 @@ export default function mainStoreActions() {
 			Vue.set(this.newMessage, 'type', 'outbox')
 			Vue.set(this.newMessage.data, 'id', message.id)
 		},
+		// Thread bucket key. threadRootId alone collides across accounts and is
+		// null for unthreaded messages, so scope it by account and fall back to
+		// the message's own id when there's no root.
+		getThreadKey(envelope) {
+			return `${envelope.accountId}:${envelope.threadRootId ?? envelope.databaseId}`
+		},
+		mergeEnvelopeIntoThread(threadKey, message) {
+			if (this.threads[threadKey] === undefined) {
+				Vue.set(this.threads, threadKey, {})
+			}
+			const existing = this.threads[threadKey][message.databaseId]
+			const merged = existing ? { ...existing, ...message } : message
+			// Preserve attachments already fetched if the incoming payload lacks
+			// them (e.g. the /thread endpoint does not return attachment metadata),
+			// so they don't vanish on sync or when the thread is opened.
+			if ((merged.attachments?.length ?? 0) === 0 && (existing?.attachments?.length ?? 0) > 0) {
+				merged.attachments = existing.attachments
+			}
+			Vue.set(this.threads[threadKey], message.databaseId, merged)
+			Vue.set(this.messageToThreadDictionnary, message.databaseId, threadKey)
+		},
+		addThreadsMutation({
+			query,
+			threads,
+			addToUnifiedMailboxes = true,
+		}) {
+			if (threads.length === 0) {
+				return
+			}
+			const isThreaded = this.getPreference('layout-message-view') === 'threaded'
+			if (isThreaded) {
+				threads.forEach((thread) => {
+					thread.forEach((message) => {
+						Vue.set(message, 'accountId', this.mailboxes[message.mailboxId].accountId)
+						this.mergeEnvelopeIntoThread(this.getThreadKey(message), message)
+					})
+				})
+			} else {
+				threads.forEach((thread) => {
+					this.mergeEnvelopeIntoThread(thread[0].databaseId, thread[0])
+				})
+			}
+			// Only the representative (thread[0], the latest message in this
+			// mailbox per the backend) goes into the list; the rest are kept in
+			// this.threads above and shown when the thread is opened.
+			const representatives = threads.map((thread) => thread[0])
+			this.addEnvelopesMutation({
+				query,
+				envelopes: representatives,
+				addToUnifiedMailboxes,
+			})
+		},
 		addEnvelopesMutation({
 			query,
 			envelopes,
@@ -2068,18 +2110,23 @@ export default function mainStoreActions() {
 			if (envelopes.length === 0) {
 				return
 			}
-
-			const idToDateInt = (id) => this.envelopes[id].dateInt
+			const idToDateInt = (id) => this.getEnvelope(id).dateInt
 
 			const listId = normalizedEnvelopeListId(query)
 			const orderByDateInt = orderBy(idToDateInt, this.preferences['sort-order'] === 'newest' ? 'desc' : 'asc')
-
 			envelopes.forEach((envelope) => {
 				const mailbox = this.mailboxes[envelope.mailboxId]
 				const existing = mailbox.envelopeLists[listId] || []
 				this.normalizeTags(envelope)
-				Vue.set(this.envelopes, envelope.databaseId, { ...this.envelopes[envelope.databaseId] || {}, ...envelope })
 				Vue.set(envelope, 'accountId', mailbox.accountId)
+				const threadKey = this.getThreadKey(envelope)
+				if (this.threads[threadKey] === undefined) {
+					Vue.set(this.threads, threadKey, {})
+				}
+				if (this.threads[threadKey][envelope.databaseId] === undefined) {
+					Vue.set(this.threads[threadKey], envelope.databaseId, envelope)
+					Vue.set(this.messageToThreadDictionnary, envelope.databaseId, threadKey)
+				}
 				Vue.set(mailbox.envelopeLists, listId, uniq(orderByDateInt(this.appendOrReplaceEnvelopeId(existing, envelope))))
 				if (!addToUnifiedMailboxes) {
 					return
@@ -2099,7 +2146,7 @@ export default function mainStoreActions() {
 			})
 		},
 		updateEnvelopeMutation({ envelope }) {
-			const existing = this.envelopes[envelope.databaseId]
+			const existing = this.getEnvelope(envelope.databaseId)
 			if (!existing) {
 				return
 			}
@@ -2157,8 +2204,11 @@ export default function mainStoreActions() {
 		}) {
 			Vue.set(envelope, 'tags', envelope.tags.filter((id) => id !== tagId))
 		},
+		removeThreadMutation({ id }) {
+			Vue.delete(this.threads, id)
+		},
 		removeEnvelopeMutation({ id }) {
-			const envelope = this.envelopes[id]
+			const envelope = this.getEnvelope(id)
 			if (!envelope) {
 				logger.warn('envelope ' + id + ' is unknown, can\'t remove it')
 				return
@@ -2181,6 +2231,16 @@ export default function mainStoreActions() {
 				Vue.set(mailbox, 'unread', mailbox.unread - 1)
 			}
 
+			// Remove envelope from its thread
+			const threadKey = this.getThreadKey(envelope)
+			if (this.threads[threadKey]) {
+				const thread = this.threads[threadKey]
+				Vue.delete(thread, id)
+				Vue.delete(this.messageToThreadDictionnary, id)
+				if (Object.keys(this.threads[threadKey]).length === 0) {
+					Vue.delete(this.threads, threadKey)
+				}
+			}
 			this.accountsUnmapped[UNIFIED_ACCOUNT_ID].mailboxes
 				.map((mailboxId) => this.mailboxes[mailboxId])
 				.filter((mb) => mb.specialRole && mb.specialRole === mailbox.specialRole)
@@ -2199,18 +2259,6 @@ export default function mainStoreActions() {
 						list.splice(idx, 1)
 					}
 				})
-
-			// Delete references from other threads
-			for (const [key, env] of Object.entries(this.envelopes)) {
-				if (!env.thread) {
-					continue
-				}
-
-				const thread = env.thread.filter((threadId) => threadId !== id)
-				Vue.set(this.envelopes[key], 'thread', thread)
-			}
-
-			Vue.delete(this.envelopes, id)
 		},
 		removeEnvelopesMutation({ id }) {
 			Vue.set(this.mailboxes[id], 'envelopeLists', {})
@@ -2256,22 +2304,14 @@ export default function mainStoreActions() {
 			id,
 			thread,
 		}) {
-			// Store the envelopes, merge into any existing object if one exists
+			// Merge each fetched message into the existing thread bucket so
+			// previously loaded data (e.g. attachments) is preserved.
 			thread.forEach((e) => {
 				this.normalizeTags(e)
 				const mailbox = this.mailboxes[e.mailboxId]
 				Vue.set(e, 'accountId', mailbox.accountId)
-				const existing = this.envelopes[e.databaseId] || {}
-				const merged = { ...existing, ...e }
-				// preserve attachments
-				if (existing.attachments && existing.attachments.length > 0) {
-					merged.attachments = existing.attachments
-				}
-				Vue.set(this.envelopes, e.databaseId, merged)
+				this.mergeEnvelopeIntoThread(this.getThreadKey(e), e)
 			})
-
-			// Store the references
-			Vue.set(this.envelopes[id], 'thread', thread.map((e) => e.databaseId))
 		},
 		removeMessageMutation({ id }) {
 			Vue.delete(this.messages, id)
@@ -2453,29 +2493,41 @@ export default function mainStoreActions() {
 				.filter((mailbox) => mailbox.specialRole === specialRole))
 		},
 		getEnvelope(id) {
-			return this.envelopes[id]
+			const isThreaded = this.getPreference('layout-message-view') === 'threaded'
+			if (isThreaded) {
+				const threadKey = this.messageToThreadDictionnary[id]
+				return this.threads[threadKey]?.[id]
+			}
+			return this.threads[id]?.[id]
 		},
 		getEnvelopes(mailboxId, query) {
 			const list = this.getMailbox(mailboxId).envelopeLists[normalizedEnvelopeListId(query)] || []
-			return list.map((msgId) => this.envelopes[msgId])
+			return list.map((msgId) => this.getEnvelope(msgId)).filter((message) => message)
 		},
-		getEnvelopesByThreadRootId(accountId, threadRootId) {
+		getEnvelopesByThreadRootId(envelope) {
 			return sortBy(
 				prop('dateInt'),
-				Object.values(this.envelopes).filter((envelope) => envelope.accountId === accountId && envelope.threadRootId === threadRootId),
+				Object.values(this.threads[this.getThreadKey(envelope)] ?? {}),
 			)
 		},
 		getMessage(id) {
 			return this.messages[id]
 		},
 		getEnvelopeThread(id) {
-			logger.debug('get thread for envelope', { id, envelope: this.envelopes[id] })
-			const thread = this.envelopes[id]?.thread ?? []
-			const envelopes = thread.map((id) => this.envelopes[id])
-			return sortBy(prop('dateInt'), envelopes)
+			const isThreaded = this.getPreference('layout-message-view') === 'threaded'
+			const threadKey = isThreaded ? this.messageToThreadDictionnary[id] : id
+			const envelopes = this.threads[threadKey] ?? {}
+			return sortBy(prop('dateInt'), Object.values(envelopes))
 		},
 		getEnvelopeTags(id) {
-			const tags = this.envelopes[id]?.tags ?? []
+			const envelope = this.getEnvelope(id)
+			if (!envelope) {
+				return []
+			}
+			if (!Array.isArray(envelope.tags)) {
+				this.normalizeTags(envelope)
+			}
+			const tags = envelope.tags
 			return tags.map((tagId) => this.tags[tagId])
 		},
 		getTag(id) {

--- a/src/store/mainStore/getters.js
+++ b/src/store/mainStore/getters.js
@@ -25,7 +25,8 @@ export default function mainStore() {
 			return Object.values(state.tags).find((tag) => tag.imapLabel === FOLLOW_UP_TAG_LABEL)
 		},
 		getFollowUpReminderEnvelopes: (state) => {
-			return Object.values(state.envelopes)
+			return Object.values(state.threads)
+				.flatMap((thread) => Object.values(thread))
 				.filter((envelope) => envelope.tags
 					?.map((tagId) => state.tags[tagId])
 					.some((tag) => tag.imapLabel === FOLLOW_UP_TAG_LABEL))

--- a/src/tests/unit/components/Thread.vue.spec.js
+++ b/src/tests/unit/components/Thread.vue.spec.js
@@ -52,8 +52,8 @@ describe('Thread', () => {
 			return undefined
 		})
 
-		store.getEnvelopesByThreadRootId = vi.fn().mockImplementation((accountId, threadRootId) => {
-			if (threadRootId === '123-456-789') {
+		store.getEnvelopesByThreadRootId = vi.fn().mockImplementation((envelope) => {
+			if (envelope.threadRootId === '123-456-789') {
 				return [
 					{
 						accountId: 100,
@@ -84,7 +84,7 @@ describe('Thread', () => {
 					},
 				]
 			}
-			if (threadRootId === '456-789-123') {
+			if (envelope.threadRootId === '456-789-123') {
 				return [
 					{
 						accountId: 200,

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -165,34 +165,28 @@ describe('Vuex store actions', () => {
 			},
 		})
 
-		store.addEnvelopesMutation = vi.fn()
+		store.addThreadsMutation = vi.fn()
 
-		MessageService.fetchEnvelopes.mockReturnValueOnce(Promise.resolve([{
+		MessageService.fetchEnvelopes.mockReturnValueOnce(Promise.resolve([[{
 			databaseId: 123,
 			mailboxId: 21,
 			uid: 321,
 			subject: 'msg1',
-		}]))
+			threadRootId: 'root-1',
+		}]]))
 
-		const envelopes = await store.fetchEnvelopes({
+		await store.fetchEnvelopes({
 			mailboxId: UNIFIED_INBOX_ID,
 		})
 
-		expect(envelopes).toEqual([
-			{
+		expect(store.addThreadsMutation).toBeCalledWith({
+			threads: [[{
 				databaseId: 123,
 				mailboxId: 21,
 				uid: 321,
 				subject: 'msg1',
-			},
-		])
-		expect(store.addEnvelopesMutation).toBeCalledWith({
-			envelopes: [{
-				databaseId: 123,
-				mailboxId: 21,
-				uid: 321,
-				subject: 'msg1',
-			}],
+				threadRootId: 'root-1',
+			}]],
 			query: undefined,
 		})
 	})
@@ -232,13 +226,13 @@ describe('Vuex store actions', () => {
 			addToUnifiedMailboxes: true,
 		})
 
-		// Mock fetching next pages
+		// Mock fetching next pages (threaded view returns one group per thread)
 		MessageService.fetchEnvelopes.mockImplementation(async (accountId, mailboxId) => {
 			if (accountId !== 13 || mailboxId !== 11) {
 				return []
 			}
 
-			return page1.map(mockEnvelope(11))
+			return page1.map(mockEnvelope(11)).map((e) => [e])
 		})
 
 		await store.fetchNextEnvelopePage({
@@ -274,6 +268,7 @@ describe('Vuex store actions', () => {
 		}
 
 		store.preferences['sort-order'] = 'newest'
+		store.preferences['layout-message-view'] = 'threaded'
 
 		store.addAccountMutation(account13)
 		store.addMailboxMutation({
@@ -397,7 +392,7 @@ describe('Vuex store actions', () => {
 			}
 
 			expect(sortOrder).toBe('newest')
-			return page2.map(mockEnvelope(11)).filter((e) => e.dateInt < cursor).slice(0, limit)
+			return page2.map(mockEnvelope(11)).filter((e) => e.dateInt < cursor).slice(0, limit).map((e) => [e])
 		})
 
 		await store.fetchNextEnvelopePage({

--- a/src/tests/unit/store/getters.spec.js
+++ b/src/tests/unit/store/getters.spec.js
@@ -54,123 +54,55 @@ describe('Pinia main store getters', () => {
 		})
 	})
 	it('returns an envelope\'s empty thread', () => {
-		store.envelopes[1] = {
-			databaseId: 1,
-			uid: 101,
-			mailboxId: 13,
-		}
-
 		const thread = store.getEnvelopeThread(1)
 
 		expect(thread.length).toEqual(0)
 	})
-	it('returns an envelope\'s empty thread', () => {
-		store.envelopes[1] = {
-			databaseId: 1,
-			uid: 101,
-			mailboxId: 13,
-			thread: [
-				1,
-				2,
-				3,
-			],
-		}
-		store.envelopes[2] = {
-			databaseId: 1,
-			uid: 101,
-			mailboxId: 13,
-		}
-		store.envelopes[3] = {
-			databaseId: 1,
-			uid: 101,
-			mailboxId: 13,
-		}
+	it('returns an envelope\'s thread', () => {
+		store.$patch({
+			threads: {
+				'1:root-1': {
+					1: { accountId: 1, databaseId: 1, uid: 101, mailboxId: 13, threadRootId: 'root-1', dateInt: 1 },
+					2: { accountId: 1, databaseId: 2, uid: 102, mailboxId: 13, threadRootId: 'root-1', dateInt: 2 },
+					3: { accountId: 1, databaseId: 3, uid: 103, mailboxId: 13, threadRootId: 'root-1', dateInt: 3 },
+				},
+			},
+			messageToThreadDictionnary: { 1: '1:root-1', 2: '1:root-1', 3: '1:root-1' },
+			preferences: { 'layout-message-view': 'threaded' },
+		})
 
 		const thread = store.getEnvelopeThread(1)
 
-		expect(thread.length).toBeGreaterThanOrEqual(1)
-		expect(thread).toEqual([
-			{
-				databaseId: 1,
-				uid: 101,
-				mailboxId: 13,
-				thread: [
-					1,
-					2,
-					3,
-				],
-			},
-			{
-				databaseId: 1,
-				uid: 101,
-				mailboxId: 13,
-			},
-			{
-				databaseId: 1,
-				uid: 101,
-				mailboxId: 13,
-			},
-		])
+		expect(thread.length).toEqual(3)
+		expect(thread.map((e) => e.databaseId)).toEqual([1, 2, 3])
 	})
 
 	it('return envelopes by thread root id', () => {
-		store.envelopes[0] = {
-			accountId: 1,
-			databaseId: 1,
-			uid: 101,
-			mailboxId: 13,
-			threadRootId: '123-456-789',
-		}
-		store.envelopes[1] = {
-			accountId: 1,
-			databaseId: 2,
-			uid: 102,
-			mailboxId: 13,
-			threadRootId: '123-456-789',
-		}
-		store.envelopes[2] = {
-			accountId: 1,
-			databaseId: 3,
-			uid: 103,
-			mailboxId: 13,
-			threadRootId: '234-567-890',
-		}
-		store.envelopes[3] = {
-			accountId: 1,
-			databaseId: 4,
-			uid: 104,
-			mailboxId: 13,
-			threadRootId: '234-567-890',
-		}
-		store.envelopes[4] = {
-			accountId: 2,
-			databaseId: 5,
-			uid: 105,
-			mailboxId: 23,
-			threadRootId: '123-456-789',
-		}
+		store.$patch({
+			threads: {
+				'1:123-456-789': {
+					1: { accountId: 1, databaseId: 1, uid: 101, mailboxId: 13, threadRootId: '123-456-789', dateInt: 1 },
+					2: { accountId: 1, databaseId: 2, uid: 102, mailboxId: 13, threadRootId: '123-456-789', dateInt: 2 },
+				},
+				'1:234-567-890': {
+					3: { accountId: 1, databaseId: 3, uid: 103, mailboxId: 13, threadRootId: '234-567-890', dateInt: 3 },
+					4: { accountId: 1, databaseId: 4, uid: 104, mailboxId: 13, threadRootId: '234-567-890', dateInt: 4 },
+				},
+			},
+		})
 
-		const envelopesA = store.getEnvelopesByThreadRootId(1, '123-456-789')
+		const envelopesA = store.getEnvelopesByThreadRootId({ accountId: 1, threadRootId: '123-456-789' })
 		expect(envelopesA.length).toEqual(2)
-		expect(envelopesA).toEqual([
-			{
-				accountId: 1,
-				databaseId: 1,
-				uid: 101,
-				mailboxId: 13,
-				threadRootId: '123-456-789',
-			},
-			{
-				accountId: 1,
-				databaseId: 2,
-				uid: 102,
-				mailboxId: 13,
-				threadRootId: '123-456-789',
-			},
-		])
+		expect(envelopesA.map((e) => e.databaseId)).toEqual([1, 2])
 
-		const envelopesB = store.getEnvelopesByThreadRootId('345-678-901')
+		const envelopesB = store.getEnvelopesByThreadRootId({ accountId: 1, threadRootId: '345-678-901' })
 		expect(envelopesB.length).toEqual(0)
+	})
+
+	it('returns undefined for an envelope that is not loaded', () => {
+		store.$patch({ preferences: { 'layout-message-view': 'threaded' } })
+
+		expect(store.getEnvelope(999)).toBeUndefined()
 	})
 
 	it('find mailbox by special role: inbox', () => {

--- a/src/tests/unit/store/mutations.spec.js
+++ b/src/tests/unit/store/mutations.spec.js
@@ -620,7 +620,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
-			preferences: { 'sort-order': 'newest' },
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
 		})
 
 		store.addEnvelopesMutation({
@@ -631,6 +631,7 @@ describe('Pinia store mutations', () => {
 				id: 123,
 				subject: 'henlo',
 				uid: 321,
+				threadRootId: '123-456-789',
 			}],
 		})
 
@@ -642,15 +643,20 @@ describe('Pinia store mutations', () => {
 					mailboxes: [],
 				},
 			},
-			envelopes: {
-				12345: {
-					mailboxId: 27,
-					databaseId: 12345,
-					uid: 321,
-					id: 123,
-					subject: 'henlo',
-					tags: [],
+			threads: {
+				'13:123-456-789': {
+					12345: {
+						mailboxId: 27,
+						databaseId: 12345,
+						uid: 321,
+						id: 123,
+						subject: 'henlo',
+						tags: [],
+					},
 				},
+			},
+			messageToThreadDictionnary: {
+				12345: '13:123-456-789',
 			},
 			mailboxes: {
 				27: {
@@ -686,7 +692,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
-			preferences: { 'sort-order': 'newest' },
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
 		})
 
 		store.addEnvelopesMutation({
@@ -720,25 +726,33 @@ describe('Pinia store mutations', () => {
 					mailboxes: [],
 				},
 			},
-			envelopes: {
-				12345: {
-					mailboxId: 27,
-					databaseId: 12345,
-					uid: 321,
-					id: 123,
-					subject: 'henlo',
-					tags: [],
-					threadRootId: '123-456-789',
+			threads: {
+				'13:123-456-789': {
+					12345: {
+						mailboxId: 27,
+						databaseId: 12345,
+						uid: 321,
+						id: 123,
+						subject: 'henlo',
+						tags: [],
+						threadRootId: '123-456-789',
+					},
 				},
-				12346: {
-					mailboxId: 27,
-					databaseId: 12346,
-					id: 124,
-					subject: 'henlo 2',
-					uid: 322,
-					tags: [],
-					threadRootId: '234-567-890',
+				'13:234-567-890': {
+					12346: {
+						mailboxId: 27,
+						databaseId: 12346,
+						id: 124,
+						subject: 'henlo 2',
+						uid: 322,
+						tags: [],
+						threadRootId: '234-567-890',
+					},
 				},
+			},
+			messageToThreadDictionnary: {
+				12345: '13:123-456-789',
+				12346: '13:234-567-890',
 			},
 			mailboxes: {
 				27: {
@@ -780,7 +794,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
-			preferences: { 'sort-order': 'newest' },
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
 		})
 
 		store.addEnvelopesMutation({
@@ -790,6 +804,7 @@ describe('Pinia store mutations', () => {
 				databaseId: 12345,
 				subject: 'henlo',
 				uid: 321,
+				threadRootId: '123-456-789',
 			}],
 		})
 
@@ -801,14 +816,19 @@ describe('Pinia store mutations', () => {
 					mailboxes: [UNIFIED_INBOX_ID],
 				},
 			},
-			envelopes: {
-				12345: {
-					databaseId: 12345,
-					mailboxId: 27,
-					uid: 321,
-					subject: 'henlo',
-					tags: [],
+			threads: {
+				'2:123-456-789': {
+					12345: {
+						databaseId: 12345,
+						mailboxId: 27,
+						uid: 321,
+						subject: 'henlo',
+						tags: [],
+					},
 				},
+			},
+			messageToThreadDictionnary: {
+				12345: '2:123-456-789',
 			},
 			mailboxes: {
 				27: {
@@ -842,19 +862,27 @@ describe('Pinia store mutations', () => {
 					mailboxes: [UNIFIED_INBOX_ID, PRIORITY_INBOX_ID],
 				},
 			},
-			envelopes: {
-				12345: {
-					mailboxId: 27,
-					id: 123,
-					uid: 12345,
-				},
-				12346: {
-					mailboxId: 27,
-					id: 123,
-					uid: 12345,
-					thread: [12345, 12346],
+			threads: {
+				'1:root-1': {
+					12345: {
+						mailboxId: 27,
+						accountId: 1,
+						databaseId: 12345,
+						id: 123,
+						uid: 12345,
+						threadRootId: 'root-1',
+					},
+					12346: {
+						mailboxId: 27,
+						accountId: 1,
+						databaseId: 12346,
+						id: 124,
+						uid: 12346,
+						threadRootId: 'root-1',
+					},
 				},
 			},
+			messageToThreadDictionnary: { 12345: '1:root-1', 12346: '1:root-1' },
 			mailboxes: {
 				27: {
 					specialUse: ['inbox'],
@@ -882,6 +910,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
+			preferences: { 'layout-message-view': 'threaded' },
 		})
 
 		store.removeEnvelopeMutation({
@@ -896,14 +925,19 @@ describe('Pinia store mutations', () => {
 					mailboxes: [UNIFIED_INBOX_ID, PRIORITY_INBOX_ID],
 				},
 			},
-			envelopes: {
-				12346: {
-					mailboxId: 27,
-					id: 123,
-					uid: 12345,
-					thread: [12346],
+			threads: {
+				'1:root-1': {
+					12346: {
+						mailboxId: 27,
+						accountId: 1,
+						databaseId: 12346,
+						id: 124,
+						uid: 12346,
+						threadRootId: 'root-1',
+					},
 				},
 			},
+			messageToThreadDictionnary: { 12346: '1:root-1' },
 			mailboxes: {
 				27: {
 					specialUse: ['inbox'],
@@ -932,15 +966,12 @@ describe('Pinia store mutations', () => {
 			tagList: [],
 			tags: {},
 		})
+
+		expect(store.threads['1:root-1']).not.toHaveProperty('12345')
+		expect(store.messageToThreadDictionnary).not.toHaveProperty('12345')
 	})
 
 	it('adds a thread', () => {
-		const envelope = {
-			databaseId: 123,
-			mailboxId: 27,
-			uid: 12345,
-			attachments: [{ id: 1, fileName: 'example' }],
-		}
 		store.$patch({
 			mailboxes: {
 				27: {
@@ -948,9 +979,19 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				[envelope.databaseId]: envelope,
+			threads: {
+				'1:root-1': {
+					123: {
+						databaseId: 123,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12345,
+						threadRootId: 'root-1',
+						attachments: [{ id: 1, fileName: 'example' }],
+					},
+				},
 			},
+			messageToThreadDictionnary: { 123: '1:root-1' },
 			tagList: [],
 			tags: {},
 		})
@@ -962,17 +1003,20 @@ describe('Pinia store mutations', () => {
 					databaseId: 122,
 					mailboxId: 27,
 					uid: 12344,
+					threadRootId: 'root-1',
 				},
 				{
 					databaseId: 123,
 					mailboxId: 27,
 					uid: 12345,
+					threadRootId: 'root-1',
 					attachments: [],
 				},
 				{
 					databaseId: 124,
 					mailboxId: 27,
 					uid: 12346,
+					threadRootId: 'root-1',
 				},
 			],
 		})
@@ -984,35 +1028,34 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				122: {
-					databaseId: 122,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12344,
-					tags: [],
-				},
-				123: {
-					databaseId: 123,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12345,
-					thread: [
-						122,
-						123,
-						124,
-					],
-					tags: [],
-					attachments: [{ id: 1, fileName: 'example' }],
-				},
-				124: {
-					databaseId: 124,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12346,
-					tags: [],
+			threads: {
+				'1:root-1': {
+					122: {
+						databaseId: 122,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12344,
+						tags: [],
+					},
+					123: {
+						databaseId: 123,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12345,
+						tags: [],
+						// attachments preserved from the previously loaded envelope
+						attachments: [{ id: 1, fileName: 'example' }],
+					},
+					124: {
+						databaseId: 124,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12346,
+						tags: [],
+					},
 				},
 			},
+			messageToThreadDictionnary: { 122: '1:root-1', 123: '1:root-1', 124: '1:root-1' },
 			tagList: [],
 			tags: {},
 		})
@@ -1037,7 +1080,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
-			preferences: { 'sort-order': 'newest' },
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
 		})
 
 		store.addEnvelopesMutation({
@@ -1049,6 +1092,7 @@ describe('Pinia store mutations', () => {
 				id: 123,
 				subject: 'henlo',
 				uid: 321,
+				threadRootId: 'root-1',
 				tags: {
 					1: {
 						id: 1,
@@ -1070,15 +1114,17 @@ describe('Pinia store mutations', () => {
 					mailboxes: [],
 				},
 			},
-			envelopes: {
-				12345: {
-					mailboxId: 27,
-					databaseId: 12345,
-					attachments: [],
-					uid: 321,
-					id: 123,
-					subject: 'henlo',
-					tags: [1],
+			threads: {
+				'13:root-1': {
+					12345: {
+						mailboxId: 27,
+						databaseId: 12345,
+						attachments: [],
+						uid: 321,
+						id: 123,
+						subject: 'henlo',
+						tags: [1],
+					},
 				},
 			},
 			mailboxes: {
@@ -1120,6 +1166,7 @@ describe('Pinia store mutations', () => {
 			databaseId: 123,
 			mailboxId: 27,
 			uid: 12345,
+			threadRootId: 'root-1',
 		}
 		store.$patch({
 			mailboxes: {
@@ -1128,9 +1175,12 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				[envelope.databaseId]: envelope,
+			threads: {
+				'1:root-1': {
+					[envelope.databaseId]: envelope,
+				},
 			},
+			messageToThreadDictionnary: { 123: '1:root-1' },
 			// State contains old version of envelope with no label
 			tagList: [],
 			tags: {},
@@ -1143,6 +1193,7 @@ describe('Pinia store mutations', () => {
 					databaseId: 122,
 					mailboxId: 27,
 					uid: 12344,
+					threadRootId: 'root-1',
 					tags: {
 						$label1: tag,
 					},
@@ -1151,6 +1202,7 @@ describe('Pinia store mutations', () => {
 					databaseId: 123,
 					mailboxId: 27,
 					uid: 12345,
+					threadRootId: 'root-1',
 					tags: {
 						$label1: tag,
 					},
@@ -1165,24 +1217,22 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				122: {
-					databaseId: 122,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12344,
-					tags: [1],
-				},
-				123: {
-					databaseId: 123,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12345,
-					thread: [
-						122,
-						123,
-					],
-					tags: [1],
+			threads: {
+				'1:root-1': {
+					122: {
+						databaseId: 122,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12344,
+						tags: [1],
+					},
+					123: {
+						databaseId: 123,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12345,
+						tags: [1],
+					},
 				},
 			},
 			tagList: [
@@ -1207,6 +1257,7 @@ describe('Pinia store mutations', () => {
 			mailboxId: 27,
 			uid: 12345,
 			accountId: 1,
+			threadRootId: 'root-1',
 		}
 		store.$patch({
 			mailboxes: {
@@ -1215,12 +1266,16 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				[envelope.databaseId]: envelope,
+			threads: {
+				'root-1': {
+					[envelope.databaseId]: envelope,
+				},
 			},
+			messageToThreadDictionnary: { 123: 'root-1' },
 			// State contains old version of envelope with no label
 			tagList: [],
 			tags: {},
+			preferences: { 'layout-message-view': 'threaded' },
 		})
 
 		store.updateEnvelopeMutation({
@@ -1246,14 +1301,16 @@ describe('Pinia store mutations', () => {
 					accountId: 1,
 				},
 			},
-			envelopes: {
-				123: {
-					databaseId: 123,
-					mailboxId: 27,
-					accountId: 1,
-					uid: 12345,
-					flags: undefined,
-					tags: [1],
+			threads: {
+				'root-1': {
+					123: {
+						databaseId: 123,
+						mailboxId: 27,
+						accountId: 1,
+						uid: 12345,
+						flags: undefined,
+						tags: [1],
+					},
 				},
 			},
 			tagList: [
@@ -1421,7 +1478,7 @@ describe('Pinia store mutations', () => {
 			},
 			tagList: [],
 			tags: {},
-			preferences: { 'sort-order': 'newest' },
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
 		})
 
 		store.addEnvelopesMutation({
@@ -1451,5 +1508,43 @@ describe('Pinia store mutations', () => {
 		})
 
 		expect(store.mailboxes[27].envelopeLists[''].length).toEqual(1)
+	})
+
+	it('adds only the thread representative to the list but keeps all members', () => {
+		store.$patch({
+			accountsUnmapped: {
+				[UNIFIED_ACCOUNT_ID]: {
+					accountId: UNIFIED_ACCOUNT_ID,
+					id: UNIFIED_ACCOUNT_ID,
+					mailboxes: [],
+				},
+			},
+			mailboxes: {
+				27: {
+					name: 'INBOX',
+					databaseId: 27,
+					accountId: 13,
+					envelopeLists: {},
+				},
+			},
+			tagList: [],
+			tags: {},
+			preferences: { 'sort-order': 'newest', 'layout-message-view': 'threaded' },
+		})
+
+		store.addThreadsMutation({
+			query: undefined,
+			addToUnifiedMailboxes: false,
+			threads: [[
+				{ databaseId: 1, mailboxId: 27, uid: 1, dateInt: 3, threadRootId: 'root-1' },
+				{ databaseId: 2, mailboxId: 27, uid: 2, dateInt: 2, threadRootId: 'root-1' },
+				{ databaseId: 3, mailboxId: 27, uid: 3, dateInt: 1, threadRootId: 'root-1' },
+			]],
+		})
+
+		// Only the representative (thread[0]) is shown in the list
+		expect(store.mailboxes[27].envelopeLists['']).toEqual([1])
+		// All members are stored so the thread can be expanded when opened
+		expect(Object.keys(store.threads['13:root-1'])).toEqual(['1', '2', '3'])
 	})
 })

--- a/tests/Integration/Db/MessageMapperTest.php
+++ b/tests/Integration/Db/MessageMapperTest.php
@@ -45,6 +45,7 @@ class MessageMapperTest extends TestCase {
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')->willReturnCallback(fn () => $this->timestamp);
 		$tagMapper = $this->createMock(TagMapper::class);
+		$tagMapper->method('getAllTagsForMessages')->willReturn([]);
 		$performanceLogger = $this->createMock(PerformanceLogger::class);
 		$this->mapper = new MessageMapper(
 			$this->db,
@@ -269,5 +270,23 @@ class MessageMapperTest extends TestCase {
 
 		$mails = $this->mapper->findIdsAfter($mailbox, 2, 1234567890 + 200, 5);
 		$this->assertEquals([], $mails);
+	}
+
+	public function testFindMessageListsByIdsKeepsUnthreadedMessagesSeparate(): void {
+		$account = $this->createMock(Account::class);
+		$account->method('getId')->willReturn(13);
+		array_map(function ($i) {
+			$this->insertMessageWithId($i, 1);
+		}, range(1, 3));
+
+		$lists = $this->mapper->findMessageListsByIds($account, 'user', [1, 2, 3], 'DESC', true);
+
+		$this->assertCount(3, $lists);
+		foreach ($lists as $list) {
+			$this->assertCount(1, $list);
+		}
+		$ids = array_map(static fn (array $list) => $list[0]->getId(), $lists);
+		sort($ids);
+		$this->assertEquals([1, 2, 3], $ids);
 	}
 }

--- a/tests/Integration/MailboxSynchronizationTest.php
+++ b/tests/Integration/MailboxSynchronizationTest.php
@@ -139,7 +139,8 @@ class MailboxSynchronizationTest extends TestCase {
 		$syncJson = $jsonResponse->getData()->jsonSerialize();
 
 		self::assertCount(1, $syncJson['newMessages']);
-		self::assertEquals($newUid, $syncJson['newMessages'][0]->getUid());
+		// newMessages is grouped by thread (Message[][]); the new message is its own thread
+		self::assertEquals($newUid, $syncJson['newMessages'][0][0]->getUid());
 		self::assertCount(0, $syncJson['changedMessages']);
 		self::assertCount(0, $syncJson['vanishedMessages']);
 	}

--- a/tests/Unit/IMAP/PreviewEnhancerTest.php
+++ b/tests/Unit/IMAP/PreviewEnhancerTest.php
@@ -58,7 +58,8 @@ class PreviewEnhancerTest extends TestCase {
 			$this->dbMapper,
 			$this->logger,
 			$this->avatarService,
-			$this->attachmentService
+			$this->attachmentService,
+			$this->createMock(\OCA\Mail\Db\MailboxMapper::class),
 		);
 	}
 

--- a/tests/Unit/Service/Search/MailSearchTest.php
+++ b/tests/Unit/Service/Search/MailSearchTest.php
@@ -139,16 +139,16 @@ class MailSearchTest extends TestCase {
 			->with('my search')
 			->willReturn($query);
 		$this->messageMapper->expects($this->once())
-			->method('findByIds')
+			->method('findMessageListsByIds')
 			->willReturn([
-				$this->createMock(Message::class),
-				$this->createMock(Message::class),
+				[$this->createMock(Message::class)],
+				[$this->createMock(Message::class)],
 			]);
 		$this->imapSearchProvider->expects($this->never())
 			->method('findMatches');
 		$this->previewEnhancer->expects($this->once())
-			->method('process')
-			->willReturnArgument(2);
+			->method('processMany')
+			->willReturnArgument(1);
 
 		$messages = $this->search->findMessages(
 			$account,
@@ -185,14 +185,14 @@ class MailSearchTest extends TestCase {
 			->with($account, $mailbox, $query)
 			->willReturn([2, 3]);
 		$this->messageMapper->expects($this->once())
-			->method('findByIds')
+			->method('findMessageListsByIds')
 			->willReturn([
-				$this->createMock(Message::class),
-				$this->createMock(Message::class),
+				[$this->createMock(Message::class)],
+				[$this->createMock(Message::class)],
 			]);
 		$this->previewEnhancer->expects($this->once())
-			->method('process')
-			->willReturnArgument(2);
+			->method('processMany')
+			->willReturnArgument(1);
 
 		$messages = $this->search->findMessages(
 			$account,

--- a/tests/Unit/Service/Sync/SyncServiceTest.php
+++ b/tests/Unit/Service/Sync/SyncServiceTest.php
@@ -55,7 +55,9 @@ final class SyncServiceTest extends TestCase {
 			$this->messageMapper,
 			$this->createStub(PreviewEnhancer::class),
 			$this->createStub(\Psr\Log\LoggerInterface::class),
-			$this->mailboxSync
+			$this->mailboxSync,
+			$this->createStub(\OCP\IAppConfig::class),
+			$this->createStub(\OCA\Mail\Contracts\IUserPreferences::class),
 		);
 	}
 


### PR DESCRIPTION
Ref https://github.com/nextcloud/mail/issues/11065#issuecomment-3083354991

PR revived with assistance from Claude:claude-opus-4-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Threaded mail views now support conversation-aware grouping for sync and search results.
  * Thread message retrieval and ordering are now configurable (defaulting to newest-first).

* **Bug Fixes**
  * Improved threaded attachment display by aggregating attachments across the full conversation.
  * Updated thread ordering for more consistent newest-first behavior.

* **Tests**
  * Updated unit/integration tests to reflect grouped (nested) message results and threaded state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->