### PR TITLE
fix: allow reloading the INBOX favorites page

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -26,6 +26,11 @@ return [
 			'verb' => 'GET'
 		],
 		[
+			'name' => 'page#mailboxStarred',
+			'url' => '/box/starred/{id}',
+			'verb' => 'GET'
+		],
+		[
 			'name' => 'page#thread',
 			'url' => '/box/{mailboxId}/thread/{id}',
 			'verb' => 'GET'

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -363,6 +363,16 @@ class PageController extends Controller {
 	 *
 	 * @return TemplateResponse
 	 */
+	public function mailboxStarred(int $id): TemplateResponse {
+		return $this->index();
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 *
+	 * @return TemplateResponse
+	 */
 	public function thread(int $mailboxId, int $id): TemplateResponse {
 		return $this->index();
 	}


### PR DESCRIPTION
## How to test

1. Open the app
2. Navigate to *Favorites* of any account
3. Reload the page

main: route not found error
here: same page again