### PR TITLE
feat(deps): add PHP8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         nextcloud-version: ${{ matrix.nextcloud-versions }}
         php-version: ${{ matrix.php-versions }}
         php-coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
-        patch-php-version-check: ${{ matrix.php-versions == '8.5' }}
+        patch-php-version-check: ${{ matrix.php-versions == '8.6' }}
         node-version: 'false'
         install: true
     - name: Checkout Mail
@@ -170,8 +170,8 @@ jobs:
             working-directory: nextcloud/apps/mail
             run: composer install
           - name: Patch version check for nightly PHP
-            if: ${{ matrix.php-versions == '8.5' }}
-            run: sed -i 's/max-version="8.4"/max-version="8.5"/' nextcloud/apps/mail/appinfo/info.xml
+            if: ${{ matrix.php-versions == '8.6' }}
+            run: sed -i 's/max-version="8.5"/max-version="8.6"/' nextcloud/apps/mail/appinfo/info.xml
           - name: Install Mail
             run: php -f nextcloud/occ app:enable mail
           - name: Configure Nextcloud for testing

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -52,7 +52,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	<repository type="git">https://github.com/nextcloud/mail.git</repository>
 	<screenshot>https://user-images.githubusercontent.com/12728974/266270227-86b99bbb-03ea-468b-8408-e248e1730bed.png</screenshot>
 	<dependencies>
-		<php min-version="8.1" max-version="8.4" />
+		<php min-version="8.1" max-version="8.5" />
 		<nextcloud min-version="31" max-version="33" />
 	</dependencies>
 	<background-jobs>


### PR DESCRIPTION
We have run tests with PHP8.5 for a long time. Now that server supports 8.5 we can allow it too.

The test workflow is already adjusted for 8.6 once we add it to the matrix.