### PR TITLE
fix(settings): dont show acknowledgements twice

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -211,11 +211,6 @@
 						</NcFormBoxSwitch>
 					</NcFormBox>
 				</NcAppSettingsSection>
-				<NcAppSettingsSection id="about-settings" :name="t('mail', 'About')">
-					<NcFormGroup
-						:label="t('mail', 'Acknowledgements')"
-						:description="t('mail', 'This application includes CKEditor, an open-source editor. Copyright © CKEditor contributors. Licensed under GPLv2.')" />
-				</NcAppSettingsSection>
 				<NcAppSettingsShortcutsSection>
 					<NcHotkeyList>
 						<NcHotkey :label="t('mail', 'Compose new message')" hotkey="C" />


### PR DESCRIPTION
Regression from https://github.com/nextcloud/mail/pull/11150

| B | A |
| --- | --- |
| <img width="731" height="1078" alt="Screenshot From 2026-01-26 22-27-52" src="https://github.com/user-attachments/assets/bf2e39ff-0369-4d84-804e-257f15ce475e" /> | <img width="731" height="1078" alt="image" src="https://github.com/user-attachments/assets/363842dd-a96a-4530-813a-7a2ec3a9d17d" /> |



