### PR TITLE
chore: flip shortcuts and about

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -200,11 +200,7 @@
 						</NcFormBoxSwitch>
 					</NcFormBox>
 				</NcAppSettingsSection>
-				<NcAppSettingsSection id="about-settings" :name="t('mail', 'About')">
-					<NcFormGroup
-						:label="t('mail', 'Acknowledgements')"
-						:description="t('mail', 'This application includes CKEditor, an open-source editor. Copyright © CKEditor contributors. Licensed under GPLv2.')" />
-				</NcAppSettingsSection>
+
 				<NcAppSettingsShortcutsSection>
 					<NcHotkeyList>
 						<NcHotkey :label="t('mail', 'Compose new message')" hotkey="C" />
@@ -219,6 +215,12 @@
 						<NcHotkey :label="t('mail', 'Refresh')" hotkey="R" />
 					</NcHotkeyList>
 				</NcAppSettingsShortcutsSection>
+
+				<NcAppSettingsSection id="about-settings" :name="t('mail', 'About')">
+					<NcFormGroup
+						:label="t('mail', 'Acknowledgements')"
+						:description="t('mail', 'This application includes CKEditor, an open-source editor. Copyright © CKEditor contributors. Licensed under GPLv2.')" />
+				</NcAppSettingsSection>
 
 				<NcDialog
 					:open.sync="textBlockDialogOpen"


### PR DESCRIPTION
This was lost in the forms overhaul, now its back ;)

| **B** | **A** |
|--------|--------|
| <img width="1148" height="1012" alt="Screenshot From 2025-12-16 13-41-26" src="https://github.com/user-attachments/assets/63ef52c1-6b51-4a8c-b675-2432aee05893" /> | <img width="1148" height="1012" alt="Screenshot From 2025-12-16 13-42-29" src="https://github.com/user-attachments/assets/7389da5d-4209-4903-bd0d-63066fa3449f" /> |




