### PR TITLE
fix(migration): guard repair stop for possibly missing method

### DIFF
--- a/lib/Migration/ProvisionAccounts.php
+++ b/lib/Migration/ProvisionAccounts.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Migration;
 
+use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -31,6 +32,11 @@ class ProvisionAccounts implements IRepairStep {
 	 */
 	#[\Override]
 	public function run(IOutput $output) {
+		// Skip if method does not exist yet during upgrade
+		if (!method_exists(AccountService::class, 'scheduleBackgroundJobs')) {
+			return;
+		}
+
 		$cnt = $this->provisioningManager->provision();
 		$output->info("$cnt accounts provisioned");
 	}


### PR DESCRIPTION
Hotfix for

```
Error: Call to undefined method OCA\Mail\Service\AccountService::scheduleBackgroundJobs() in /var/www/nextcloud/apps/mail/lib/Service/Provisioning/Manager.php:219
Stack trace:
#0 /var/www/nextcloud/apps/mail/lib/Service/Provisioning/Manager.php(115): OCA\Mail\Service\Provisioning\Manager->provisionSingleUser()
#1 /var/www/nextcloud/lib/private/User/Manager.php(566): OCA\Mail\Service\Provisioning\Manager->{closure:OCA\Mail\Service\Provisioning\Manager::provision():114}()
#2 /var/www/nextcloud/apps/mail/lib/Service/Provisioning/Manager.php(114): OC\User\Manager->callForAllUsers()
#3 /var/www/nextcloud/apps/mail/lib/Migration/ProvisionAccounts.php(34): OCA\Mail\Service\Provisioning\Manager->provision()
#4 /var/www/nextcloud/lib/private/Repair.php(107): OCA\Mail\Migration\ProvisionAccounts->run()
#5 /var/www/nextcloud/lib/private/legacy/OC_App.php(574): OC\Repair->run()
#6 /var/www/nextcloud/lib/private/App/AppManager.php(1059): OC_App::executeRepairSteps()
#7 /var/www/nextcloud/lib/private/Installer.php(111): OC\App\AppManager->upgradeApp()
#8 /var/www/nextcloud/core/Command/App/Update.php(88): OC\Installer->updateAppstoreApp()
#9 /var/www/nextcloud/3rdparty/symfony/console/Command/Command.php(326): OC\Core\Command\App\Update->execute()
#10 /var/www/nextcloud/3rdparty/symfony/console/Application.php(1078): Symfony\Component\Console\Command\Command->run()
#11 /var/www/nextcloud/3rdparty/symfony/console/Application.php(324): Symfony\Component\Console\Application->doRunCommand()
#12 /var/www/nextcloud/3rdparty/symfony/console/Application.php(175): Symfony\Component\Console\Application->doRun()
#13 /var/www/nextcloud/lib/private/Console/Application.php(187): Symfony\Component\Console\Application->run()
#14 /var/www/nextcloud/console.php(90): OC\Console\Application->run()
#15 /var/www/nextcloud/occ(33): require_once('...')
#16 {main}
```