### PR TITLE
perf: switch webpack mode to lazy

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -375,9 +375,7 @@ export default {
 
 				/* eslint-disable @stylistic/comma-dangle, @stylistic/function-paren-newline */
 				const { default: coreTranslations } = await import(
-					/* webpackMode: "lazy-once" */
-					/* webpackPrefetch: true */
-					/* webpackPreload: true */
+					/* webpackMode: "lazy" */
 					`ckeditor5/translations/${language}.js`
 				)
 				/* eslint-enable @stylistic/comma-dangle, @stylistic/function-paren-newline */


### PR DESCRIPTION
Create separate module for each ckeditor translation instead one large bundle with all translations.

Testing:
- Set the language in nextcloud to not english
- Open network inspector
- Click "new message"
- See an xhr request for a js file containing the translations (on main you won't see that, as there bundle with all translations was fetched before).



**main:**

<img width="989" height="720" alt="image" src="https://github.com/user-attachments/assets/256de9f4-ccb9-47e1-acde-a1f4351231f7" />

**this branch:**


<img width="1591" height="755" alt="image" src="https://github.com/user-attachments/assets/532d398f-e3b8-409e-91b9-0985d20a94fd" />
