### PR TITLE
fix(composer): drop envelope from store when saving a draft

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -332,6 +332,9 @@ export default {
 					let idToReturn
 					const dataForServer = this.getDataForServer(data, true)
 					if (!id) {
+						if (dataForServer.draftId) {
+							this.mainStore.removeEnvelopeMutation({ id: dataForServer.draftId })
+						}
 						const { id } = await saveDraft(dataForServer)
 						dataForServer.id = id
 						await this.mainStore.patchComposerData({ id, draftId: dataForServer.draftId })


### PR DESCRIPTION
For #12320 

### Change

- Addresses a timing issue when updating drafts.
- Since drafts are immutable, updating a draft deletes the old message and creates a new one.
- If the user is quick or the sync is slow, the draft being deleted can still appear in the list after closing the composer.
- Reopening that envelope/draft leads to a state where further edits fail.

### Trade off

- **Good:** The draft is gone right away, no confusion.
- **Bad:** UX is meh. Depending on the imap server, it might take a while until the new draft appears. One could assume that it just didn't worked on the draft is lost. I've tried to trigger a sync right after the draft being saved, but that didn't work out (the backend usually takes a few bits to process, we don't have the current search query available in that scope).