### PR TITLE
fix(oauth): close popup window in parent window

### DIFF
--- a/src/integration/oauth.js
+++ b/src/integration/oauth.js
@@ -22,6 +22,7 @@ export async function getUserConsent(redirectUrl) {
 
 			if (data === 'DONE') {
 				logger.info('OAUTH2 user consent given')
+				ssoWindow.close()
 				resolve()
 			}
 		})

--- a/src/main-oauth-popup.js
+++ b/src/main-oauth-popup.js
@@ -20,5 +20,4 @@ new View({}).$mount('#mail-oauth-done')
 
 if (window.opener) {
 	window.opener.postMessage('DONE')
-	window.close()
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/9159

Hypothesis: the popup emits the DONE event. The event is processed slower than closing the window. So it's either never received or at the wrong time.

This changes the flow so the popup doesn't detroy itself but the parent window takes care of that.

Debugged with @hamza221 