### PR TITLE
fix(quickaction): fix deleting quick action steps

### DIFF
--- a/src/components/quickActions/Settings.vue
+++ b/src/components/quickActions/Settings.vue
@@ -300,7 +300,7 @@ export default {
 			this.actions = this.actions.map((action, index) => ({ ...action, order: index + 1 }))
 		},
 		async deleteAction(item) {
-			if (!this.editMode) {
+			if (this.editMode) {
 				try {
 					await deleteActionStep(item.id)
 				} catch (e) {


### PR DESCRIPTION
Small logic error

## Steps to reproduce for new action

1. Open quick actions
2. Create new quick action
3. Add a step
4. Remove the step

main: :boom: with HTTP error in a request with `{id}` in its URL
here: :sunglasses: 

## Steps to reproduce for existing action

1. Open quick actions
2. Create a new quick action
3. Add a step
4. Save
5. Reload the page
6. Open quick actions
7. Edit the quick action

main: step is back (was never really deleted)
here: step is gone