### PR TITLE
build: use npm ci with krankerl

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -3,7 +3,7 @@
 [package]
 before_cmds = [
 	"composer install --no-dev -o",
-	"npm install --deps",
+	"npm ci",
 	"npm run build",
 	"composer openapi"
 ]


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/10471

As npm ci is preferred for production builds.

I will log a follow-up because we still build the app two times (once with the workflow, once with krankerl). 
