### PR TITLE
fix: align quick action settings button properly

### DIFF
--- a/src/components/quickActions/Settings.vue
+++ b/src/components/quickActions/Settings.vue
@@ -315,9 +315,6 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
-.quick-actions-settings{
-	padding: 10px;
-}
 
 .modal-content{
 	padding: 30px;


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="553" height="515" alt="image" src="https://github.com/user-attachments/assets/1302ecab-13fc-44e4-8075-35f70114bf56" /> | <img width="553" height="515" alt="image" src="https://github.com/user-attachments/assets/f8263dbc-2372-47e8-ad01-cf0a8c31d48b" /> | 