### PR TITLE
fix(imap): avoid Horde's LIST-STATUS optimization for STATUS

### DIFF
--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -127,10 +127,9 @@ class FolderMapper {
 	 */
 	public function getFoldersStatusAsObject(Horde_Imap_Client_Socket $client,
 		array $mailboxes): array {
-		$multiStatus = $client->status($mailboxes);
-
 		$statuses = [];
-		foreach ($multiStatus as $mailbox => $status) {
+		foreach ($mailboxes as $mailbox) {
+			$status = $client->status($mailbox);
 			try {
 				if (!isset($status['messages'], $status['unseen'])) {
 					throw new ServiceException('Could not fetch stats of mailbox: ' . $mailbox);
@@ -143,7 +142,7 @@ class FolderMapper {
 				$this->logger->warning($e->getMessage(), [
 					'exception' => $e,
 					'mailboxes' => $mailboxes,
-					'statuses' => $multiStatus,
+					'status' => $status,
 				]);
 			}
 		}

--- a/tests/Unit/IMAP/FolderMapperTest.php
+++ b/tests/Unit/IMAP/FolderMapperTest.php
@@ -209,12 +209,10 @@ class FolderMapperTest extends TestCase {
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('status')
-			->with(['INBOX'])
+			->with('INBOX')
 			->willReturn([
-				'INBOX' => [
-					'messages' => 123,
-					'unseen' => 2,
-				],
+				'messages' => 123,
+				'unseen' => 2,
 			]);
 
 		$stats = $this->mapper->getFoldersStatusAsObject($client, ['INBOX']);
@@ -228,25 +226,15 @@ class FolderMapperTest extends TestCase {
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$client->expects($this->once())
 			->method('status')
-			->with(['INBOX'])
+			->with('INBOX')
 			->willReturn([
-				'INBOX' => [
-					'messages' => null,
-					'unseen' => 2,
-				],
-				'Company' => [
-					'messages' => 123,
-					'unseen' => 2,
-				],
+				'messages' => null,
+				'unseen' => 2,
 			]);
 
 		$stats = $this->mapper->getFoldersStatusAsObject($client, ['INBOX']);
 
 		self::assertArrayNotHasKey('INBOX', $stats);
-		self::assertArrayHasKey('Company', $stats);
-		$expected = new MailboxStats(123, 2);
-		self::assertEquals($expected, $stats['Company']);
-
 	}
 
 	public function testDetectSpecialUseFromAttributes() {


### PR DESCRIPTION
Horde has an optimization for multi STATUS calls. Here's a comparison.

An account without the LIST-STATUS capability fetches statues like this:

```
C: 7 STATUS INBOX (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS INBOX (MESSAGES 4 RECENT 0 UIDNEXT 112 UIDVALIDITY 14 UNSEEN 4)
S: 7 OK STATUS completed.
>> Command 7 took 0.0458 seconds.
C: 8 STATUS Tasks (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Tasks (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 248 UNSEEN 0)
S: 8 OK STATUS completed.
>> Command 8 took 0.0444 seconds.
C: 9 STATUS "Junk Email" (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS "Junk Email" (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 246 UNSEEN 0)
S: 9 OK STATUS completed.
>> Command 9 took 0.0452 seconds.
C: 10 STATUS Contacts (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Contacts (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 231 UNSEEN 0)
S: 10 OK STATUS completed.
>> Command 10 took 0.0446 seconds.
C: 11 STATUS "Sent Items" (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS "Sent Items" (MESSAGES 2 RECENT 0 UIDNEXT 12 UIDVALIDITY 11 UNSEEN 0)
S: 11 OK STATUS completed.
>> Command 11 took 0.0446 seconds.
C: 12 STATUS "Deleted Items" (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS "Deleted Items" (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 12 UNSEEN 0)
S: 12 OK STATUS completed.
```
:heavy_check_mark: works

With LIST-STATUS it will look like this:

```
C: 6 LIST () "" (INBOX Spam Drafts "Sent Items" Archive Trash) RETURN (STATUS (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN))
S: 6 OK LIST completed
```

:x: This does not work. The statuses are empty.

By sending individual status calls we do the iteration ourselves and avoid the pitfall. Communication will look like this:

```
C: 6 STATUS INBOX (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS INBOX (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953391 UNSEEN 0)
S: 6 OK STATUS completed
>> Command 6 took 0.0184 seconds.
C: 7 STATUS Drafts (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Drafts (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953280 UNSEEN 0)
S: 7 OK STATUS completed
>> Command 7 took 0.0217 seconds.
C: 8 STATUS Trash (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Trash (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953280 UNSEEN 0)
S: 8 OK STATUS completed
>> Command 8 took 0.0288 seconds.
C: 9 STATUS Archive (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Archive (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953280 UNSEEN 0)
S: 9 OK STATUS completed
>> Command 9 took 0.0229 seconds.
C: 10 STATUS Spam (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS Spam (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953280 UNSEEN 0)
S: 10 OK STATUS completed
>> Command 10 took 0.0215 seconds.
C: 11 STATUS "Sent Items" (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)
S: * STATUS "Sent Items" (MESSAGES 0 RECENT 0 UIDNEXT 1 UIDVALIDITY 1762953280 UNSEEN 0)
S: 11 OK STATUS completed
```