### PR TITLE
[stable5.5] perf: switch webpack mode to lazy

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -335,9 +335,7 @@ export default {
 			try {
 				logger.debug(`loading ${language} translations for CKEditor`)
 				await import(
-					/* webpackMode: "lazy-once" */
-					/* webpackPrefetch: true */
-					/* webpackPreload: true */
+					/* webpackMode: "lazy" */
 					`@ckeditor/ckeditor5-build-decoupled-document/build/translations/${language}`
 				)
 				this.showEditor(language)


### PR DESCRIPTION
Backport of https://github.com/nextcloud/mail/pull/12005

Create separate module for each ckeditor translation instead one large bundle with all translations.