### PR TITLE
fix: list separators depending on sort by date

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -579,8 +579,9 @@ export default {
 				return t('mail', 'Last week')
 			case 'lastMonth':
 				return t('mail', 'Last month')
+			default:
+				return group
 			}
-			return t('mail', 'Older')
 		},
 	},
 }


### PR DESCRIPTION
fixes https://github.com/nextcloud/mail/issues/11567 

Also changes the sorting from:

['lastHour', 'today', 'yesterday', 'lastWeek', 'lastMonth']
to
['lastHour', 'today', 'yesterday', 'lastWeek', 'lastMonth', 'Months', 'Years' ]