### PR TITLE
fix(Settings): followup on redesign

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -28,7 +28,7 @@
 							:aria-label="t('mail', 'Account settings')"
 							@click="openAccountSettings(account.id)">
 							<template #icon>
-								<IconLink :size="20" />
+								<IconArrow :size="20" />
 							</template>
 							{{ account.emailAddress }}
 						</NcFormBoxButton>
@@ -112,7 +112,10 @@
 						<List
 							:text-blocks="getMyTextBlocks()"
 							@show-toolbar="handleShowToolbar" />
-						<NcButton variant="secondary" @click="() => textBlockDialogOpen = true" wide>
+						<NcButton variant="secondary" wide @click="() => textBlockDialogOpen = true">
+							<template #icon>
+								<IconAdd :size="20" />
+							</template>
 							{{ t('mail', 'New text block') }}
 						</NcButton>
 						<template v-if="getSharedTextBlocks().length > 0">
@@ -129,7 +132,7 @@
 					<NcFormBoxSwitch
 						v-model="useDataCollection"
 						:label="t('mail', 'Data collection')"
-						:description="t('mail', 'Allow the app to collect and process data locally to adapt to your preferences.')"
+						:description="t('mail', 'Allow the app to collect and process data locally to adapt to your preferences')"
 						@update:modelValue="onToggleCollectData" />
 
 					<NcFormGroup :label="t('mail', 'Always show images from')">
@@ -141,7 +144,7 @@
 						v-model="useInternalAddresses"
 						:disabled="loadingInternalAddresses"
 						:label="internalAddressText"
-						:description="t('mail', 'Highlight external email addresses by enabling this feature, manage your internal addresses and domains to ensure recognized contacts stay unmarked.')"
+						:description="t('mail', 'Manage your internal addresses and domains to ensure recognized contacts stay unmarked')"
 						@update:modelValue="onToggleInternalAddress" />
 					<InternalAddress />
 
@@ -279,7 +282,7 @@ import {
 } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapState, mapStores } from 'pinia'
-import IconLink from 'vue-material-design-icons/ArrowTopRight.vue'
+import IconArrow from 'vue-material-design-icons/ArrowRight.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
 import HorizontalSplit from 'vue-material-design-icons/DockBottom.vue'
@@ -323,11 +326,11 @@ export default {
 		NcFormBoxButton,
 		NcFormBoxSwitch,
 		NcFormGroup,
-		IconLink,
 		IconDomain,
 		NcNoteCard,
 		NcHotkeyList,
 		NcHotkey,
+		IconArrow,
 	},
 
 	props: {

--- a/src/components/InternalAddress.vue
+++ b/src/components/InternalAddress.vue
@@ -53,6 +53,9 @@
 			type="secondary"
 			wide
 			@click="openDialog = true">
+			<template #icon>
+				<IconAdd :size="20" />
+			</template>
 			{{ t('mail', 'Add internal address') }}
 		</ButtonVue>
 		<NcDialog
@@ -76,6 +79,7 @@ import sortBy from 'lodash/fp/sortBy.js'
 import { mapStores } from 'pinia'
 import IconDomain from 'vue-material-design-icons/Domain.vue'
 import IconEmail from 'vue-material-design-icons/EmailOutline.vue'
+import IconAdd from 'vue-material-design-icons/Plus.vue'
 import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import logger from '../logger.js'
 import useMainStore from '../store/mainStore.js'
@@ -93,6 +97,7 @@ export default {
 		IconDomain,
 		IconEmail,
 		IconDelete,
+		IconAdd,
 	},
 
 	data() {


### PR DESCRIPTION
Address issues from followup on Settings redesign https://github.com/nextcloud/mail/pull/12031#pullrequestreview-3476131039

What this PR solves
- [x] Plus icons are missing from <kbd>+ New text block</kbd> and <kbd>+ Add internal address</kbd>
- ~The <kbd>+ Add mail account</kbd> button has rounded top corners, as opposed to on the mockup.~ - Will be done in Nextcloud Vue
- ~The text in lists is not aligned with that of form components cc ShGKme (how) can this be done?~ - Will be done in Nextcloud Vue
- [x] There are wording discrepancies that I outlined
- [x] > The icon on the account settings feels like a link file it acts like a button (it changes the settings dialog content) 
The current dialog content? Originally, it opened a separate dialog. If so, an icon like arrow_forward can be used to indicate navigation instead.