### PR TITLE
refactor: remove some methods of the Account class

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -11,7 +11,6 @@ namespace OCA\Mail;
 
 use JsonSerializable;
 use OCA\Mail\Db\MailAccount;
-use OCA\Mail\Service\Quota;
 use ReturnTypeWillChange;
 
 class Account implements JsonSerializable {
@@ -62,36 +61,4 @@ class Account implements JsonSerializable {
 		return $this->account->getUserId();
 	}
 
-	/**
-	 * @return bool
-	 */
-	public function getDebug(): bool {
-		return $this->account->getDebug();
-	}
-
-	public function getImipCreate(): bool {
-		return $this->account->getImipCreate();
-	}
-
-	/**
-	 * Set the quota percentage
-	 * @param Quota $quota
-	 * @return void
-	 */
-	public function calculateAndSetQuotaPercentage(Quota $quota): void {
-		if ($quota->getLimit() === 0) {
-			$this->account->setQuotaPercentage(0);
-			return;
-		}
-		$percentage = (int)round($quota->getUsage() / $quota->getLimit() * 100);
-		$this->account->setQuotaPercentage($percentage);
-	}
-
-	public function getQuotaPercentage(): ?int {
-		return $this->account->getQuotaPercentage();
-	}
-
-	public function getClassificationEnabled(): bool {
-		return $this->account->getClassificationEnabled();
-	}
 }

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -60,7 +60,7 @@ class TrainImportanceClassifierJob extends TimedJob {
 			return;
 		}
 
-		if (!$account->getClassificationEnabled()) {
+		if (!$account->getMailAccount()->getClassificationEnabled()) {
 			$this->logger->debug("classification is turned off for account $accountId");
 			return;
 		}

--- a/lib/Command/TrainAccount.php
+++ b/lib/Command/TrainAccount.php
@@ -72,7 +72,7 @@ final class TrainAccount extends Command {
 			return 1;
 		}
 
-		if (!$force && !$account->getClassificationEnabled()) {
+		if (!$force && !$account->getMailAccount()->getClassificationEnabled()) {
 			$output->writeln("<info>classification is turned off for account $accountId</info>");
 			return 2;
 		}

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -129,7 +129,7 @@ class IMAPClientFactory {
 				'backend' => $this->hordeCacheFactory->newCache($account),
 			];
 		}
-		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+		if ($account->getMailAccount()->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
 			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-imap.log';
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -82,7 +82,7 @@ class SmtpClientFactory {
 				$decryptedAccessToken,
 			);
 		}
-		if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+		if ($account->getMailAccount()->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
 			$fn = 'mail-' . $account->getUserId() . '-' . $account->getId() . '-smtp.log';
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}

--- a/lib/Service/Classification/NewMessagesClassifier.php
+++ b/lib/Service/Classification/NewMessagesClassifier.php
@@ -57,7 +57,7 @@ class NewMessagesClassifier {
 		Account $account,
 		Tag $importantTag,
 	): bool {
-		if (!$account->getClassificationEnabled()) {
+		if (!$account->getMailAccount()->getClassificationEnabled()) {
 			return false;
 		}
 

--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -121,7 +121,7 @@ class IMipService {
 
 			$userId = $account->getUserId();
 			$recipient = $account->getEmail();
-			$imipCreate = $account->getImipCreate();
+			$imipCreate = $account->getMailAccount()->getImipCreate();
 			$systemVersion = $this->serverVersion->getMajorVersion();
 
 			foreach ($filteredMessages as $message) {

--- a/lib/Sieve/SieveClientFactory.php
+++ b/lib/Sieve/SieveClientFactory.php
@@ -38,7 +38,7 @@ class SieveClientFactory {
 				$password = $account->getMailAccount()->getInboundPassword();
 			}
 
-			if ($account->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
+			if ($account->getMailAccount()->getDebug() || $this->config->getSystemValueBool('app.mail.debug')) {
 				$logFile = $this->config->getSystemValue('datadirectory') . '/mail-' . $account->getUserId() . '-' . $account->getId() . '-sieve.log';
 			} else {
 				$logFile = null;

--- a/tests/Unit/BackgroundJob/QuotaJobTest.php
+++ b/tests/Unit/BackgroundJob/QuotaJobTest.php
@@ -142,12 +142,6 @@ class QuotaJobTest extends TestCase {
 		$this->serviceMock->getParameter('mailManager')
 			->expects(self::never())
 			->method('getQuota');
-		$account->expects(self::never())
-			->method('calculateAndSetQuotaPercentage')
-			->with($quotaDTO);
-		$account->expects(self::never())
-			->method('getQuotaPercentage')
-			->willReturn($newQuota);
 		$this->serviceMock->getParameter('accountService')
 			->expects(self::never())
 			->method('update')
@@ -162,12 +156,12 @@ class QuotaJobTest extends TestCase {
 	}
 
 	public function testQuotaTooLow(): void {
-		$oldQuota = 10;
-		$newQuota = 20;
 		$quotaDTO = new Quota(20, 100);
-		$mailAccount = $this->createConfiguredMock(MailAccount::class, [
-			'canAuthenticateImap' => true,
-		]);
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(123);
+		$mailAccount->setUserId('user123');
+		$mailAccount->setInboundPassword('password');
+		$mailAccount->setQuotaPercentage(10);
 		$account = $this->createConfiguredMock(Account::class, [
 			'getId' => 123,
 			'getUserId' => 'user123',
@@ -182,8 +176,6 @@ class QuotaJobTest extends TestCase {
 			->method('findById')
 			->with(123)
 			->willReturn($account);
-		$mailAccount->expects(self::once())
-			->method('canAuthenticateImap');
 		$this->serviceMock->getParameter('userManager')
 			->expects(self::once())
 			->method('get')
@@ -196,15 +188,6 @@ class QuotaJobTest extends TestCase {
 			->expects(self::once())
 			->method('getQuota')
 			->willReturn($quotaDTO);
-		$account->expects(self::once())
-			->method('calculateAndSetQuotaPercentage')
-			->with($quotaDTO);
-		$account->expects(self::exactly(3))
-			->method('getMailAccount')
-			->willReturn($mailAccount);
-		$account->expects(self::once())
-			->method('getQuotaPercentage')
-			->willReturn($newQuota);
 		$this->serviceMock->getParameter('accountService')
 			->expects(self::once())
 			->method('update')
@@ -219,12 +202,13 @@ class QuotaJobTest extends TestCase {
 	}
 
 	public function testQuotaWithNotification(): void {
-		$oldQuota = 85;
 		$newQuota = 95;
 		$quotaDTO = new Quota(95, 100);
-		$mailAccount = $this->createConfiguredMock(MailAccount::class, [
-			'canAuthenticateImap' => true,
-		]);
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(123);
+		$mailAccount->setUserId('user123');
+		$mailAccount->setInboundPassword('password');
+		$mailAccount->setQuotaPercentage(85);
 		$account = $this->createConfiguredMock(Account::class, [
 			'getId' => 123,
 			'getUserId' => 'user123',
@@ -250,21 +234,6 @@ class QuotaJobTest extends TestCase {
 			->expects(self::once())
 			->method('getQuota')
 			->willReturn($quotaDTO);
-		$account->expects(self::once())
-			->method('calculateAndSetQuotaPercentage')
-			->with($quotaDTO);
-		$account->expects(self::exactly(3))
-			->method('getMailAccount')
-			->willReturn($mailAccount);
-		$account->expects(self::once())
-			->method('getQuotaPercentage')
-			->willReturn($newQuota);
-		$account->expects(self::exactly(2))
-			->method('getUserId')
-			->willReturn('user123');
-		$account->expects(self::exactly(2))
-			->method('getEmail')
-			->willReturn('user123@test.com');
 		$this->serviceMock->getParameter('accountService')
 			->expects(self::once())
 			->method('update')
@@ -325,12 +294,12 @@ class QuotaJobTest extends TestCase {
 	}
 
 	public function testQuotaZero(): void {
-		$oldQuota = 0;
-		$newQuota = 0;
 		$quotaDTO = new Quota(0, 0);
-		$mailAccount = $this->createConfiguredMock(MailAccount::class, [
-			'canAuthenticateImap' => true,
-		]);
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(123);
+		$mailAccount->setUserId('user123');
+		$mailAccount->setInboundPassword('password');
+		$mailAccount->setQuotaPercentage(0);
 		$account = $this->createConfiguredMock(Account::class, [
 			'getId' => 123,
 			'getUserId' => 'user123',
@@ -357,15 +326,6 @@ class QuotaJobTest extends TestCase {
 			->expects(self::once())
 			->method('getQuota')
 			->willReturn($quotaDTO);
-		$account->expects(self::once())
-			->method('calculateAndSetQuotaPercentage')
-			->with($quotaDTO);
-		$account->expects(self::exactly(3))
-			->method('getMailAccount')
-			->willReturn($mailAccount);
-		$account->expects(self::once())
-			->method('getQuotaPercentage')
-			->willReturn($newQuota);
 		$this->serviceMock->getParameter('accountService')
 			->expects(self::once())
 			->method('update')


### PR DESCRIPTION
For https://github.com/nextcloud/mail/issues/2038

This is my next attempt at https://github.com/nextcloud/mail/pull/10160 to get the Account class removed because we also have MailAccount and that is confusing.
This PR refactors the usage of the methods with least call sites.