### PR TITLE
feat: add occ command to list mail accounts

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -85,6 +85,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\DiagnoseAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>
 		<command>OCA\Mail\Command\ExportAccountThreads</command>
+		<command>OCA\Mail\Command\ListAccounts</command>
 		<command>OCA\Mail\Command\PredictImportance</command>
 		<command>OCA\Mail\Command\SyncAccount</command>
 		<command>OCA\Mail\Command\Thread</command>

--- a/lib/Command/ListAccounts.php
+++ b/lib/Command/ListAccounts.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Service\AccountService;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListAccounts extends Command {
+	public const ARGUMENT_USER_ID = 'user';
+	public const OPTION_FULL = 'full';
+	public const OPTION_ALL = 'all';
+
+	public function __construct(
+		private IUserManager $userManager,
+		private AccountService $accountService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('mail:account:list')
+			->setDescription('List mail accounts')
+			->addArgument(
+				self::ARGUMENT_USER_ID,
+				InputArgument::OPTIONAL,
+				'User ID to list accounts for'
+			)
+			->addOption(
+				self::OPTION_FULL,
+				'f',
+				InputOption::VALUE_NONE,
+				'Show full account details including server configuration'
+			)
+			->addOption(
+				self::OPTION_ALL,
+				'a',
+				InputOption::VALUE_NONE,
+				'List accounts for all users'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument(self::ARGUMENT_USER_ID);
+		$showFull = $input->getOption(self::OPTION_FULL);
+		$listAll = $input->getOption(self::OPTION_ALL);
+
+		if ($listAll) {
+			return $this->listAllAccounts($output, $showFull);
+		}
+
+		if ($userId === null) {
+			$output->writeln('<error>Please provide a user-id or use --all to list all accounts</error>');
+			return self::FAILURE;
+		}
+
+		if (!$this->userManager->userExists($userId)) {
+			$output->writeln("<error>User <$userId> does not exist</error>");
+			return self::FAILURE;
+		}
+
+		return $this->listUserAccounts($output, $userId, $showFull);
+	}
+
+	private function listUserAccounts(OutputInterface $output, string $userId, bool $showFull): int {
+		$accounts = $this->accountService->findByUserId($userId);
+
+		if (count($accounts) === 0) {
+			$output->writeln("<info>User <$userId> has no mail accounts</info>");
+			return self::SUCCESS;
+		}
+
+		$mailAccounts = array_map(fn ($account) => $account->getMailAccount(), $accounts);
+
+		$output->writeln("<info>Mail accounts for user <$userId>:</info>");
+		$this->renderAccountsTable($output, $mailAccounts, $showFull, false);
+
+		return self::SUCCESS;
+	}
+
+	private function listAllAccounts(OutputInterface $output, bool $showFull): int {
+		$mailAccounts = $this->accountService->getAllAcounts();
+
+		if (count($mailAccounts) === 0) {
+			$output->writeln('<info>No mail accounts found</info>');
+			return self::SUCCESS;
+		}
+
+		$output->writeln('<info>All mail accounts:</info>');
+		$this->renderAccountsTable($output, $mailAccounts, $showFull, true);
+
+		return self::SUCCESS;
+	}
+
+	/**
+	 * @param array<MailAccount> $mailAccounts
+	 */
+	private function renderAccountsTable(OutputInterface $output, array $mailAccounts, bool $showFull, bool $showUserId): void {
+		$table = new Table($output);
+
+		if ($showFull) {
+			$headers = ['ID'];
+			if ($showUserId) {
+				$headers[] = 'User ID';
+			}
+			$headers = array_merge($headers, [
+				'Email',
+				'Name',
+				'IMAP Host',
+				'IMAP Port',
+				'IMAP SSL',
+				'SMTP Host',
+				'SMTP Port',
+				'SMTP SSL',
+				'Provisioned',
+				'Debug',
+			]);
+			$table->setHeaders($headers);
+
+			foreach ($mailAccounts as $mailAccount) {
+				$row = [$mailAccount->getId()];
+				if ($showUserId) {
+					$row[] = $mailAccount->getUserId();
+				}
+				$row = array_merge($row, [
+					$mailAccount->getEmail(),
+					$mailAccount->getName(),
+					$mailAccount->getInboundHost(),
+					$mailAccount->getInboundPort(),
+					$mailAccount->getInboundSslMode(),
+					$mailAccount->getOutboundHost(),
+					$mailAccount->getOutboundPort(),
+					$mailAccount->getOutboundSslMode(),
+					$mailAccount->getProvisioningId() !== null ? 'Yes' : 'No',
+					$mailAccount->getDebug() ? 'Yes' : 'No',
+				]);
+				$table->addRow($row);
+			}
+		} else {
+			$headers = ['ID'];
+			if ($showUserId) {
+				$headers[] = 'User ID';
+			}
+			$headers = array_merge($headers, ['Email', 'Name', 'Provisioned', 'Debug']);
+			$table->setHeaders($headers);
+
+			foreach ($mailAccounts as $mailAccount) {
+				$row = [$mailAccount->getId()];
+				if ($showUserId) {
+					$row[] = $mailAccount->getUserId();
+				}
+				$row = array_merge($row, [
+					$mailAccount->getEmail(),
+					$mailAccount->getName(),
+					$mailAccount->getProvisioningId() !== null ? 'Yes' : 'No',
+					$mailAccount->getDebug() ? 'Yes' : 'No',
+				]);
+				$table->addRow($row);
+			}
+		}
+
+		$table->render();
+	}
+}


### PR DESCRIPTION
### Summary
- Added command to list mail accounts

### Usage
List for single user
occ mail:account:list 'user name'

List for all users
occ mail:account:list --all

List with full details
occ mail:account:list --all --full

### Output

List all users
<img width="729" height="141" alt="image" src="https://github.com/user-attachments/assets/558a0474-348c-4bd6-91af-a0f0fc3737d0" />

List single user
<img width="571" height="125" alt="image" src="https://github.com/user-attachments/assets/8e9fd037-9145-45a8-981a-5bb69773fe60" />
