### PR TITLE
chore(docs): Update links to admin and user documentation in README.md and info.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ We are also available on [our public Mail development chat](https://cloud.nextcl
 ## Documentation
 
 Need help? Check out our documentation. It's split into three parts.
-* [Admin documentation](doc/admin.md) (installation, configuration, troubleshooting)
+* [Admin documentation](https://docs.nextcloud.com/server/stable/admin_manual/groupware/mail.html) (installation, configuration, troubleshooting)
 * [Developer documentation](doc/developer.md) (developer setup, nightly builds)
-* [User documentation](doc/user.md) (usage, keyboard shortcuts)
+* [User documentation](https://docs.nextcloud.com/server/stable/user_manual/en/groupware/mail.html) (usage)
 
 ## Credits
 This project uses [CKEditor](https://ckeditor.com), which is licensed under the [GPLv2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -41,8 +41,8 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	<author homepage="https://github.com/kesselb">kesselb</author>
 	<namespace>Mail</namespace>
 	<documentation>
-		<user>https://github.com/nextcloud/mail/blob/main/doc/user.md</user>
-		<admin>https://github.com/nextcloud/mail/blob/main/doc/admin.md</admin>
+		<user>https://docs.nextcloud.com/server/stable/user_manual/en/groupware/mail.html</user>
+		<admin>https://docs.nextcloud.com/server/stable/admin_manual/groupware/mail.html</admin>
 		<developer>https://github.com/nextcloud/mail/blob/main/doc/developer.md</developer>
 	</documentation>
 	<category>social</category>


### PR DESCRIPTION
The documentation for administrators and users have moved to `nextcloud/documentation` (#12267). In this PR, the links to the documentation mentioned in the README.md hasn't been updated, which was resulted in #12299.

To fix that, I've updated the links to point to the documentation of the stable branch from `nextcloud/documentation`.

Fixes #12299