### PR TITLE
fix: search input field doesnt extend properly

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -514,7 +514,7 @@ export default {
 	position: absolute;
 	overflow: scroll;
 	width: 100% !important;
-	top: 52px;
+	top: 40px;
 }
 
 :deep(.app-content-wrapper) {

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -633,7 +633,6 @@ export default {
 	position: sticky;
 	top: 0;
 	z-index: 10;
-	height: 52px;
 	background-color: var(--color-main-background);
 	&__input {
 		min-height: 52px;


### PR DESCRIPTION
ref: #11328 

before

<img width="587" height="135" alt="Screenshot from 2025-11-17 14-02-54" src="https://github.com/user-attachments/assets/58a964cd-0c70-4dc3-a682-9630835646c6" />

after
<img width="488" height="173" alt="Screenshot from 2025-11-17 13-57-33" src="https://github.com/user-attachments/assets/d3e1064e-fb1d-4f9f-9882-cb876de0fb84" />
after. The before was that the filter buttons were not shown at all
<img width="960" height="203" alt="Screenshot from 2025-11-17 13-57-57" src="https://github.com/user-attachments/assets/f9bc1d93-2811-47dd-aaf3-adfd98c29383" />

before(the space on top of section title)
<img width="581" height="154" alt="Screenshot from 2025-11-17 14-05-02" src="https://github.com/user-attachments/assets/a8147e20-1299-4b00-90b9-db4c7cf6877e" />

after
<img width="483" height="136" alt="Screenshot from 2025-11-17 13-56-55" src="https://github.com/user-attachments/assets/00df9ebb-4ff7-44dd-9ed3-682e0ecaf4b5" />
