### PR TITLE
fix: correct the default sort order value

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -134,7 +134,7 @@ export default {
 	computed: {
 		...mapStores(useMainStore),
 		sortOrder() {
-			return this.mainStore.getPreference('sort-order', 'DESC')
+			return this.mainStore.getPreference('sort-order', 'newest')
 		},
 		envelopes() {
 			return this.mainStore.getEnvelopes(this.mailbox.databaseId, this.searchQuery)


### PR DESCRIPTION
Somehow escaped reviews 
sort-order can either be `newest`or `oldest`
https://github.com/nextcloud/mail/blob/main/lib/Controller/PageController.php#L195