### PR TITLE
fix(contacts): Use correct default for shareapi_allow_share_dialog_user_enumeration

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -52,7 +52,7 @@ class ContactsIntegration {
 
 		// If 'Allow username autocompletion in share dialog' is disabled in the admin sharing settings, then we must not
 		// auto-complete system users
-		$shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+		$shareeEnumeration = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 		$shareeEnumerationInGroupOnly = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_to_group', 'no') === 'yes';
 		$shareeEnumerationFullMatch = $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match', 'yes') === 'yes';
 		$shareeEnumerationFullMatchUserId = $shareeEnumerationFullMatch && $this->config->getAppValue('core', 'shareapi_restrict_user_enumeration_full_match_userid', 'yes') === 'yes';
@@ -233,7 +233,7 @@ class ContactsIntegration {
 	 * @param string[] $fields
 	 */
 	private function doSearch(string $term, array $fields, bool $strictSearch) : array {
-		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 
 		$result = $this->contactsManager->search($term, $fields, [
 			'strict_search' => $strictSearch,

--- a/lib/Service/Group/ContactsGroupService.php
+++ b/lib/Service/Group/ContactsGroupService.php
@@ -44,7 +44,7 @@ class ContactsGroupService implements IGroupService {
 
 		// If 'Allow username autocompletion in share dialog' is disabled in the admin sharing settings, then we must not
 		// auto-complete system users
-		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 
 		$result = $this->contactsManager->search($term, ['CATEGORIES']);
 		$receivers = [];
@@ -73,7 +73,7 @@ class ContactsGroupService implements IGroupService {
 
 		// If 'Allow username autocompletion in share dialog' is disabled in the admin sharing settings, then we must not
 		// auto-complete system users
-		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'no') === 'yes';
+		$allowSystemUsers = $this->config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes') === 'yes';
 
 		$result = $this->contactsManager->search($groupId, ['CATEGORIES']);
 		$receivers = [];

--- a/tests/Unit/Service/ContactsIntegrationTest.php
+++ b/tests/Unit/Service/ContactsIntegrationTest.php
@@ -347,7 +347,7 @@ class ContactsIntegrationTest extends TestCase {
 		$this->config->expects(self::atLeast(3))
 			->method('getAppValue')
 			->withConsecutive(
-				['core', 'shareapi_allow_share_dialog_user_enumeration', 'no'],
+				['core', 'shareapi_allow_share_dialog_user_enumeration', 'yes'],
 				['core', 'shareapi_restrict_user_enumeration_to_group', 'no'],
 				['core', 'shareapi_restrict_user_enumeration_full_match', 'yes'],
 				['core', 'shareapi_restrict_user_enumeration_full_match_userid', 'yes'],

--- a/tests/Unit/Service/Group/ContactsGroupServiceTest.php
+++ b/tests/Unit/Service/Group/ContactsGroupServiceTest.php
@@ -72,7 +72,7 @@ class ContactsGroupServiceTest extends TestCase {
 		];
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'no')
+			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
 			->willReturn('yes');
 		$this->contactsManager->expects($this->once())
 			->method('isEnabled')
@@ -135,7 +135,7 @@ class ContactsGroupServiceTest extends TestCase {
 		];
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'no')
+			->with('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes')
 			->willReturn('yes');
 		$this->contactsManager->expects($this->once())
 			->method('isEnabled')


### PR DESCRIPTION
**Problem:** 

Mail is using a default for shareapi_allow_share_dialog_user_enumeration that's different to other apps and server. The default in server is yes.[^1]

If an admin never changed the state in server (on => off => on), then the mail app behaves different to other apps. 




[^1]: https://github.com/search?q=org%3Anextcloud+%27shareapi_allow_share_dialog_user_enumeration%27&type=code