### PR TITLE
fix(quick-actions): delete local steps

### DIFF
--- a/src/components/quickActions/Settings.vue
+++ b/src/components/quickActions/Settings.vue
@@ -321,7 +321,7 @@ export default {
 			this.actions = this.actions.map((action, index) => ({ ...action, order: index + 1 }))
 		},
 		async deleteAction(item) {
-			if (this.editMode) {
+			if (item.id) {
 				try {
 					await deleteActionStep(item.id)
 				} catch (error) {


### PR DESCRIPTION
sequel for #11720

## reproduction 
1. Edit or create new action 
2. Add a step 
3. Don't save
4. try to remove step 
5. voilà 

Local steps don't have an id yet whereas saved steps (having an id)  should also be deleted through the Api 