### PR TITLE
fix(search): apply correct search query when fetching envelopes

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -260,7 +260,7 @@ export default {
 				return this.mainStore.getEnvelopes(this.mailbox.databaseId, this.appendToSearch(priorityImportantQuery)).length > 0
 					|| this.mainStore.getEnvelopes(this.mailbox.databaseId, this.appendToSearch(priorityOtherQuery)).length > 0
 			}
-			return this.mainStore.getEnvelopes(this.mailbox.databaseId, this.searchQuery).length > 0
+			return this.mainStore.getEnvelopes(this.mailbox.databaseId, this.query).length > 0
 		},
 
 		hasImportantEnvelopes() {
@@ -316,10 +316,7 @@ export default {
 
 		query() {
 			if (this.$route.params.filter === 'starred') {
-				if (this.searchQuery) {
-					return this.appendToSearch('is:starred')
-				}
-				return 'is:starred'
+				return this.appendToSearch('is:starred')
 			}
 			return this.searchQuery
 		},
@@ -329,7 +326,7 @@ export default {
 		},
 
 		groupEnvelopes() {
-			const allEnvelopes = this.mainStore.getEnvelopes(this.mailbox.databaseId, this.searchQuery)
+			const allEnvelopes = this.mainStore.getEnvelopes(this.mailbox.databaseId, this.query)
 			return this.getGroupedEnvelopes(allEnvelopes, this.mainStore.syncTimestamp, this.sortOrder)
 		},
 
@@ -384,11 +381,11 @@ export default {
 		},
 
 		async fetchEnvelopes() {
-			const existingEnvelopes = this.mainStore.getEnvelopes(this.mailbox.databaseId, this.searchQuery || '')
+			const existingEnvelopes = this.mainStore.getEnvelopes(this.mailbox.databaseId, this.query)
 			if (!existingEnvelopes.length) {
 				await this.mainStore.fetchEnvelopes({
 					mailboxId: this.mailbox.databaseId,
-					query: this.searchQuery || '',
+					query: this.query,
 				})
 			}
 		},

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -811,7 +811,15 @@ export default function mainStoreActions() {
 					return Promise.reject(new Error('Cannot find last envelope. Required for the mailbox cursor'))
 				}
 
-				return fetchEnvelopes(mailbox.accountId, mailboxId, query, lastEnvelope.dateInt, quantity, this.getPreference('sort-order')).then((envelopes) => {
+				return fetchEnvelopes(
+					mailbox.accountId,
+					mailboxId,
+					query,
+					lastEnvelope.dateInt,
+					quantity,
+					this.getPreference('sort-order'),
+					this.getPreference('layout-message-view'),
+				).then((envelopes) => {
 					logger.debug(`fetched ${envelopes.length} messages for mailbox ${mailboxId}`, {
 						envelopes,
 						addToUnifiedMailboxes,

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -204,6 +204,7 @@ describe('Vuex store actions', () => {
 		}
 
 		store.preferences['sort-order'] = 'newest'
+		store.preferences['layout-message-view'] = 'threaded'
 
 		store.addAccountMutation(account13)
 		store.addMailboxMutation({
@@ -245,7 +246,7 @@ describe('Vuex store actions', () => {
 
 		expect(MessageService.fetchEnvelopes).toHaveBeenCalledTimes(1)
 		expect(MessageService.fetchEnvelopes)
-			.toHaveBeenNthCalledWith(1, 13, 11, undefined, 300000, PAGE_SIZE, 'newest')
+			.toHaveBeenNthCalledWith(1, 13, 11, undefined, 300000, PAGE_SIZE, 'newest', 'threaded')
 		expect(store.mailboxes[UNIFIED_INBOX_ID].envelopeLists[''].toSorted()).toEqual([
 			// Initial envelopes
 			...msgs1.map(mockEnvelope(11)),
@@ -335,6 +336,7 @@ describe('Vuex store actions', () => {
 		}
 
 		store.preferences['sort-order'] = 'newest'
+		store.preferences['layout-message-view'] = 'threaded'
 
 		store.addAccountMutation(account13)
 		store.addAccountMutation(account26)
@@ -403,9 +405,9 @@ describe('Vuex store actions', () => {
 
 		expect(MessageService.fetchEnvelopes).toHaveBeenCalledTimes(2)
 		expect(MessageService.fetchEnvelopes)
-			.toHaveBeenNthCalledWith(1, 13, 11, undefined, 300000, PAGE_SIZE, 'newest')
+			.toHaveBeenNthCalledWith(1, 13, 11, undefined, 300000, PAGE_SIZE, 'newest', 'threaded')
 		expect(MessageService.fetchEnvelopes)
-			.toHaveBeenNthCalledWith(2, 26, 21, undefined, 600000, PAGE_SIZE, 'newest')
+			.toHaveBeenNthCalledWith(2, 26, 21, undefined, 600000, PAGE_SIZE, 'newest', 'threaded')
 		expect(store.mailboxes[UNIFIED_INBOX_ID].envelopeLists[''].toSorted()).toEqual([
 			// Initial envelopes
 			...page1.map(mockEnvelope(11)),


### PR DESCRIPTION
Fix #11629 

https://github.com/nextcloud/mail/pull/12062/commits/6e7b529f5d9cc8bd9de8e6ce0fab19f5ced05523

`searchQuery` is only mutated when entering a search term. 
To apply `is:starred` (depending on the route), one must use the computed query property.

https://github.com/nextcloud/mail/pull/12062/commits/6c788ceb55e9b25424d5cd2c3b4d9848fe303a29

I noticed while testing that the view mode is not applied in fetchNextEnvelopes. Will do some more testing if that's on purpose or not.

Test cases:

1) Switch to inbox
2) Switch to favorite
3) Enter a search term in inbox
4) Enter a search term in favorites

The expected outcome is to see `?filter` for all requests with the right value. 