### PR TITLE
fix(imap): Add support for mail services that enforce a client id

### DIFF
--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\IMAP;
 
 use Horde_Imap_Client_Exception;
+use Horde_Imap_Client_Exception_NoSupportExtension;
 use Horde_Imap_Client_Socket;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IMemcache;
@@ -35,6 +36,19 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 		$this->rateLimiterCache = $cache;
 		$this->timeFactory = $timeFactory;
 		$this->hash = $hash;
+	}
+
+	#[\Override]
+	public function login() {
+		parent::login();
+
+		try {
+			$this->sendID();
+			/* ID is queued - force sending the queued command. */
+			$this->_sendCmd($this->_pipeline());
+		} catch (Horde_Imap_Client_Exception_NoSupportExtension $e) {
+			// Ignore if server doesn't support ID extension.
+		}
 	}
 
 	#[\Override]


### PR DESCRIPTION
Fix #12151 

Some mail services (e.g. mail163.com) do require an imap id to be given.

Without further configuration sendID just sends NIL as ID.
