### PR TITLE
fix(account): use classification state from account

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -225,6 +225,7 @@
 					required
 					@change="clearFeedback" />
 				<NcCheckboxRadioSwitch
+					v-if="isSetup"
 					id="auto-classification-enabled"
 					v-model="classificationEnabled"
 					:disabled="loading">
@@ -365,6 +366,10 @@ export default {
 
 		settingsPage() {
 			return this.account !== undefined
+		},
+
+		isSetup() {
+			return this.account === undefined
 		},
 
 		isDisabledAuto() {


### PR DESCRIPTION
### State 1

AccountForm used in setup view. The value for the classification checkbox should follow the default (admin -> groupware -> classification). :white_check_mark: 

<img width="459" height="767" alt="Screenshot From 2026-01-26 14-01-51" src="https://github.com/user-attachments/assets/76e8006c-c460-4a5f-98e7-af2648bcc6db" />

### State 2

Configuration for classification in account settings. Is using the account value. :white_check_mark: 

<img width="449" height="126" alt="Screenshot From 2026-01-26 14-03-09" src="https://github.com/user-attachments/assets/686598d7-8176-49b9-af2f-03fdbd33b830" />


### State 3

AccountForm used in accounts settings view. The checkbox is using the global default like in the setup view. :x: 

<img width="439" height="199" alt="Screenshot From 2026-01-26 14-02-35" src="https://github.com/user-attachments/assets/7f0458ef-e91a-4444-9293-f4e2fb94ba60" />

### To clarify

It appears weird, to have the classification two times in the account settings. With this change applied, the one in the account form at least also shows the right state.

Should we probably remove/hide when not in setup?