### PR TITLE
fix: update wording for mailvelope

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -214,26 +214,26 @@
 					@close="displaySmimeCertificateModal = false" />
 
 				<h4>{{ t('mail', 'Mailvelope') }}</h4>
+				<p class="settings-hint">
+					{{ t('mail', 'Mailvelope is a browser extension that enables easy OpenPGP encryption and decryption for emails.') }}
+				</p>
 				<div class="mailvelope-section">
 					<div v-if="mailvelopeIsAvailable">
-						{{ t('mail', 'Mailvelope is enabled for the current domain!') }}
+						{{ t('mail', 'Mailvelope is enabled for the current domain.') }}
 					</div>
 					<div v-else>
-						<p>
-							{{ t('mail', 'Looking for a way to encrypt your emails?') }}
-						</p>
 						<p>
 							<a href="https://www.mailvelope.com/"
 								target="_blank"
 								class="button"
 								rel="noopener noreferrer">
-								{{ t('mail', 'Install Mailvelope browser extension') }}
+								{{ t('mail', 'Step 1: Install Mailvelope browser extension') }}
 							</a>
 						</p>
 						<p>
 							<a class="button"
 								@click="mailvelopeAuthorizeDomain">
-								{{ t('mail', 'Enable Mailvelope for the current domain') }}
+								{{ t('mail', 'Step 2: Enable Mailvelope for the current domain') }}
 							</a>
 						</p>
 					</div>


### PR DESCRIPTION
Close #11550 

Make it clearer to first install the extension and then click the button.


| B | A |
| --- | --- |
| <img width="452" height="261" alt="Screenshot From 2025-08-26 17-58-06" src="https://github.com/user-attachments/assets/85e0178a-d17e-4490-984b-b97b96993414" />  | <img width="551" height="296" alt="Screenshot From 2025-08-26 20-44-14" src="https://github.com/user-attachments/assets/698743f6-e1c6-46d1-ad4f-859fb4cbc23a" />  |

It doesn’t seem possible to detect when Mailvelope is installed but not authorized for the current domain, and also handling the CSP error from loading the dummy iframe. So for now, I’ll just adjust the wording a bit.


