### PR TITLE
ci: let releases cool down 7d before bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
 	"commitMessageTopic": "{{depName}}",
 	"commitMessageExtra": "from {{currentVersion}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
 	"rangeStrategy": "bump",
+	"minimumReleaseAge": "7 days",
 	"rebaseWhen": "conflicted",
 	"ignoreUnstable": false,
 	"baseBranches": [


### PR DESCRIPTION
Ref https://docs.renovatebot.com/key-concepts/minimum-release-age/