### PR TITLE
fix(ui): revert composer session close icon to filled variant

### DIFF
--- a/src/components/ComposerSessionIndicator.vue
+++ b/src/components/ComposerSessionIndicator.vue
@@ -41,7 +41,7 @@
 import { NcActions, NcActionButton } from '@nextcloud/vue'
 import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
 import ArrowExpandIcon from 'vue-material-design-icons/ArrowExpand.vue'
-import CloseIcon from 'vue-material-design-icons/CloseOutline.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
 import useMainStore from '../store/mainStore.js'
 import { mapStores, mapState } from 'pinia'
 


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="430" height="163" alt="Bildschirmfoto vom 2025-08-20 10-17-11" src="https://github.com/user-attachments/assets/62e6625c-b533-46b6-96f1-290ae8fc1f35" /> | <img width="430" height="163" alt="Bildschirmfoto vom 2025-08-20 10-17-39" src="https://github.com/user-attachments/assets/891bcd64-7631-4f4c-bf17-713bab1d8da9" /> | 

