### PR TITLE
fix: show user avatar in recipient info

### DIFF
--- a/src/components/RecipientInfo.vue
+++ b/src/components/RecipientInfo.vue
@@ -12,7 +12,8 @@
 						:email="recipients[0].email"
 						:size="55"
 						:disable-tooltip="true"
-						:disable-menu="true" />
+						:disable-menu="true"
+						:avatar="getAvatarForRecipient(recipients[0])" />
 				</div>
 				<div class="recipient-info__details">
 					<DisplayContactDetails :email="recipients[0].email" />
@@ -29,7 +30,8 @@
 							:email="recipient.email"
 							:size="55"
 							:disable-tooltip="true"
-							:disable-menu="true" />
+							:disable-menu="true"
+							:avatar="getAvatarForRecipient(recipient)" />
 					</div>
 					<div v-if="!expandedRecipients[index]" class="recipient-info__name">
 						<h6>{{ recipient.email }}</h6>
@@ -95,6 +97,15 @@ export default {
 		},
 		isExpanded(index) {
 			return this.expandedRecipients[index]
+		},
+		getAvatarForRecipient(recipient) {
+			if ((recipient.source && recipient.source === 'contacts') && recipient.photo) {
+				return {
+					isExternal: false,
+					url: recipient.photo,
+				}
+			}
+			return null
 		},
 	},
 }


### PR DESCRIPTION
| B | A |
| --- | --- |
| <img width="1073" height="424" alt="Screenshot From 2025-09-10 17-24-49" src="https://github.com/user-attachments/assets/6a2e7ee2-41f8-490c-a13e-df2fe1d34877" /> | <img width="1073" height="424" alt="Screenshot From 2025-09-10 17-23-38" src="https://github.com/user-attachments/assets/7a409a73-7a2d-4193-aa8d-de5db03658c5" /> |




