### PR TITLE
fix(setup): allow setup with ms oauth and no password

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -364,6 +364,7 @@ export default {
 
 			return !this.emailAddress || !this.isValidEmail(this.emailAddress)
 				|| (!this.googleOauthUrl && !this.autoConfig.password)
+				|| (!this.microsoftOauthUrl && !this.autoConfig.password)
 		},
 
 		isDisabledManual() {


### PR DESCRIPTION
Autoconfig should work with oauth and an empty password. There was logic for gmail but the ms one was missing.

## How to test

1. Set up MS oauth (or just enter random values)
2. Open account setup
3. Enter name and email

main: *Connect* button is disabled
here: *Connect* button is enabled