### PR TITLE
test: avoid calling Job::setId

### DIFF
--- a/tests/Unit/BackgroundJob/QuotaJobTest.php
+++ b/tests/Unit/BackgroundJob/QuotaJobTest.php
@@ -43,8 +43,6 @@ class QuotaJobTest extends TestCase {
 		$this->job->setArgument([
 			'accountId' => 123,
 		]);
-		// Set a fake ID
-		$this->job->setId(99);
 	}
 
 	public function testAccountDoesntExist(): void {

--- a/tests/Unit/BackgroundJob/SyncJobTest.php
+++ b/tests/Unit/BackgroundJob/SyncJobTest.php
@@ -39,8 +39,6 @@ class SyncJobTest extends TestCase {
 		$this->job->setArgument([
 			'accountId' => 123,
 		]);
-		// Set a fake ID
-		$this->job->setId(99);
 	}
 
 	public function testAccountDoesntExist(): void {


### PR DESCRIPTION
The OCP API changed from int to string, which makes it hard to call the method correctly for multi-version apps like Mail.