### PR TITLE
fix(ui): bind attr to popover trigger

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -27,8 +27,10 @@
 						<Popover
 							v-if="threadParticipants.length > participantsToDisplay"
 							class="avatar-more">
-							<template #trigger>
-								<span class="avatar-more">
+							<template #trigger="{ attrs }">
+								<span
+									class="avatar-more"
+									v-bind="attrs">
 									{{ moreParticipantsString }}
 								</span>
 							</template>


### PR DESCRIPTION
Fixes

```
[Vue warn]: It looks like you are using a custom button as a <NcPopover> or other popover #trigger. If you are not using <NcButton> as a trigger, you need to bind attrs from the #trigger slot props to your custom button. See <NcPopover> docs for an example.

found in

---> <NcPopover>
       <NcActions>
         <RouterLink>
           <EnvelopeSkeleton> at src/components/EnvelopeSkeleton.vue
             <Envelope> at src/components/Envelope.vue
               <TransitionGroup>
                 <EnvelopeList> at src/components/EnvelopeList.vue
                   <Mailbox> at src/components/Mailbox.vue
                     <NcAppContentList>
                       <Pane>
                         <Splitpanes>
                           <NcAppContent>
                             <MailboxThread> at src/components/MailboxThread.vue
                               <NcContent>
                                 <Home> at src/views/Home.vue
                                   <App> at src/App.vue
                                     <Root>
```

after page load

From https://nextcloud-vue-components.netlify.app/#/Components/NcPopover

> If you are using your own custom button as a trigger make sure to bind attrs from the trigger slot props.