### PR TITLE
fix: set createdAt timestamp for local attachments

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>5.8.0-dev.1</version>
+	<version>5.8.0-dev.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/lib/Migration/Version5008Date20260320000001.php
+++ b/lib/Migration/Version5008Date20260320000001.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * @psalm-api
+ */
+#[ModifyColumn(
+	table: 'mail_attachments',
+	description: 'Remove default value for created_at')
+]
+class Version5008Date20260320000001 extends SimpleMigrationStep {
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('mail_attachments')) {
+			return $schema;
+		}
+
+		$attachments = $schema->getTable('mail_attachments');
+
+		// Drop default value for created_at column
+		if ($attachments->hasColumn('created_at')) {
+			$attachments->modifyColumn('created_at', [
+				'default' => null,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -26,6 +26,7 @@ use OCA\Mail\Exception\SmimeDecryptException;
 use OCA\Mail\Exception\UploadException;
 use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
@@ -72,6 +73,7 @@ class AttachmentService implements IAttachmentService {
 		private IURLGenerator $urlGenerator,
 		private IMimeTypeDetector $mimeTypeDetector,
 		LoggerInterface $logger,
+		private ITimeFactory $timeFactory,
 	) {
 		$this->mapper = $mapper;
 		$this->storage = $storage;
@@ -92,6 +94,7 @@ class AttachmentService implements IAttachmentService {
 		$attachment->setUserId($userId);
 		$attachment->setFileName($file->getFileName());
 		$attachment->setMimeType($file->getMimeType());
+		$attachment->setCreatedAt($this->timeFactory->getTime());
 
 		$persisted = $this->mapper->insert($attachment);
 		try {
@@ -110,6 +113,7 @@ class AttachmentService implements IAttachmentService {
 		$attachment->setUserId($userId);
 		$attachment->setFileName($name);
 		$attachment->setMimeType($mime);
+		$attachment->setCreatedAt($this->timeFactory->getTime());
 
 		$persisted = $this->mapper->insert($attachment);
 		try {

--- a/tests/Integration/Service/DraftServiceIntegrationTest.php
+++ b/tests/Integration/Service/DraftServiceIntegrationTest.php
@@ -102,7 +102,8 @@ class DraftServiceIntegrationTest extends TestCase {
 			Server::get(ICacheFactory::class),
 			Server::get(IURLGenerator::class),
 			Server::get(IMimeTypeDetector::class),
-			new NullLogger()
+			new NullLogger(),
+			Server::get(ITimeFactory::class)
 		);
 		$this->client = $this->getClient($this->account);
 		$this->mapper = Server::get(LocalMessageMapper::class);

--- a/tests/Integration/Service/OutboxServiceIntegrationTest.php
+++ b/tests/Integration/Service/OutboxServiceIntegrationTest.php
@@ -103,7 +103,8 @@ class OutboxServiceIntegrationTest extends TestCase {
 			Server::get(ICacheFactory::class),
 			Server::get(IURLGenerator::class),
 			Server::get(IMimeTypeDetector::class),
-			new NullLogger()
+			new NullLogger(),
+			Server::get(ITimeFactory::class)
 		);
 		$this->client = $this->getClient($this->account);
 		$this->mapper = Server::get(LocalMessageMapper::class);

--- a/tests/Unit/Service/Attachment/AttachmentServiceTest.php
+++ b/tests/Unit/Service/Attachment/AttachmentServiceTest.php
@@ -29,6 +29,7 @@ use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\Attachment\AttachmentStorage;
 use OCA\Mail\Service\Attachment\UploadedFile;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\NotPermittedException;
@@ -51,8 +52,9 @@ class AttachmentServiceTest extends TestCase {
 	private IURLGenerator&MockObject $urlGenerator;
 	private IMimeTypeDetector&MockObject $mimeTypeDetector;
 	private LoggerInterface&MockObject $logger;
-
+	private ITimeFactory&MockObject $timeFactory;
 	private AttachmentService $service;
+
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -68,6 +70,8 @@ class AttachmentServiceTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->mimeTypeDetector = $this->createMock(IMimeTypeDetector::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getTime')->willReturn(123456);
 
 		$this->service = new AttachmentService(
 			$this->userFolder,
@@ -78,7 +82,8 @@ class AttachmentServiceTest extends TestCase {
 			$this->cacheFactory,
 			$this->urlGenerator,
 			$this->mimeTypeDetector,
-			$this->logger
+			$this->logger,
+			$this->timeFactory,
 		);
 	}
 
@@ -91,6 +96,7 @@ class AttachmentServiceTest extends TestCase {
 		$attachment = LocalAttachment::fromParams([
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -122,7 +128,8 @@ class AttachmentServiceTest extends TestCase {
 			->willReturn('cat.jpg');
 		$attachment = LocalAttachment::fromParams([
 			'userId' => $userId,
-			'fileName' => 'cat.jpg'
+			'fileName' => 'cat.jpg',
+			'createdAt' => 123456
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -147,6 +154,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'image/jpg',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -177,6 +185,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'image/jpg',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -292,6 +301,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -343,6 +353,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -452,6 +463,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,


### PR DESCRIPTION
Local copy of https://github.com/nextcloud/mail/pull/11943 with squashed commits. 

- Inject ITimeFactory into AttachmentService constructor
- Set createdAt using timeFactory.getTime() when creating attachments
- Update unit tests to mock ITimeFactory and expect createdAt value
- Update integration tests to pass ITimeFactory dependency