### PR TITLE
feat: show mail version in settings

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -25,6 +25,7 @@ use OCA\Mail\Service\OutboxService;
 use OCA\Mail\Service\QuickActionsService;
 use OCA\Mail\Service\SmimeService;
 use OCA\Viewer\Event\LoadViewer;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -74,7 +75,8 @@ class PageController extends Controller {
 	private InternalAddressService $internalAddressService;
 	private QuickActionsService $quickActionsService;
 
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
 		IURLGenerator $urlGenerator,
 		IConfig $config,
@@ -97,6 +99,7 @@ class PageController extends Controller {
 		InternalAddressService $internalAddressService,
 		IAvailabilityCoordinator $availabilityCoordinator,
 		QuickActionsService $quickActionsService,
+		private IAppManager $appManager,
 	) {
 		parent::__construct($appName, $request);
 
@@ -142,6 +145,11 @@ class PageController extends Controller {
 		$this->initialStateService->provideInitialState(
 			'ncVersion',
 			$this->config->getSystemValue('version', '0.0.0')
+		);
+
+		$this->initialStateService->provideInitialState(
+			'mailVersion',
+			$this->appManager->getAppVersion('mail'),
 		);
 
 		$mailAccounts = $this->accountService->findByUserId($this->currentUserId);

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -230,9 +230,6 @@
 					</NcCheckboxRadioSwitch>
 				</p>
 			</NcAppSettingsSection>
-			<NcAppSettingsSection id="about-settings" :name="t('mail', 'About')">
-				<p>{{ t('mail', 'This application includes CKEditor, an open-source editor. Copyright © CKEditor contributors. Licensed under GPLv2.') }}</p>
-			</NcAppSettingsSection>
 			<NcAppSettingsSection id="keyboard-shortcut-settings" :name="t('mail', 'Keyboard shortcuts')">
 				<dl>
 					<div>
@@ -279,6 +276,13 @@
 					</div>
 				</dl>
 			</NcAppSettingsSection>
+			<NcAppSettingsSection id="about-settings" :name="t('mail', 'About')">
+				<p>{{ t('mail', 'This application includes CKEditor, an open-source editor. Copyright © CKEditor contributors. Licensed under GPLv2.') }}</p>
+			</NcAppSettingsSection>
+			<p
+				class="app-settings-section__version">
+				{{ t('mail', 'Mail version: {version}', { version: mailVersion }) }}
+			</p>
 			<NcDialog
 				:open.sync="textBlockDialogOpen"
 				:name="t('mail', 'New text block')"
@@ -442,6 +446,10 @@ export default {
 
 		allowNewMailAccounts() {
 			return this.mainStore.getPreference('allow-new-accounts', true)
+		},
+
+		mailVersion() {
+			return this.mainStore.getPreference('mailVersion', '0.0.0')
 		},
 
 		layoutMode: {
@@ -769,6 +777,12 @@ p.app-settings {
 
 .app-settings-section {
 	list-style: none;
+
+	&__version {
+		margin-block-end: calc(2 * var(--default-grid-baseline));
+		text-align: center;
+		color: var(--color-text-maxcontrast);
+	}
 }
 
 .text-block-buttons {

--- a/src/init.js
+++ b/src/init.js
@@ -22,6 +22,10 @@ export default function initAfterAppCreation() {
 		key: 'ncVersion',
 		value: loadState('mail', 'ncVersion'),
 	})
+	mainStore.savePreferenceMutation({
+		key: 'mailVersion',
+		value: loadState('mail', 'mailVersion'),
+	})
 
 	mainStore.savePreferenceMutation({
 		key: 'sort-order',

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -25,6 +25,7 @@ use OCA\Mail\Service\MailManager;
 use OCA\Mail\Service\OutboxService;
 use OCA\Mail\Service\QuickActionsService;
 use OCA\Mail\Service\SmimeService;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -112,6 +113,7 @@ class PageControllerTest extends TestCase {
 	private QuickActionsService|MockObject $quickActionsService;
 
 	private IAvailabilityCoordinator&MockObject $availabilityCoordinator;
+	private IAppManager $appManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -139,6 +141,8 @@ class PageControllerTest extends TestCase {
 		$this->internalAddressService = $this->createMock(InternalAddressService::class);
 		$this->availabilityCoordinator = $this->createMock(IAvailabilityCoordinator::class);
 		$this->quickActionsService = $this->createMock(QuickActionsService::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appManager->method('getAppVersion')->willReturn('0.0.1-dev.0');
 
 		$this->controller = new PageController(
 			$this->appName,
@@ -164,6 +168,7 @@ class PageControllerTest extends TestCase {
 			$this->internalAddressService,
 			$this->availabilityCoordinator,
 			$this->quickActionsService,
+			$this->appManager,
 		);
 	}
 
@@ -314,11 +319,12 @@ class PageControllerTest extends TestCase {
 			->method('findAll')
 			->with($this->userId)
 			->willReturn([]);
-		$this->initialState->expects($this->exactly(24))
+		$this->initialState->expects($this->exactly(25))
 			->method('provideInitialState')
 			->withConsecutive(
 				['debug', true],
 				['ncVersion', '26.0.0'],
+				['mailVersion', '0.0.1-dev.0'],
 				['accounts', $accountsJson],
 				['account-settings', []],
 				['tags', []],


### PR DESCRIPTION
<img width="885" height="311" alt="image" src="https://github.com/user-attachments/assets/1d0a7416-62da-43d2-9004-173405d64563" />

1) Add mail version to app settings
2) Flipped keyboard shortcuts and about (for me about is always the last section and I've found it weird to have it otherwise in mail, however I'm fine to change it back)