### PR TITLE
fix(psalm): remove unnecessary var declarations

### DIFF
--- a/lib/Migration/Version4001Date20241017154801.php
+++ b/lib/Migration/Version4001Date20241017154801.php
@@ -26,7 +26,6 @@ class Version4001Date20241017154801 extends SimpleMigrationStep {
 	 * @return ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		if ($schema->hasTable('mail_text_blocks')) {
 			return null;

--- a/lib/Migration/Version4001Date20241017155914.php
+++ b/lib/Migration/Version4001Date20241017155914.php
@@ -26,7 +26,6 @@ class Version4001Date20241017155914 extends SimpleMigrationStep {
 	 * @return ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		if ($schema->hasTable('mail_blocks_shares')) {
 			return null;

--- a/lib/Migration/Version5005Date20250903114906.php
+++ b/lib/Migration/Version5005Date20250903114906.php
@@ -24,7 +24,6 @@ class Version5005Date20250903114906 extends SimpleMigrationStep {
 	 */
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		if ($schema->hasTable('mail_actions')) {
 			return null;

--- a/lib/Migration/Version5005Date20250903114909.php
+++ b/lib/Migration/Version5005Date20250903114909.php
@@ -25,7 +25,6 @@ class Version5005Date20250903114909 extends SimpleMigrationStep {
 	 */
 	#[\Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 		if ($schema->hasTable('mail_action_step')) {
 			return null;

--- a/lib/Migration/Version5006Date20250927130132.php
+++ b/lib/Migration/Version5006Date20250927130132.php
@@ -22,7 +22,6 @@ class Version5006Date20250927130132 extends SimpleMigrationStep {
 
 	#[Override]
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
-		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
 		$mailboxes = $schema->getTable('mail_mailboxes');

--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -79,7 +79,6 @@ class IMipService {
 			}
 		}, $accountIds));
 
-		/** @var Mailbox $mailbox */
 		foreach ($existingMailboxes as $mailbox) {
 			/** @var Account $account */
 			$account = $accounts[$mailbox->getAccountId()];


### PR DESCRIPTION
Psalm v6 auto fixes for `UnnecessaryVarAnnotation`