### PR TITLE
feat: provisioning sender name templates

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -97,7 +97,7 @@ class AccountsController extends Controller {
 		$json = [];
 		foreach ($mailAccounts as $mailAccount) {
 			$conf = $mailAccount->jsonSerialize();
-			$conf['aliases'] = $this->aliasesService->findAll($conf['accountId'], $this->currentUserId);
+			$conf['aliases'] = $this->aliasesService->findAllWithDeletable($conf['accountId'], $this->currentUserId);
 			$json[] = $conf;
 		}
 		return new JSONResponse($json);

--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -42,7 +42,9 @@ class AliasesController extends Controller {
 	 */
 	#[TrapError]
 	public function index(int $accountId): JSONResponse {
-		return new JSONResponse($this->aliasService->findAll($accountId, $this->currentUserId));
+		return new JSONResponse(
+			$this->aliasService->findAllWithDeletable($accountId, $this->currentUserId)
+		);
 	}
 
 	/**

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -152,7 +152,7 @@ class PageController extends Controller {
 		$accountsJson = [];
 		foreach ($mailAccounts as $mailAccount) {
 			$json = $mailAccount->jsonSerialize();
-			$json['aliases'] = $this->aliasesService->findAll($mailAccount->getId(),
+			$json['aliases'] = $this->aliasesService->findAllWithDeletable($mailAccount->getId(),
 				$this->currentUserId);
 			try {
 				$mailboxes = $this->mailManager->getMailboxes($mailAccount);

--- a/lib/Db/AliasMapper.php
+++ b/lib/Db/AliasMapper.php
@@ -68,6 +68,25 @@ class AliasMapper extends QBMapper {
 	}
 
 	/**
+	 * @throws DoesNotExistException
+	 */
+	public function findByAliasAndName(string $alias, string $name, string $currentUserId): Alias {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('aliases.*', 'accounts.provisioning_id')
+			->from($this->getTableName(), 'aliases')
+			->join('aliases', 'mail_accounts', 'accounts', $qb->expr()->eq('aliases.account_id', 'accounts.id'))
+			->where(
+				$qb->expr()->andX(
+					$qb->expr()->eq('accounts.user_id', $qb->createNamedParameter($currentUserId)),
+					$qb->expr()->eq('aliases.alias', $qb->createNamedParameter($alias)),
+					$qb->expr()->eq('aliases.name', $qb->createNamedParameter($name))
+				)
+			);
+
+		return $this->findEntity($qb);
+	}
+
+	/**
 	 * @param int $accountId
 	 * @param string $currentUserId
 	 *

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -122,6 +122,8 @@ class ProvisioningMapper extends QBMapper {
 
 		$provisioning->setLdapAliasesProvisioning($ldapAliasesProvisioning);
 		$provisioning->setLdapAliasesAttribute($ldapAliasesAttribute);
+		$nameTemplates = $data['nameTemplates'] ?? [];
+		$provisioning->setNameTemplates(!empty($nameTemplates) ? json_encode($nameTemplates) : null);
 
 		return $provisioning;
 	}

--- a/lib/Migration/Version5007Date20260114100548.php
+++ b/lib/Migration/Version5007Date20260114100548.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version5007Date20260114100548 extends SimpleMigrationStep {
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$provisioningTable = $schema->getTable('mail_provisionings');
+
+		if (!$provisioningTable->hasColumn('name_templates')) {
+			$provisioningTable->addColumn('name_templates', Types::TEXT, [
+				'notnull' => false,
+				'default' => '["%DISPLAYNAME%"]',
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/src/components/AliasForm.vue
+++ b/src/components/AliasForm.vue
@@ -55,7 +55,7 @@
 					</template>
 				</NcButton>
 				<NcButton
-					v-if="enableDelete && !alias.provisioned"
+					v-if="enableDelete && alias.deletable"
 					variant="tertiary-no-background"
 					:aria-label="t('mail', 'Delete alias')"
 					:name="t('mail', 'Delete alias')"

--- a/src/components/settings/ProvisionPreview.vue
+++ b/src/components/settings/ProvisionPreview.vue
@@ -13,6 +13,7 @@
 		{{ t('mail', 'Domain Match: {provisioningDomain}', { provisioningDomain }) }}
 		<br>
 		{{ t('mail', 'Email: {email}', { email }) }}<br>
+		{{ t('mail', 'Names: {names}', { names }) }}<br>
 		{{
 			t('mail', 'IMAP: {user} on {host}:{port} ({ssl} encryption)', {
 				user: imapUser,
@@ -60,6 +61,17 @@ export default {
 	computed: {
 		email() {
 			return this.templates.email.replace('%USERID%', this.data.uid).replace('%EMAIL%', this.data.email)
+		},
+
+		names() {
+			const templates = this.templates.nameTemplates || []
+			if (!templates.length) {
+				return this.data.displayName || 'Display Name'
+			}
+			return templates.map(t => t
+				.replace('%USERID%', this.data.uid)
+				.replace('%DISPLAYNAME%', this.data.displayName || '')
+			).join(', ')
 		},
 
 		provisioningDomain() {

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -31,6 +31,16 @@
 							:disabled="loading"
 							name="emailTemplate"
 							type="text">
+						<br>
+						<label :for="'mail-provision-name' + setting.id"> {{ t('mail', 'Name templates (one per line)') }}** </label>
+						<br>
+						<textarea
+							:id="'mail-provision-name' + setting.id"
+							v-model="nameTemplates"
+							:disabled="loading"
+							name="nameTemplates"
+							rows="3"
+							@keydown.enter.stop />
 					</div>
 				</div>
 				<div class="settings-group">
@@ -349,9 +359,10 @@
 							{{ t('mail', 'Unprovision & Delete Config') }}
 						</ButtonVue>
 						<br>
-						<small>{{
-							t('mail', '* %USERID% and %EMAIL% will be replaced with the user\'s UID and email')
-						}}</small>
+						<small>
+							{{ t('mail', '* %USERID% and %EMAIL% will be replaced with the user\'s UID and email') }}<br>
+							{{ t('mail', '** %USERID% and %DISPLAYNAME% will be replaced with the user\'s UID and display name') }}
+						</small>
 					</div>
 				</div>
 			</form>
@@ -416,6 +427,7 @@ export default {
 			active: !!this.setting.active,
 			provisioningDomain: this.setting.provisioningDomain || '',
 			emailTemplate: this.setting.emailTemplate || '',
+			nameTemplates: (this.setting.nameTemplates ?? ['%DISPLAYNAME%']).join('\n'),
 			imapHost: this.setting.imapHost || 'mx.domain.com',
 			imapPort: this.setting.imapPort || 993,
 			imapUser: this.setting.imapUser || '%USERID%domain.com',
@@ -434,11 +446,13 @@ export default {
 			previewData1: {
 				uid: 'user123',
 				email: '',
+				displayName: 'User One',
 			},
 
 			previewData2: {
 				uid: 'user321',
 				email: 'user@domain.com',
+				displayName: 'Jane Doe',
 			},
 
 			ldapAliasesProvisioning: this.setting.ldapAliasesProvisioning || false,
@@ -451,6 +465,7 @@ export default {
 		previewTemplates() {
 			return {
 				email: this.emailTemplate,
+				nameTemplates: this.nameTemplates.split('\n').filter(t => t.trim()),
 				provisioningDomain: this.provisioningDomain,
 				imapUser: this.imapUser,
 				imapHost: this.imapHost,
@@ -486,6 +501,7 @@ export default {
 					id: this.setting.id || null,
 					active: this.setting.active || true,
 					emailTemplate: this.emailTemplate,
+					nameTemplates: this.nameTemplates.split('\n').filter(t => t.trim()),
 					provisioningDomain: this.provisioningDomain,
 					imapUser: this.imapUser,
 					imapHost: this.imapHost,
@@ -555,6 +571,9 @@ export default {
 
 		input[type='text'] {
 			min-width: 200px;
+		}
+		textarea {
+			width: 100%;
 		}
 		.config-button {
 			display: inline-block;


### PR DESCRIPTION
**Summary**

This adds configurable sender name templates to mail provisioning, allowing admins to define how the "From" sender name (e.g., `Jane Doe <jane.doe@example.org>`) is set for provisioned accounts. 

Currently, provisioned mail accounts use the Nextcloud display name as the sender name. This addition allows to configure different formats like "Jane Doe | Organization Name" or "Support Team" in the provisioning config. In a new multi-line text field, admins can specify one sender name template per line using the `%DISPLAYNAME%` and `%USERID%` placeholders, for example:

```
%DISPLAYNAME%
%DISPLAYNAME% | Org Name
Support Team
```

This creates three aliases per email address, each with a different sender name that users can choose from when composing emails. The first line is the default sender name.

**Points that might be worth discussing**
- **Deletable aliases**: When an admin removes a name template from the configuration, the corresponding alias are not deleted automatically if the email address still exists (as deleting them might affect ongoing conversations using that sender identity), but instead become deletable by users themselves. Not sure whether it might be better to delete aliases for removed names automatically.
- **Defaults**: The migration sets `%DISPLAYNAME%` as a default value mirroring the current version's behaviour. An empty value also falls back to just `%DISPLAYNAME%`. This way, updating shouldn't change anything for existing installations (but I might have missed a detail somewhere).

**Note**
While the code is working and ready to test, this is a draft PR to gather feedback and see if this could be a candidate for merging. If so, I'll need to update the tests accordingly (which currently don't pass due to constructor changes).