### PR TITLE
refactor: drop unused length option for columns

### DIFF
--- a/lib/Migration/Version0100Date20180825194217.php
+++ b/lib/Migration/Version0100Date20180825194217.php
@@ -36,7 +36,6 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
@@ -130,11 +129,9 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$table->addColumn('account_id', Types::INTEGER, [
 				'notnull' => true,
-				'length' => 4,
 				'default' => 0,
 			]);
 			$table->addColumn('name', Types::STRING, [
@@ -153,7 +150,6 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
@@ -167,7 +163,6 @@ class Version0100Date20180825194217 extends SimpleMigrationStep {
 			]);
 			$table->addColumn('created_at', Types::INTEGER, [
 				'notnull' => true,
-				'length' => 4,
 				'default' => 0,
 			]);
 			$table->setPrimaryKey(['id']);

--- a/lib/Migration/Version0156Date20190828140357.php
+++ b/lib/Migration/Version0156Date20190828140357.php
@@ -40,7 +40,6 @@ class Version0156Date20190828140357 extends SimpleMigrationStep {
 		]);
 		$mailboxTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('sync_token', Types::STRING, [
 			'notnull' => true,
@@ -56,11 +55,9 @@ class Version0156Date20190828140357 extends SimpleMigrationStep {
 		]);
 		$mailboxTable->addColumn('messages', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('unseen', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('selectable', Types::BOOLEAN, [
 			'notnull' => false,

--- a/lib/Migration/Version0161Date20190902103701.php
+++ b/lib/Migration/Version0161Date20190902103701.php
@@ -40,7 +40,6 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 		$mailboxTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$mailboxTable->addColumn('name', Types::STRING, [
 			'notnull' => true,
@@ -48,7 +47,6 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 		]);
 		$mailboxTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('sync_token', Types::STRING, [
 			'notnull' => false,
@@ -64,11 +62,9 @@ class Version0161Date20190902103701 extends SimpleMigrationStep {
 		]);
 		$mailboxTable->addColumn('messages', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('unseen', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('selectable', Types::BOOLEAN, [
 			'notnull' => false,

--- a/lib/Migration/Version0210Date20191212144925.php
+++ b/lib/Migration/Version0210Date20191212144925.php
@@ -30,7 +30,6 @@ class Version0210Date20191212144925 extends SimpleMigrationStep {
 		$accountsTable = $schema->getTable('mail_accounts');
 		$accountsTable->addColumn('order', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 			'default' => 1,
 		]);
 

--- a/lib/Migration/Version1020Date20191002091035.php
+++ b/lib/Migration/Version1020Date20191002091035.php
@@ -40,11 +40,9 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$messagesTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$messagesTable->addColumn('uid', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$messagesTable->addColumn('message_id', Types::STRING, [
 			'notnull' => false,
@@ -61,7 +59,6 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		]);
 		$messagesTable->addColumn('sent_at', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$messagesTable->addColumn('flag_answered', Types::BOOLEAN, [
 			'notnull' => false,
@@ -97,7 +94,6 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		]);
 		$messagesTable->addColumn('updated_at', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$messagesTable->setPrimaryKey(['id']);
 		// We allow each UID just once
@@ -111,15 +107,12 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$recipientsTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$recipientsTable->addColumn('message_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$recipientsTable->addColumn('type', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 2,
 		]);
 		$recipientsTable->addColumn('label', Types::STRING, [
 			'notnull' => false,
@@ -136,15 +129,12 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		$mailboxTable = $schema->getTable('mail_mailboxes');
 		$mailboxTable->addColumn('sync_new_lock', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('sync_changed_lock', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('sync_vanished_lock', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$mailboxTable->addColumn('sync_new_token', Types::STRING, [
 			'notnull' => false,

--- a/lib/Migration/Version1040Date20200422142920.php
+++ b/lib/Migration/Version1040Date20200422142920.php
@@ -32,11 +32,9 @@ class Version1040Date20200422142920 extends SimpleMigrationStep {
 		$messagesTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$messagesTable->addColumn('uid', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$messagesTable->addColumn('message_id', Types::STRING, [
 			'notnull' => false,
@@ -44,7 +42,6 @@ class Version1040Date20200422142920 extends SimpleMigrationStep {
 		]);
 		$messagesTable->addColumn('mailbox_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$messagesTable->addColumn('subject', Types::STRING, [
 			'notnull' => true,
@@ -53,7 +50,6 @@ class Version1040Date20200422142920 extends SimpleMigrationStep {
 		]);
 		$messagesTable->addColumn('sent_at', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$messagesTable->addColumn('flag_answered', Types::BOOLEAN, [
 			'notnull' => false,
@@ -105,7 +101,6 @@ class Version1040Date20200422142920 extends SimpleMigrationStep {
 		]);
 		$messagesTable->addColumn('updated_at', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$messagesTable->setPrimaryKey(['id']);
 		// We allow each UID just once

--- a/lib/Migration/Version1040Date20200506111214.php
+++ b/lib/Migration/Version1040Date20200506111214.php
@@ -32,11 +32,9 @@ class Version1040Date20200506111214 extends SimpleMigrationStep {
 		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$table->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 20,
 		]);
 		$table->addColumn('type', Types::STRING, [
 			'notnull' => true,
@@ -52,11 +50,9 @@ class Version1040Date20200506111214 extends SimpleMigrationStep {
 		]);
 		$table->addColumn('training_set_size', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('validation_set_size', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('recall_important', Types::DECIMAL, [
 			'notnull' => true,
@@ -75,7 +71,6 @@ class Version1040Date20200506111214 extends SimpleMigrationStep {
 		]);
 		$table->addColumn('duration', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('active', Types::BOOLEAN, [
 			'notnull' => false,
@@ -83,7 +78,6 @@ class Version1040Date20200506111214 extends SimpleMigrationStep {
 		]);
 		$table->addColumn('created_at', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 
 		$table->setPrimaryKey(['id']);

--- a/lib/Migration/Version1060Date20201015084952.php
+++ b/lib/Migration/Version1060Date20201015084952.php
@@ -39,17 +39,14 @@ class Version1060Date20201015084952 extends SimpleMigrationStep {
 		$accountsTable->addColumn('drafts_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
-			'length' => 20,
 		]);
 		$accountsTable->addColumn('sent_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
-			'length' => 20,
 		]);
 		$accountsTable->addColumn('trash_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
-			'length' => 20,
 		]);
 
 		return $schema;

--- a/lib/Migration/Version1080Date20201119084820.php
+++ b/lib/Migration/Version1080Date20201119084820.php
@@ -31,7 +31,6 @@ class Version1080Date20201119084820 extends SimpleMigrationStep {
 		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('email', Types::STRING, [
 			'notnull' => true,

--- a/lib/Migration/Version1100Date20210304143008.php
+++ b/lib/Migration/Version1100Date20210304143008.php
@@ -34,7 +34,6 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 			$tagsTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$tagsTable->addColumn('user_id', Types::STRING, [
 				'notnull' => true,
@@ -74,7 +73,6 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 			$tagsMessageTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$tagsMessageTable->addColumn('imap_message_id', Types::STRING, [
 				'notnull' => true,
@@ -82,7 +80,6 @@ class Version1100Date20210304143008 extends SimpleMigrationStep {
 			]);
 			$tagsMessageTable->addColumn('tag_id', Types::INTEGER, [
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$tagsMessageTable->setPrimaryKey(['id']);
 		}

--- a/lib/Migration/Version1100Date20210419080523.php
+++ b/lib/Migration/Version1100Date20210419080523.php
@@ -52,7 +52,6 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 			$provisioningTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$provisioningTable->addColumn('provisioning_domain', Types::STRING, [
 				'notnull' => true,
@@ -133,7 +132,6 @@ class Version1100Date20210419080523 extends SimpleMigrationStep {
 
 		$accountsTable = $schema->getTable('mail_accounts');
 		$accountsTable->addColumn('provisioning_id', Types::INTEGER, [
-			'length' => 4,
 			'notnull' => false,
 		]);
 

--- a/lib/Migration/Version1120Date20220223094709.php
+++ b/lib/Migration/Version1120Date20220223094709.php
@@ -31,24 +31,19 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 		$localMessageTable->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$localMessageTable->addColumn('type', Types::INTEGER, [
 			'notnull' => true,
 			'unsigned' => true,
-			'length' => 1,
 		]);
 		$localMessageTable->addColumn('account_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$localMessageTable->addColumn('alias_id', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$localMessageTable->addColumn('send_at', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4
 		]);
 		$localMessageTable->addColumn('subject', Types::TEXT, [
 			'notnull' => true,
@@ -71,7 +66,6 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 		$recipientsTable = $schema->getTable('mail_recipients');
 		$recipientsTable->addColumn('local_message_id', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$recipientsTable->changeColumn('message_id', [
 			'notnull' => false
@@ -81,7 +75,6 @@ class Version1120Date20220223094709 extends SimpleMigrationStep {
 		$attachmentsTable = $schema->getTable('mail_attachments');
 		$attachmentsTable->addColumn('local_message_id', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$attachmentsTable->addForeignKeyConstraint($localMessageTable, ['local_message_id'], ['id'], ['onDelete' => 'CASCADE']);
 

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -123,7 +123,6 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 			// Change primary column to bigint
 			$recipientsTable->changeColumn('id', [
 				'type' => Type::getType(Types::BIGINT),
-				'length' => 20,
 			]);
 		}
 
@@ -137,7 +136,6 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 			// Change primary column to bigint
 			$messagesTable->changeColumn('id', [
 				'type' => Type::getType(Types::BIGINT),
-				'length' => 20,
 			]);
 		}
 

--- a/lib/Migration/Version2010Date20221002201527.php
+++ b/lib/Migration/Version2010Date20221002201527.php
@@ -39,7 +39,6 @@ class Version2010Date20221002201527 extends SimpleMigrationStep {
 		$accountsTable->addColumn('archive_mailbox_id', Types::INTEGER, [
 			'notnull' => false,
 			'default' => null,
-			'length' => 20,
 		]);
 
 		return $schema;

--- a/lib/Migration/Version2020Date20221103140538.php
+++ b/lib/Migration/Version2020Date20221103140538.php
@@ -32,7 +32,6 @@ class Version2020Date20221103140538 extends SimpleMigrationStep {
 		if (!$localMessagesTable->hasColumn('updated_at')) {
 			$localMessagesTable->addColumn('updated_at', Types::INTEGER, [
 				'notnull' => false,
-				'length' => 4,
 			]);
 		}
 		$localMessagesTable->changeColumn('send_at', [

--- a/lib/Migration/Version2100Date20221013143851.php
+++ b/lib/Migration/Version2100Date20221013143851.php
@@ -44,7 +44,6 @@ class Version2100Date20221013143851 extends SimpleMigrationStep {
 				Types::INTEGER,
 				[
 					'notnull' => false,
-					'length' => 8,
 				],
 			);
 		}

--- a/lib/Migration/Version2300Date20221216115727.php
+++ b/lib/Migration/Version2300Date20221216115727.php
@@ -33,7 +33,6 @@ class Version2300Date20221216115727 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::BIGINT, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 20,
 			]);
 			$table->addColumn('user_id', Types::STRING, [
 				'notnull' => true,

--- a/lib/Migration/Version2300Date20230127093733.php
+++ b/lib/Migration/Version2300Date20230127093733.php
@@ -37,7 +37,6 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 		if (!$outboxTable->hasColumn('smime_certificate_id')) {
 			$outboxTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
-				'length' => 4,
 			]);
 		}
 
@@ -45,7 +44,6 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 		if (!$accountsTable->hasColumn('smime_certificate_id')) {
 			$accountsTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
-				'length' => 4,
 			]);
 		}
 
@@ -53,7 +51,6 @@ class Version2300Date20230127093733 extends SimpleMigrationStep {
 		if (!$aliasesTable->hasColumn('smime_certificate_id')) {
 			$aliasesTable->addColumn('smime_certificate_id', Types::INTEGER, [
 				'notnull' => false,
-				'length' => 4,
 			]);
 		}
 

--- a/lib/Migration/Version3001Date20230307113544.php
+++ b/lib/Migration/Version3001Date20230307113544.php
@@ -23,7 +23,6 @@ class Version3001Date20230307113544 extends SimpleMigrationStep {
 		$accountsTable->addColumn('junk_mailbox_id', 'integer', [
 			'notnull' => false,
 			'default' => null,
-			'length' => 20,
 		]);
 		$accountsTable->addColumn('move_junk', 'boolean', [
 			'notnull' => false,

--- a/lib/Migration/Version3300Date20230801124717.php
+++ b/lib/Migration/Version3300Date20230801124717.php
@@ -40,7 +40,6 @@ class Version3300Date20230801124717 extends SimpleMigrationStep {
 			$messagesRetentionTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$messagesRetentionTable->addColumn('message_id', Types::STRING, [
 				'notnull' => true,
@@ -48,7 +47,6 @@ class Version3300Date20230801124717 extends SimpleMigrationStep {
 			]);
 			$messagesRetentionTable->addColumn('known_since', Types::INTEGER, [
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$messagesRetentionTable->setPrimaryKey(['id'], 'mail_msg_retention_id_idx');
 		}

--- a/lib/Migration/Version3400Date20230807300513.php
+++ b/lib/Migration/Version3400Date20230807300513.php
@@ -32,7 +32,6 @@ class Version3400Date20230807300513 extends SimpleMigrationStep {
 			$accountsTable->addColumn('snooze_mailbox_id', Types::INTEGER, [
 				'notnull' => false,
 				'default' => null,
-				'length' => 20,
 			]);
 		}
 
@@ -41,7 +40,6 @@ class Version3400Date20230807300513 extends SimpleMigrationStep {
 			$messagesSnoozedTable->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$messagesSnoozedTable->addColumn('message_id', Types::STRING, [
 				'notnull' => true,
@@ -49,7 +47,6 @@ class Version3400Date20230807300513 extends SimpleMigrationStep {
 			]);
 			$messagesSnoozedTable->addColumn('snoozed_until', Types::INTEGER, [
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$messagesSnoozedTable->setPrimaryKey(['id'], 'mail_msg_snoozed_id_idx');
 		}

--- a/lib/Migration/Version3400Date20230818160236.php
+++ b/lib/Migration/Version3400Date20230818160236.php
@@ -31,7 +31,6 @@ class Version3400Date20230818160236 extends SimpleMigrationStep {
 		if (!$snoozeTable->hasColumn('src_mailbox_id')) {
 			$snoozeTable->addColumn('src_mailbox_id', Types::INTEGER, [
 				'notnull' => false,
-				'length' => 20,
 			]);
 		}
 

--- a/lib/Migration/Version4000Date20240716172702.php
+++ b/lib/Migration/Version4000Date20240716172702.php
@@ -31,7 +31,6 @@ class Version4000Date20240716172702 extends SimpleMigrationStep {
 			$table->addColumn('id', Types::INTEGER, [
 				'autoincrement' => true,
 				'notnull' => true,
-				'length' => 4,
 			]);
 			$table->addColumn('address', Types::STRING, [
 				'notnull' => true,

--- a/lib/Migration/Version4001Date20241017154801.php
+++ b/lib/Migration/Version4001Date20241017154801.php
@@ -35,7 +35,6 @@ class Version4001Date20241017154801 extends SimpleMigrationStep {
 		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('owner', Types::STRING, [
 			'notnull' => true,

--- a/lib/Migration/Version4001Date20241017155914.php
+++ b/lib/Migration/Version4001Date20241017155914.php
@@ -35,7 +35,6 @@ class Version4001Date20241017155914 extends SimpleMigrationStep {
 		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('type', Types::STRING, [
 			'notnull' => true,
@@ -47,7 +46,6 @@ class Version4001Date20241017155914 extends SimpleMigrationStep {
 		]);
 		$table->addColumn('text_block_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->setPrimaryKey(['id']);
 		$table->addUniqueIndex(['text_block_id', 'share_with'], 'mail_blocks_shares_tbid_sw_idx');

--- a/lib/Migration/Version5005Date20250903114909.php
+++ b/lib/Migration/Version5005Date20250903114909.php
@@ -34,7 +34,6 @@ class Version5005Date20250903114909 extends SimpleMigrationStep {
 		$table->addColumn('id', Types::INTEGER, [
 			'autoincrement' => true,
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('name', Types::STRING, [
 			'notnull' => true,
@@ -42,19 +41,15 @@ class Version5005Date20250903114909 extends SimpleMigrationStep {
 		]);
 		$table->addColumn('order', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('action_id', Types::INTEGER, [
 			'notnull' => true,
-			'length' => 4,
 		]);
 		$table->addColumn('mailbox_id', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 		$table->addColumn('tag_id', Types::INTEGER, [
 			'notnull' => false,
-			'length' => 4,
 		]);
 
 		$table->setPrimaryKey(['id']);


### PR DESCRIPTION
The length option has no effect when using Types::BIGINT, Types::INTEGER or Types::SMALLINT