### PR TITLE
chore(ci): Switch to setup-php@verbose version due to stuck runs

### DIFF
--- a/.github/workflows/lint-php-cs.yml
+++ b/.github/workflows/lint-php-cs.yml
@@ -34,7 +34,7 @@ jobs:
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
       - name: Set up php${{ steps.versions.outputs.php-min }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@verbose # v2.36.0 with verbose logging due to stuck runs
         with:
           php-version: ${{ steps.versions.outputs.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@verbose # v2.36.0 with verbose logging due to stuck runs
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -35,7 +35,7 @@ jobs:
         uses: icewind1991/nextcloud-version-matrix@58becf3b4bb6dc6cef677b15e2fd8e7d48c0908f # v1.3.1
 
       - name: Set up php
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@verbose # v2.36.0 with verbose logging due to stuck runs
         with:
           php-version: ${{ steps.php_versions.outputs.php-available }}
           extensions: xml

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up php${{ matrix.php-min }}
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
+        uses: shivammathur/setup-php@verbose # v2.36.0 with verbose logging due to stuck runs
         with:
           php-version: ${{ matrix.php-min }}
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite


### PR DESCRIPTION
At least @SebastianKrupinski and myself experienced some workflow runs where the `set up php` step stuck. As discussed in the talk channel, this seem to affect more people from within the company. It also [happened today](https://github.com/nextcloud/mail/actions/runs/21071987240/job/60603837762?pr=12259#step:3:60) with the `setup-nextcloud` workflow action from @ChristophWurst , which tags `@v2` and therefore already uses the latest version:

<img width="1920" height="1570" alt="Screenshot 2026-01-16 at 22-25-19 fix(imap) Add support for mail services that enforce a client id · nextcloud_mail@0f64a8b" src="https://github.com/user-attachments/assets/004f5c1b-5567-4979-9ab0-dba6af392566" />

To be able to find the root cause for that issue, I've decided to switch the daily workflows to the `@verbose` version (see: https://github.com/shivammathur/setup-php?tab=readme-ov-file#verbose-setup). It might be worth to do that for the `setup-nextcloud` workflow as well, to get more verbose logging on possibly stuck runs faster.
