### PR TITLE
fix(DKIMValidator): Fix broken canonical handling in upstream dependency

### DIFF
--- a/.patches/dkimvalidator-fix-broken-canonical-handling.patch
+++ b/.patches/dkimvalidator-fix-broken-canonical-handling.patch
@@ -1,0 +1,93 @@
+From 6e33cfb59d22fff20dbf1ee429308e1587c62ab3 Mon Sep 17 00:00:00 2001
+From: David Dreschner <github-2017@dreschner.net>
+Date: Tue, 13 Jan 2026 17:21:57 +0100
+Subject: [PATCH] fix: Make c= flag optional, remove requirement of two
+ canonical rules and fix broken raw message for c=simple
+
+---
+ src/DKIM.php      |  8 ++++----
+ src/Validator.php | 21 +++++++++++++++++++--
+ 2 files changed, 23 insertions(+), 6 deletions(-)
+
+diff --git a/src/DKIM.php b/src/DKIM.php
+index 616dc38..7481b14 100644
+--- a/src/DKIM.php
++++ b/src/DKIM.php
+@@ -82,7 +82,7 @@ abstract class DKIM
+      *
+      * @throws DKIMException
+      */
+-    protected function canonicalizeHeaders(array $headers, string $style = 'relaxed'): string
++    protected function canonicalizeHeaders(array $headers, string $style): string
+     {
+         if (count($headers) === 0) {
+             throw new DKIMException('Attempted to canonicalize empty header array');
+@@ -124,7 +124,7 @@ abstract class DKIM
+      *
+      * @return string
+      */
+-    protected function canonicalizeBody(string $body, string $style = 'relaxed', int $length = -1): string
++    protected function canonicalizeBody(string $body, string $style, int $length = -1): string
+     {
+         if ($body === '') {
+             return self::CRLF;
+@@ -245,7 +245,7 @@ abstract class DKIM
+                         'unfolded'   => $currentHeaderValue,
+                         'decoded'    => self::rfc2047Decode($currentHeaderValue),
+                         'rawarray'   => $currentRawHeaderLines,
+-                        'raw'        => implode(self::CRLF . ' ', $currentRawHeaderLines), //Refold lines
++                        'raw'        => implode(self::CRLF, $currentRawHeaderLines), //Refold lines
+                     ];
+                 }
+                 $currentHeaderLabel = $matches[1];
+@@ -257,7 +257,7 @@ abstract class DKIM
+                 }
+                 //This is a folded continuation of the current header
+                 $currentHeaderValue .= $matches[1];
+-                $currentRawHeaderLines[] = $matches[1];
++                $currentRawHeaderLines[] = $matches[0];
+             }
+             ++$headerLineIndex;
+             if ($headerLineIndex >= $headerLineCount) {
+diff --git a/src/Validator.php b/src/Validator.php
+index fc558c0..62b7340 100644
+--- a/src/Validator.php
++++ b/src/Validator.php
+@@ -83,8 +83,24 @@ class Validator extends DKIM
+                 ];
+             }
+ 
+-            //Validate canonicalization algorithms for header and body
+-            [$headerCA, $bodyCA] = explode('/', $dkimTags['c']);
++            //Validate optional canonicalization algorithms for header and body
++            //Use simple/simple as default unless defined differently
++            $headerCA = 'simple';
++            $bodyCA = 'simple';
++
++            if (array_key_exists('c', $dkimTags)) {
++                $containsBodyAndHeaderAlgorithm = strpos($dkimTags['c'], '/') !== false;
++
++                if ($containsBodyAndHeaderAlgorithm) {
++                    $rules = explode('/', $dkimTags['c']);
++
++                    $headerCA = $rules[0];
++                    $bodyCA = $rules[1];
++                } else {
++                    $headerCA = $dkimTags['c'];
++                }
++            }
++
+             if ($headerCA !== 'relaxed' && $headerCA !== 'simple') {
+                 $output[$signatureIndex][] = [
+                     'status' => 'PERMFAIL',
+@@ -298,6 +314,7 @@ class Validator extends DKIM
+         $host = sprintf('%s._domainkey.%s', $selector, $domain);
+         $textRecords = dns_get_record($host, DNS_TXT);
+ 
++
+         if ($textRecords === false) {
+             return false;
+         }
+-- 
+2.43.0
+

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -160,3 +160,15 @@ path = [".tx/backport"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "none"
 SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = ["patches.json", "patches.lock.json"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
+path = [".patches/dkimvalidator-fix-broken-canonical-handling.patch"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "angrychimp, Teon d.o.o. - Bostjan Skufca, Marcus Bointon"
+SPDX-License-Identifier = "MIT"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
 		},
 		"sort-packages": true,
 		"allow-plugins": {
-			"bamarni/composer-bin-plugin": true
+			"bamarni/composer-bin-plugin": true,
+			"cweagans/composer-patches": true
 		},
 		"optimize-autoloader": true,
 		"autoloader-suffix": "Mail"
@@ -26,6 +27,7 @@
 		"bytestream/horde-text-flowed": "^2.1",
 		"bytestream/horde-util": "^2.8.0",
 		"cerdic/css-tidy": "v2.2.1",
+		"cweagans/composer-patches": "~2.0",
 		"ezyang/htmlpurifier": "4.19.0",
 		"glenscott/url-normalizer": "^1.4",
 		"gravatarphp/gravatar": "dev-master#6b9f6a45477ce48285738d9d0c3f0dbf97abe263",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f7575d9c8725cf45f05496c9802bc46",
+    "content-hash": "58118b5d211447f560722687603b9e91",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1648,6 +1648,129 @@
                 "source": "https://github.com/Cerdic/CSSTidy/tree/v2.2.1"
             },
             "time": "2024-11-18T16:18:51+00:00"
+        },
+        {
+            "name": "cweagans/composer-configurable-plugin",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-configurable-plugin.git",
+                "reference": "15433906511a108a1806710e988629fd24b89974"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-configurable-plugin/zipball/15433906511a108a1806710e988629fd24b89974",
+                "reference": "15433906511a108a1806710e988629fd24b89974",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a lightweight configuration system for Composer plugins.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-configurable-plugin/issues",
+                "source": "https://github.com/cweagans/composer-configurable-plugin/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-12T04:58:58+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "reference": "bfa6018a5f864653d9ed899b902ea72f858a2cf7",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cweagans/composer-configurable-plugin": "^2.0",
+                "ext-json": "*",
+                "php": ">=8.0.0"
+            },
+            "require-dev": {
+                "codeception/codeception": "~4.0",
+                "codeception/module-asserts": "^2.0",
+                "codeception/module-cli": "^2.0",
+                "codeception/module-filesystem": "^2.0",
+                "composer/composer": "~2.0",
+                "php-coveralls/php-coveralls": "~2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpro/grumphp": "^1.8.0",
+                "sebastian/phpcpd": "^6.0",
+                "squizlabs/php_codesniffer": "^4.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "_": "The following two lines ensure that composer-patches is loaded as early as possible.",
+                "class": "cweagans\\Composer\\Plugin\\Patches",
+                "plugin-modifies-downloads": true,
+                "plugin-modifies-install-path": true
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/cweagans",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-30T23:44:22+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",

--- a/patches.json
+++ b/patches.json
@@ -1,0 +1,14 @@
+{
+	"patches": {
+		"phpmailer/dkimvalidator": [
+			{
+				"description": "Fix incorrect canonicalization handling and modified message content",
+				"url": ".patches/dkimvalidator-fix-broken-canonical-handling.patch",
+				"sha256": "7d49ca7bc143d5a861cf27f01b33b16269e5f31550ec0ebb770b251bb21df316",
+				"extra": {
+					"upstream-fix-url": "https://github.com/PHPMailer/DKIMValidator/pull/21"
+				}
+			}
+		]
+	}
+}

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,0 +1,18 @@
+{
+    "_hash": "0e361a02397cd9d8d46e434d387c107639b0c9b7541b3f9446da4e3c90758e98",
+    "patches": {
+        "phpmailer/dkimvalidator": [
+            {
+                "package": "phpmailer/dkimvalidator",
+                "description": "Fix incorrect canonicalization handling and modified message content",
+                "url": ".patches/dkimvalidator-fix-broken-canonical-handling.patch",
+                "sha256": "7d49ca7bc143d5a861cf27f01b33b16269e5f31550ec0ebb770b251bb21df316",
+                "depth": 1,
+                "extra": {
+                    "upstream-fix-url": "https://github.com/PHPMailer/DKIMValidator/pull/21",
+                    "provenance": "patches-file:patches.json"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
There are several bugs in the DKIMValidator library which we use in mail. These affect the canonical flag (`c=`) in the following cases:
- `c=` is missing as described in the RFC (`c=simple/simple` must be used then). This will trigger a `Undefined offset` or `Undefined index` notice and may throw a `TypeError` exception later on.
- `c=` contains only a header algorithm (`c=relaxed` or `c=simple` - `simple` must be used for the body then). This will trigger a `TypeError` exception as described in ticket https://github.com/nextcloud/mail/issues/12206.
- `c=simple` being used for header canonicalization. This will result in an invalid DKIM validation, although the mail contains a valid DKIM signature.

As being discussed with @ChristophWurst, we will introduce this patch until the fix is accepted and released upstream (https://github.com/PHPMailer/DKIMValidator/pull/21 - contains additional unit tests for each case).

Fixes https://github.com/nextcloud/mail/issues/12206