### PR TITLE
fix: leftover design changes for the composer

### DIFF
--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -34,7 +34,7 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
-import Close from 'vue-material-design-icons/CloseOutline.vue'
+import Close from 'vue-material-design-icons/Close.vue'
 import Cloud from 'vue-material-design-icons/CloudOutline.vue'
 import EmailArrowRightIcon from 'vue-material-design-icons/EmailArrowRightOutline.vue'
 

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -661,7 +661,7 @@ export default {
 	flex: 0 0 370px;
 	overflow-y: auto;
 	padding-inline-start: 5px;
-	border-inline-start: 1px solid #ccc;
+	border-inline-start: 1px solid var(--color-text-maxcontrast);
 	@media (max-width: 1024px) {
 		display: none;
 	}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -571,9 +571,9 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 
 .ck.ck-toolbar {
 	border-radius: var(--border-radius-large) !important;
-	background: none;
 	background: var(--color-main-background) !important;
     color: var(--color-main-text) !important;
+	border: 1px solid var(--color-text-maxcontrast) !important;
 }
 
 .ck-rounded-corners .ck.ck-dropdown__panel, .ck.ck-dropdown__panel.ck-rounded-corners {


### PR DESCRIPTION
fix pr fixes:

- close icon for the attachment should not be outlined
- border of ckeditor bar and the split of recipient info
- recipient info show more alighnment
-  the color of the right pane split

after
<img width="1082" height="729" alt="Screenshot from 2025-10-02 12-32-51" src="https://github.com/user-attachments/assets/162cbb0b-4775-4d57-8818-86cf19207be9" />

