### PR TITLE
fix(attachementNames): lower log level

### DIFF
--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -278,7 +278,7 @@ class AttachmentService implements IAttachmentService {
 			);
 			$attachments = $imapMessage->getAttachments();
 		} catch (ServiceException $e) {
-			$this->logger->error('Could not get attachment names', ['exception' => $e, 'messageId' => $message->getUid()]);
+			$this->logger->warning('Could not get attachment names', ['exception' => $e, 'messageId' => $message->getUid()]);
 		}
 
 		$result = array_map(function ($attachment) use ($message) {


### PR DESCRIPTION
Lower log level when message is not found, as the code is able to proceed after the exception