### PR TITLE
fix(imap): make mailbox status errors debuggable

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -140,7 +140,11 @@ class FolderMapper {
 					$status['unseen'],
 				);
 			} catch (ServiceException $e) {
-				$this->logger->warning($e->getMessage());
+				$this->logger->warning($e->getMessage(), [
+					'exception' => $e,
+					'mailboxes' => $mailboxes,
+					'statuses' => $multiStatus,
+				]);
 			}
 		}
 		return $statuses;


### PR DESCRIPTION
The current warning log does not have a trace. This makes debugging tricky because there are two possible paths. I also added the mailbox names and status responses to the log.