### PR TITLE
Improve accessibility of envelope actions on mobile by disabling browser context menu overlapping our actions on long press

### DIFF
--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -30,6 +30,7 @@
 					@focus="showActions"
 					@focusout="handleBlur"
 					@click="onClick($event, navigate, routerLinkHref)"
+					@contextmenu.prevent
 					@keydown.esc="hideActions">
 					<!-- @slot This slot is used for the NcAvatar or icon, the content of this slot must not be interactive -->
 					<slot name="icon" />


### PR DESCRIPTION
| Before | After |
| - | - |
| [recording_20250915-121153.webm](https://github.com/user-attachments/assets/99fe6f8a-b30f-4130-a625-0c5b00136170) | [recording_20250915-121049.webm](https://github.com/user-attachments/assets/c5cee295-4e59-42d6-a856-15e5fbf3c6db) |

This is done by long pressing an envelope on mobile

On desktop chrome this doesn't seem like much of a problem, but on certain browser like the mobile firefox the context menu would basically cover the whole screen, causing the actions to not be usable.