### PR TITLE
fix(MailTransmission): Handle clients/servers picky about empty headers

### DIFF
--- a/tests/Unit/Service/MailTransmissionTest.php
+++ b/tests/Unit/Service/MailTransmissionTest.php
@@ -13,6 +13,8 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Imap_Client_Socket;
 use Horde_Mail_Transport;
 use OCA\Mail\Account;
+use OCA\Mail\Address;
+use OCA\Mail\AddressList;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\LocalAttachment;
@@ -136,7 +138,6 @@ class MailTransmissionTest extends TestCase {
 	}
 
 	public function testSendMessageFromAlias() {
-		// Arrange
 		$mailAccount = new MailAccount();
 		$mailAccount->setName('Bob');
 		$mailAccount->setEmail('bob@example.org');
@@ -167,17 +168,14 @@ class MailTransmissionTest extends TestCase {
 			->method('getEncryptMimePart')
 			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
-		// Act
 		$this->transmission->sendMessage($account, $localMessage);
 
-		// Assert
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
 		$this->assertStringContainsString('From: Info <info@example.org', $localMessage->getRaw());
 		$this->assertStringContainsString('Disposition-Notification-To: Info <info@example.org>', $localMessage->getRaw());
 	}
 
 	public function testSendMessageAliasFallbackName() {
-		// Arrange
 		$mailAccount = new MailAccount();
 		$mailAccount->setName('Bob');
 		$mailAccount->setEmail('bob@example.org');
@@ -207,17 +205,14 @@ class MailTransmissionTest extends TestCase {
 			->method('getEncryptMimePart')
 			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
-		// Act
 		$this->transmission->sendMessage($account, $localMessage);
 
-		// Assert
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
 		$this->assertStringContainsString('From: Bob <info@example.org', $localMessage->getRaw());
 		$this->assertStringContainsString('Disposition-Notification-To: Bob <info@example.org>', $localMessage->getRaw());
 	}
 
 	public function testSendMessageAliasDoesNotExist() {
-		// Arrange
 		$mailAccount = new MailAccount();
 		$mailAccount->setName('Bob');
 		$mailAccount->setEmail('bob@example.org');
@@ -244,10 +239,8 @@ class MailTransmissionTest extends TestCase {
 			->method('getEncryptMimePart')
 			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
 
-		// Act
 		$this->transmission->sendMessage($account, $localMessage);
 
-		// Assert
 		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
 		$this->assertStringContainsString('From: Bob <bob@example.org', $localMessage->getRaw());
 		$this->assertStringContainsString('Disposition-Notification-To: Bob <bob@example.org>', $localMessage->getRaw());
@@ -432,5 +425,92 @@ class MailTransmissionTest extends TestCase {
 			->method('save');
 
 		$this->transmission->saveLocalDraft(new Account($mailAccount), $localMessage);
+	}
+
+	public function testSendMessageCc() {
+		$mailAccount = new MailAccount();
+		$mailAccount->setName('Bob');
+		$mailAccount->setEmail('bob@mail.example');
+		$mailAccount->setUserId('bob');
+		$mailAccount->setSentMailboxId(123);
+		$account = new Account($mailAccount);
+		$localMessage = new LocalMessage();
+		$localMessage->setSubject('Test');
+		$localMessage->setBodyPlain('Test');
+		$localMessage->setHtml(false);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->smtpClientFactory->expects($this->once())
+			->method('create')
+			->willReturn($transport);
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::exactly(3))
+			->method('getAddressList')
+			->willReturnCallback(function ($localMessage, $type) {
+				$addresses = [];
+
+				if ($type === Recipient::TYPE_CC) {
+					$addresses[] = Address::fromRaw('Alice', 'alice@mail.example');
+				}
+
+				if ($type === Recipient::TYPE_BCC) {
+					$addresses[] = Address::fromRaw('Jane', 'jane@mail.example');
+				}
+
+				return new AddressList($addresses);
+			});
+
+
+		$this->transmission->sendMessage($account, $localMessage);
+
+		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
+		$this->assertStringContainsString('From: Bob <bob@mail.example>', $localMessage->getRaw());
+		$this->assertStringContainsString('Cc: Alice <alice@mail.example>', $localMessage->getRaw());
+		$this->assertStringNotContainsString('Bcc:', $localMessage->getRaw());
+	}
+
+	public function testSendMessageOmitCc() {
+		$mailAccount = new MailAccount();
+		$mailAccount->setName('Bob');
+		$mailAccount->setEmail('bob@example.org');
+		$mailAccount->setUserId('bob');
+		$mailAccount->setSentMailboxId(123);
+		$account = new Account($mailAccount);
+		$localMessage = new LocalMessage();
+		$localMessage->setSubject('Test');
+		$localMessage->setBodyPlain('Test');
+		$localMessage->setHtml(false);
+		$transport = $this->createMock(Horde_Mail_Transport::class);
+		$this->smtpClientFactory->expects($this->once())
+			->method('create')
+			->willReturn($transport);
+		$this->transmissionService->expects(self::once())
+			->method('getSignMimePart')
+			->willReturnCallback(static fn ($localMessage, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::once())
+			->method('getEncryptMimePart')
+			->willReturnCallback(static fn ($localMessage, $to, $cc, $bcc, $account, $mimePart) => $mimePart);
+		$this->transmissionService->expects(self::exactly(3))
+			->method('getAddressList')
+			->willReturnCallback(static function ($message, $type) {
+				$addresses = [];
+
+				if ($type === Recipient::TYPE_TO) {
+					$addresses[] = Address::fromRaw('Alice', 'alice@mail.example');
+				}
+
+				return new AddressList($addresses);
+			});
+
+		$this->transmission->sendMessage($account, $localMessage);
+
+		$this->assertEquals(LocalMessage::STATUS_RAW, $localMessage->getStatus());
+		$this->assertStringContainsString('From: Bob <bob@example.org>', $localMessage->getRaw());
+		$this->assertStringNotContainsString('Cc:', $localMessage->getRaw());
+		$this->assertStringNotContainsString('Bcc:', $localMessage->getRaw());
 	}
 }


### PR DESCRIPTION
Came up on the forum:

- https://help.nextcloud.com/t/emails-sent-from-nextcloud-contain-an-empty-cc-field/240195
- https://github.com/simple-login/app/discussions/2676

Changes:

- New function buildHeaders to have same logic applied to sendMessage, saveDraft, saveLocalDraft
- Set Cc and Bcc header on demand
- Drop the detour through ModelMessage
- Drop Date header (done by Horde Mime later)