### PR TITLE
fix(imap): Send ID only when capability is announced

### DIFF
--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -42,12 +42,14 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 	public function login() {
 		parent::login();
 
-		try {
-			$this->sendID();
-			/* ID is queued - force sending the queued command. */
-			$this->_sendCmd($this->_pipeline());
-		} catch (Horde_Imap_Client_Exception_NoSupportExtension $e) {
-			// Ignore if server doesn't support ID extension.
+		if ($this->capability->query('ID')) {
+			try {
+				$this->sendID();
+				/* ID is queued - force sending the queued command. */
+				$this->_sendCmd($this->_pipeline());
+			} catch (Horde_Imap_Client_Exception_NoSupportExtension) {
+				// Ignore if server doesn't support ID extension.
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow up for https://github.com/nextcloud/mail/pull/12259

Horde_Imap_Client_Base::sendID throws Horde_Imap_Client_Exception_NoSupportExtension when the ID capability is not advertised by the server. Since missing ID support is valid and expected IMAP behavior, we avoid using exceptions for control flow by checking the capability upfront.