### PR TITLE
fix(EnvelopeSkeleton): text shifting on hover

### DIFF
--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -57,7 +57,7 @@
 							</div>
 
 							<div class="list-item-content__inner__details">
-								<div v-if="showDetails" class="list-item-content__inner__details__details">
+								<div :class="['list-item-content__inner__details__details', { 'list-item-content__inner__details__details--hidden': showDetails }]">
 									<!-- @slot This slot is used for some details in form of icon (prop `details` as a fallback) -->
 									<slot name="details">{{ details }}</slot>
 								</div>
@@ -453,6 +453,10 @@ export default {
 		margin-inline-end: auto;
 		overflow: hidden;
 		text-overflow: ellipsis;
+
+		&--hidden {
+			visibility: hidden;
+		}
 	}
 }
 
@@ -483,10 +487,6 @@ export default {
 	&:has(:active),
 	&:has(:focus-visible) {
 		background-color: var(--color-background-hover);
-
-		a {
-			max-width: calc(100% - var(--default-clickable-area));
-		}
 	}
 
 	&:has(&__anchor:focus-visible) {


### PR DESCRIPTION
I figured out a better way to do https://github.com/nextcloud/mail/pull/10583
Fix https://github.com/nextcloud/mail/issues/10561

## Before 
[recording_20250916-132205.webm](https://github.com/user-attachments/assets/113ea37b-ba3a-49ca-a032-0d96d6d7ba76)

## After
[recording_20250916-132018.webm](https://github.com/user-attachments/assets/3177fb9a-cf4e-493d-94d4-00c371737cab)

(this doesn't remove the background becoming darker on hover, the video just didn't register it for some reason)