### PR TITLE
chore(i18n): Fixed grammar

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -260,7 +260,7 @@ export default {
 		return {
 
 			importantInfo: t('mail', 'Messages will automatically be marked as important based on which messages you interacted with or marked as important. In the beginning you might have to manually change the importance to teach the system, but it will improve over time.'),
-			favoritesInfo: t('mail', 'Messages that your mark as favorite will be shown at the top of folders. You can disable this behavior in the app settings'),
+			favoritesInfo: t('mail', 'Messages that you marked as favorite will be shown at the top of folders. You can disable this behavior in the app settings'),
 			followupInfo: t('mail', 'Messages sent by you that require a reply but did not receive one after a couple of days will be shown here.'),
 			bus: mitt(),
 			searchQuery: undefined,


### PR DESCRIPTION
Reported at Transifex.

zh_HK
* The sentence used "that" which referred to an action already done in the past. Hence the verb that followed should be in past tense.
* To keep "mark" in the present tense, the sentence would need to be repharsed e.g. “Messages you mark as favourite…”