### PR TITLE
fix: retrieve classification preference

### DIFF
--- a/lib/Migration/Version5007Date20251024153423.php
+++ b/lib/Migration/Version5007Date20251024153423.php
@@ -56,7 +56,7 @@ class Version5007Date20251024153423 extends SimpleMigrationStep {
 			);
 
 		$res = $qb->executeQuery();
-		$users = $res->fetchAll();
+		$users = $res->fetchAll(\PDO::FETCH_COLUMN);
 
 		$res->closeCursor();
 		$output->info('Migrating classification user preferences to mail_accounts table');


### PR DESCRIPTION
This fixes a regression of https://github.com/nextcloud/mail/pull/11968 where the migration does not set the classification as off.