### PR TITLE
fix: warning for accounts that can't connect

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -26,7 +26,10 @@
 					:is-first="isFirst(group.account)"
 					:is-last="isLast(group.account)"
 					:is-disabled="isDisabled(group.account)" />
-				<template v-if="!isDisabled(group.account)">
+				<template v-if="group.account.error">
+					{{ t('mail', 'Connection failed. Please verify your information and try again') }}
+				</template>
+				<template v-else-if="!isDisabled(group.account)">
 					<template v-for="item in group.mailboxes">
 						<NavigationMailbox
 							v-show="


### PR DESCRIPTION
fixes #11918 

Having the icon in front of the account address it will not work because `NcAppNavigationCaption` doesnt allow us to add an icon.
i think this is a nice solution as well
<img width="324" height="132" alt="Screenshot from 2025-11-13 18-21-49" src="https://github.com/user-attachments/assets/ee83d7b8-3c3d-4eee-bd83-0a650a827f22" />


@nimishavijay @marcoambrosini for design approval