### PR TITLE
fix(OutOfOfficeForm): datepicker overlapping with sidebar

### DIFF
--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -387,4 +387,10 @@ export default {
 		}
 	}
 }
+
+#ooo-first-day {
+	:deep(.mx-datepicker-popup) {
+		inset-inline-start: 0 !important;
+	}
+}
 </style>


### PR DESCRIPTION
This is being caused by the main view of the settings having its overflow hidden by the sidebar, and the popup of the datepicker is contained inside the main view and isn't appended somewhere later in the DOM

The ideal solution here would be to have the popup somewhere else where it isn't constrained, but seeing as it comes from a third party library I don't know what we can do about that.

| Before | After |
| - | - |
| <img width="902" height="547" alt="image" src="https://github.com/user-attachments/assets/e8589426-c715-4051-a4cd-cbff67840983" /> | <img width="894" height="551" alt="swappy-20260123_131330" src="https://github.com/user-attachments/assets/f8497744-50e8-4cc6-9b36-d38af34f583d" /> |
 