### PR TITLE
fix(classification): break large SQL IN queries into chunks

### DIFF
--- a/lib/Db/StatisticsDao.php
+++ b/lib/Db/StatisticsDao.php
@@ -12,9 +12,11 @@ namespace OCA\Mail\Db;
 use OCA\Mail\Address;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use function array_chunk;
 use function array_column;
 use function array_combine;
 use function array_map;
+use function array_reduce;
 
 class StatisticsDao {
 	/** @var IDBConnection */
@@ -33,6 +35,22 @@ class StatisticsDao {
 		);
 	}
 
+	/**
+	 * @see emailCountResultToIndexedArray
+	 */
+	private function groupEmailCountResults(array $results): array {
+		$combined = [];
+		foreach ($results as $index) {
+			foreach ($index as $email => $count) {
+				if (!isset($combined[$email])) {
+					$combined[$email] = 0;
+				}
+				$combined[$email] += $count;
+			}
+		}
+		return $combined;
+	}
+
 	public function getMessagesTotal(Mailbox ...$mb): int {
 		$qb = $this->db->getQueryBuilder();
 
@@ -43,11 +61,14 @@ class StatisticsDao {
 			->from('mail_recipients', 'r')
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id'))
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY));
-		$result = $select->executeQuery();
-		$cnt = $result->fetchColumn();
-		$result->closeCursor();
-		return (int)$cnt;
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createParameter('mailbox_ids'), IQueryBuilder::PARAM_INT_ARRAY));
+		return array_reduce(array_chunk($mailboxIds, 1000), static function ($carry, $mailboxIds) use ($select) {
+			$select->setParameter('mailbox_ids', $mailboxIds, IQueryBuilder::PARAM_INT_ARRAY);
+			$result = $select->executeQuery();
+			$cnt = $result->fetchColumn();
+			$result->closeCursor();
+			return $carry + (int)$cnt;
+		}, 0);
 	}
 
 	public function getMessagesSentTo(Mailbox $mb, string $email): int {
@@ -77,13 +98,18 @@ class StatisticsDao {
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_TO), IQueryBuilder::PARAM_INT))
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
-			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createParameter('mailbox_ids'), IQueryBuilder::PARAM_INT_ARRAY))
 			->groupBy('r.email');
-		$result = $select->executeQuery();
-		$rows = $result->fetchAll();
-		$data = $this->emailCountResultToIndexedArray($rows);
-		$result->closeCursor();
-		return $data;
+		return $this->groupEmailCountResults(
+			array_map(function (array $mailboxIds) use ($select) {
+				$select->setParameter('mailbox_ids', $mailboxIds, IQueryBuilder::PARAM_INT_ARRAY);
+				$result = $select->executeQuery();
+				$rows = $result->fetchAll();
+				$data = $this->emailCountResultToIndexedArray($rows);
+				$result->closeCursor();
+				return $data;
+			}, array_chunk($mailboxIds, 1000))
+		);
 	}
 
 	public function getNrOfImportantMessages(Mailbox $mb, string $email): int {
@@ -134,14 +160,19 @@ class StatisticsDao {
 			->from('mail_recipients', 'r')
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createParameter('mailbox_ids')))
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
 			->groupBy('r.email');
-		$result = $select->executeQuery();
-		$rows = $result->fetchAll();
-		$data = $this->emailCountResultToIndexedArray($rows);
-		$result->closeCursor();
-		return $data;
+		return $this->groupEmailCountResults(
+			array_map(function (array $mailboxIds) use ($select) {
+				$select->setParameter('mailbox_ids', $mailboxIds, IQueryBuilder::PARAM_INT_ARRAY);
+				$result = $select->executeQuery();
+				$rows = $result->fetchAll();
+				$data = $this->emailCountResultToIndexedArray($rows);
+				$result->closeCursor();
+				return $data;
+			}, array_chunk($mailboxIds, 1000))
+		);
 	}
 
 	public function getNrOfReadMessages(Mailbox $mb, string $email): int {
@@ -178,15 +209,20 @@ class StatisticsDao {
 			->from('mail_recipients', 'r')
 			->join('r', 'mail_messages', 'm', $qb->expr()->eq('m.id', 'r.message_id', IQueryBuilder::PARAM_INT))
 			->where($qb->expr()->eq('r.type', $qb->createNamedParameter(Address::TYPE_FROM, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
-			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createNamedParameter($mailboxIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->in('m.mailbox_id', $qb->createParameter('mailbox_ids')))
 			->andWhere($qb->expr()->eq("m.flag_$flag", $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
 			->andWhere($qb->expr()->in('r.email', $qb->createNamedParameter($emails, IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR_ARRAY))
 			->groupBy('r.email');
-		$result = $select->executeQuery();
-		$rows = $result->fetchAll();
-		$data = $this->emailCountResultToIndexedArray($rows);
-		$result->closeCursor();
-		return $data;
+		return $this->groupEmailCountResults(
+			array_map(function (array $mailboxIds) use ($select) {
+				$select->setParameter('mailbox_ids', $mailboxIds, IQueryBuilder::PARAM_INT_ARRAY);
+				$result = $select->executeQuery();
+				$rows = $result->fetchAll();
+				$data = $this->emailCountResultToIndexedArray($rows);
+				$result->closeCursor();
+				return $data;
+			}, array_chunk($mailboxIds, 1000))
+		);
 	}
 
 	public function getNrOfRepliedMessages(Mailbox $mb, string $email): int {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9069

This can be tested by replacing `1000` with `1`. It gives identical results for `occ mail:account:train <id> -vvv`. It also gives identical results to the same command on main.