### PR TITLE
test(unit): add PHP type hint for better PHPUnit stub

### DIFF
--- a/lib/AddressList.php
+++ b/lib/AddressList.php
@@ -124,10 +124,7 @@ class AddressList implements Countable, JsonSerializable {
 		return new AddressList($addresses);
 	}
 
-	/**
-	 * @return Horde_Mail_Rfc822_List
-	 */
-	public function toHorde() {
+	public function toHorde(): Horde_Mail_Rfc822_List {
 		$hordeAddresses = array_map(static fn (Address $address) => $address->toHorde(), $this->addresses);
 		return new Horde_Mail_Rfc822_List($hordeAddresses);
 	}


### PR DESCRIPTION
Not having a native return type hint means PHPUnits automatically generated method stub will return `null`. In unit tests this can lead to the following deprecation warning:

```
PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/bytestream/horde-mail/lib/Horde/Mail/Rfc822.php on line 173
```