### PR TITLE
fix(database): Add foreign keys to `*_mailbox_id` fields in `mail_accounts` table

### DIFF
--- a/lib/Migration/Version5007Date20260108124422.php
+++ b/lib/Migration/Version5007Date20260108124422.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use Doctrine\DBAL\Schema\Table;
+use OCP\DB\Exception;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+use Psr\Log\LoggerInterface;
+
+#[ModifyColumn(
+	table: 'mail_accounts',
+	description: 'Remove invalid mailbox_id from *_mailbox_id columns and add foreign keys to ensure consistency')
+]
+class Version5007Date20260108124422 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $db,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param string $mailboxType
+	 */
+	private function removeInconsistentMailboxEntries(string $mailboxType): void {
+		$selectQueryBuilder = $this->db->getQueryBuilder();
+
+		$selectQueryBuilder->select('accounts.id')
+			->from('mail_accounts', 'accounts')
+			->leftJoin(
+				'accounts',
+				'mail_mailboxes',
+				'mailboxes',
+				$selectQueryBuilder->expr()->eq(
+					"accounts.{$mailboxType}_mailbox_id",
+					'mailboxes.id',
+					IQueryBuilder::PARAM_INT
+				)
+			)
+			->where($selectQueryBuilder->expr()->isNull('mailboxes.id'))
+			->andWhere($selectQueryBuilder->expr()->isNotNull("accounts.{$mailboxType}_mailbox_id"));
+
+		try {
+			$affectedRows = $selectQueryBuilder->executeQuery()->fetchAll();
+
+			foreach ($affectedRows as $row) {
+				$updateQueryBuilder = $this->db->getQueryBuilder();
+				$updateQueryBuilder->update('mail_accounts')
+					->set(
+						"{$mailboxType}_mailbox_id",
+						$updateQueryBuilder->createNamedParameter(null, IQueryBuilder::PARAM_NULL)
+					)
+					->where(
+						$updateQueryBuilder->expr()->eq(
+							'id',
+							$updateQueryBuilder->createNamedParameter($row['id'], IQueryBuilder::PARAM_INT)
+						)
+					);
+				$updateQueryBuilder->executeStatement();
+			}
+		} catch (Exception $e) {
+			$this->logger->error("Emptying inconsistent {$mailboxType}_mailbox_id field failed", [
+				'exception' => $e
+			]);
+		}
+	}
+
+	/**
+	 * @param Table $accountsTable
+	 * @param Table $mailboxesTable
+	 * @param string $mailboxType
+	 * @return void
+	 */
+	private function addMailboxKey(Table $accountsTable, Table $mailboxesTable, string $mailboxType): void {
+		$accountsTable->addForeignKeyConstraint(
+			$mailboxesTable,
+			["{$mailboxType}_mailbox_id"],
+			['id'],
+			[
+				'onDelete' => 'SET NULL',
+			],
+		);
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[Override]
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$this->removeInconsistentMailboxEntries('drafts');
+		$this->removeInconsistentMailboxEntries('sent');
+		$this->removeInconsistentMailboxEntries('trash');
+		$this->removeInconsistentMailboxEntries('junk');
+		$this->removeInconsistentMailboxEntries('archive');
+		$this->removeInconsistentMailboxEntries('snooze');
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('mail_accounts')) {
+			$accountsTable = $schema->getTable('mail_accounts');
+			$mailboxesTable = $schema->getTable('mail_mailboxes');
+
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'drafts');
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'sent');
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'trash');
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'junk');
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'archive');
+			$this->addMailboxKey($accountsTable, $mailboxesTable, 'snooze');
+		}
+
+		return $schema;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -35,6 +35,7 @@
 				<referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform" />
 				<referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform" />
 				<referencedClass name="Doctrine\DBAL\Platforms\SqlitePlatform" />
+				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="Doctrine\DBAL\Types\Type" />
 				<referencedClass name="Doctrine\DBAL\Types\Types" />
 				<referencedClass name="IPLib\Factory" />


### PR DESCRIPTION
The `mail_accounts` table includes several fields with references to the `mail_mailboxes` table. This relation wasn't declared via foreign keys previously, which means that mailboxes with a special meaning (e.g., Junk) can be deleted without removing them from the corresponding `*_mailbox_id` field. Inconsistent entries are being set to `NULL` before changing the database schema.

<details>

<summary>Testing</summary>

```
MariaDB [nextcloud]> SELECT drafts_mailbox_id, sent_mailbox_id, trash_mailbox_id,junk_mailbox_id,archive_mailbox_id,snooze_mailbox_id FROM oc_mail_accounts;
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
| drafts_mailbox_id | sent_mailbox_id | trash_mailbox_id | junk_mailbox_id | archive_mailbox_id | snooze_mailbox_id |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
|                47 |              48 |               49 |              46 |                 45 |              NULL |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
1 row in set (0.000 sec)

MariaDB [nextcloud]> DELETE FROM oc_mail_mailboxes WHERE id=46;
Query OK, 1 row affected (0.015 sec)

MariaDB [nextcloud]> DELETE FROM oc_mail_mailboxes WHERE id=48;
Query OK, 1 row affected (0.007 sec)

MariaDB [nextcloud]> SELECT drafts_mailbox_id, sent_mailbox_id, trash_mailbox_id,junk_mailbox_id,archive_mailbox_id,snooze_mailbox_id FROM oc_mail_accounts;
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
| drafts_mailbox_id | sent_mailbox_id | trash_mailbox_id | junk_mailbox_id | archive_mailbox_id | snooze_mailbox_id |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
|                47 |              48 |               49 |              46 |                 45 |              NULL |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
1 row in set (0.000 sec)

### MIGRATION RUN ###

MariaDB [nextcloud]> SELECT drafts_mailbox_id, sent_mailbox_id, trash_mailbox_id,junk_mailbox_id,archive_mailbox_id,snooze_mailbox_id FROM oc_mail_accounts;
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
| drafts_mailbox_id | sent_mailbox_id | trash_mailbox_id | junk_mailbox_id | archive_mailbox_id | snooze_mailbox_id |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
|                47 |            NULL |               49 |            NULL |                 45 |              NULL |
+-------------------+-----------------+------------------+-----------------+--------------------+-------------------+
1 row in set (0.000 sec)

MariaDB [nextcloud]> SHOW CREATE TABLE oc_mail_accounts;

[...]

  PRIMARY KEY (`id`),
  KEY `mail_userid_index` (`user_id`),
  KEY `IDX_61A7E87F59A77CDC` (`drafts_mailbox_id`),
  KEY `IDX_61A7E87F75F54A4B` (`sent_mailbox_id`),
  KEY `IDX_61A7E87F1FA4CF4D` (`trash_mailbox_id`),
  KEY `IDX_61A7E87F5FDB8C8A` (`junk_mailbox_id`),
  KEY `IDX_61A7E87FA47FE329` (`archive_mailbox_id`),
  KEY `IDX_61A7E87F7587D725` (`snooze_mailbox_id`),
  CONSTRAINT `FK_61A7E87F1FA4CF4D` FOREIGN KEY (`trash_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL,
  CONSTRAINT `FK_61A7E87F59A77CDC` FOREIGN KEY (`drafts_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL,
  CONSTRAINT `FK_61A7E87F5FDB8C8A` FOREIGN KEY (`junk_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL,
  CONSTRAINT `FK_61A7E87F7587D725` FOREIGN KEY (`snooze_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL,
  CONSTRAINT `FK_61A7E87F75F54A4B` FOREIGN KEY (`sent_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL,
  CONSTRAINT `FK_61A7E87FA47FE329` FOREIGN KEY (`archive_mailbox_id`) REFERENCES `oc_mail_mailboxes` (`id`) ON DELETE SET NULL
) ENGINE=InnoDB AUTO_INCREMENT=26 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+------------------
+
1 row in set (0.000 sec)

MariaDB [nextcloud]> 
```
</details>

This fixes #11243.