### PR TITLE
fix(phishing): compare links using lowercase

### DIFF
--- a/lib/Service/PhishingDetection/LinkCheck.php
+++ b/lib/Service/PhishingDetection/LinkCheck.php
@@ -43,9 +43,9 @@ class LinkCheck {
 
 	private function parse(string $url): string {
 		if (!str_contains($url, '://')) {
-			return 'http://' . $url;
+			$url = 'http://' . $url;
 		}
-		return $url;
+		return strtolower($url);
 	}
 
 	public function run(string $htmlMessage) : PhishingDetectionResult {

--- a/tests/Unit/Service/Phishing/LinkCheckTest.php
+++ b/tests/Unit/Service/Phishing/LinkCheckTest.php
@@ -86,4 +86,11 @@ class LinkCheckTest extends TestCase {
 		]], $actualJson['additionalData']);
 		$this->assertTrue(is_string(json_encode($actualJson, JSON_THROW_ON_ERROR)));
 	}
+
+	public function testAddressCasing(): void {
+		$htmlMessage = '<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body><a href="https://Nextcloud.example">Nextcloud.example</a></body></html>';
+
+		$result = $this->service->run($htmlMessage);
+		$this->assertFalse($result->isPhishing());
+	}
 }


### PR DESCRIPTION
I'd think we should compare href and link text both in lowercase.

Href is already "lowercased" by https://github.com/nextcloud/mail/blob/b937da1081e1260d107c9c2e29f085bd87e987da/lib/Service/PhishingDetection/LinkCheck.php#L77-L78 and thus, we need to do the same for the link text.

Otherwise a warning is shown even for `<a href="https://Nextcloud.com">Nextcloud.com</a>`