### PR TITLE
fix(OutOfOfficeParser): Exclude mailing lists and newsletters from out-of-office autoresponder

### DIFF
--- a/lib/Service/OutOfOffice/OutOfOfficeParser.php
+++ b/lib/Service/OutOfOffice/OutOfOfficeParser.php
@@ -115,10 +115,12 @@ class OutOfOfficeParser {
 		$formattedStart = $this->formatDateForSieve($state->getStart());
 		if ($state->getEnd() !== null) {
 			$formattedEnd = $this->formatDateForSieve($state->getEnd());
-			$condition = "allof(currentdate :value \"ge\" \"iso8601\" \"$formattedStart\", currentdate :value \"le\" \"iso8601\" \"$formattedEnd\")";
+			$vacationCondition = "allof(currentdate :value \"ge\" \"iso8601\" \"$formattedStart\", currentdate :value \"le\" \"iso8601\" \"$formattedEnd\")";
 		} else {
-			$condition = "currentdate :value \"ge\" \"iso8601\" \"$formattedStart\"";
+			$vacationCondition = "currentdate :value \"ge\" \"iso8601\" \"$formattedStart\"";
 		}
+
+		$automaticMailCondition = 'anyof(exists "List-Id", exists "List-Unsubscribe")';
 
 		$escapedSubject = SieveUtils::escapeString($state->getSubject());
 		$vacation = [
@@ -166,8 +168,10 @@ class OutOfOfficeParser {
 			$vacationSection = array_merge($vacationSection, $subjectSection);
 		}
 		$vacationSection = array_merge($vacationSection, [
-			"if $condition {",
-			"\t$vacationCommand;",
+			"if $vacationCondition {",
+			"\tif not $automaticMailCondition {",
+			"\t\t$vacationCommand;",
+			"\t}",
 			'}',
 			self::SEPARATOR,
 		]);

--- a/tests/data/mail-filter/parser3.sieve
+++ b/tests/data/mail-filter/parser3.sieve
@@ -16,6 +16,8 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/parser3_untouched.sieve
+++ b/tests/data/mail-filter/parser3_untouched.sieve
@@ -16,6 +16,8 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/parser4.sieve
+++ b/tests/data/mail-filter/parser4.sieve
@@ -26,6 +26,8 @@ if address :is :all "From" ["marketing@mail.internal"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/parser4_untouched.sieve
+++ b/tests/data/mail-filter/parser4_untouched.sieve
@@ -16,6 +16,8 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/service1.sieve
+++ b/tests/data/mail-filter/service1.sieve
@@ -16,6 +16,8 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/service1_new.sieve
+++ b/tests/data/mail-filter/service1_new.sieve
@@ -26,6 +26,8 @@ if address :is :all "From" ["marketing@mail.internal"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/service2.sieve
+++ b/tests/data/mail-filter/service2.sieve
@@ -30,6 +30,8 @@ if header :contains "Subject" ["World"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/mail-filter/service2_new.sieve
+++ b/tests/data/mail-filter/service2_new.sieve
@@ -26,6 +26,8 @@ if header :contains "Subject" ["Hello"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-no-end-date.sieve
+++ b/tests/data/sieve-vacation-on-no-end-date.sieve
@@ -13,6 +13,8 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-no-tz.sieve
+++ b/tests/data/sieve-vacation-on-no-tz.sieve
@@ -13,6 +13,8 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02","end":"2022-09-08","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01", currentdate :value "le" "iso8601" "2022-09-08") {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-special-chars-message.sieve
+++ b/tests/data/sieve-vacation-on-special-chars-message.sieve
@@ -13,8 +13,10 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation.\r\n\"Hello, World!\"\r\n\\ escaped backslash"}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.
 \"Hello, World!\"
 \\ escaped backslash";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-special-chars-subject.sieve
+++ b/tests/data/sieve-vacation-on-special-chars-subject.sieve
@@ -13,6 +13,8 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation, \"Hello, World!\", \\ escaped backslash","message":"I'm on vacation."}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	vacation :days 4 :subject "On vacation, \"Hello, World!\", \\ escaped backslash" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation, \"Hello, World!\", \\ escaped backslash" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on-subject-placeholder.sieve
+++ b/tests/data/sieve-vacation-on-subject-placeholder.sieve
@@ -18,6 +18,8 @@ if header :matches "subject" "*" {
 	set "subject" "${1}";
 }
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	vacation :days 4 :subject "Re: ${subject}" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "Re: ${subject}" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###

--- a/tests/data/sieve-vacation-on.sieve
+++ b/tests/data/sieve-vacation-on.sieve
@@ -13,6 +13,8 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
+	}
 }
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###


### PR DESCRIPTION
The sieve script used by the autoresponder didn't exclude mailing lists and newsletters. This is a problem for multiple reasons:

- **Privacy**: You don't want to inform anyone you subscribed a newsletter from to know that you're out-of-office. Additionally, you don't want your out-of-office message being archived in a potentially public mailing list.
- **Spam on mailing lists**: You don't want your out-of-office message as reply to any mailing list message as that will be considered spam by the users and administrators
- **Spam through return mails**: When replying to newsletters, you could send them to an address that's not configured for receiving mails. This could mean that you're receiving multiple messages from the mailer daemon that can be very confusing for regular users.

To achive that, I use the `List-Id` header field (like being described in https://github.com/nextcloud/mail/issues/11660). But when looking for potential test mails, I've realized that I wouldn't cover newsletters when checking only for that field. That's why I choose `List-Unsubscribe` additionally, as that header is present in messages from most regular newsletters (as that is being [enforced by more and more providers for large mail volumes](https://postmarkapp.com/blog/list-unsubscribe-header#complying-with-one-click-list-unsubscribe-requirements-by-gmail-and-yahoo)).

I've tested my changes with three mails, one containing only a `List-Unsubscribe` header field (mail.txt), one that doesn't have any `List-*` headers (mail2.txt) and one that only has a `List-Id` header (mail3.txt). As rule, I used the one from the [tests/data/mail-filter/service1_new.sieve](https://github.com/DerDreschner/mail/blob/4dd382487bc50b84076dace4c45b2a3c2f73b7c3/tests/data/mail-filter/service1_new.sieve) file.

<details>

<summary>This is the output from `sieve-test`</summary>

```
 ~ ▓▒░ sieve-test -t - -Tlevel=matching rule.txt mail.txt                                                                                                 ░▒▓ ✔ │ 55s │ 19:06:46 

      ## Started executing script 'rule.txt'
  12: address test
  12:   starting `:is' match with `i;ascii-casemap' comparator:
  12:   extracting `From' headers from message
  12:   parsing address header value `"kununu Jobupdates" <jobupdates@info.kununu.com>'
  12:   address value `jobupdates@info.kununu.com'
  12:   extracting `all' part from address <jobupdates@info.kununu.com>
  12:   matching value `jobupdates@info.kununu.com'
  12:     with key `noreply@help.nextcloud.org' => 0
  12:   finishing match with result: not matched
  13: jump if result is false
  13:   jumping to line 22
  22: address test
  22:   starting `:is' match with `i;ascii-casemap' comparator:
  22:   extracting `From' headers from message
  22:   parsing address header value `"kununu Jobupdates" <jobupdates@info.kununu.com>'
  22:   address value `jobupdates@info.kununu.com'
  22:   extracting `all' part from address <jobupdates@info.kununu.com>
  22:   matching value `jobupdates@info.kununu.com'
  22:     with key `marketing@mail.internal' => 0
  22:   finishing match with result: not matched
  22: jump if result is false
  22:   jumping to line 28
  28: currentdatedate test
  28:   starting `:value-ge' match with `i;ascii-casemap' comparator:
  28:   matching value `2026-01-08T19:06:51+01:00'
  28:     with key `2024-10-08T22:00:00Z' => 1
  28:   finishing match with result: matched
  28: jump if result is false
  28:   not jumping
  29: exists test
  29:   header `List-Id' is missing
  29:   headers are missing
  29: jump if result is true
  29:   not jumping
  29: exists test
  29:   header `List-Unsubscribe' exists
  29:   all headers exist
  29: jump if result is true
  29:   jumping to line 30
      ## Finished executing script 'rule.txt'


Performed actions:

  (none)

Implicit keep:

 * store message in folder: INBOX

sieve-test(ddreschner): Info: final result: success

 ~ ▓▒░ sieve-test -t - -Tlevel=matching rule.txt mail2.txt                                                                                                      ░▒▓ ✔ │ 19:06:51 

      ## Started executing script 'rule.txt'
  12: address test
  12:   starting `:is' match with `i;ascii-casemap' comparator:
  12:   extracting `From' headers from message
  12:   parsing address header value `PayPal <service@paypal.de>'
  12:   address value `service@paypal.de'
  12:   extracting `all' part from address <service@paypal.de>
  12:   matching value `service@paypal.de'
  12:     with key `noreply@help.nextcloud.org' => 0
  12:   finishing match with result: not matched
  13: jump if result is false
  13:   jumping to line 22
  22: address test
  22:   starting `:is' match with `i;ascii-casemap' comparator:
  22:   extracting `From' headers from message
  22:   parsing address header value `PayPal <service@paypal.de>'
  22:   address value `service@paypal.de'
  22:   extracting `all' part from address <service@paypal.de>
  22:   matching value `service@paypal.de'
  22:     with key `marketing@mail.internal' => 0
  22:   finishing match with result: not matched
  22: jump if result is false
  22:   jumping to line 28
  28: currentdatedate test
  28:   starting `:value-ge' match with `i;ascii-casemap' comparator:
  28:   matching value `2026-01-08T19:06:55+01:00'
  28:     with key `2024-10-08T22:00:00Z' => 1
  28:   finishing match with result: matched
  28: jump if result is false
  28:   not jumping
  29: exists test
  29:   header `List-Id' is missing
  29:   headers are missing
  29: jump if result is true
  29:   not jumping
  29: exists test
  29:   header `List-Unsubscribe' is missing
  29:   headers are missing
  29: jump if result is true
  29:   not jumping
  30: vacation action
  30:   auto-reply with message `I'm not here, please try again later. '
      ## Finished executing script 'rule.txt'


Performed actions:

 * send vacation message:
    => seconds : 345600
    => subject : Thanks for your message!
    => handle  : I'm not here, please try again later. Thanks for your message!<default-from><NO-MIME>

START MESSAGE
I'm not here, please try again later. 
END MESSAGE

Implicit keep:

 * store message in folder: INBOX

sieve-test(ddreschner): Info: final result: success

 ~ ▓▒░ sieve-test -t - -Tlevel=matching rule.txt mail3.txt                                                                                                      ░▒▓ ✔ │ 19:06:55 

      ## Started executing script 'rule.txt'
  12: address test
  12:   starting `:is' match with `i;ascii-casemap' comparator:
  12:   extracting `From' headers from message
  12:   parsing address header value `DHL Paket <noreply@dhl.de>'
  12:   address value `noreply@dhl.de'
  12:   extracting `all' part from address <noreply@dhl.de>
  12:   matching value `noreply@dhl.de'
  12:     with key `noreply@help.nextcloud.org' => 0
  12:   finishing match with result: not matched
  13: jump if result is false
  13:   jumping to line 22
  22: address test
  22:   starting `:is' match with `i;ascii-casemap' comparator:
  22:   extracting `From' headers from message
  22:   parsing address header value `DHL Paket <noreply@dhl.de>'
  22:   address value `noreply@dhl.de'
  22:   extracting `all' part from address <noreply@dhl.de>
  22:   matching value `noreply@dhl.de'
  22:     with key `marketing@mail.internal' => 0
  22:   finishing match with result: not matched
  22: jump if result is false
  22:   jumping to line 28
  28: currentdatedate test
  28:   starting `:value-ge' match with `i;ascii-casemap' comparator:
  28:   matching value `2026-01-08T19:06:58+01:00'
  28:     with key `2024-10-08T22:00:00Z' => 1
  28:   finishing match with result: matched
  28: jump if result is false
  28:   not jumping
  29: exists test
  29:   header `List-Id' exists
  29:   all headers exist
  29: jump if result is true
  29:   jumping to line 30
      ## Finished executing script 'rule.txt'


Performed actions:

  (none)

Implicit keep:

 * store message in folder: INBOX

sieve-test(ddreschner): Info: final result: success

 ~ ▓▒░  
```

</details>

This fixes https://github.com/nextcloud/mail/issues/11660.