### PR TITLE
feat(PhishingDetection): Add support for the `$Phishing` IMAP flag

### DIFF
--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -84,6 +84,7 @@ class Message extends Entity implements JsonSerializable {
 		'forwarded',
 		'$junk',
 		'$notjunk',
+		'$phishing',
 		'mdnsent',
 		Tag::LABEL_IMPORTANT,
 		'$important' // @todo remove this when we have removed all references on IMAP to $important @link https://github.com/nextcloud/mail/issues/25

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -532,7 +532,7 @@ class ImapMessageFetcher {
 		$this->hasDkimSignature = $dkimSignatureHeader !== null;
 
 		if ($this->runPhishingCheck) {
-			$this->phishingDetails = $this->phishingDetectionService->checkHeadersForPhishing($parsedHeaders, $this->hasHtmlMessage, $this->htmlMessage);
+			$this->phishingDetails = $this->phishingDetectionService->checkHeadersForPhishing($parsedHeaders, $fetch->getFlags(), $this->hasHtmlMessage, $this->htmlMessage);
 		}
 
 		$listUnsubscribeHeader = $parsedHeaders->getHeader('list-unsubscribe');

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -537,7 +537,6 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			|| in_array('junk', $flags, true)
 		);
 		$msg->setFlagNotjunk(in_array(Horde_Imap_Client::FLAG_NOTJUNK, $flags, true) || in_array('nonjunk', $flags, true));// While this is not a standard IMAP Flag, Thunderbird uses it to mark "not junk"
-		// @todo remove this as soon as possible @link https://github.com/nextcloud/mail/issues/25
 		$msg->setFlagImportant(in_array('$important', $flags, true) || in_array('$labelimportant', $flags, true) || in_array(Tag::LABEL_IMPORTANT, $flags, true));
 		$msg->setFlagAttachments(false);
 		$msg->setFlagMdnsent(in_array(Horde_Imap_Client::FLAG_MDNSENT, $flags, true));
@@ -554,6 +553,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			Horde_Imap_Client::FLAG_JUNK,
 			Horde_Imap_Client::FLAG_NOTJUNK,
 			'nonjunk', // While this is not a standard IMAP Flag, Thunderbird uses it to mark "not junk"
+			'$phishing', // Horde has no const for this flag yet
 			Horde_Imap_Client::FLAG_MDNSENT,
 			Horde_Imap_Client::FLAG_RECENT,
 			Horde_Imap_Client::FLAG_SEEN,

--- a/lib/PhishingDetectionList.php
+++ b/lib/PhishingDetectionList.php
@@ -30,7 +30,7 @@ class PhishingDetectionList implements JsonSerializable {
 
 	private function isWarning(): bool {
 		foreach ($this->checks as $check) {
-			if (in_array($check->getType(), [PhishingDetectionResult::DATE_CHECK, PhishingDetectionResult::LINK_CHECK, PhishingDetectionResult::CUSTOM_EMAIL_CHECK, PhishingDetectionResult::CONTACTS_CHECK]) && $check->isPhishing()) {
+			if (in_array($check->getType(), [PhishingDetectionResult::DATE_CHECK, PhishingDetectionResult::LINK_CHECK, PhishingDetectionResult::CUSTOM_EMAIL_CHECK, PhishingDetectionResult::CONTACTS_CHECK, PhishingDetectionResult::IMAP_FLAG_CHECK]) && $check->isPhishing()) {
 				return true;
 			}
 		}

--- a/lib/PhishingDetectionResult.php
+++ b/lib/PhishingDetectionResult.php
@@ -21,6 +21,7 @@ final class PhishingDetectionResult implements JsonSerializable {
 	public const REPLYTO_CHECK = 'Reply-To';
 	public const CUSTOM_EMAIL_CHECK = 'Custom Email';
 	public const CONTACTS_CHECK = 'Contacts';
+	public const IMAP_FLAG_CHECK = 'IMAP Flag';
 	public const TRUSTED_CHECK = 'Trusted';
 
 	private string $message = '';

--- a/lib/Service/PhishingDetection/ImapFlagCheck.php
+++ b/lib/Service/PhishingDetection/ImapFlagCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Service\PhishingDetection;
+
+use Horde_Imap_Client;
+use OCA\Mail\PhishingDetectionResult;
+use OCP\IL10N;
+
+class ImapFlagCheck {
+	protected IL10N $l10n;
+
+	public function __construct(IL10N $l10n) {
+		$this->l10n = $l10n;
+	}
+
+	/**
+	 * @param string[] $messageFlags
+	 */
+	public function run(array $messageFlags): PhishingDetectionResult {
+		$flaggedAsSpam = in_array(Horde_Imap_Client::FLAG_JUNK, $messageFlags, true) || in_array('junk', $messageFlags, true);
+		// TODO: Use Horde const once the flag is implemented there
+		//  (https://github.com/bytestream/Imap_Client/blob/master/lib/Horde/Imap/Client.php#L153).
+		$flaggedAsPhishing = in_array('$phishing', $messageFlags, true);
+
+		if ($flaggedAsSpam && $flaggedAsPhishing) {
+			return new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, true, $this->l10n->t('Mail server marked this message as phishing attempt'));
+		}
+
+		return new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, false);
+	}
+}

--- a/lib/Service/PhishingDetection/PhishingDetectionService.php
+++ b/lib/Service/PhishingDetection/PhishingDetectionService.php
@@ -21,10 +21,19 @@ class PhishingDetectionService {
 		private DateCheck $dateCheck,
 		private ReplyToCheck $replyToCheck,
 		private LinkCheck $linkCheck,
+		private ImapFlagCheck $imapFlagCheck,
 	) {
 	}
 
-	public function checkHeadersForPhishing(Horde_Mime_Headers $headers, bool $hasHtmlMessage, string $htmlMessage = ''): array {
+	/**
+	 * @param Horde_Mime_Headers $headers
+	 * @param string[] $flags
+	 * @param bool $hasHtmlMessage
+	 * @param string $htmlMessage
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function checkHeadersForPhishing(Horde_Mime_Headers $headers, array $flags, bool $hasHtmlMessage, string $htmlMessage = ''): array {
 		/** @var string|null $fromFN */
 		$fromFN = null;
 		/** @var string|null $fromEmail */
@@ -66,6 +75,9 @@ class PhishingDetectionService {
 		if ($date !== null) {
 			$list->addCheck($this->dateCheck->run($date));
 		}
+
+		$list->addCheck($this->imapFlagCheck->run($flags));
+
 		if ($hasHtmlMessage) {
 			$list->addCheck($this->linkCheck->run($htmlMessage));
 		}

--- a/src/tests/unit/components/PhishingWarning.vue.spec.js
+++ b/src/tests/unit/components/PhishingWarning.vue.spec.js
@@ -1,0 +1,165 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import PhishingWarning from '../../../components/PhishingWarning.vue'
+import Nextcloud from '../../../mixins/Nextcloud.js'
+
+const localVue = createLocalVue()
+localVue.mixin(Nextcloud)
+
+describe('PhishingWarning', () => {
+	it('Should only show messages from positive checks', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [
+					{
+						isPhishing: false,
+						message: 'Lorem ipsum',
+					},
+					{
+						isPhishing: true,
+						message: 'Ipsum lorem',
+					},
+				],
+			},
+			localVue,
+		})
+
+		expect(view.text()).not.toContain('Lorem ipsum')
+		expect(view.text()).toContain('Ipsum lorem')
+	})
+
+	it('Should show the messages of multiple positive checks', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [{
+					isPhishing: true,
+					message: 'Lorem ipsum',
+				},
+				{
+					isPhishing: true,
+					message: 'Ipsum lorem',
+				}],
+			},
+			localVue,
+		})
+
+		expect(view.text()).toContain('Lorem ipsum')
+		expect(view.text()).toContain('Ipsum lorem')
+	})
+
+	it('Should display the option to expand the list of suspicious links', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [{
+					isPhishing: true,
+					message: 'Lorem ipsum',
+					type: 'Link',
+					additionalData: [
+						{
+							href: 'http://lorem.ipsum/',
+							linkText: 'Stet clita kasd gubergren',
+						},
+						{
+							href: 'http://lorem2.ipsum/',
+							linkText: 'At vero eos et',
+						},
+					],
+				}],
+			},
+			localVue,
+		})
+
+		expect(view.text()).toContain('Show suspicious links')
+	})
+
+	it('Should hide the list of suspicious links by default', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [{
+					isPhishing: true,
+					message: 'Lorem ipsum',
+					type: 'Link',
+					additionalData: [
+						{
+							href: 'http://lorem.ipsum/',
+							linkText: 'Stet clita kasd gubergren',
+						},
+						{
+							href: 'http://lorem2.ipsum/',
+							linkText: 'At vero eos et',
+						},
+					],
+				}],
+			},
+			localVue,
+		})
+
+		expect(view.text()).not.toContain('href: http://lorem.ipsum/')
+		expect(view.text()).not.toContain('link text: Stet clita kasd gubergren')
+		expect(view.text()).not.toContain('href: http://lorem2.ipsum/')
+		expect(view.text()).not.toContain('At vero eos et')
+	})
+
+	it('Should show a list of suspicious links when requested', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [{
+					isPhishing: true,
+					message: 'Lorem ipsum',
+					type: 'Link',
+					additionalData: [
+						{
+							href: 'http://lorem.ipsum/',
+							linkText: 'Stet clita kasd gubergren',
+						},
+						{
+							href: 'http://lorem2.ipsum/',
+							linkText: 'At vero eos et',
+						},
+					],
+				}],
+			},
+			data() {
+				return { showMore: true }
+			},
+			localVue,
+		})
+
+		expect(view.text()).toContain('href: http://lorem.ipsum/')
+		expect(view.text()).toContain('link text: Stet clita kasd gubergren')
+		expect(view.text()).toContain('href: http://lorem2.ipsum/')
+		expect(view.text()).toContain('At vero eos et')
+	})
+
+	it('Should display the option to collapse the list of suspicious links', async () => {
+		const view = shallowMount(PhishingWarning, {
+			propsData: {
+				phishingData: [{
+					isPhishing: true,
+					message: 'Lorem ipsum',
+					type: 'Link',
+					additionalData: [
+						{
+							href: 'http://lorem.ipsum/',
+							linkText: 'Stet clita kasd gubergren',
+						},
+						{
+							href: 'http://lorem2.ipsum/',
+							linkText: 'At vero eos et',
+						},
+					],
+				}],
+			},
+			data() {
+				return { showMore: true }
+			},
+			localVue,
+		})
+
+		expect(view.text()).toContain('Hide suspicious links')
+	})
+})

--- a/tests/Unit/Service/Phishing/ImapFlagCheckTest.php
+++ b/tests/Unit/Service/Phishing/ImapFlagCheckTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Integration\Service\Phishing;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+
+use Horde_Imap_Client;
+use OCA\Mail\Service\PhishingDetection\ImapFlagCheck;
+use OCP\IL10N;
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ImapFlagCheckTest extends TestCase {
+
+	private IL10N|MockObject $l10n;
+	private ImapFlagCheck $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->service = new ImapFlagCheck($this->l10n);
+	}
+
+	public function testNoFlags(): void {
+		$flags = [];
+		$result = $this->service->run($flags);
+
+		$this->assertFalse($result->isPhishing());
+	}
+
+	public function testOnlySpamFlag(): void {
+		$flags = [Horde_Imap_Client::FLAG_JUNK];
+		$result = $this->service->run($flags);
+
+		$this->assertFalse($result->isPhishing());
+	}
+
+	public function testOnlyPhishingFlag(): void {
+		// TODO: Use Horde const once the flag is implemented there
+		//  (https://github.com/bytestream/Imap_Client/blob/master/lib/Horde/Imap/Client.php#L153).
+		$flags = ['$phishing'];
+		$result = $this->service->run($flags);
+
+		$this->assertFalse($result->isPhishing());
+	}
+
+	public function testSpamAndPhishingFlag(): void {
+		// TODO: Use Horde const for $phishing once the flag is implemented there
+		//  (https://github.com/bytestream/Imap_Client/blob/master/lib/Horde/Imap/Client.php#L153).
+		$flags = [Horde_Imap_Client::FLAG_JUNK, '$phishing'];
+		$result = $this->service->run($flags);
+
+		$this->assertTrue($result->isPhishing());
+	}
+
+	public function testThunderbirdSpamAndPhishingFlag(): void {
+		// TODO: Use Horde const for $phishing once the flag is implemented there
+		//  (https://github.com/bytestream/Imap_Client/blob/master/lib/Horde/Imap/Client.php#L153).
+		$flags = ['junk', '$phishing'];
+		$result = $this->service->run($flags);
+
+		$this->assertTrue($result->isPhishing());
+	}
+}

--- a/tests/Unit/Service/Phishing/PhishingDetectionServiceTest.php
+++ b/tests/Unit/Service/Phishing/PhishingDetectionServiceTest.php
@@ -14,6 +14,7 @@ use OCA\Mail\PhishingDetectionResult;
 use OCA\Mail\Service\PhishingDetection\ContactCheck;
 use OCA\Mail\Service\PhishingDetection\CustomEmailCheck;
 use OCA\Mail\Service\PhishingDetection\DateCheck;
+use OCA\Mail\Service\PhishingDetection\ImapFlagCheck;
 use OCA\Mail\Service\PhishingDetection\LinkCheck;
 use OCA\Mail\Service\PhishingDetection\PhishingDetectionService;
 use OCA\Mail\Service\PhishingDetection\ReplyToCheck;
@@ -27,6 +28,7 @@ class PhishingDetectionServiceTest extends TestCase {
 	private DateCheck|MockObject $dateCheck;
 	private ReplyToCheck|MockObject $replyToCheck;
 	private LinkCheck|MockObject $linkCheck;
+	private ImapFlagCheck $imapFlagCheck;
 	private PhishingDetectionService $service;
 
 	protected function setUp(): void {
@@ -36,7 +38,8 @@ class PhishingDetectionServiceTest extends TestCase {
 		$this->dateCheck = $this->createMock(DateCheck::class);
 		$this->replyToCheck = $this->createMock(ReplyToCheck::class);
 		$this->linkCheck = $this->createMock(LinkCheck::class);
-		$this->service = new PhishingDetectionService($this->contactCheck, $this->customEmailCheck, $this->dateCheck, $this->replyToCheck, $this->linkCheck);
+		$this->imapFlagCheck = $this->createMock(ImapFlagCheck::class);
+		$this->service = new PhishingDetectionService($this->contactCheck, $this->customEmailCheck, $this->dateCheck, $this->replyToCheck, $this->linkCheck, $this->imapFlagCheck);
 	}
 
 	public function testCheckHeadersForPhishing(): void {
@@ -60,7 +63,10 @@ class PhishingDetectionServiceTest extends TestCase {
 		$this->linkCheck->expects($this->once())
 			->method('run')
 			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::LINK_CHECK, false));
-		$result = $this->service->checkHeadersForPhishing($parsedHeaders, true, '');
+		$this->imapFlagCheck->expects($this->once())
+			->method('run')
+			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, false));
+		$result = $this->service->checkHeadersForPhishing($parsedHeaders, [], true, '');
 		$this->assertFalse($result['warning']);
 	}
 
@@ -81,7 +87,10 @@ class PhishingDetectionServiceTest extends TestCase {
 		$this->linkCheck->expects($this->once())
 			->method('run')
 			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::LINK_CHECK, false));
-		$result = $this->service->checkHeadersForPhishing($parsedHeaders, true, '');
+		$this->imapFlagCheck->expects($this->once())
+			->method('run')
+			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, false));
+		$result = $this->service->checkHeadersForPhishing($parsedHeaders, [], true, '');
 		$this->assertFalse($result['warning']);
 	}
 
@@ -104,7 +113,10 @@ class PhishingDetectionServiceTest extends TestCase {
 		$this->linkCheck->expects($this->once())
 			->method('run')
 			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::LINK_CHECK, false));
-		$result = $this->service->checkHeadersForPhishing($parsedHeaders, true, '');
+		$this->imapFlagCheck->expects($this->once())
+			->method('run')
+			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, false));
+		$result = $this->service->checkHeadersForPhishing($parsedHeaders, [], true, '');
 		$this->assertFalse($result['warning']);
 	}
 
@@ -129,7 +141,10 @@ class PhishingDetectionServiceTest extends TestCase {
 		$this->linkCheck->expects($this->once())
 			->method('run')
 			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::LINK_CHECK, false));
-		$result = $this->service->checkHeadersForPhishing($parsedHeaders, true, '');
+		$this->imapFlagCheck->expects($this->once())
+			->method('run')
+			->willReturn(new PhishingDetectionResult(PhishingDetectionResult::IMAP_FLAG_CHECK, false));
+		$result = $this->service->checkHeadersForPhishing($parsedHeaders, [], true, '');
 		$this->assertFalse($result['warning']);
 	}
 }


### PR DESCRIPTION
This PR introduces support for the `$Phishing` IMAP flag defined since IMAP4rev2 (see [RFC9051](https://datatracker.ietf.org/doc/html/rfc9051#name-flags-message-attribute)). When the flag is set by the delivery agent (e.g., Dovecot), the following warning is being shown to the user:

<img width="614" height="261" alt="Screenshot 2025-12-18 at 22-21-40 Mail - Nextcloud" src="https://github.com/user-attachments/assets/db9711c5-7a97-4589-8c0c-2de4e60fd864" />

**Important**: For compatibility reasons, the warning is only being shown when both the `$Junk` / `Junk` and `$Phishing` flags are present. That matches the behavior described in the RFC with the exception that Thunderbird is being supported as well, although it uses a non-standard flag for junk/non-junk flagging.

Additionally, I've added some unit tests for the phishing warning front-end component.

Closes https://github.com/nextcloud/mail/issues/11169