### PR TITLE
fix(provisioning): Do not provision mail account for users without access to mail app

### DIFF
--- a/lib/Db/AliasMapper.php
+++ b/lib/Db/AliasMapper.php
@@ -106,12 +106,7 @@ class AliasMapper extends QBMapper {
 	/**
 	 * Delete all provisioned aliases for the given uid
 	 *
-	 * Exception for Nextcloud 20: \Doctrine\DBAL\DBALException
-	 * Exception for Nextcloud 21 and newer: \OCP\DB\Exception
-	 *
-	 * @TODO: Change throws to \OCP\DB\Exception once Mail does not support Nextcloud 20.
-	 *
-	 * @throws \Exception
+	 * @throws \OCP\DB\Exception
 	 */
 	public function deleteProvisionedAliasesByUid(string $uid): void {
 		$qb = $this->db->getQueryBuilder();

--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -160,6 +160,9 @@ class MailAccountMapper extends QBMapper {
 		return $this->update($account);
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function deleteProvisionedAccounts(int $provisioningId): void {
 		$qb = $this->db->getQueryBuilder();
 
@@ -169,6 +172,9 @@ class MailAccountMapper extends QBMapper {
 		$delete->executeStatement();
 	}
 
+	/**
+	 * @throws Exception
+	 */
 	public function deleteProvisionedAccountsByUid(string $uid): void {
 		$qb = $this->db->getQueryBuilder();
 

--- a/tests/Unit/Service/Provisioning/ManagerTest.php
+++ b/tests/Unit/Service/Provisioning/ManagerTest.php
@@ -61,6 +61,30 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(0, $count);
 	}
 
+	public function testDisabledAppDoesUnprovision() {
+		/** @var IUser|MockObject $user */
+		$user = $this->createConfiguredMock(IUser::class, [
+			'getEmailAddress' => 'bruce.wayne@batman.com',
+			'getUID' => 'bruce'
+		]);
+		$configs = [new Provisioning()];
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(false);
+		$this->mock->getParameter('aliasMapper')
+			->expects($this->once())
+			->method('deleteProvisionedAliasesByUid')
+			->with($user->getUID());
+		$this->mock->getParameter('mailAccountMapper')
+			->expects($this->once())
+			->method('deleteProvisionedAccountsByUid')
+			->with($user->getUID());
+
+		$result = $this->manager->provisionSingleUser($configs, $user);
+		$this->assertFalse($result);
+	}
+
 	public function testUpdateProvisionSingleUser() {
 		/** @var IUser|MockObject $user */
 		$user = $this->createConfiguredMock(IUser::class, [
@@ -74,6 +98,10 @@ class ManagerTest extends TestCase {
 		$configs = [$config];
 		$mailAccount = new MailAccount();
 		$mailAccount->setId(1000);
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->once())
 			->method('findProvisionedAccount')
@@ -100,6 +128,10 @@ class ManagerTest extends TestCase {
 		$config->setProvisioningDomain('batman.com');
 		$config->setEmailTemplate('%USER%@batman.com');
 		$configs = [$config];
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->once())
 			->method('findProvisionedAccount')
@@ -133,6 +165,10 @@ class ManagerTest extends TestCase {
 		$configs = [$config];
 		$mailAccount = new MailAccount();
 		$mailAccount->setId(1000);
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->once())
 			->method('findProvisionedAccount')
@@ -159,6 +195,10 @@ class ManagerTest extends TestCase {
 		$config->setProvisioningDomain('*');
 		$config->setEmailTemplate('%USER%@batman.com');
 		$configs = [$config];
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->once())
 			->method('findProvisionedAccount')
@@ -186,6 +226,10 @@ class ManagerTest extends TestCase {
 		$config->setProvisioningDomain('arkham-asylum.com');
 		$config->setEmailTemplate('%USER%@batman.com');
 		$configs = [$config];
+		$this->mock->getParameter('appManager')
+			->expects($this->once())
+			->method('isEnabledForUser')
+			->willReturn(true);
 		$this->mock->getParameter('mailAccountMapper')
 			->expects($this->never())
 			->method('findProvisionedAccount');


### PR DESCRIPTION
When using the provisioning functionality, only the configured pattern where checked before pushing the mail account configuration into the database. This is fine as long as all users can use the mail app. But as the access to specific apps can be limited to specific groups, this can lead to accounts that are configured and synced in the background, yet being never used and only eat up precious resources.

To ensure this does not happen anymore, I use the `IAppManager` to check if the specific user has the right to use the mail app. If not, the provisioning for the user will be stopped.

This fixes https://github.com/nextcloud/mail/issues/12057.