### PR TITLE
fix(ui): handle mailbox sorting of 'all' and unknown special use

### DIFF
--- a/src/imap/MailboxSorter.js
+++ b/src/imap/MailboxSorter.js
@@ -5,7 +5,7 @@
 
 import clone from 'lodash/fp/clone.js'
 
-const specialRolesOrder = ['all', 'inbox', 'flagged', 'drafts', 'sent', 'archive', 'junk', 'trash']
+const specialRolesOrder = ['inbox', 'flagged', 'drafts', 'sent', 'archive', 'all', 'junk', 'trash']
 
 export const sortMailboxes = (mailboxes, account) => {
 	const c = clone(mailboxes)
@@ -16,6 +16,14 @@ export const sortMailboxes = (mailboxes, account) => {
 
 			if (s1 === s2) {
 				return f1.name.localeCompare(f2.name)
+			}
+
+			// Handle invalid special uses
+			// if both are invalid it's caught at the previous if
+			if (s1 === -1) {
+				return 1
+			} else if (s2 === -1) {
+				return -1
 			}
 
 			return s1 - s2

--- a/src/tests/unit/imap/MailboxSorter.spec.js
+++ b/src/tests/unit/imap/MailboxSorter.spec.js
@@ -28,6 +28,50 @@ describe('mailboxSorter', () => {
 		expect(sorted).toEqual([mb1, mb2])
 	})
 
+	it('puts inbox before all', () => {
+		const mbAll = {
+			name: 'All emails',
+			specialUse: ['all'],
+			databaseId: 1,
+		}
+		const inbox = {
+			name: 'INBOX',
+			specialUse: ['inbox'],
+			databaseId: 2,
+		}
+		const mailboxes = [inbox, mbAll]
+
+		const account = {
+			snoozeMailboxId: 0,
+		}
+
+		const sorted = sortMailboxes(mailboxes, account)
+
+		expect(sorted).toEqual([inbox, mbAll])
+	})
+
+	it('handles unknown special use', () => {
+		const specialMb = {
+			name: 'Special emails',
+			specialUse: ['special'],
+			databaseId: 1,
+		}
+		const inbox = {
+			name: 'INBOX',
+			specialUse: ['inbox'],
+			databaseId: 2,
+		}
+		const mailboxes = [inbox, specialMb]
+
+		const account = {
+			snoozeMailboxId: 0,
+		}
+
+		const sorted = sortMailboxes(mailboxes, account)
+
+		expect(sorted).toEqual([inbox, specialMb])
+	})
+
 	it('lists special mailboxes first', () => {
 		const mb1 = {
 			name: 'Inbox 1',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/6455

The handling of \\all is not universal. According to internet research it looks like this in popular clients:

1. Apple Mail: Shows All Mail below Archive and other system folders.
2. Thunderbird: Puts “All Mail” at the bottom of the folder list, after all regular and special folders.
3. Outlook IMAP: Doesn’t expose \All by default; users see aggregated folders in search results.

I like the apple mail approach.

A typo made me realize that unknown special uses will be put to the very top. This is now fixed too.