### PR TITLE
fix(composer): handle missing message body gracefully 

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -577,12 +577,13 @@ class MessagesController extends Controller {
 				$message = $this->mailManager->getMessage($this->currentUserId, $id);
 				$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 				$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
-			} catch (DoesNotExistException $e) {
+			} catch (DoesNotExistException) {
 				return new TemplateResponse(
 					$this->appName,
 					'error',
 					['message' => 'Not allowed'],
 					TemplateResponse::RENDER_AS_BLANK,
+					Http::STATUS_NOT_FOUND,
 				);
 			}
 
@@ -637,6 +638,7 @@ class MessagesController extends Controller {
 				'error',
 				['message' => $ex->getMessage()],
 				TemplateResponse::RENDER_AS_BLANK,
+				Http::STATUS_INTERNAL_SERVER_ERROR
 			);
 		}
 	}

--- a/src/service/MessageService.js
+++ b/src/service/MessageService.js
@@ -196,6 +196,18 @@ export async function fetchMessage(id) {
 	}
 }
 
+export async function fetchMessageHtmlBody(id) {
+	const url = generateUrl('/apps/mail/api/messages/{id}/html?plain=true', {
+		id,
+	})
+
+	try {
+		return (await axios.get(url)).data
+	} catch (e) {
+		throw convertAxiosError(e)
+	}
+}
+
 export async function fetchMessageItineraries(id) {
 	const url = generateUrl('/apps/mail/api/messages/{id}/itineraries', {
 		id,


### PR DESCRIPTION
For #12320 

### How to test

```diff
Index: lib/Controller/MessagesController.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/lib/Controller/MessagesController.php b/lib/Controller/MessagesController.php
--- a/lib/Controller/MessagesController.php	(revision 45cdf0a8e9e5c08e69454c207d8845b86ca59223)
+++ b/lib/Controller/MessagesController.php	(date 1769552067333)
@@ -574,7 +574,7 @@
 	public function getHtmlBody(int $id, bool $plain = false): Response {
 		try {
 			try {
-				$message = $this->mailManager->getMessage($this->currentUserId, $id);
+				$message = $this->mailManager->getMessage($this->currentUserId, PHP_INT_MIN);
 				$mailbox = $this->mailManager->getMailbox($this->currentUserId, $message->getMailboxId());
 				$account = $this->accountService->find($this->currentUserId, $mailbox->getAccountId());
 			} catch (DoesNotExistException) {
```

### Render template without skeleton

- Open Inbox
- Pick any message with an html body

| B | A |
| --- | --- |
| <img width="1220" height="447" alt="Screenshot From 2026-01-27 23-16-47" src="https://github.com/user-attachments/assets/dde3b8f2-ed0f-48d3-aa8c-8f92bd46b2d5" />  | <img width="1220" height="447" alt="Screenshot From 2026-01-27 23-16-05" src="https://github.com/user-attachments/assets/60c9f158-785c-4407-a5cf-9a803ef4f817" /> |

I'm aware the font looks off, and no, I'm not going to fix that :rofl: 

### Handle missing body

- Open Drafts
- Click on an existing draft

| B | A |
| --- | --- |
| <img width="676" height="896" alt="Screenshot From 2026-01-27 23-21-12" src="https://github.com/user-attachments/assets/c4b5883b-edda-4173-bbb0-9bb2ce77ea42" /> | <img width="1043" height="128" alt="Screenshot From 2026-01-27 23-22-55" src="https://github.com/user-attachments/assets/68db5d62-540d-4caa-bb18-44239f963b2a" /> |






