### PR TITLE
fix: action items icons on compact mode

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -32,27 +32,30 @@
 		@toggle-seen="onToggleSeen"
 		@update:menuOpen="closeMoreAndSnoozeOptions">
 		<template #icon>
-			<Star
-				v-if="data.flags.flagged"
-				fill-color="#f9cf3d"
-				:size="18"
-				class="app-content-list-item-star favorite-icon-style"
-				:class="{ 'one-line': oneLineLayout, 'favorite-icon-style': !oneLineLayout, 'favorite-icon-style--compact': compactMode }"
-				:data-starred="data.flags.flagged ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? onToggleFlagged() : false" />
-			<ImportantIcon
-				v-if="isImportant"
-				:size="compactMode ? 14 : 18"
-				class="app-content-list-item-star icon-important"
-				:class="{ 'important-one-line': oneLineLayout, 'icon-important': !oneLineLayout, 'icon-important--compact': compactMode }"
-				data-starred="true" />
-			<JunkIcon
-				v-if="data.flags.$junk"
-				:size="18"
-				class="app-content-list-item-star junk-icon-style"
-				:class="{ 'one-line': oneLineLayout, 'junk-icon-style': !oneLineLayout }"
-				:data-starred="data.flags.$junk ? 'true' : 'false'"
-				@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
+			<div v-if="!compactMode">
+				<Star
+					v-if="data.flags.flagged"
+					:size="22"
+					fill-color="#f9cf3d"
+					class="app-content-list-item-star favorite-icon-style"
+					:class="{ 'one-line': oneLineLayout, 'favorite-icon-style': !oneLineLayout }"
+					:data-starred="data.flags.flagged ? 'true' : 'false'"
+					@click.prevent="hasWriteAcl ? onToggleFlagged() : false" />
+				<ImportantIcon
+					v-if="isImportant"
+					fill-color="#00679e"
+					:size="20"
+					class="app-content-list-item-star icon-important"
+					:class="{ 'important-one-line': oneLineLayout, 'icon-important': !oneLineLayout }"
+					data-starred="true" />
+				<JunkIcon
+					v-if="data.flags.$junk"
+					:size="20"
+					class="app-content-list-item-star junk-icon-style"
+					:class="{ 'one-line': oneLineLayout, 'junk-icon-style': !oneLineLayout }"
+					:data-starred="data.flags.$junk ? 'true' : 'false'"
+					@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
+			</div>
 			<div
 				class="hovering-status"
 				:class="{ 'hover-active': hoveringAvatar && !selected && !compactMode }"
@@ -93,11 +96,40 @@
 				</template>
 			</div>
 		</template>
+		<template #name>
+			<div class="envelope__recipient-row">
+				<template v-if="compactMode && oneLineLayout">
+					<ImportantIcon
+						v-if="isImportant"
+						fill-color="#00679e"
+						:size="20"
+						class="recipient-icon important-icon--recipient"
+						@click.stop.prevent="hasWriteAcl ? onToggleFlagged() : false" />
+					<Star
+						v-if="data.flags.flagged"
+						fill-color="#f9cf3d"
+						:size="20"
+						class="recipient-icon favorite-icon--recipient"
+						@click.stop.prevent="hasWriteAcl ? onToggleFlagged() : false" />
+
+					<JunkIcon
+						v-if="data.flags.$junk"
+						:size="20"
+						class="app-content-list-item-star junk-icon-style junk-icon--recipient"
+						:data-starred="data.flags.$junk ? 'true' : 'false'"
+						@click.stop.prevent="hasWriteAcl ? onToggleJunk() : false" />
+				</template>
+
+				<span class="envelope__recipient-text">
+					{{ addresses }}
+				</span>
+			</div>
+		</template>
 		<template #subname>
 			<div
 				class="line-two"
 				:class="{ 'one-line': oneLineLayout }">
-				<div class="envelope__subtitle">
+				<div class="envelope__subtitle envelope__subtitle--compact-wrapper">
 					<Reply
 						v-if="data.flags.answered"
 						class="seen-icon-style"
@@ -106,6 +138,30 @@
 						v-if="data.flags.hasAttachments === true"
 						class="attachment-icon-style"
 						:size="18" />
+					<div
+						v-if="compactMode && !oneLineLayout"
+						class="compact-subject-icons">
+						<ImportantIcon
+							v-if="isImportant"
+							fill-color="#00679e"
+							:size="20"
+							class="icon-important--compact"
+							@click.stop.prevent="hasWriteAcl ? onToggleFlagged() : false" />
+
+						<Star
+							v-if="data.flags.flagged"
+							fill-color="#f9cf3d"
+							:size="22"
+							class="favorite-icon-style--compact"
+							@click.prevent="hasWriteAcl ? onToggleFlagged() : false" />
+
+						<JunkIcon
+							v-if="data.flags.$junk"
+							:size="18"
+							class="junk-icon-style--compact"
+							@click.prevent="hasWriteAcl ? onToggleJunk() : false" />
+					</div>
+
 					<span
 						class="envelope__subtitle__subject"
 						:class="{ 'one-line': oneLineLayout }"
@@ -1453,7 +1509,7 @@ export default {
 
 .icon-important {
 	:deep(path) {
-		fill: #ffcc00;
+		fill: var(--color-primary);
 		stroke: var(--color-main-background);
 		stroke-width: 2;
 	}
@@ -1675,13 +1731,58 @@ export default {
 	justify-content: center;
 }
 
-.icon-important--compact {
-	margin-inline-start: 30px;
-	top: 7px !important;
+.list-item--compact {
+	.envelope__subtitle__subject {
+		margin-inline-start: 0;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }
 
-.favorite-icon-style--compact {
-	margin-top: 25px;
+.list-item--compact .envelope__subtitle {
+	display: flex;
+	align-items: center;
+	padding-inline-start: 0;
 }
 
+.envelope__subtitle--compact-wrapper {
+	display: flex;
+	align-items: center;
+}
+
+.compact-subject-icons {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	margin-inline-end: 4px;
+}
+
+.envelope__recipient-row {
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+}
+
+.recipient-icon {
+	flex: 0 0 auto;
+	margin-inline-end: 6px;
+}
+
+.envelope__recipient-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.envelope--compact.envelope--one-line {
+	.favorite-icon-style,
+	.icon-important {
+		display: none;
+	}
+}
 </style>


### PR DESCRIPTION
@nimishavijay In your mockup, the important icon is second. Since we have the important icon first in the avatar, I thought  to do the same here.
If you have a strong opinion on that, I'm happy to change the order


list view
<img width="1258" height="218" alt="Screenshot from 2026-01-26 14-13-14" src="https://github.com/user-attachments/assets/3c25c0fe-249a-4f11-a48c-7a7fe217f317" />

vertical view
<img width="479" height="252" alt="Screenshot from 2026-01-26 14-30-47" src="https://github.com/user-attachments/assets/3b6045ac-1b2c-4159-bf42-0d1810a83dc8" />
