### PR TITLE
fix(ui): use fluid background image for the setup view

### DIFF
--- a/css/fluid.scss
+++ b/css/fluid.scss
@@ -1,0 +1,14 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+@mixin background {
+	background-size: cover;
+	background-repeat: no-repeat;
+	background-position: right 100% bottom 40%;
+}
+
+@mixin gradient-background {
+	background: radial-gradient(100% 100% at 100% 100%, var(--color-primary-element) 0%, rgba(var(--color-main-background-rgb), 0) 100%), var(--color-main-background);
+}

--- a/src/components/NoMessageSelected.vue
+++ b/src/components/NoMessageSelected.vue
@@ -58,6 +58,8 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+@use '../../css/fluid';
+
 .no-message-selected {
 	display: flex;
 	flex-direction: column;
@@ -68,13 +70,11 @@ export default {
 	height: 100%;
 	max-width: 100% !important; /* restricted otherwise by stronger selector */
 
-	background-size: cover;
-	background-repeat: no-repeat;
-	background-position: right 100% bottom 40%;
+	@include fluid.background;
 
 	/** fallback gradient when the theme color isn't standard blue */
 	&--themed {
-		background: radial-gradient(100% 100% at 100% 100%, var(--color-primary-element) 0%, rgba(var(--color-main-background-rgb), 0) 100%), var(--color-main-background);
+		@include fluid.gradient-background;
 	}
 
 	&__heading {

--- a/src/views/Setup.vue
+++ b/src/views/Setup.vue
@@ -6,29 +6,35 @@
 	<NcContent app-name="mail">
 		<Navigation v-if="hasAccounts" />
 		<AppContent>
-			<EmptyContent v-if="allowNewMailAccounts"
-				class="setup__form-content"
-				:name="t('mail', 'Connect your mail account')">
-				<template #icon>
-					<div class="setup__form-content__svg-wrapper" v-html="FluidMail" />
-				</template>
-				<template #action>
-					<AccountForm :display-name="displayName"
-						:email="email"
-						:error.sync="error"
-						@account-created="onAccountCreated" />
-				</template>
-			</EmptyContent>
-			<EmptyContent v-else :name="t('mail', 'To add a mail account, please contact your administrator.')">
-				<template #icon>
-					<IconMail />
-				</template>
-			</EmptyContent>
+			<div class="setup"
+				:class="{ 'setup--themed': isThemed, }"
+				:style="{ 'backgroundImage': isThemed ? undefined: backgroundImgSrc, }">
+				<EmptyContent v-if="allowNewMailAccounts"
+					class="setup__form-content"
+					:name="t('mail', 'Connect your mail account')">
+					<template #icon>
+						<div class="setup__form-content__svg-wrapper" v-html="FluidMail" />
+					</template>
+					<template #action>
+						<AccountForm :display-name="displayName"
+							:email="email"
+							:error.sync="error"
+							class="setup__form-content__form"
+							@account-created="onAccountCreated" />
+					</template>
+				</EmptyContent>
+				<EmptyContent v-else :name="t('mail', 'To add a mail account, please contact your administrator.')">
+					<template #icon>
+						<div class="setup__form-content__svg-wrapper" v-html="FluidMail" />
+					</template>
+				</EmptyContent>
+			</div>
 		</AppContent>
 	</NcContent>
 </template>
 
 <script>
+import { generateFilePath } from '@nextcloud/router'
 import { NcContent, NcAppContent as AppContent, NcEmptyContent as EmptyContent } from '@nextcloud/vue'
 import { loadState } from '@nextcloud/initial-state'
 
@@ -55,6 +61,12 @@ export default {
 			FluidMail,
 			allowNewMailAccounts: loadState('mail', 'allow-new-accounts', true),
 			error: null,
+			backgroundImgSrc: this.isDarkTheme
+				? 'url("' + generateFilePath('mail', 'img', 'welcome-connection-dark.png') + '")'
+				: 'url("' + generateFilePath('mail', 'img', 'welcome-connection-light.png') + '")',
+			isThemed: this.isDarkTheme
+				? window.getComputedStyle(document.body).getPropertyValue('--color-primary-element') !== '#0091f2'
+				: window.getComputedStyle(document.body).getPropertyValue('--color-primary-element') !== '#00679e',
 		}
 	},
 	computed: {
@@ -74,27 +86,53 @@ export default {
 }
 </script>
 
-<style scoped>
-.setup__form-content {
+<style lang="scss" scoped>
+@use '../../css/fluid';
+
+.setup {
+	/* make sure the background image covers everything */
 	min-height: 100%;
-}
+	min-width: 100%;
 
-/* overrides for custom icon size and full opacity */
-:deep(.empty-content__icon) {
-	width: 128px !important;
-	height: 128px !important;
-	opacity: 1 !important;
+	@include fluid.background;
 
-	.setup__form-content__svg-wrapper {
-		width: 128px;
-		height: 128px;
+	/* put the contents to the center */
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	/** fallback gradient when the theme color isn't standard blue */
+	&--themed {
+		@include fluid.gradient-background;
 	}
 
-	:deep(svg) {
-		width: 128px !important;
-		height: 128px !important;
-		max-width: 128px !important;
-		max-height: 128px !important;
+	&__form-content {
+		/** make it as narrow as possible */
+		flex-grow: 0;
+
+		background-color: var(--color-main-background-blur);
+		padding: calc(3 * var(--default-grid-baseline));
+		border-radius: var(--border-radius-container);
+		box-shadow: 0 0 10px var(--color-box-shadow);
+
+		/* overrides for custom icon size and full opacity */
+		:deep(.empty-content__icon) {
+			width: 128px !important;
+			height: 128px !important;
+			opacity: 1 !important;
+
+			.setup__form-content__svg-wrapper {
+				width: 128px;
+				height: 128px;
+
+				svg {
+					width: 128px !important;
+					height: 128px !important;
+					max-width: 128px !important;
+					max-height: 128px !important;
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-06-45" src="https://github.com/user-attachments/assets/693aa3e1-cfcd-43b3-939a-9f1252ab0282" /> | <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-07-05" src="https://github.com/user-attachments/assets/8bc2c829-759e-4a35-bc88-8010fc0ac762" /> |
| <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-04-50" src="https://github.com/user-attachments/assets/13a07553-4b58-4e70-9051-1cd9e4610aa1" /> | <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-04-31" src="https://github.com/user-attachments/assets/a9f3932b-4703-420c-b356-ba44662b13ba" /> |
| <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-03-42" src="https://github.com/user-attachments/assets/1a064132-b474-4c21-8e06-79c08407351a" /> | <img width="1670" height="786" alt="Bildschirmfoto vom 2025-09-05 10-04-16" src="https://github.com/user-attachments/assets/9659260e-0ac3-4d13-ba41-355062345095" /> | 

Fixes https://github.com/nextcloud/mail/issues/11589