### PR TITLE
fix: error in mounted hook

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,6 @@ export default {
 		this.sync()
 		await this.mainStore.fetchCurrentUserPrincipal()
 		await this.mainStore.loadCollections()
-		await this.mainStore.fetchAllQuickActions()
 		this.mainStore.hasCurrentUserPrincipalAndCollectionsMutation(true)
 	},
 	methods: {


### PR DESCRIPTION
Fix #11711

Regression from https://github.com/nextcloud/mail/pull/11618

The error `Error in mounted hook (Promise/async): "TypeError: this.mainStore.fetchAllQuickActions is not a function"` prevents hasCurrentUserPrincipalAndCollectionsMutation becoming true and thus the imip preview do not work.

B: Opening an email with an imip invitation does not show the preview
A: Opening an email with an imip invitation does show the preview