### PR TITLE
fix(auth): show more specific error for denied authentication

### DIFF
--- a/lib/Exception/CouldNotConnectException.php
+++ b/lib/Exception/CouldNotConnectException.php
@@ -65,7 +65,11 @@ class CouldNotConnectException extends ServiceException {
 
 		switch ($this->previous->getCode()) {
 			case Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED:
-				return 'AUTHENTICATION';
+				return match ($this->previous->getMessage()) {
+					'Authentication failed.' => 'AUTHENTICATION_WRONG_PASSWORD',
+					'Mail server denied authentication.' => 'AUTHENTICATION_DENIED',
+					default => 'AUTHENTICATION',
+				};
 			case Horde_Imap_Client_Exception::SERVER_CONNECT:
 			case Horde_Imap_Client_Exception::SERVER_READERROR:
 				return 'CONNECTION_ERROR';

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -683,11 +683,23 @@ export default {
 					} else if (error.data.service === 'SMTP') {
 						this.feedback = t('mail', 'SMTP server is not reachable')
 					}
-				} else if (error.data?.error === 'AUTHENTICATION') {
+				} else if (error.data?.error === 'AUTHENTICATION_WRONG_PASSWORD') {
 					if (error.data.service === 'IMAP') {
 						this.feedback = t('mail', 'IMAP username or password is wrong')
 					} else if (error.data.service === 'SMTP') {
 						this.feedback = t('mail', 'SMTP username or password is wrong')
+					}
+				} else if (error.data?.error === 'AUTHENTICATION_DENIED') {
+					if (error.data.service === 'IMAP') {
+						this.feedback = t('mail', 'IMAP server denied authentication')
+					} else if (error.data.service === 'SMTP') {
+						this.feedback = t('mail', 'SMTP server denied authentication')
+					}
+				} else if (error.data?.error === 'AUTHENTICATION') {
+					if (error.data.service === 'IMAP') {
+						this.feedback = t('mail', 'IMAP authentication error')
+					} else if (error.data.service === 'SMTP') {
+						this.feedback = t('mail', 'SMTP authentication error')
 					}
 				} else {
 					if (error.data?.service === 'IMAP') {


### PR DESCRIPTION
Before: every auth error shows as *Username or password is wrong*:

<img width="396" height="266" alt="Bildschirmfoto vom 2025-12-16 11-05-13" src="https://github.com/user-attachments/assets/56629d7e-7e1d-4aca-9704-8d90b11a6de8" />

Now: specific handling for authentication denied, username/password wrong, and generic auth errors:

<img width="396" height="266" alt="Bildschirmfoto vom 2025-12-16 11-06-13" src="https://github.com/user-attachments/assets/d3ba3c48-f059-4f62-833d-500323768341" />

Ref https://github.com/nextcloud/mail/issues/12168