### PR TITLE
fix EnvelopeSkeleton: make action hover area square again

### DIFF
--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -678,8 +678,15 @@ export default {
 	}
 
 	&--multiline &__actions {
-		:deep(.button-vue__wrapper) {
-			margin-top: calc(var(--default-grid-baseline) * -3);
+		:deep(.button-vue__icon), :deep(.button-vue__wrapper), :deep(button) {
+			min-height: unset !important;
+			min-width: unset !important;
+			height: calc(var(--default-grid-baseline) * 8) !important;
+			width: calc(var(--default-grid-baseline) * 8 + 2px) !important;
+		}
+
+		:deep(button) {
+			margin-top: calc(var(--default-grid-baseline) * -1);
 		}
 	}
 


### PR DESCRIPTION
| Before | After |
| - | - | 
| <img width="649" height="101" alt="image" src="https://github.com/user-attachments/assets/8fe85e7e-6519-4cc7-b064-22c5fbc8a3cf" /> | <img width="643" height="98" alt="swappy-20250821_193604" src="https://github.com/user-attachments/assets/e82338dc-fa72-480c-9dcc-2344f963eb05" /> |

What was causing the issue is the default hover area around the actions menu dots was `32px*32px`. This made it impossible to align with the title text, hence needing to move the inner contents upward. However, that caused the misalignment of the dots with the area. This PR resizes the whole area and moves it upwards to align with the title.