### PR TITLE
ci: remove minimum release age for @nextcloud/*

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -154,6 +154,11 @@
 			"reviewers": []
 		},
 		{
+			"description": "Disable minimum release age checks for internal dependencies",
+			"matchPackageNames": ["@nextcloud/*"],
+			"minimumReleaseAge": null
+		},
+		{
 			"description": "Only automerge packages that follow semver",
 			"matchPackageNames": [
 				"@nextcloud/vue",


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/mail/pull/12282. 

Ref https://docs.renovatebot.com/key-concepts/minimum-release-age/#how-do-i-opt-out-dependencies-from-minimum-release-age-checks