### PR TITLE
feat: automated appointment creation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>5.7.0-beta.2</version>
+	<version>5.7.0-beta.3</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/lib/Account.php
+++ b/lib/Account.php
@@ -69,6 +69,10 @@ class Account implements JsonSerializable {
 		return $this->account->getDebug();
 	}
 
+	public function getImipCreate(): bool {
+		return $this->account->getImipCreate();
+	}
+
 	/**
 	 * Set the quota percentage
 	 * @param Quota $quota

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -234,7 +234,9 @@ class AccountsController extends Controller {
 		?int $trashRetentionDays = null,
 		?int $junkMailboxId = null,
 		?bool $searchBody = null,
-		?bool $classificationEnabled = null): JSONResponse {
+		?bool $classificationEnabled = null,
+		?bool $imipCreate = null,
+	): JSONResponse {
 		$account = $this->accountService->find($this->currentUserId, $id);
 
 		$dbAccount = $account->getMailAccount();
@@ -284,6 +286,9 @@ class AccountsController extends Controller {
 		}
 		if ($classificationEnabled !== null) {
 			$dbAccount->setClassificationEnabled($classificationEnabled);
+		}
+		if ($imipCreate !== null) {
+			$dbAccount->setImipCreate($imipCreate);
 		}
 		return new JSONResponse(
 			new Account($this->accountService->save($dbAccount))

--- a/lib/Db/MailAccount.php
+++ b/lib/Db/MailAccount.php
@@ -105,6 +105,8 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDebug(bool $debug)
  * @method bool getClassificationEnabled()
  * @method void setClassificationEnabled(bool $classificationEnabled)
+ * @method bool getImipCreate()
+ * @method void setImipCreate(bool $value)
  */
 class MailAccount extends Entity {
 	public const SIGNATURE_MODE_PLAIN = 0;
@@ -190,6 +192,8 @@ class MailAccount extends Entity {
 	protected bool $debug = false;
 	protected bool $classificationEnabled = true;
 
+	protected bool $imipCreate = false;
+
 	/**
 	 * @param array $params
 	 */
@@ -253,6 +257,9 @@ class MailAccount extends Entity {
 		if (isset($params['classificationEnabled'])) {
 			$this->setClassificationEnabled($params['classificationEnabled']);
 		}
+		if (isset($params['imipCreate'])) {
+			$this->setImipCreate($params['imipCreate']);
+		}
 
 		$this->addType('inboundPort', 'integer');
 		$this->addType('outboundPort', 'integer');
@@ -278,6 +285,7 @@ class MailAccount extends Entity {
 		$this->addType('oooFollowsSystem', 'boolean');
 		$this->addType('debug', 'boolean');
 		$this->addType('classificationEnabled', 'boolean');
+		$this->addType('imipCreate', 'boolean');
 	}
 
 	public function getOutOfOfficeFollowsSystem(): bool {
@@ -328,6 +336,7 @@ class MailAccount extends Entity {
 			'outOfOfficeFollowsSystem' => $this->getOutOfOfficeFollowsSystem(),
 			'debug' => $this->getDebug(),
 			'classificationEnabled' => $this->getClassificationEnabled(),
+			'imipCreate' => $this->getImipCreate(),
 		];
 
 		if (!is_null($this->getOutboundHost())) {

--- a/lib/Migration/Version5007Date20251208000000.php
+++ b/lib/Migration/Version5007Date20251208000000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version5007Date20251208000000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		$accountsTable = $schema->getTable('mail_accounts');
+		if (!$accountsTable->hasColumn('imip_create')) {
+			$accountsTable->addColumn('imip_create', Types::BOOLEAN, [
+				'default' => false,
+				'notnull' => false,
+			]);
+		}
+		return $schema;
+	}
+}

--- a/lib/Util/ServerVersion.php
+++ b/lib/Util/ServerVersion.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Util;
+
+use OCP\ServerVersion as OCPServerVersion;
+
+class ServerVersion {
+
+	public function __construct(
+		private OCPServerVersion $serverVersion,
+	) {
+	}
+
+	public function getMajorVersion(): int {
+		return $this->serverVersion->getMajorVersion();
+	}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextcloud-mail",
-  "version": "5.7.0-beta.2",
+  "version": "5.7.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "5.7.0-beta.2",
+      "version": "5.7.0-beta.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud-mail",
-  "version": "5.7.0-beta.2",
+  "version": "5.7.0-beta.3",
   "private": true,
   "description": "Nextcloud Mail",
   "license": "AGPL-3.0-only",

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -63,6 +63,12 @@
 			</div>
 		</AppSettingsSection>
 		<AppSettingsSection
+			v-if="account && systemVersion >= 33"
+			id="calendar-settings"
+			:name="t('mail', 'Calendar settings')">
+			<CalendarSettings :account="account" />
+		</AppSettingsSection>
+		<AppSettingsSection
 			v-if="account"
 			id="classification"
 			:name="t('mail', 'Classification settings')">
@@ -138,6 +144,7 @@ import AccountForm from '../components/AccountForm.vue'
 import AliasSettings from '../components/AliasSettings.vue'
 import EditorSettings from '../components/EditorSettings.vue'
 import SignatureSettings from '../components/SignatureSettings.vue'
+import CalendarSettings from './CalendarSettings.vue'
 import CertificateSettings from './CertificateSettings.vue'
 import MailFilters from './mailFilter/MailFilters.vue'
 import OutOfOfficeForm from './OutOfOfficeForm.vue'
@@ -161,6 +168,7 @@ export default {
 		AppSettingsDialog,
 		AppSettingsSection,
 		AccountDefaultsSettings,
+		CalendarSettings,
 		OutOfOfficeForm,
 		CertificateSettings,
 		TrashRetentionSettings,
@@ -188,6 +196,7 @@ export default {
 			trapElements: [],
 			fetchActiveSieveScript: this.account.sieveEnabled,
 			loadingClassificationToggle: false,
+			systemVersion: parseInt(OC.config.version.split('.')[0], 10),
 		}
 	},
 

--- a/src/components/CalendarSettings.vue
+++ b/src/components/CalendarSettings.vue
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div>
+		<NcCheckboxRadioSwitch
+			id="imip-create"
+			:checked="imipCreate"
+			:disabled="saving"
+			@update:checked="onToggleImipCreate">
+			{{ t('mail', 'Automatically create tentative appointments in calendar') }}
+		</NcCheckboxRadioSwitch>
+	</div>
+</template>
+
+<script>
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import Logger from '../logger.js'
+import useMainStore from '../store/mainStore.js'
+
+export default {
+	name: 'CalendarSettings',
+	components: {
+		NcCheckboxRadioSwitch,
+	},
+
+	props: {
+		account: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			imipCreate: this.account.imipCreate,
+			saving: false,
+		}
+	},
+
+	computed: {
+		...mapStores(useMainStore),
+	},
+
+	methods: {
+		async onToggleImipCreate(val) {
+			if (this.saving) {
+				return
+			}
+
+			const oldVal = this.imipCreate
+			this.imipCreate = val
+			this.saving = true
+
+			try {
+				await this.mainStore.patchAccount({
+					account: this.account,
+					data: {
+						imipCreate: val,
+					},
+				})
+				Logger.info(`Automatic calendar appointment creation ${val ? 'enabled' : 'disabled'}`)
+			} catch (error) {
+				Logger.error(`could not ${val ? 'enable' : 'disable'} automatic calendar appointment creation`, { error })
+				this.imipCreate = oldVal
+				throw error
+			} finally {
+				this.saving = false
+			}
+		},
+	},
+}
+</script>

--- a/tests/Integration/Db/MailAccountTest.php
+++ b/tests/Integration/Db/MailAccountTest.php
@@ -73,6 +73,7 @@ class MailAccountTest extends TestCase {
 			'debug' => false,
 			'classificationEnabled' => true,
 			'authMethod' => 'password',
+			'imipCreate' => false,
 		], $a->toJson());
 	}
 
@@ -113,6 +114,7 @@ class MailAccountTest extends TestCase {
 			'debug' => false,
 			'classificationEnabled' => true,
 			'authMethod' => 'password',
+			'imipCreate' => false,
 		];
 		$a = new MailAccount($expected);
 		// TODO: fix inconsistency


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/mail/issues/7750
- Requires: https://github.com/nextcloud/server/pull/56924
- Added option in account setting to enable feature per account
- Modified imip service to use new imip handler

### Testing
- Navigate to mail account settings, turn on "Automatically create tentative appointments"
- Using another external account/service send a calendar invitation to the configure nc mail account
- Trigger cron job to run background jobs

<img width="945" height="132" alt="image" src="https://github.com/user-attachments/assets/79cae23e-0935-47ff-bbd5-3e78154cda49" />

### Documentation
https://github.com/nextcloud/documentation/pull/14009
