### PR TITLE
fix: Fix incorrect flag for MDN sent and hide junk flag used by Thunderbird

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -472,7 +472,7 @@ class MessagesController extends Controller {
 
 		try {
 			$this->mailTransmission->sendMdn($account, $mailbox, $message);
-			$this->mailManager->flagMessage($account, $mailbox->getName(), $message->getUid(), 'mdnsent', true);
+			$this->mailManager->flagMessage($account, $mailbox->getName(), $message->getUid(), '$mdnsent', true);
 		} catch (ServiceException $ex) {
 			$this->logger->error('Sending mdn failed: ' . $ex->getMessage());
 			throw $ex;

--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -85,7 +85,7 @@ class Message extends Entity implements JsonSerializable {
 		'$junk',
 		'$notjunk',
 		'$phishing',
-		'mdnsent',
+		'$mdnsent',
 		Tag::LABEL_IMPORTANT,
 		'$important' // @todo remove this when we have removed all references on IMAP to $important @link https://github.com/nextcloud/mail/issues/25
 	];
@@ -287,6 +287,8 @@ class Message extends Entity implements JsonSerializable {
 			$this->setFlagJunk($value);
 		} elseif ($flag === '$notjunk') {
 			$this->setFlagNotjunk($value);
+		} elseif ($flag === '$mdnsent') {
+			$this->setFlagMdnsent($value);
 		} else {
 			$this->setter(
 				$this->columnToProperty("flag_$flag"),
@@ -339,7 +341,7 @@ class Message extends Entity implements JsonSerializable {
 				'important' => ($this->getFlagImportant() === true),
 				'$junk' => ($this->getFlagJunk() === true),
 				'$notjunk' => ($this->getFlagNotjunk() === true),
-				'mdnsent' => ($this->getFlagMdnsent() === true),
+				'$mdnsent' => ($this->getFlagMdnsent() === true),
 			],
 			'tags' => $indexed,
 			'from' => $this->getFrom()->jsonSerialize(),

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -162,7 +162,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			'draft' => in_array(Horde_Imap_Client::FLAG_DRAFT, $this->flags),
 			'forwarded' => in_array(Horde_Imap_Client::FLAG_FORWARDED, $this->flags),
 			'hasAttachments' => $this->hasAttachments,
-			'mdnsent' => in_array(Horde_Imap_Client::FLAG_MDNSENT, $this->flags, true),
+			'$mdnsent' => in_array(Horde_Imap_Client::FLAG_MDNSENT, $this->flags, true),
 			'important' => in_array(Tag::LABEL_IMPORTANT, $this->flags, true)
 		];
 	}
@@ -535,8 +535,11 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		$msg->setFlagJunk(
 			in_array(Horde_Imap_Client::FLAG_JUNK, $flags, true)
 			|| in_array('junk', $flags, true)
-		);
-		$msg->setFlagNotjunk(in_array(Horde_Imap_Client::FLAG_NOTJUNK, $flags, true) || in_array('nonjunk', $flags, true));// While this is not a standard IMAP Flag, Thunderbird uses it to mark "not junk"
+		); // While this is not a standard IMAP Flag, Thunderbird uses it to mark "junk"
+		$msg->setFlagNotjunk(
+			in_array(Horde_Imap_Client::FLAG_NOTJUNK, $flags, true)
+			|| in_array('nonjunk', $flags, true)
+		); // While this is not a standard IMAP Flag, Thunderbird uses it to mark "not junk"
 		$msg->setFlagImportant(in_array('$important', $flags, true) || in_array('$labelimportant', $flags, true) || in_array(Tag::LABEL_IMPORTANT, $flags, true));
 		$msg->setFlagAttachments(false);
 		$msg->setFlagMdnsent(in_array(Horde_Imap_Client::FLAG_MDNSENT, $flags, true));
@@ -551,6 +554,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 			Horde_Imap_Client::FLAG_DELETED,
 			Horde_Imap_Client::FLAG_DRAFT,
 			Horde_Imap_Client::FLAG_JUNK,
+			'junk', // While this is not a standard IMAP Flag, Thunderbird uses it to mark "junk"
 			Horde_Imap_Client::FLAG_NOTJUNK,
 			'nonjunk', // While this is not a standard IMAP Flag, Thunderbird uses it to mark "not junk"
 			'$phishing', // Horde has no const for this flag yet

--- a/src/components/MdnRequest.vue
+++ b/src/components/MdnRequest.vue
@@ -51,7 +51,7 @@ export default {
 	computed: {
 		...mapStores(useMainStore),
 		mdnSent() {
-			return this.message.flags.mdnsent
+			return this.message.flags.$mdnsent
 		},
 	},
 
@@ -62,7 +62,7 @@ export default {
 
 			try {
 				await sendMdn(this.message.databaseId)
-				this.mainStore.flagEnvelopeMutation({ envelope: this.message, flag: 'mdnsent', value: true })
+				this.mainStore.flagEnvelopeMutation({ envelope: this.message, flag: '$mdnsent', value: true })
 			} catch (error) {
 				logger.error('could not send mdn', error)
 				showError(t('mail', 'Could not send mdn'))

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -145,7 +145,7 @@ class IMAPMessageTest extends TestCase {
 				'draft' => false,
 				'forwarded' => false,
 				'hasAttachments' => false,
-				'mdnsent' => false,
+				'$mdnsent' => false,
 				'important' => true,
 			],
 			'unsubscribeUrl' => null,


### PR DESCRIPTION
This is a follow-up PR from #12187 and fixes the following points that were discovered during development there:
- **Fix**: Use correct flag for MDNSent throughout the code base (`mdnsent` -> `$mdnsent` - $ sign was missing). There is no case known to me where this flag is being used without the $ sign (even Thunderbird does it, I've tested that).
- **Fix**: Thunderbird uses the non-standard `junk` flag without $ sign, which was previously shown to the user as tag. This is being fixed here.