### PR TITLE
fix: Dont hijack mailto links

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -126,7 +126,7 @@ class Html {
 		$html = $config->getDefinition('HTML');
 		$html->info_attr_transform_post['imagesrc'] = new TransformImageSrc($this->urlGenerator);
 		$html->info_attr_transform_post['cssbackground'] = new TransformStyleURLs($this->urlGenerator);
-		$html->info_attr_transform_post['htmllinks'] = new TransformHTMLLinks($this->urlGenerator);
+		$html->info_attr_transform_post['htmllinks'] = new TransformHTMLLinks();
 
 		/** @var HTMLPurifier_URIDefinition $uri */
 		$uri = $config->getDefinition('URI');

--- a/lib/Service/HtmlPurify/TransformHTMLLinks.php
+++ b/lib/Service/HtmlPurify/TransformHTMLLinks.php
@@ -13,19 +13,11 @@ namespace OCA\Mail\Service\HtmlPurify;
 use HTMLPurifier_AttrTransform;
 use HTMLPurifier_Config;
 use HTMLPurifier_Context;
-use OCP\IURLGenerator;
 
 /**
  * Adds target="_blank" to all outbound links.
  */
 class TransformHTMLLinks extends HTMLPurifier_AttrTransform {
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	public function __construct(IURLGenerator $urlGenerator) {
-		$this->urlGenerator = $urlGenerator;
-	}
-
 	/**
 	 * @param array $attr
 	 * @param HTMLPurifier_Config $config
@@ -40,11 +32,6 @@ class TransformHTMLLinks extends HTMLPurifier_AttrTransform {
 
 		$attr['target'] = '_blank';
 		$attr['rel'] = 'external noopener noreferrer';
-
-		// Open mailto: links in Mail
-		if (stripos($attr['href'], 'mailto:') === 0) {
-			$attr['href'] = $this->urlGenerator->linkToRoute('mail.page.mailto') . '?to=' . substr($attr['href'], 7);
-		}
 
 		return $attr;
 	}


### PR DESCRIPTION
I'd dislike mail hijacking mailto links. 

1) This should go through the usual flow to the default mailto handler.
2) The current implementation also does not play well with additional parameters (e.g. `mailto:bob@example.test?subject=123`)