### PR TITLE
fix(ui): use gradient as fallback for themed fluid design

### DIFF
--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -5,7 +5,8 @@
 
 <template>
 	<AppContentDetails class="app-content no-message-selected"
-		:style="{ 'backgroundImage': backgroundImgSrc }">
+		:class="{ 'no-message-selected--themed': isThemed, }"
+		:style="{ 'backgroundImage': isThemed ? undefined: backgroundImgSrc, }">
 		<div class="no-message-selected__heading">
 			{{ t('mail', 'Welcome to {productName} Mail', { productName }, null, {escape: false}) }}
 		</div>
@@ -20,7 +21,7 @@
 
 <script>
 import { generateFilePath } from '@nextcloud/router'
-import { isDarkTheme } from '@nextcloud/vue/functions/isDarkTheme'
+import { useIsDarkTheme } from '@nextcloud/vue/composables/useIsDarkTheme'
 import { NcAppContentDetails as AppContentDetails } from '@nextcloud/vue'
 
 import NewMessageButtonHeader from './NewMessageButtonHeader.vue'
@@ -32,11 +33,20 @@ export default {
 		AppContentDetails,
 	},
 
+	setup() {
+		return {
+			isDarkTheme: useIsDarkTheme(),
+		}
+	},
+
 	data() {
 		return {
-			backgroundImgSrc: isDarkTheme
+			backgroundImgSrc: this.isDarkTheme
 				? 'url("' + generateFilePath('mail', 'img', 'welcome-connection-dark.png') + '")'
 				: 'url("' + generateFilePath('mail', 'img', 'welcome-connection-light.png') + '")',
+			isThemed: this.isDarkTheme
+				? window.getComputedStyle(document.body).getPropertyValue('--color-primary-element') !== '#0091f2'
+				: window.getComputedStyle(document.body).getPropertyValue('--color-primary-element') !== '#00679e',
 		}
 	},
 
@@ -61,6 +71,14 @@ export default {
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: right 100% bottom 40%;
+
+	/** fallback gradient when the theme color isn't standard blue */
+	&--themed {
+		background: radial-gradient(100% 100% at 100% 100%, var(--color-primary-element) 0%, rgba(var(--color-main-background-rgb), 0) 100%), var(--color-main-background);
+		:deep(button) {
+			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2)
+		}
+	}
 
 	&__heading {
 		font-weight: bold;


### PR DESCRIPTION
The png looks odd when the instance is not blue. Therefore we want to show a simple gradient as fallback for now. Later we might be able to use an svg instead of the png and adjust gradient stop colors.

|   | Light | Dark |
|--------|--------|--------|
| Default | <img width="1226" height="828" alt="Bildschirmfoto vom 2025-08-20 11-03-30" src="https://github.com/user-attachments/assets/924a274d-44e7-4de1-b475-6702e718204a" /> | <img width="1226" height="828" alt="Bildschirmfoto vom 2025-08-20 11-03-16" src="https://github.com/user-attachments/assets/20572c5a-55f7-48f5-b2cc-bfc804a83c10" /> |
| Custom | <img width="1226" height="828" alt="Bildschirmfoto vom 2025-08-20 11-04-42" src="https://github.com/user-attachments/assets/5a60eb0c-5ab9-466f-b1ee-0a8ec35d8753" /> | <img width="1226" height="828" alt="Bildschirmfoto vom 2025-08-20 11-04-30" src="https://github.com/user-attachments/assets/c170304c-19f4-4d21-bf5b-0e236eebd639" /> | 

This is a follow-up to https://github.com/nextcloud/mail/pull/11504.


