### PR TITLE
fix: Preview transfer encoding

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -954,10 +954,8 @@ class MessageMapper {
 				/** @var Horde_Mime_Headers_ContentTransferEncoding $transferEncoding */
 				$transferEncoding = $mimeHeaders->getHeader('content-transfer-encoding');
 
-				if (!$contentType && !$transferEncoding) {
-					// Nothing to convert here ...
-					return $body;
-				}
+				// Don't exit early here when neither $contentType nor $transferEncoding is set.
+				// It is possible that $structure already has a transferEncoding set and we need to convert anyway.
 
 				if ($transferEncoding) {
 					$structure->setTransferEncoding($transferEncoding->value_single);


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/mail/issues/12228

For the message in question, both (`$contentType` and `$transferEncoding`)  were null:

https://github.com/nextcloud/mail/blob/10b3f54ef9003a451abfb4d57edd0a63881f54e7/lib/IMAP/MessageMapper.php#L952-L955

so we exit early at

https://github.com/nextcloud/mail/blob/681b9a69481e0d32e9035fdd54918c007e6eabaa/lib/IMAP/MessageMapper.php#L957-L960

and therefore never call 
```php
$structure->setContents($body);
return $this->converter->convert($structure);
```

but it is possible, that `$structure` already has a transferEncoding set. When `setContents` is called, this transferEncoding is used (although we never explicitly called `setTransferEncoding`. Relevant part is https://github.com/horde/Mime/blob/7e3fc9a912cfe8b6f1f0b03f92f96c78c80917ee/lib/Horde/Mime/Part.php#L328-L330
