### PR TITLE
fix: clean text blocks on user deletion

### DIFF
--- a/lib/Db/TextBlockMapper.php
+++ b/lib/Db/TextBlockMapper.php
@@ -73,4 +73,11 @@ class TextBlockMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	public function deleteByUserId(string $userId) {
+		$qb = $this->db->getQueryBuilder();
+		$delete = $qb->delete($this->getTableName())
+			->where($qb->expr()->eq('owner', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)));
+		$delete->executeStatement();
+	}
+
 }

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Listener;
 
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\TextBlockService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\User\Events\UserDeletedEvent;
@@ -26,8 +27,11 @@ class UserDeletedListener implements IEventListener {
 	/** @var LoggerInterface */
 	private $logger;
 
-	public function __construct(AccountService $accountService,
-		LoggerInterface $logger) {
+	public function __construct(
+		AccountService $accountService,
+		private TextBlockService $textBlockService,
+		LoggerInterface $logger,
+	) {
 		$this->accountService = $accountService;
 		$this->logger = $logger;
 	}
@@ -52,5 +56,8 @@ class UserDeletedListener implements IEventListener {
 				]);
 			}
 		}
+		$this->textBlockService->deleteByUserId(
+			$user->getUID()
+		);
 	}
 }

--- a/lib/Service/TextBlockService.php
+++ b/lib/Service/TextBlockService.php
@@ -149,4 +149,8 @@ class TextBlockService {
 		$share = $this->textBlockShareMapper->find($textBlockId, $shareWith);
 		$this->textBlockShareMapper->delete($share);
 	}
+
+	public function deleteByUserId(string $userId): void {
+		$this->textBlockMapper->deleteByUserId($userId);
+	}
 }

--- a/tests/Unit/Service/TextBlockServiceTest.php
+++ b/tests/Unit/Service/TextBlockServiceTest.php
@@ -349,5 +349,12 @@ final class TextBlockServiceTest extends TestCase {
 		$this->assertSame($shares, $result);
 	}
 
+	public function testDeleteByUserId(): void {
+		$userId = 'toBeDeleted';
+		$this->textBlockMapper->expects($this->once())
+			->method('deleteByUserId')
+			->with($userId);
+		$this->textBlockService->deleteByUserId($userId);
+	}
 
 }


### PR DESCRIPTION
Deletes all text blocks and their shares once a user gets deletd