### PR TITLE
feat(attachments): Add support for changed API due to introduction of snowflake ids in server

### DIFF
--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -82,6 +82,10 @@ class AttachmentService implements IAttachmentService {
 		$attachment->setMimeType($file->getMimeType());
 
 		$persisted = $this->mapper->insert($attachment);
+		if ($persisted->id === null) {
+			throw new UploadException('Given attachmentId is null');
+		}
+
 		try {
 			$this->storage->save($userId, $persisted->id, $file);
 		} catch (UploadException $ex) {
@@ -100,6 +104,10 @@ class AttachmentService implements IAttachmentService {
 		$attachment->setMimeType($mime);
 
 		$persisted = $this->mapper->insert($attachment);
+		if ($persisted->id === null) {
+			throw new UploadException('Given attachmentId is null');
+		}
+
 		try {
 			$this->storage->saveContent($userId, $persisted->id, $fileContents);
 		} catch (NotFoundException|NotPermittedException $e) {

--- a/lib/Service/Attachment/AttachmentStorage.php
+++ b/lib/Service/Attachment/AttachmentStorage.php
@@ -48,14 +48,14 @@ class AttachmentStorage {
 	 * Copy uploaded file content to a app data file
 	 *
 	 * @param string $userId
-	 * @param int $attachmentId
+	 * @param int|string $attachmentId
 	 * @param UploadedFile $uploadedFile
 	 *
 	 * @throws UploadException
 	 *
 	 * @return void
 	 */
-	public function save(string $userId, int $attachmentId, UploadedFile $uploadedFile): void {
+	public function save(string $userId, int|string $attachmentId, UploadedFile $uploadedFile): void {
 		$folder = $this->getAttachmentFolder($userId);
 
 		$file = $folder->newFile((string)$attachmentId);
@@ -80,12 +80,12 @@ class AttachmentStorage {
 	 * Copy uploaded file content to a app data file
 	 *
 	 * @param string $userId
-	 * @param int $attachmentId
+	 * @param int|string $attachmentId
 	 *
 	 * @return void
 	 * @throws NotFoundException|NotPermittedException
 	 */
-	public function saveContent(string $userId, int $attachmentId, string $fileContent): void {
+	public function saveContent(string $userId, int|string $attachmentId, string $fileContent): void {
 		$folder = $this->getAttachmentFolder($userId);
 		$file = $folder->newFile((string)$attachmentId);
 		$file->putContent($fileContent);


### PR DESCRIPTION
The underlying server is introducing [snowflake ids](https://en.wikipedia.org/wiki/Snowflake_ID). This means that the API will change when using them (`id` will be from type `string` in the future, instead of `int`).

Although we don't use them right now, there were some [breaking changes](https://github.com/nextcloud/server/commit/7c1a8a4060413b85448dc61c315a9f03368e750a#diff-b5b13a13f1cff8ae531cbba72e8a905e01be6515108f6c450ab19b06ca421426L20) in the entity model (that are going [to be reverted partially](https://github.com/nextcloud/server/pull/57442)). As we have to use them in the future anyway, I think it's a good idea to merge the changes from this PR anyway to be a bit more prepared.