### PR TITLE
fix(imap): cache message body

### DIFF
--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -137,6 +137,10 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		return Horde_Mime_Headers_MessageId::create('nextcloud-mail-generated')->value;
 	}
 
+	public function hasHtmlMessage(): bool {
+		return $this->hasHtmlMessage;
+	}
+
 	/**
 	 * @return int
 	 */

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -13,6 +13,7 @@ namespace OCA\Mail\Tests\Unit\Controller;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Imap_Client_Socket;
 use OC\AppFramework\Http\Request;
+use OC\Memcache\NullCache;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OCA\Mail\Account;
 use OCA\Mail\Attachment;
@@ -48,6 +49,7 @@ use OCP\AppFramework\Http\ZipResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
+use OCP\ICacheFactory;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -130,6 +132,8 @@ class MessagesControllerTest extends TestCase {
 	/** @var MockObject|AiIntegrationsService */
 	private $aiIntegrationsService;
 
+	private ICacheFactory&MockObject $cacheFactory;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -155,6 +159,10 @@ class MessagesControllerTest extends TestCase {
 		$this->userPreferences = $this->createMock(IUserPreferences::class);
 		$this->snoozeService = $this->createMock(SnoozeService::class);
 		$this->aiIntegrationsService = $this->createMock(AiIntegrationsService::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+
+		$this->cacheFactory->method('createDistributed')
+			->willReturn(new NullCache());
 
 		$timeFactory = $this->createMocK(ITimeFactory::class);
 		$timeFactory->expects($this->any())
@@ -185,6 +193,7 @@ class MessagesControllerTest extends TestCase {
 			$this->userPreferences,
 			$this->snoozeService,
 			$this->aiIntegrationsService,
+			$this->cacheFactory,
 		);
 
 		$this->account = $this->createMock(Account::class);
@@ -1241,6 +1250,7 @@ class MessagesControllerTest extends TestCase {
 			$this->userPreferences,
 			$this->snoozeService,
 			$this->aiIntegrationsService,
+			$this->cacheFactory,
 		);
 
 		$actualResponse = $controller->needsTranslation(100);


### PR DESCRIPTION
Should help with https://github.com/nextcloud/mail/issues/10384

For HTML messages we already know that after the "body" request there is also an "html" request which also needs the body part, so keeping them in cache makes it a bit faster.

I went with distributed because even in these cases I would expect a small improvement. We skip the usual IMAP handshake and just fetch what we need.