### PR TITLE
fix: outbox icon opacity

### DIFF
--- a/src/components/NavigationOutbox.vue
+++ b/src/components/NavigationOutbox.vue
@@ -11,7 +11,6 @@
 		:to="to">
 		<template #icon>
 			<IconOutbox
-				class="outbox-opacity-icon"
 				:size="20" />
 		</template>
 		<template #counter>
@@ -60,10 +59,4 @@ export default {
 	}
 }
 
-.outbox-opacity-icon {
-	opacity: .7;
-	&:hover {
-		opacity: 1;
-	}
-}
 </style>


### PR DESCRIPTION
Fixes #11516 

Removes the outbox-icon-opacity CSS class, so that the outbox icon's opacity is the same as the opacity of the other icons.