### PR TITLE
chore: Fix RedundantFunctionCall error from psalm when running against ocp:dev-master

### DIFF
--- a/lib/Db/MailAccountMapper.php
+++ b/lib/Db/MailAccountMapper.php
@@ -256,7 +256,7 @@ class MailAccountMapper extends QBMapper {
 			if (!is_array($rids)) {
 				$rids = [$rids];
 			}
-			return array_intersect_key($ids, array_values($rids));
+			return array_intersect_key($ids, $rids);
 		}
 		return $ids;
 	}


### PR DESCRIPTION
Psalm complains about a `RedundantFunctionCall` since [this PR](https://github.com/nextcloud/server/pull/58261) is being merged to server:master. This is being fixed here. The function is only used by the `MailConnectionPerformance` unit tests and have no impact on the app itself.

There is [another PR](https://github.com/nextcloud/server/pull/58261) that introduced an `InvalidArgument` error which might be reverted as far as I understand [this conversation](https://github.com/nextcloud/server/pull/58261#discussion_r2797983192) (see [my question here as well](https://github.com/nextcloud/server/pull/58261#issuecomment-3897153580)).