### PR TITLE
fix: render recipient info later

### DIFF
--- a/src/components/RecipientInfo.vue
+++ b/src/components/RecipientInfo.vue
@@ -49,7 +49,7 @@
 						</template>
 					</div>
 				</div>
-				<div v-show="expandedRecipients[index]" class="recipient-info__details">
+				<div v-if="expandedRecipients[index]" class="recipient-info__details">
 					<DisplayContactDetails :email="recipient.email" />
 				</div>
 			</div>


### PR DESCRIPTION
To quote Daniel: 
_We render the component right's right away and thus also emit that fetchContacts methods.
If we change v-show to v-if, it's only rendered once one presses on show more (for emails with multiple recpients).
It does not address any of the structural issues we have, but it ensures to not emit many requests when opening the compose._