### PR TITLE
fix(classification): log if classification was executed or skipped

### DIFF
--- a/lib/Service/Classification/NewMessagesClassifier.php
+++ b/lib/Service/Classification/NewMessagesClassifier.php
@@ -49,22 +49,22 @@ class NewMessagesClassifier {
 	 * @param Mailbox $mailbox
 	 * @param Account $account
 	 * @param Tag $importantTag
-	 * @return void
+	 * @return bool true if classification was done
 	 */
 	public function classifyNewMessages(
 		array $messages,
 		Mailbox $mailbox,
 		Account $account,
 		Tag $importantTag,
-	): void {
+	): bool {
 		if (!$account->getClassificationEnabled()) {
-			return;
+			return false;
 		}
 
 		foreach (self::EXEMPT_FROM_CLASSIFICATION as $specialUse) {
 			if ($mailbox->isSpecialUse($specialUse)) {
 				// Nothing to do then
-				return;
+				return false;
 			}
 		}
 
@@ -101,5 +101,6 @@ class NewMessagesClassifier {
 				'exception' => $e,
 			]);
 		}
+		return true;
 	}
 }

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -436,19 +436,24 @@ class ImapToDbSynchronizer {
 				$this->dbMapper->insertBulk($account, ...$dbMessages);
 
 				if ($importantTag) {
-					$this->newMessagesClassifier->classifyNewMessages(
+					$classified = $this->newMessagesClassifier->classifyNewMessages(
 						$dbMessages,
 						$mailbox,
 						$account,
 						$importantTag,
 					);
+					if ($classified) {
+						$perf->step('classified a chunk of new messages');
+					} else {
+						$perf->step('skipped classification');
+					}
 				}
 
 				$this->dispatcher->dispatch(
 					NewMessagesSynchronized::class,
 					new NewMessagesSynchronized($account, $mailbox, $dbMessages)
 				);
-				$perf->step('classified a chunk of new messages');
+				$perf->step('emitted NewMessagesSynchronized event');
 			}
 			$perf->step('persist new messages');
 


### PR DESCRIPTION
The `occ mail:account:sync -vvv` output is misleading. It talks about classification even when it is skipped. This changes the output when classification is skipped:

Before:
```
...
[debug] partial sync 4634:INBOX - get new messages via Horde took 0s. 19/20MB memory used
[debug] partial sync 4634:INBOX - classified a chunk of new messages took 0s. 20/20MB memory used
[debug] partial sync 4634:INBOX - persist new messages took 0s. 20/20MB memory use
...
```

After:
```
...
[debug] partial sync 4634:INBOX - get new messages via Horde took 0s. 19/20MB memory used
[debug] partial sync 4634:INBOX - skipped classification took 0s. 19/20MB memory used
[debug] partial sync 4634:INBOX - emitted NewMessagesSynchronized event took 0s. 20/20MB memory used
...
```