### PR TITLE
feat: make summary thread similar to normal thread style

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -83,7 +83,7 @@
 				<div v-if="data.encrypted || data.previewText"
 					class="envelope__preview-text"
 					:title="data.summary ? t('mail', 'This summary was AI generated') : null">
-					<SparkleIcon v-if="data.summary" :size="15" />
+					<NcAssistantIcon v-if="data.summary" :size="15" class="envelope__preview-text__icon" />
 					{{ isEncrypted ? t('mail', 'Encrypted message') : data.summary ? data.summary.trim() : data.previewText.trim() }}
 				</div>
 				<EnvelopeSingleClickActions v-if="oneLineLayout"
@@ -357,13 +357,12 @@ import {
 	NcActionLink as ActionLink,
 	NcActionSeparator,
 	NcActionInput,
-	NcActionText as ActionText,
+	NcActionText as ActionText, NcAssistantIcon,
 } from '@nextcloud/vue'
 import EnvelopeSkeleton from './EnvelopeSkeleton.vue'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import Avatar from './Avatar.vue'
 import IconCreateEvent from 'vue-material-design-icons/CalendarOutline.vue'
-import SparkleIcon from 'vue-material-design-icons/CreationOutline.vue'
 import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
@@ -437,7 +436,6 @@ export default {
 		PlusIcon,
 		TagIcon,
 		TagModal,
-		SparkleIcon,
 		Star,
 		StarOutline,
 		EmailRead,
@@ -454,6 +452,7 @@ export default {
 		CalendarClock,
 		EnvelopeSingleClickActions,
 		AlarmIcon,
+		NcAssistantIcon,
 	},
 	directives: {
 		draggableEnvelope: DraggableEnvelopeDirective,
@@ -1013,6 +1012,9 @@ export default {
 
 			position: relative;
 			top: 2px;
+		}
+		&__icon {
+			display: inline;
 		}
 	}
 }

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -44,13 +44,13 @@
 		<div id="reply-composer" />
 		<div class="reply-buttons">
 			<div v-if="smartReplies.length > 0" class="reply-buttons__suggested">
-				<NcButton v-for="(reply,index) in smartReplies"
+				<NcAssistantButton v-for="(reply,index) in smartReplies"
 					:key="index"
 					class="reply-buttons__suggested__button"
 					type="secondary"
 					@click="onReply(reply)">
 					{{ reply }}
-				</NcButton>
+				</NcAssistantButton>
 			</div>
 			<NcButton type="primary"
 				class="reply-buttons__notsuggested"
@@ -66,7 +66,7 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
-import { NcButton } from '@nextcloud/vue'
+import { NcButton, NcAssistantButton } from '@nextcloud/vue'
 
 import { html, plain } from '../util/text.js'
 import { isPgpgMessage } from '../crypto/pgp.js'
@@ -95,6 +95,7 @@ export default {
 		LockOffIcon,
 		ReplyIcon,
 		NcButton,
+		NcAssistantButton,
 	},
 	props: {
 		envelope: {
@@ -183,19 +184,17 @@ export default {
 	margin: 0 calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 2) calc(var(--default-grid-baseline) * 14);
 	display: flex;
 	flex-wrap: wrap;
-	gap: 5px;
+	gap: 8px;
 	justify-content: space-between;
 	align-items: center;
 
 	&__suggested {
-		justify-content: flex-start;
 		display: flex;
 		flex-wrap: wrap;
-		gap: 5px;
+		gap: 8px;
 
 		&__button {
-			margin-inline-end: 5px;
-			border-radius: 12px;
+			box-sizing: border-box;
 
 			:deep(.button-vue__text) {
 				font-weight: normal;
@@ -207,6 +206,7 @@ export default {
 		margin-inline-start: auto;
 	}
 }
+
 @media screen and (max-width: 600px) {
 	.reply-buttons {
 		display: flex;

--- a/src/components/ThreadSummary.vue
+++ b/src/components/ThreadSummary.vue
@@ -3,38 +3,49 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<div class="summary">
-		<div class="summary__header">
-			<div class="summary__header__actions">
-				<NcChip :icon-svg="creation" no-close>
-					{{ brand }}
-				</NcChip>
-				<NcButton :aria-label=" t('mail', 'Go to latest message')"
-					type="secondary"
-					@click="onScroll">
-					{{ t('mail', 'Go to newest message') }}
-					<template #icon>
-						<ArrowDownIcon :size="20" />
-					</template>
-				</NcButton>
+	<NcAssistantContent class="wrapper">
+		<div class="summary">
+			<div class="summary__header">
+				<div class="summary__header__actions">
+					<div class="summary__header__info">
+						<NcAssistantIcon class="summary__header__icon" />
+						<div class="summary__header__text">
+							<div class="summary__header__title">
+								{{ t('mail', 'Thread summary') }}
+							</div>
+							<div class="summary__header__brand">
+								{{ brand }}
+							</div>
+						</div>
+					</div>
+
+					<NcButton :aria-label=" t('mail', 'Go to latest message')"
+						type="tertiary-no-background"
+						@click="onScroll">
+						{{ t('mail', 'Newest message') }}
+						<template #icon>
+							<ArrowDownIcon :size="20" />
+						</template>
+					</NcButton>
+				</div>
 			</div>
-			<div class="summary__header__title">
-				<h2>{{ t('mail', 'Thread summary') }}</h2>
+			<div class="summary__body">
+				<LoadingSkeleton v-if="loading" :number-of-lines="1" :with-avatar="false" />
+				<p v-else>
+					{{ summary }}
+				</p>
+			</div>
+			<div class="summary__notice">
+				{{ t('mail', 'This summary is AI generated and may contain mistakes.') }}
 			</div>
 		</div>
-		<div class="summary__body">
-			<LoadingSkeleton v-if="loading" :number-of-lines="1" :with-avatar="false" />
-			<p v-else>
-				{{ summary }}
-			</p>
-		</div>
-	</div>
+	</NcAssistantContent>
 </template>
 <script>
 import ArrowDownIcon from 'vue-material-design-icons/ArrowDown.vue'
-import creation from '@mdi/svg/svg/creation-outline.svg'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import NcChip from '@nextcloud/vue/components/NcChip'
+import NcAssistantContent from '@nextcloud/vue/components/NcAssistantContent'
+import NcAssistantIcon from '@nextcloud/vue/components/NcAssistantIcon'
 import LoadingSkeleton from './LoadingSkeleton.vue'
 
 export default {
@@ -42,8 +53,9 @@ export default {
 	components: {
 		LoadingSkeleton,
 		NcButton,
-		NcChip,
 		ArrowDownIcon,
+		NcAssistantContent,
+		NcAssistantIcon,
 	},
 	props: {
 		summary: {
@@ -54,11 +66,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-	},
-	data() {
-		return {
-			creation,
-		}
 	},
 	computed: {
 		brand() {
@@ -81,47 +88,69 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.summary{
-    border: 2px solid var(--color-primary-element);
-    border-radius:var( --border-radius-large) ;
-    margin: 0 10px 20px 10px;
-    padding: 10px;
-    display: flex;
-    flex-direction: column;
+.wrapper {
+	max-width: calc(100% - 20px);
+	margin: 0 auto;
+	width: 100%;
+}
 
-    &__header{
-        display: flex;
-        flex-direction: column;
-        &__actions{
+.summary {
+	position: relative;
+	border-radius: var(--border-radius-large);
+	padding: 10px;
+	display: flex;
+	flex-direction: column;
+	&__header {
+		display: flex;
+		flex-direction: column;
+
+		&__actions {
 			display: flex;
 			justify-content: space-between;
-            &__brand{
-                display: flex;
-                align-items: center;
-                background-color: var(--color-primary-light);
-                border-radius: var(--border-radius-pill);
-                width: fit-content;
-                padding-inline: 4px 10px;
-				margin: 8px 0 8px 0;
+			align-items: center;
+			padding-bottom: 10px;
+		}
 
-                &__icon{
-                    color:var(--color-primary-element);
-                    margin-inline: 5px
-                }
-            }
-        }
+		&__info {
+			display: flex;
+			align-items: center;
+			gap: var(--default-grid-baseline);
+		}
 
-    }
+		&__text {
+			display: flex;
+			flex-direction: column;
+			line-height: 1.2;
+		}
+
+		&__title {
+			font-weight: bold;
+		}
+
+		&__brand {
+			color: var(--color-text-maxcontrast);
+		}
+		&__icon {
+			padding-inline-end: 14px;
+		}
+	}
+	&__body {
+		margin-inline-start: 35px;
+	}
 	@media only screen and (max-width: 600px) {
-		.summary{
-			&__header{
+		.summary {
+			&__header {
 				flex-direction: column;
-				&__actions{
+				&__actions {
 					flex-direction: column;
 				}
 			}
 		}
 	}
+	.summary__notice {
+		margin-top: 0.5rem;
+		margin-inline-start: 35px;
+		color: var(--color-text-maxcontrast);
+	}
 }
-
 </style>


### PR DESCRIPTION
ref #11328 

smart reply:
<img width="323" height="84" alt="Screenshot from 2025-09-01 18-40-23" src="https://github.com/user-attachments/assets/ca3736e8-d34d-4d80-a96d-d0ff28c049c0" />

thread summary:
<img width="931" height="228" alt="Screenshot from 2025-09-02 17-08-38" src="https://github.com/user-attachments/assets/1a20f26b-74d2-4a7c-9132-e5207f33ace2" />


Envelope summary:
<img width="645" height="130" alt="Screenshot from 2025-09-02 16-38-05" src="https://github.com/user-attachments/assets/d6879cda-9a79-41f5-8ac2-e34d4b656fcc" />

