### PR TITLE
perf(sync): Reuse existing sync token

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -361,9 +361,10 @@ class ImapToDbSynchronizer {
 			throw new IncompleteSyncException("Initial sync is not complete for $loggingMailboxId ($cached of $total messages cached).");
 		}
 
-		$mailbox->setSyncNewToken($client->getSyncToken($mailbox->getName()));
-		$mailbox->setSyncChangedToken($client->getSyncToken($mailbox->getName()));
-		$mailbox->setSyncVanishedToken($client->getSyncToken($mailbox->getName()));
+		$syncToken = $client->getSyncToken($mailbox->getName());
+		$mailbox->setSyncNewToken($syncToken);
+		$mailbox->setSyncChangedToken($syncToken);
+		$mailbox->setSyncVanishedToken($syncToken);
 		$this->mailboxMapper->update($mailbox);
 
 		$perf->end();


### PR DESCRIPTION
I don't expect a large performance gain; but there's also no need to ask the IMAP server three times for the same data.