### PR TITLE
fix(ui): show box-shadow for fluid design button all the time

### DIFF
--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -75,9 +75,6 @@ export default {
 	/** fallback gradient when the theme color isn't standard blue */
 	&--themed {
 		background: radial-gradient(100% 100% at 100% 100%, var(--color-primary-element) 0%, rgba(var(--color-main-background-rgb), 0) 100%), var(--color-main-background);
-		:deep(button) {
-			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2)
-		}
 	}
 
 	&__heading {
@@ -89,6 +86,12 @@ export default {
 	&__text {
 		text-wrap-style: balance;
 		max-width: 50%;
+	}
+
+	&__action {
+		:deep(button) {
+			box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2)
+		}
 	}
 }
 </style>


### PR DESCRIPTION
Addresses https://github.com/nextcloud/mail/pull/11540#pullrequestreview-3135864279

| Before | After |
|--------|--------|
| <img width="1153" height="701" alt="Bildschirmfoto vom 2025-08-20 12-44-52" src="https://github.com/user-attachments/assets/60f8c86c-7d76-4f27-a09c-bf51bd0394c2" /> | <img width="1153" height="701" alt="Bildschirmfoto vom 2025-08-20 12-44-35" src="https://github.com/user-attachments/assets/2a5fa38b-e725-4523-9850-20e003f4556f" /> | 



