### PR TITLE
feat(provisioning): add support for Dovecot master user auth

### DIFF
--- a/lib/Db/Provisioning.php
+++ b/lib/Db/Provisioning.php
@@ -39,6 +39,10 @@ use ReturnTypeWillChange;
  * @method void setMasterPasswordEnabled(bool $masterPasswordEnabled)
  * @method string|null getMasterPassword()
  * @method void setMasterPassword(string $masterPassword)
+ * @method string|null getMasterUser()
+ * @method void setMasterUser(?string $masterUser)
+ * @method string|null getMasterUserSeparator()
+ * @method void setMasterUserSeparator(?string $masterUserSeparator)
  * @method bool|null getSieveEnabled()
  * @method void setSieveEnabled(bool $sieveEnabled)
  * @method string|null getSieveHost()
@@ -72,6 +76,8 @@ class Provisioning extends Entity implements JsonSerializable {
 	protected $smtpSslMode;
 	protected $masterPasswordEnabled;
 	protected $masterPassword;
+	protected $masterUser;
+	protected $masterUserSeparator;
 	protected $sieveEnabled;
 	protected $sieveUser;
 	protected $sieveHost;
@@ -86,6 +92,8 @@ class Provisioning extends Entity implements JsonSerializable {
 		$this->addType('smtpPort', 'integer');
 		$this->addType('masterPasswordEnabled', 'boolean');
 		$this->addType('masterPassword', 'string');
+		$this->addType('masterUser', 'string');
+		$this->addType('masterUserSeparator', 'string');
 		$this->addType('sieveEnabled', 'boolean');
 		$this->addType('sievePort', 'integer');
 		$this->addType('ldapAliasesProvisioning', 'boolean');
@@ -108,6 +116,8 @@ class Provisioning extends Entity implements JsonSerializable {
 			'smtpSslMode' => $this->getSmtpSslMode(),
 			'masterPasswordEnabled' => $this->getMasterPasswordEnabled(),
 			'masterPassword' => !empty($this->getMasterPassword()) ? self::MASTER_PASSWORD_PLACEHOLDER : null,
+			'masterUser' => !empty($this->getMasterUser()) ? self::MASTER_PASSWORD_PLACEHOLDER : null,
+			'masterUserSeparator' => $this->getMasterUserSeparator() ?? '*',
 			'sieveEnabled' => $this->getSieveEnabled(),
 			'sieveUser' => $this->getSieveUser(),
 			'sieveHost' => $this->getSieveHost(),

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -92,6 +92,13 @@ class ProvisioningMapper extends QBMapper {
 			$exception->setField('ldapAliasesAttribute', false);
 		}
 
+		// Master password is required when master user is set
+		$masterUser = $data['masterUser'] ?? '';
+		$masterPasswordEnabled = (bool)($data['masterPasswordEnabled'] ?? false);
+		if (!empty($masterUser) && $masterUser !== Provisioning::MASTER_PASSWORD_PLACEHOLDER && !$masterPasswordEnabled) {
+			$exception->setField('masterPasswordEnabled', false);
+		}
+
 		if (!empty($exception->getFields())) {
 			throw $exception;
 		}
@@ -113,6 +120,10 @@ class ProvisioningMapper extends QBMapper {
 		if (isset($data['masterPassword']) && $data['masterPassword'] !== Provisioning::MASTER_PASSWORD_PLACEHOLDER) {
 			$provisioning->setMasterPassword($data['masterPassword']);
 		}
+		if (isset($data['masterUser']) && $data['masterUser'] !== Provisioning::MASTER_PASSWORD_PLACEHOLDER) {
+			$provisioning->setMasterUser($data['masterUser']);
+		}
+		$provisioning->setMasterUserSeparator($data['masterUserSeparator'] ?? '*');
 
 		$provisioning->setSieveEnabled((bool)$data['sieveEnabled']);
 		$provisioning->setSieveHost($data['sieveHost'] ?? '');

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -28,133 +28,133 @@ use function implode;
 use function json_encode;
 
 class IMAPClientFactory {
-    /** @var ICrypto */
-    private $crypto;
+	/** @var ICrypto */
+	private $crypto;
 
-    /** @var IConfig */
-    private $config;
+	/** @var IConfig */
+	private $config;
 
-    /** @var ICacheFactory */
-    private $cacheFactory;
+	/** @var ICacheFactory */
+	private $cacheFactory;
 
-    /** @var IEventDispatcher */
-    private $eventDispatcher;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
 
-    private ITimeFactory $timeFactory;
-    private HordeCacheFactory $hordeCacheFactory;
-    private ProvisioningMapper $provisioningMapper;
+	private ITimeFactory $timeFactory;
+	private HordeCacheFactory $hordeCacheFactory;
+	private ProvisioningMapper $provisioningMapper;
 
-    public function __construct(ICrypto $crypto,
-        IConfig $config,
-        ICacheFactory $cacheFactory,
-        IEventDispatcher $eventDispatcher,
-        ITimeFactory $timeFactory,
-        HordeCacheFactory $hordeCacheFactory,
-        ProvisioningMapper $provisioningMapper) {
-        $this->crypto = $crypto;
-        $this->config = $config;
-        $this->cacheFactory = $cacheFactory;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->timeFactory = $timeFactory;
-        $this->hordeCacheFactory = $hordeCacheFactory;
-        $this->provisioningMapper = $provisioningMapper;
-    }
+	public function __construct(ICrypto $crypto,
+		IConfig $config,
+		ICacheFactory $cacheFactory,
+		IEventDispatcher $eventDispatcher,
+		ITimeFactory $timeFactory,
+		HordeCacheFactory $hordeCacheFactory,
+		ProvisioningMapper $provisioningMapper) {
+		$this->crypto = $crypto;
+		$this->config = $config;
+		$this->cacheFactory = $cacheFactory;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->timeFactory = $timeFactory;
+		$this->hordeCacheFactory = $hordeCacheFactory;
+		$this->provisioningMapper = $provisioningMapper;
+	}
 
-    /**
-     * Get the connection object for the given account
-     *
-     * Connections are not closed until destruction, so the caller site is
-     * responsible to log out as soon as possible to keep the number of open
-     * (and stale) connections at a minimum.
-     *
-     * @param Account $account
-     * @param bool $useCache
-     *
-     * @return Horde_Imap_Client_Socket
-     * @throws ServiceException
-     */
-    public function getClient(Account $account, bool $useCache = true): Horde_Imap_Client_Socket {
-        $this->eventDispatcher->dispatchTyped(
-            new BeforeImapClientCreated($account)
-        );
-        $host = $account->getMailAccount()->getInboundHost();
-        $user = $account->getMailAccount()->getInboundUser();
-        $decryptedPassword = null;
-        if ($account->getMailAccount()->getInboundPassword() !== null) {
-            $decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
-        }
-        $port = $account->getMailAccount()->getInboundPort();
-        $sslMode = $account->getMailAccount()->getInboundSslMode();
-        if ($sslMode === 'none') {
-            $sslMode = false;
-        }
+	/**
+	 * Get the connection object for the given account
+	 *
+	 * Connections are not closed until destruction, so the caller site is
+	 * responsible to log out as soon as possible to keep the number of open
+	 * (and stale) connections at a minimum.
+	 *
+	 * @param Account $account
+	 * @param bool $useCache
+	 *
+	 * @return Horde_Imap_Client_Socket
+	 * @throws ServiceException
+	 */
+	public function getClient(Account $account, bool $useCache = true): Horde_Imap_Client_Socket {
+		$this->eventDispatcher->dispatchTyped(
+			new BeforeImapClientCreated($account)
+		);
+		$host = $account->getMailAccount()->getInboundHost();
+		$user = $account->getMailAccount()->getInboundUser();
+		$decryptedPassword = null;
+		if ($account->getMailAccount()->getInboundPassword() !== null) {
+			$decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
+		}
+		$port = $account->getMailAccount()->getInboundPort();
+		$sslMode = $account->getMailAccount()->getInboundSslMode();
+		if ($sslMode === 'none') {
+			$sslMode = false;
+		}
 
-        // Check for Dovecot master user authentication
-        $provisioningId = $account->getMailAccount()->getProvisioningId();
-        if ($provisioningId !== null) {
-            $provisioning = $this->provisioningMapper->get($provisioningId);
-            if ($provisioning !== null && !empty($provisioning->getMasterUser())) {
-                $separator = $provisioning->getMasterUserSeparator() ?? '*';
-                $user = $user . $separator . $provisioning->getMasterUser();
-            }
-        }
+		// Check for Dovecot master user authentication
+		$provisioningId = $account->getMailAccount()->getProvisioningId();
+		if ($provisioningId !== null) {
+			$provisioning = $this->provisioningMapper->get($provisioningId);
+			if ($provisioning !== null && !empty($provisioning->getMasterUser())) {
+				$separator = $provisioning->getMasterUserSeparator() ?? '*';
+				$user = $user . $separator . $provisioning->getMasterUser();
+			}
+		}
 
-        $params = [
-            'username' => $user,
-            'password' => $decryptedPassword,
-            'hostspec' => $host,
-            'port' => $port,
-            'secure' => $sslMode,
-            'timeout' => (int)$this->config->getSystemValue('app.mail.imap.timeout', 5),
-            'context' => [
-                'ssl' => [
-                    'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-                    'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-                ],
-            ],
-        ];
-        if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
-            try {
-                $oauthAccessToken = $account->getMailAccount()->getOauthAccessToken();
-                if ($oauthAccessToken === null) {
-                    throw new ServiceException('Missing access token for xoauth2 account');
-                }
-                $decryptedAccessToken = $this->crypto->decrypt($oauthAccessToken);
-            } catch (Exception $e) {
-                throw new ServiceException('Could not decrypt account access token: ' . $e->getMessage(), 0, $e);
-            }
+		$params = [
+			'username' => $user,
+			'password' => $decryptedPassword,
+			'hostspec' => $host,
+			'port' => $port,
+			'secure' => $sslMode,
+			'timeout' => (int)$this->config->getSystemValue('app.mail.imap.timeout', 5),
+			'context' => [
+				'ssl' => [
+					'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+					'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+				],
+			],
+		];
+		if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
+			try {
+				$oauthAccessToken = $account->getMailAccount()->getOauthAccessToken();
+				if ($oauthAccessToken === null) {
+					throw new ServiceException('Missing access token for xoauth2 account');
+				}
+				$decryptedAccessToken = $this->crypto->decrypt($oauthAccessToken);
+			} catch (Exception $e) {
+				throw new ServiceException('Could not decrypt account access token: ' . $e->getMessage(), 0, $e);
+			}
 
-            $params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
-            $params['xoauth2_token'] = new Horde_Imap_Client_Password_Xoauth2(
-                $account->getEmail(),
-                $decryptedAccessToken,
-            );
-        }
-        $paramHash = hash(
-            'sha512',
-            implode('-', [
-                $this->config->getSystemValueString('secret'),
-                $account->getId(),
-                json_encode($params)
-            ]),
-        );
-        if ($useCache) {
-            $params['cache'] = [
-                'backend' => $this->hordeCacheFactory->newCache($account),
-            ];
-        }
-        if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
-            $fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
-            $params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
-        }
+			$params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
+			$params['xoauth2_token'] = new Horde_Imap_Client_Password_Xoauth2(
+				$account->getEmail(),
+				$decryptedAccessToken,
+			);
+		}
+		$paramHash = hash(
+			'sha512',
+			implode('-', [
+				$this->config->getSystemValueString('secret'),
+				$account->getId(),
+				json_encode($params)
+			]),
+		);
+		if ($useCache) {
+			$params['cache'] = [
+				'backend' => $this->hordeCacheFactory->newCache($account),
+			];
+		}
+		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
+			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
+		}
 
-        $client = new HordeImapClient($params);
+		$client = new HordeImapClient($params);
 
-        $rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
-        if ($rateLimitingCache instanceof IMemcache) {
-            $client->enableRateLimiter($rateLimitingCache, $paramHash, $this->timeFactory);
-        }
+		$rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
+		if ($rateLimitingCache instanceof IMemcache) {
+			$client->enableRateLimiter($rateLimitingCache, $paramHash, $this->timeFactory);
+		}
 
-        return $client;
-    }
+		return $client;
+	}
 }

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -14,6 +14,7 @@ use Horde_Imap_Client_Password_Xoauth2;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Cache\HordeCacheFactory;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\Events\BeforeImapClientCreated;
 use OCA\Mail\Exception\ServiceException;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -27,120 +28,133 @@ use function implode;
 use function json_encode;
 
 class IMAPClientFactory {
-	/** @var ICrypto */
-	private $crypto;
+    /** @var ICrypto */
+    private $crypto;
 
-	/** @var IConfig */
-	private $config;
+    /** @var IConfig */
+    private $config;
 
-	/** @var ICacheFactory */
-	private $cacheFactory;
+    /** @var ICacheFactory */
+    private $cacheFactory;
 
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
+    /** @var IEventDispatcher */
+    private $eventDispatcher;
 
-	private ITimeFactory $timeFactory;
-	private HordeCacheFactory $hordeCacheFactory;
+    private ITimeFactory $timeFactory;
+    private HordeCacheFactory $hordeCacheFactory;
+    private ProvisioningMapper $provisioningMapper;
 
-	public function __construct(ICrypto $crypto,
-		IConfig $config,
-		ICacheFactory $cacheFactory,
-		IEventDispatcher $eventDispatcher,
-		ITimeFactory $timeFactory,
-		HordeCacheFactory $hordeCacheFactory) {
-		$this->crypto = $crypto;
-		$this->config = $config;
-		$this->cacheFactory = $cacheFactory;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->timeFactory = $timeFactory;
-		$this->hordeCacheFactory = $hordeCacheFactory;
-	}
+    public function __construct(ICrypto $crypto,
+        IConfig $config,
+        ICacheFactory $cacheFactory,
+        IEventDispatcher $eventDispatcher,
+        ITimeFactory $timeFactory,
+        HordeCacheFactory $hordeCacheFactory,
+        ProvisioningMapper $provisioningMapper) {
+        $this->crypto = $crypto;
+        $this->config = $config;
+        $this->cacheFactory = $cacheFactory;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->timeFactory = $timeFactory;
+        $this->hordeCacheFactory = $hordeCacheFactory;
+        $this->provisioningMapper = $provisioningMapper;
+    }
 
-	/**
-	 * Get the connection object for the given account
-	 *
-	 * Connections are not closed until destruction, so the caller site is
-	 * responsible to log out as soon as possible to keep the number of open
-	 * (and stale) connections at a minimum.
-	 *
-	 * @param Account $account
-	 * @param bool $useCache
-	 *
-	 * @return Horde_Imap_Client_Socket
-	 * @throws ServiceException
-	 */
-	public function getClient(Account $account, bool $useCache = true): Horde_Imap_Client_Socket {
-		$this->eventDispatcher->dispatchTyped(
-			new BeforeImapClientCreated($account)
-		);
-		$host = $account->getMailAccount()->getInboundHost();
-		$user = $account->getMailAccount()->getInboundUser();
-		$decryptedPassword = null;
-		if ($account->getMailAccount()->getInboundPassword() !== null) {
-			$decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
-		}
-		$port = $account->getMailAccount()->getInboundPort();
-		$sslMode = $account->getMailAccount()->getInboundSslMode();
-		if ($sslMode === 'none') {
-			$sslMode = false;
-		}
+    /**
+     * Get the connection object for the given account
+     *
+     * Connections are not closed until destruction, so the caller site is
+     * responsible to log out as soon as possible to keep the number of open
+     * (and stale) connections at a minimum.
+     *
+     * @param Account $account
+     * @param bool $useCache
+     *
+     * @return Horde_Imap_Client_Socket
+     * @throws ServiceException
+     */
+    public function getClient(Account $account, bool $useCache = true): Horde_Imap_Client_Socket {
+        $this->eventDispatcher->dispatchTyped(
+            new BeforeImapClientCreated($account)
+        );
+        $host = $account->getMailAccount()->getInboundHost();
+        $user = $account->getMailAccount()->getInboundUser();
+        $decryptedPassword = null;
+        if ($account->getMailAccount()->getInboundPassword() !== null) {
+            $decryptedPassword = $this->crypto->decrypt($account->getMailAccount()->getInboundPassword());
+        }
+        $port = $account->getMailAccount()->getInboundPort();
+        $sslMode = $account->getMailAccount()->getInboundSslMode();
+        if ($sslMode === 'none') {
+            $sslMode = false;
+        }
 
-		$params = [
-			'username' => $user,
-			'password' => $decryptedPassword,
-			'hostspec' => $host,
-			'port' => $port,
-			'secure' => $sslMode,
-			'timeout' => (int)$this->config->getSystemValue('app.mail.imap.timeout', 5),
-			'context' => [
-				'ssl' => [
-					'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-					'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
-				],
-			],
-		];
-		if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
-			try {
-				$oauthAccessToken = $account->getMailAccount()->getOauthAccessToken();
-				if ($oauthAccessToken === null) {
-					throw new ServiceException('Missing access token for xoauth2 account');
-				}
-				$decryptedAccessToken = $this->crypto->decrypt($oauthAccessToken);
-			} catch (Exception $e) {
-				throw new ServiceException('Could not decrypt account access token: ' . $e->getMessage(), 0, $e);
-			}
+        // Check for Dovecot master user authentication
+        $provisioningId = $account->getMailAccount()->getProvisioningId();
+        if ($provisioningId !== null) {
+            $provisioning = $this->provisioningMapper->get($provisioningId);
+            if ($provisioning !== null && !empty($provisioning->getMasterUser())) {
+                $separator = $provisioning->getMasterUserSeparator() ?? '*';
+                $user = $user . $separator . $provisioning->getMasterUser();
+            }
+        }
 
-			$params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
-			$params['xoauth2_token'] = new Horde_Imap_Client_Password_Xoauth2(
-				$account->getEmail(),
-				$decryptedAccessToken,
-			);
-		}
-		$paramHash = hash(
-			'sha512',
-			implode('-', [
-				$this->config->getSystemValueString('secret'),
-				$account->getId(),
-				json_encode($params)
-			]),
-		);
-		if ($useCache) {
-			$params['cache'] = [
-				'backend' => $this->hordeCacheFactory->newCache($account),
-			];
-		}
-		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
-			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
-			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
-		}
+        $params = [
+            'username' => $user,
+            'password' => $decryptedPassword,
+            'hostspec' => $host,
+            'port' => $port,
+            'secure' => $sslMode,
+            'timeout' => (int)$this->config->getSystemValue('app.mail.imap.timeout', 5),
+            'context' => [
+                'ssl' => [
+                    'verify_peer' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+                    'verify_peer_name' => $this->config->getSystemValueBool('app.mail.verify-tls-peer', true),
+                ],
+            ],
+        ];
+        if ($account->getMailAccount()->getAuthMethod() === 'xoauth2') {
+            try {
+                $oauthAccessToken = $account->getMailAccount()->getOauthAccessToken();
+                if ($oauthAccessToken === null) {
+                    throw new ServiceException('Missing access token for xoauth2 account');
+                }
+                $decryptedAccessToken = $this->crypto->decrypt($oauthAccessToken);
+            } catch (Exception $e) {
+                throw new ServiceException('Could not decrypt account access token: ' . $e->getMessage(), 0, $e);
+            }
 
-		$client = new HordeImapClient($params);
+            $params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
+            $params['xoauth2_token'] = new Horde_Imap_Client_Password_Xoauth2(
+                $account->getEmail(),
+                $decryptedAccessToken,
+            );
+        }
+        $paramHash = hash(
+            'sha512',
+            implode('-', [
+                $this->config->getSystemValueString('secret'),
+                $account->getId(),
+                json_encode($params)
+            ]),
+        );
+        if ($useCache) {
+            $params['cache'] = [
+                'backend' => $this->hordeCacheFactory->newCache($account),
+            ];
+        }
+        if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+            $fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
+            $params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
+        }
 
-		$rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
-		if ($rateLimitingCache instanceof IMemcache) {
-			$client->enableRateLimiter($rateLimitingCache, $paramHash, $this->timeFactory);
-		}
+        $client = new HordeImapClient($params);
 
-		return $client;
-	}
+        $rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
+        if ($rateLimitingCache instanceof IMemcache) {
+            $client->enableRateLimiter($rateLimitingCache, $paramHash, $this->timeFactory);
+        }
+
+        return $client;
+    }
 }

--- a/lib/Migration/Version5007Date20260124120000.php
+++ b/lib/Migration/Version5007Date20260124120000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Add master_user and master_user_separator columns to mail_provisionings table
+ * for Dovecot Master User authentication support.
+ *
+ * @codeCoverageIgnore
+ */
+class Version5007Date20260124120000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$provisioningTable = $schema->getTable('mail_provisionings');
+		if (!$provisioningTable->hasColumn('master_user')) {
+			$provisioningTable->addColumn('master_user', Types::STRING, [
+				'notnull' => false,
+				'length' => 256,
+			]);
+		}
+		if (!$provisioningTable->hasColumn('master_user_separator')) {
+			$provisioningTable->addColumn('master_user_separator', Types::STRING, [
+				'notnull' => false,
+				'length' => 8,
+				'default' => '*',
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Sieve/SieveClientFactory.php
+++ b/lib/Sieve/SieveClientFactory.php
@@ -11,17 +11,20 @@ namespace OCA\Mail\Sieve;
 
 use Horde\ManageSieve;
 use OCA\Mail\Account;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 
 class SieveClientFactory {
 	private ICrypto $crypto;
 	private IConfig $config;
+	private ProvisioningMapper $provisioningMapper;
 	private array $cache = [];
 
-	public function __construct(ICrypto $crypto, IConfig $config) {
+	public function __construct(ICrypto $crypto, IConfig $config, ProvisioningMapper $provisioningMapper) {
 		$this->crypto = $crypto;
 		$this->config = $config;
+		$this->provisioningMapper = $provisioningMapper;
 	}
 
 	/**
@@ -36,6 +39,16 @@ class SieveClientFactory {
 			$password = $account->getMailAccount()->getSievePassword();
 			if (empty($password)) {
 				$password = $account->getMailAccount()->getInboundPassword();
+			}
+
+			// Check for Dovecot master user authentication
+			$provisioningId = $account->getMailAccount()->getProvisioningId();
+			if ($provisioningId !== null) {
+				$provisioning = $this->provisioningMapper->get($provisioningId);
+				if ($provisioning !== null && !empty($provisioning->getMasterUser())) {
+					$separator = $provisioning->getMasterUserSeparator() ?? '*';
+					$user = $user . $separator . $provisioning->getMasterUser();
+				}
 			}
 
 			if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {

--- a/src/components/settings/ProvisionPreview.vue
+++ b/src/components/settings/ProvisionPreview.vue
@@ -15,7 +15,7 @@
 		{{ t('mail', 'Email: {email}', { email }) }}<br>
 		{{
 			t('mail', 'IMAP: {user} on {host}:{port} ({ssl} encryption)', {
-				user: imapUser,
+				user: imapLoginUser,
 				host: imapHost,
 				port: imapPort,
 				ssl: imapSslMode,
@@ -23,7 +23,7 @@
 		}}<br>
 		{{
 			t('mail', 'SMTP: {user} on {host}:{port} ({ssl} encryption)', {
-				user: smtpUser,
+				user: smtpLoginUser,
 				host: smtpHost,
 				port: smtpPort,
 				ssl: smtpSslMode,
@@ -32,12 +32,20 @@
 		<span v-if="sieveEnabled">
 			{{
 				t('mail', 'Sieve: {user} on {host}:{port} ({ssl} encryption)', {
-					user: sieveUser,
+					user: sieveLoginUser,
 					host: sieveHost,
 					port: sievePort,
 					ssl: sieveSslMode,
 				})
 			}}<br>
+		</span>
+		<span v-if="hasMasterUser" class="master-user-info">
+			<br>
+			<em>{{ t('mail', 'Using Dovecot master user authentication') }}</em>
+		</span>
+		<span v-else-if="masterPasswordEnabled" class="master-password-info">
+			<br>
+			<em>{{ t('mail', 'Using static password for all users') }}</em>
 		</span>
 	</div>
 </template>
@@ -116,6 +124,46 @@ export default {
 
 		sieveUser() {
 			return this.templates.sieveUser.replace('%USERID%', this.data.uid).replace('%EMAIL%', this.data.email)
+		},
+
+		masterPasswordEnabled() {
+			return this.templates.masterPasswordEnabled
+		},
+
+		masterUser() {
+			return this.templates.masterUser || ''
+		},
+
+		masterUserSeparator() {
+			return this.templates.masterUserSeparator || '*'
+		},
+
+		hasMasterUser() {
+			return this.masterUser && this.masterUser !== '********' && this.masterUser.length > 0
+		},
+
+		imapLoginUser() {
+			const baseUser = this.imapUser
+			if (this.hasMasterUser) {
+				return baseUser + this.masterUserSeparator + this.masterUser
+			}
+			return baseUser
+		},
+
+		smtpLoginUser() {
+			const baseUser = this.smtpUser
+			if (this.hasMasterUser) {
+				return baseUser + this.masterUserSeparator + this.masterUser
+			}
+			return baseUser
+		},
+
+		sieveLoginUser() {
+			const baseUser = this.sieveUser
+			if (this.hasMasterUser) {
+				return baseUser + this.masterUserSeparator + this.masterUser
+			}
+			return baseUser
 		},
 	},
 }

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -191,7 +191,8 @@
 								:id="'mail-master-password-enabled' + setting.id"
 								v-model="masterPasswordEnabled"
 								type="checkbox"
-								class="checkbox">
+								class="checkbox"
+								:required="masterUser.length > 0 && masterUser !== '********'">
 							<label :for="'mail-master-password-enabled' + setting.id">
 								{{ t('mail', 'Use master password') }}
 							</label>
@@ -204,6 +205,36 @@
 								type="password"
 								:required="masterPasswordEnabled">
 							<label for="mail-master-password"> {{ t('mail', 'Master password') }} </label>
+						</div>
+						<p v-if="!masterUser || masterUser === '********' || masterUser.length === 0">
+							{{ t('mail', 'When only master password is set, all users will authenticate with their normal username and this static password.') }}
+						</p>
+						<div>
+							<label :for="'mail-master-user' + setting.id">
+								{{ t('mail', 'Master user (Dovecot master user)') }}
+								<br>
+								<input
+									:id="'mail-master-user' + setting.id"
+									v-model="masterUser"
+									:disabled="loading"
+									type="text"
+									:placeholder="t('mail', 'e.g. masteruser')">
+							</label>
+							<p>{{ t('mail', 'When master user is set, authentication will use the Dovecot master user format: user{separator}masteruser with the master password.') }}</p>
+						</div>
+						<div v-show="masterUser && masterUser !== '********' && masterUser.length > 0">
+							<label :for="'mail-master-user-separator' + setting.id">
+								{{ t('mail', 'Separator') }}
+								<br>
+								<input
+									:id="'mail-master-user-separator' + setting.id"
+									v-model="masterUserSeparator"
+									:disabled="loading"
+									type="text"
+									style="width: 50px;"
+									maxlength="8">
+							</label>
+							<p>{{ t('mail', 'The separator between the user and master user (default: *)') }}</p>
 						</div>
 					</div>
 				</div>
@@ -426,6 +457,8 @@ export default {
 			smtpSslMode: this.setting.smtpSslMode || 'tls',
 			masterPasswordEnabled: this.setting.masterPasswordEnabled === true,
 			masterPassword: this.setting.masterPassword || '',
+			masterUser: this.setting.masterUser || '',
+			masterUserSeparator: this.setting.masterUserSeparator || '*',
 			sieveEnabled: this.setting.sieveEnabled || '',
 			sieveHost: this.setting.sieveHost || '',
 			sievePort: this.setting.sievePort || '',
@@ -462,6 +495,8 @@ export default {
 				smtpSslMode: this.smtpSslMode,
 				masterPasswordEnabled: this.masterPasswordEnabled,
 				masterPassword: this.masterPassword,
+				masterUser: this.masterUser,
+				masterUserSeparator: this.masterUserSeparator,
 				sieveEnabled: this.sieveEnabled,
 				sieveUser: this.sieveUser,
 				sieveHost: this.sieveHost,
@@ -497,6 +532,8 @@ export default {
 					smtpSslMode: this.smtpSslMode,
 					masterPasswordEnabled: this.masterPasswordEnabled,
 					masterPassword: this.masterPassword,
+					masterUser: this.masterUser,
+					masterUserSeparator: this.masterUserSeparator,
 					sieveEnabled: this.sieveEnabled,
 					sieveUser: this.sieveUser,
 					sieveHost: this.sieveHost,

--- a/tests/Integration/Framework/Caching.php
+++ b/tests/Integration/Framework/Caching.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Tests\Integration\Framework;
 
 use OC\Memcache\Factory;
 use OCA\Mail\Cache\HordeCacheFactory;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -60,6 +61,7 @@ class Caching {
 			Server::get(IEventDispatcher::class),
 			Server::get(ITimeFactory::class),
 			Server::get(HordeCacheFactory::class),
+			Server::get(ProvisioningMapper::class),
 		);
 		return [$imapClient, $cacheFactory];
 	}

--- a/tests/Integration/IMAP/IMAPClientFactoryTest.php
+++ b/tests/Integration/IMAP/IMAPClientFactoryTest.php
@@ -17,6 +17,7 @@ use OC\Memcache\Redis;
 use OCA\Mail\Account;
 use OCA\Mail\Cache\HordeCacheFactory;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\IMAP\HordeImapClient;
 use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\Tests\Integration\Framework\Caching;
@@ -44,6 +45,7 @@ class IMAPClientFactoryTest extends TestCase {
 	private IEventDispatcher|MockObject $eventDispatcher;
 	private ITimeFactory|MockObject $timeFactory;
 	private HordeCacheFactory|MockObject $hordeCacheFactory;
+	private ProvisioningMapper|MockObject $provisioningMapper;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -54,6 +56,7 @@ class IMAPClientFactoryTest extends TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->hordeCacheFactory = $this->createMock(HordeCacheFactory::class);
+		$this->provisioningMapper = $this->createMock(ProvisioningMapper::class);
 
 		$this->factory = new IMAPClientFactory(
 			$this->crypto,
@@ -62,6 +65,7 @@ class IMAPClientFactoryTest extends TestCase {
 			$this->eventDispatcher,
 			$this->timeFactory,
 			$this->hordeCacheFactory,
+			$this->provisioningMapper,
 		);
 	}
 

--- a/tests/Integration/Sieve/SieveClientFactoryTest.php
+++ b/tests/Integration/Sieve/SieveClientFactoryTest.php
@@ -13,6 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde\ManageSieve;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\Sieve\SieveClientFactory;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
@@ -26,6 +27,9 @@ class SieveClientFactoryTest extends TestCase {
 	/** @var IConfig|MockObject */
 	private $config;
 
+	/** @var ProvisioningMapper|MockObject */
+	private $provisioningMapper;
+
 	/** @var SieveClientFactory */
 	private $factory;
 
@@ -34,6 +38,7 @@ class SieveClientFactoryTest extends TestCase {
 
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->provisioningMapper = $this->createMock(ProvisioningMapper::class);
 
 		$this->config->method('getSystemValueInt')
 			->willReturnMap([
@@ -46,7 +51,7 @@ class SieveClientFactoryTest extends TestCase {
 				['app.mail.debug', false, false],
 			]);
 
-		$this->factory = new SieveClientFactory($this->crypto, $this->config);
+		$this->factory = new SieveClientFactory($this->crypto, $this->config, $this->provisioningMapper);
 	}
 
 	/**

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -13,6 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Support\HostNameFactory;
 use OCP\IConfig;
@@ -29,6 +30,9 @@ class SmtpClientFactoryTest extends TestCase {
 	/** @var HostNameFactory|MockObject */
 	private $hostNameFactory;
 
+	/** @var ProvisioningMapper|MockObject */
+	private $provisioningMapper;
+
 	/** @var SmtpClientFactory */
 	private $factory;
 
@@ -38,8 +42,9 @@ class SmtpClientFactoryTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->hostNameFactory = $this->createMock(HostNameFactory::class);
+		$this->provisioningMapper = $this->createMock(ProvisioningMapper::class);
 
-		$this->factory = new SmtpClientFactory($this->config, $this->crypto, $this->hostNameFactory);
+		$this->factory = new SmtpClientFactory($this->config, $this->crypto, $this->hostNameFactory, $this->provisioningMapper);
 	}
 
 	public function testSmtpTransport() {


### PR DESCRIPTION
Nextcloud mail app has an option called "Master password". This name is not to be mixed with Dovecot Master password system.
The functionalitys is slightly misnamed. The correct name should be "Static password for all users".

Dovecot server for pop3, imap and sieve allows various ways of authenticating users. In this case "Static password" means that Dovecot is configured so that every account has the same static password and every account can log in with the same password. That means users like user_ann@example.com and user_dean@example.com will have the same password for their accounts.
Dovecot does allow to limit the usage of static password to specific CIDR. This can be useful in some cases (webmail system and SSO).
But this system is extremely problematic if the users need to be able to use passwords to log in from other system like Thunderbird client software.

Dovecot has a more advanced system called Master passwords, which allows us to configure one or more master users that have their own passwords. For example we could have user masteruser that has password MASTERPASS. When logging into imap, pop3 or sieve, master users can use username in format "user_ann@example.com*masteruser" to log in as any specific user they are allowed to represent. Default separator in the format is * (star sign), but it is configurable in Dovecot. In all other ways the login process is exactly the same as in standard imap, pop3 or sieve login. Only the username has both useraccount and masteraccount specified with the separator.
This configuration is a lot more flexible than static user passwords. Master passwords can also be limited to being accepted from specific CIDRs.
When using this system, the users still can have their own default passwords and the master password system doesn't affect their normal usage in any way. The system also allows granular permissions for master users.

This patch adds the ability to set master user and optionally master user separator character in Nextcloud Mail app. Patch still uses master password field for the password.
If Master user is not set, old style static password is used and only defined user is used as login. If Master user is set, login will use Dovecot style user in logins.

This patch assumes that user can use Dovecot master authentication for all services. Note that Dovecot includes SMTP Submission ability to help with master password login using SMTP.