### PR TITLE
fix(ui): render HTML body error responses as blank pages

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -582,7 +582,7 @@ class MessagesController extends Controller {
 					$this->appName,
 					'error',
 					['message' => 'Not allowed'],
-					'none'
+					TemplateResponse::RENDER_AS_BLANK,
 				);
 			}
 
@@ -636,7 +636,7 @@ class MessagesController extends Controller {
 				$this->appName,
 				'error',
 				['message' => $ex->getMessage()],
-				'none'
+				TemplateResponse::RENDER_AS_BLANK,
 			);
 		}
 	}


### PR DESCRIPTION
'none' would actually render the Nextcloud headers (app menu etc). This only shows our HTML.

Fixes

```
Error: lib/Controller/MessagesController.php:585:6: InvalidArgument: Argument 4 of OCP\AppFramework\Http\TemplateResponse::__construct expects ''|'base'|'error'|'guest'|'public'|'user', but 'none' provided (see https://psalm.dev/004)
Error: lib/Controller/MessagesController.php:639:5: InvalidArgument: Argument 4 of OCP\AppFramework\Http\TemplateResponse::__construct expects ''|'base'|'error'|'guest'|'public'|'user', but 'none' provided (see https://psalm.dev/004)
```

Ref https://github.com/nextcloud/server/pull/57859