### PR TITLE
fix(DisplayContactDetails): remove box shadow

### DIFF
--- a/src/components/DisplayContactDetails.vue
+++ b/src/components/DisplayContactDetails.vue
@@ -42,3 +42,9 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+:deep(input) {
+	box-shadow: none !important;
+}
+</style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/contacts/issues/4987

Removes the shadow here:
<img width="396" height="743" alt="image" src="https://github.com/user-attachments/assets/f006cd18-a29f-495f-b9be-b3fc68588e7c" />

Why this isn't in the contacts repo:

`ContactsDetails` distinguishes between read only and writable modes, and we need to hide the shadow only in read only. However, the classes representing this aren't passed down into mail.  
