### PR TITLE
fix: also await onToggleJunk

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -820,7 +820,11 @@ export default {
 				for (const step of action.steps) {
 					switch (step.name) {
 					case 'markAsSpam':
-						this.layoutMessageViewThreaded ? await this.onToggleJunkThread() : this.onToggleJunk()
+						if (this.layoutMessageViewThreaded) {
+							await this.onToggleJunkThread()
+						} else {
+							await this.onToggleJunk()
+						}
 						break
 					case 'applyTag':
 						if (step?.tagId) {


### PR DESCRIPTION
We should also await onToggleJunk ;)

I'm migrating to the more verbose if-else instead of the ternary, as the eslint 9 update will emit a warning for ternaries, when not using the result, and thus to keep it in sync with the lines below.