### PR TITLE
feat(provisioning): Add support for Dovecot master user authentication

### DIFF
--- a/lib/Db/Provisioning.php
+++ b/lib/Db/Provisioning.php
@@ -39,6 +39,8 @@ use ReturnTypeWillChange;
  * @method void setMasterPasswordEnabled(bool $masterPasswordEnabled)
  * @method string|null getMasterPassword()
  * @method void setMasterPassword(string $masterPassword)
+ * @method string|null getMasterUser()
+ * @method void setMasterUser(string $masterUser)
  * @method bool|null getSieveEnabled()
  * @method void setSieveEnabled(bool $sieveEnabled)
  * @method string|null getSieveHost()
@@ -90,6 +92,7 @@ class Provisioning extends Entity implements JsonSerializable {
 	protected $smtpSslMode;
 	protected $masterPasswordEnabled;
 	protected $masterPassword;
+	protected $masterUser;
 	protected $sieveEnabled;
 	protected $sieveUser;
 	protected $sieveHost;
@@ -104,6 +107,7 @@ class Provisioning extends Entity implements JsonSerializable {
 		$this->addType('smtpPort', 'integer');
 		$this->addType('masterPasswordEnabled', 'boolean');
 		$this->addType('masterPassword', 'string');
+		$this->addType('masterUser', 'string');
 		$this->addType('sieveEnabled', 'boolean');
 		$this->addType('sievePort', 'integer');
 		$this->addType('ldapAliasesProvisioning', 'boolean');
@@ -126,6 +130,7 @@ class Provisioning extends Entity implements JsonSerializable {
 			'smtpSslMode' => $this->getSmtpSslMode(),
 			'masterPasswordEnabled' => $this->getMasterPasswordEnabled(),
 			'masterPassword' => !empty($this->getMasterPassword()) ? self::MASTER_PASSWORD_PLACEHOLDER : null,
+			'masterUser' => $this->getMasterUser(),
 			'sieveEnabled' => $this->getSieveEnabled(),
 			'sieveUser' => $this->getSieveUser(),
 			'sieveHost' => $this->getSieveHost(),
@@ -138,15 +143,15 @@ class Provisioning extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @param IUser $user
 	 * @param array<string, string> $ldapValues resolved %LDAP:attr% tokens, keyed by full token
-	 * @return string
 	 */
-	public function buildImapUser(IUser $user, array $ldapValues = []) {
-		if (!is_null($this->getImapUser())) {
-			return $this->buildUserEmail($this->getImapUser(), $user, $ldapValues);
+	public function buildImapUser(IUser $user, array $ldapValues = []): string {
+		if ($this->getImapUser() !== null) {
+			$imapUser = $this->buildUserEmail($this->getImapUser(), $user, $ldapValues);
+		} else {
+			$imapUser = $this->buildEmail($user, $ldapValues);
 		}
-		return $this->buildEmail($user, $ldapValues);
+		return $this->appendMasterUser($imapUser);
 	}
 
 	/**
@@ -233,26 +238,54 @@ class Provisioning extends Entity implements JsonSerializable {
 	}
 
 	/**
-	 * @param IUser $user
 	 * @param array<string, string> $ldapValues resolved %LDAP:attr% tokens, keyed by full token
-	 * @return string
 	 */
-	public function buildSmtpUser(IUser $user, array $ldapValues = []) {
-		if (!is_null($this->getSmtpUser())) {
-			return $this->buildUserEmail($this->getSmtpUser(), $user, $ldapValues);
+	public function buildSmtpUser(IUser $user, array $ldapValues = []): string {
+		if ($this->getSmtpUser() !== null) {
+			$smtpUser = $this->buildUserEmail($this->getSmtpUser(), $user, $ldapValues);
+		} else {
+			$smtpUser = $this->buildEmail($user, $ldapValues);
 		}
-		return $this->buildEmail($user, $ldapValues);
+		return $this->appendMasterUser($smtpUser);
 	}
 
 	/**
-	 * @param IUser $user
 	 * @param array<string, string> $ldapValues resolved %LDAP:attr% tokens, keyed by full token
-	 * @return string
 	 */
-	public function buildSieveUser(IUser $user, array $ldapValues = []) {
-		if (!is_null($this->getSieveUser())) {
-			return $this->buildUserEmail($this->getSieveUser(), $user, $ldapValues);
+	public function buildSieveUser(IUser $user, array $ldapValues = []): string {
+		if ($this->getSieveUser() !== null) {
+			$sieveUser = $this->buildUserEmail($this->getSieveUser(), $user, $ldapValues);
+		} else {
+			$sieveUser = $this->buildEmail($user, $ldapValues);
 		}
-		return $this->buildEmail($user, $ldapValues);
+		return $this->appendMasterUser($sieveUser);
+	}
+
+	/**
+	 * The master user contains the separator, e.g. *masteruser
+	 */
+	private function appendMasterUser(string $loginUser): string {
+		if ($this->getMasterPasswordEnabled() !== true || ($this->getMasterUser() ?? '') === '') {
+			return $loginUser;
+		}
+		return $loginUser . $this->getMasterUser();
+	}
+
+	/**
+	 * The placeholder is sent back by the settings form to keep the stored password
+	 */
+	public function enableMasterPassword(string $masterPassword, string $masterUser): void {
+		$this->setMasterPasswordEnabled(true);
+
+		if ($masterPassword !== self::MASTER_PASSWORD_PLACEHOLDER) {
+			$this->setMasterPassword($masterPassword);
+		}
+		$this->setMasterUser($masterUser);
+	}
+
+	public function disableMasterPassword(): void {
+		$this->setMasterPasswordEnabled(false);
+		$this->setMasterPassword('');
+		$this->setMasterUser('');
 	}
 }

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -67,7 +67,7 @@ class ProvisioningMapper extends QBMapper {
 			$exception->setField('imapHost', false);
 		}
 		if (!isset($data['imapPort']) || (int)$data['imapPort'] === 0) {
-			$exception->setField('imapHost', false);
+			$exception->setField('imapPort', false);
 		}
 		if (!isset($data['imapSslMode']) || $data['imapSslMode'] === '') {
 			$exception->setField('imapSslMode', false);

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -52,6 +52,7 @@ class ProvisioningMapper extends QBMapper {
 	 */
 	public function validate(array $data): Provisioning {
 		$exception = new ValidationException();
+		$isNewConfig = !isset($data['id']);
 
 		if (!isset($data['provisioningDomain']) || $data['provisioningDomain'] === '') {
 			$exception->setField('provisioningDomain', false);
@@ -97,6 +98,14 @@ class ProvisioningMapper extends QBMapper {
 			$exception->setField('ldapAliasesAttribute', false);
 		}
 
+		$masterPasswordEnabled = (bool)($data['masterPasswordEnabled'] ?? false);
+		$masterPassword = $data['masterPassword'] ?? '';
+		$masterUser = $data['masterUser'] ?? '';
+
+		if ($masterPasswordEnabled && ($masterPassword === '' || ($isNewConfig && $masterPassword === Provisioning::MASTER_PASSWORD_PLACEHOLDER))) {
+			$exception->setField('masterPassword', false);
+		}
+
 		if (!empty($exception->getFields())) {
 			throw $exception;
 		}
@@ -113,12 +122,6 @@ class ProvisioningMapper extends QBMapper {
 		$provisioning->setSmtpHost($data['smtpHost']);
 		$provisioning->setSmtpPort((int)$data['smtpPort']);
 		$provisioning->setSmtpSslMode($data['smtpSslMode']);
-
-		$provisioning->setMasterPasswordEnabled((bool)($data['masterPasswordEnabled'] ?? false));
-		if (isset($data['masterPassword']) && $data['masterPassword'] !== Provisioning::MASTER_PASSWORD_PLACEHOLDER) {
-			$provisioning->setMasterPassword($data['masterPassword']);
-		}
-
 		$provisioning->setSieveEnabled((bool)$data['sieveEnabled']);
 		$provisioning->setSieveHost($data['sieveHost'] ?? '');
 		$provisioning->setSieveUser($data['sieveUser'] ?? '');
@@ -127,6 +130,12 @@ class ProvisioningMapper extends QBMapper {
 
 		$provisioning->setLdapAliasesProvisioning($ldapAliasesProvisioning);
 		$provisioning->setLdapAliasesAttribute($ldapAliasesAttribute);
+
+		if ($masterPasswordEnabled) {
+			$provisioning->enableMasterPassword($masterPassword, $masterUser);
+		} else {
+			$provisioning->disableMasterPassword();
+		}
 
 		return $provisioning;
 	}

--- a/lib/Migration/Version5012Date20260816120000.php
+++ b/lib/Migration/Version5012Date20260816120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version5012Date20260816120000 extends SimpleMigrationStep {
+	/**
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$provisioningTable = $schema->getTable('mail_provisionings');
+		if (!$provisioningTable->hasColumn('master_user')) {
+			$provisioningTable->addColumn('master_user', Types::STRING, [
+				'notnull' => false,
+				'length' => 256,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -413,7 +413,7 @@ class Manager {
 			// Maybe research other providers as well.
 			// Ref \OCA\Mail\Controller\PageController::index()
 			//     -> initial state for password-is-unavailable
-			if ($provisioning->getMasterPasswordEnabled() === true && $provisioning->getMasterPassword() !== null) {
+			if ($provisioning->getMasterPasswordEnabled() === true && ($provisioning->getMasterPassword() ?? '') !== '') {
 				$password = $provisioning->getMasterPassword();
 				$this->logger->debug('Password set to master password for ' . $user->getUID());
 			} elseif ($password === null) {

--- a/src/components/settings/ProvisionPreview.vue
+++ b/src/components/settings/ProvisionPreview.vue
@@ -15,7 +15,7 @@
 		{{ t('mail', 'Email: {email}', { email }) }}<br>
 		{{
 			t('mail', 'IMAP: {user} on {host}:{port} ({ssl} encryption)', {
-				user: imapUser,
+				user: imapLoginUser,
 				host: imapHost,
 				port: imapPort,
 				ssl: imapSslMode,
@@ -23,7 +23,7 @@
 		}}<br>
 		{{
 			t('mail', 'SMTP: {user} on {host}:{port} ({ssl} encryption)', {
-				user: smtpUser,
+				user: smtpLoginUser,
 				host: smtpHost,
 				port: smtpPort,
 				ssl: smtpSslMode,
@@ -32,12 +32,20 @@
 		<span v-if="sieveEnabled">
 			{{
 				t('mail', 'Sieve: {user} on {host}:{port} ({ssl} encryption)', {
-					user: sieveUser,
+					user: sieveLoginUser,
 					host: sieveHost,
 					port: sievePort,
 					ssl: sieveSslMode,
 				})
 			}}<br>
+		</span>
+		<span v-if="hasMasterUser" class="master-user-info">
+			<br>
+			<em>{{ t('mail', 'Using master user and master password') }}</em>
+		</span>
+		<span v-else-if="masterPasswordEnabled" class="master-password-info">
+			<br>
+			<em>{{ t('mail', 'Using master password for all users') }}</em>
 		</span>
 	</div>
 </template>
@@ -116,6 +124,30 @@ export default {
 
 		sieveUser() {
 			return this.templates.sieveUser.replace('%USERID%', this.data.uid).replace('%EMAIL%', this.data.email)
+		},
+
+		masterPasswordEnabled() {
+			return this.templates.masterPasswordEnabled
+		},
+
+		masterUser() {
+			return this.templates.masterUser || ''
+		},
+
+		hasMasterUser() {
+			return this.masterPasswordEnabled && this.masterUser.length > 0
+		},
+
+		imapLoginUser() {
+			return this.hasMasterUser ? this.imapUser + this.masterUser : this.imapUser
+		},
+
+		smtpLoginUser() {
+			return this.hasMasterUser ? this.smtpUser + this.masterUser : this.smtpUser
+		},
+
+		sieveLoginUser() {
+			return this.hasMasterUser ? this.sieveUser + this.masterUser : this.sieveUser
 		},
 	},
 }

--- a/src/components/settings/ProvisioningSettings.vue
+++ b/src/components/settings/ProvisioningSettings.vue
@@ -197,13 +197,29 @@
 							</label>
 						</div>
 						<div>
-							<input
-								id="mail-master-password"
-								v-model="masterPassword"
-								:disabled="loading"
-								type="password"
-								:required="masterPasswordEnabled">
-							<label for="mail-master-password"> {{ t('mail', 'Master password') }} </label>
+							<label>
+								{{ t('mail', 'Master password') }}
+								<br>
+								<input
+									v-model="masterPassword"
+									:disabled="loading || !masterPasswordEnabled"
+									type="password"
+									:required="masterPasswordEnabled">
+							</label>
+							<p>{{ t('mail', 'Without a master user, all users authenticate with their normal username and this master password.') }}</p>
+						</div>
+						<div>
+							<label>
+								<!-- TRANSLATORS: Dovecot master user, an account that can log in on behalf of any other user -->
+								{{ t('mail', 'Master user') }}
+								<br>
+								<input
+									v-model="masterUser"
+									:disabled="loading || !masterPasswordEnabled"
+									type="text"
+									:placeholder="t('mail', 'e.g. {example}', { example: '*masteruser' })">
+							</label>
+							<p>{{ t('mail', 'Appended to the username. Must start with the same separator as {setting} in Dovecot.', { setting: 'auth_master_user_separator' }) }}</p>
 						</div>
 					</div>
 				</div>
@@ -426,6 +442,7 @@ export default {
 			smtpSslMode: this.setting.smtpSslMode || 'tls',
 			masterPasswordEnabled: this.setting.masterPasswordEnabled === true,
 			masterPassword: this.setting.masterPassword || '',
+			masterUser: this.setting.masterUser || '',
 			sieveEnabled: this.setting.sieveEnabled || '',
 			sieveHost: this.setting.sieveHost || '',
 			sievePort: this.setting.sievePort || '',
@@ -462,6 +479,7 @@ export default {
 				smtpSslMode: this.smtpSslMode,
 				masterPasswordEnabled: this.masterPasswordEnabled,
 				masterPassword: this.masterPassword,
+				masterUser: this.masterUser,
 				sieveEnabled: this.sieveEnabled,
 				sieveUser: this.sieveUser,
 				sieveHost: this.sieveHost,
@@ -469,6 +487,15 @@ export default {
 				sieveSslMode: this.sieveSslMode,
 				ldapAliasesProvisioning: this.ldapAliasesProvisioning,
 				ldapAliasesAttribute: this.ldapAliasesAttribute,
+			}
+		},
+	},
+
+	watch: {
+		masterPasswordEnabled(enabled) {
+			if (!enabled) {
+				this.masterPassword = ''
+				this.masterUser = ''
 			}
 		},
 	},
@@ -497,6 +524,7 @@ export default {
 					smtpSslMode: this.smtpSslMode,
 					masterPasswordEnabled: this.masterPasswordEnabled,
 					masterPassword: this.masterPassword,
+					masterUser: this.masterUser,
 					sieveEnabled: this.sieveEnabled,
 					sieveUser: this.sieveUser,
 					sieveHost: this.sieveHost,
@@ -553,7 +581,8 @@ export default {
 		margin: 10px;
 		flex-grow: 1;
 
-		input[type='text'] {
+		input[type='text'],
+		input[type='password'] {
 			min-width: 200px;
 		}
 		.config-button {

--- a/tests/Unit/Db/ProvisioningMapperTest.php
+++ b/tests/Unit/Db/ProvisioningMapperTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\Provisioning;
+use OCA\Mail\Db\ProvisioningMapper;
+use OCA\Mail\Exception\ValidationException;
+use OCP\IDBConnection;
+use Psr\Log\NullLogger;
+
+class ProvisioningMapperTest extends TestCase {
+
+	private ProvisioningMapper $mapper;
+
+	public function setup(): void {
+		parent::setUp();
+
+		$this->mapper = new ProvisioningMapper(
+			$this->createMock(IDBConnection::class),
+			new NullLogger(),
+		);
+	}
+
+	public function testValidateEmptyHost(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => '',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => '',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+		];
+
+		$exception = null;
+
+		try {
+			$this->mapper->validate($data);
+		} catch (ValidationException $e) {
+			$exception = $e;
+		}
+
+		$this->assertNotNull($exception);
+		$this->assertCount(2, $exception->getFields());
+		$this->assertArrayHasKey('imapHost', $exception->getFields());
+		$this->assertArrayHasKey('smtpHost', $exception->getFields());
+	}
+
+	public function testValidateLdapAliasesProvisioningNeedsAttribute(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'ldapAliasesProvisioning' => true,
+			'ldapAliasesAttribute' => ''
+		];
+
+		$exception = null;
+
+		try {
+			$this->mapper->validate($data);
+		} catch (ValidationException $e) {
+			$exception = $e;
+		}
+
+		$this->assertNotNull($exception);
+		$this->assertCount(1, $exception->getFields());
+		$this->assertArrayHasKey('ldapAliasesAttribute', $exception->getFields());
+	}
+
+	public function testValidateMasterPasswordNeedsPassword(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'masterPasswordEnabled' => true,
+			'masterPassword' => '',
+		];
+
+		$exception = null;
+
+		try {
+			$this->mapper->validate($data);
+		} catch (ValidationException $e) {
+			$exception = $e;
+		}
+
+		$this->assertNotNull($exception);
+		$this->assertCount(1, $exception->getFields());
+		$this->assertArrayHasKey('masterPassword', $exception->getFields());
+	}
+
+	public function testValidateMasterUser(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'sieveEnabled' => false,
+			'masterPasswordEnabled' => true,
+			'masterPassword' => 'mypassword',
+			'masterUser' => '*master',
+		];
+
+		$provisioning = $this->mapper->validate($data);
+
+		$this->assertTrue($provisioning->getMasterPasswordEnabled());
+		$this->assertSame('mypassword', $provisioning->getMasterPassword());
+		$this->assertSame('*master', $provisioning->getMasterUser());
+	}
+
+	public function testValidateKeepMasterPasswordSkipPlaceholder(): void {
+		$data = [
+			'id' => 1,
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'sieveEnabled' => false,
+			'masterPasswordEnabled' => true,
+			'masterPassword' => Provisioning::MASTER_PASSWORD_PLACEHOLDER,
+		];
+
+		$provisioning = $this->mapper->validate($data);
+
+		$this->assertTrue($provisioning->getMasterPasswordEnabled());
+		$this->assertNull($provisioning->getMasterPassword());
+	}
+
+	public function testValidateRejectsMasterPasswordPlaceholderForNewConfig(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'sieveEnabled' => false,
+			'masterPasswordEnabled' => true,
+			'masterPassword' => Provisioning::MASTER_PASSWORD_PLACEHOLDER,
+			'masterUser' => '*master',
+		];
+		$exception = null;
+
+		try {
+			$this->mapper->validate($data);
+		} catch (ValidationException $e) {
+			$exception = $e;
+		}
+
+		$this->assertNotNull($exception);
+		$this->assertCount(1, $exception->getFields());
+		$this->assertArrayHasKey('masterPassword', $exception->getFields());
+	}
+
+	public function testValidateClearsMasterUserWhenDisabled(): void {
+		$data = [
+			'provisioningDomain' => 'static.test',
+			'emailTemplate' => '%USERID%@static.test',
+			'imapUser' => '%EMAIL%',
+			'imapHost' => 'static.test',
+			'imapPort' => '143',
+			'imapSslMode' => 'none',
+			'smtpUser' => '%EMAIL%',
+			'smtpHost' => 'static.test',
+			'smtpPort' => '25',
+			'smtpSslMode' => 'none',
+			'sieveEnabled' => false,
+			'masterPasswordEnabled' => false,
+			'masterPassword' => 'mypassword',
+			'masterUser' => '*master',
+		];
+
+		$provisioning = $this->mapper->validate($data);
+
+		$this->assertFalse($provisioning->getMasterPasswordEnabled());
+		$this->assertSame('', $provisioning->getMasterPassword());
+		$this->assertSame('', $provisioning->getMasterUser());
+		$this->assertArrayHasKey('masterPassword', $provisioning->getUpdatedFields());
+		$this->assertArrayHasKey('masterUser', $provisioning->getUpdatedFields());
+	}
+
+}

--- a/tests/Unit/Db/ProvisioningTest.php
+++ b/tests/Unit/Db/ProvisioningTest.php
@@ -18,6 +18,15 @@ use OCP\IUser;
  */
 class ProvisioningTest extends TestCase {
 
+	private function createProvisioning(): Provisioning {
+		$provisioning = new Provisioning();
+		$provisioning->setEmailTemplate('%USERID%@corp.example');
+		$provisioning->setImapUser('%USERID%');
+		$provisioning->setSmtpUser('%USERID%');
+		$provisioning->setSieveUser('%USERID%');
+		return $provisioning;
+	}
+
 	public function testJsonSerialize(): void {
 		$provisioning = new Provisioning();
 
@@ -188,6 +197,124 @@ class ProvisioningTest extends TestCase {
 		$attributes = $provisioning->ldapAttributesInTemplates();
 
 		self::assertSame([], $attributes);
+	}
+
+	public function testBuildUsersWithoutMasterUser(): void {
+		$provisioning = $this->createProvisioning();
+		$user = $this->createUser();
+
+		$imapUser = $provisioning->buildImapUser($user);
+		$smtpUser = $provisioning->buildSmtpUser($user);
+		$sieveUser = $provisioning->buildSieveUser($user);
+
+		self::assertSame('jane', $imapUser);
+		self::assertSame('jane', $smtpUser);
+		self::assertSame('jane', $sieveUser);
+	}
+
+	public function testBuildUsersWithMasterUser(): void {
+		$provisioning = $this->createProvisioning();
+		$provisioning->setMasterPasswordEnabled(true);
+		$provisioning->setMasterUser('*masteruser');
+		$user = $this->createUser();
+
+		$imapUser = $provisioning->buildImapUser($user);
+		$smtpUser = $provisioning->buildSmtpUser($user);
+		$sieveUser = $provisioning->buildSieveUser($user);
+
+		self::assertSame('jane*masteruser', $imapUser);
+		self::assertSame('jane*masteruser', $smtpUser);
+		self::assertSame('jane*masteruser', $sieveUser);
+	}
+
+	public function testBuildUsersWithMasterUserAndLdapValues(): void {
+		$provisioning = new Provisioning();
+		$provisioning->setEmailTemplate('%LDAP:uid%@corp.example');
+		$provisioning->setMasterPasswordEnabled(true);
+		$provisioning->setMasterUser('*masteruser');
+		$user = $this->createUser();
+		$ldapValues = ['%LDAP:uid%' => 'jdoe'];
+
+		$imapUser = $provisioning->buildImapUser($user, $ldapValues);
+		$smtpUser = $provisioning->buildSmtpUser($user, $ldapValues);
+		$sieveUser = $provisioning->buildSieveUser($user, $ldapValues);
+
+		self::assertSame('jdoe@corp.example*masteruser', $imapUser);
+		self::assertSame('jdoe@corp.example*masteruser', $smtpUser);
+		self::assertSame('jdoe@corp.example*masteruser', $sieveUser);
+	}
+
+	public function testBuildUsersFallsBackToEmailTemplate(): void {
+		$provisioning = new Provisioning();
+		$provisioning->setEmailTemplate('%USERID%@corp.example');
+		$provisioning->setMasterPasswordEnabled(true);
+		$provisioning->setMasterUser('#masteruser');
+		$user = $this->createUser();
+
+		$imapUser = $provisioning->buildImapUser($user);
+		$smtpUser = $provisioning->buildSmtpUser($user);
+		$sieveUser = $provisioning->buildSieveUser($user);
+
+		self::assertSame('jane@corp.example#masteruser', $imapUser);
+		self::assertSame('jane@corp.example#masteruser', $smtpUser);
+		self::assertSame('jane@corp.example#masteruser', $sieveUser);
+	}
+
+	public function testBuildUsersIgnoresMasterUserWhenMasterPasswordDisabled(): void {
+		$provisioning = $this->createProvisioning();
+		$provisioning->setMasterPasswordEnabled(false);
+		$provisioning->setMasterUser('*masteruser');
+		$user = $this->createUser();
+
+		$imapUser = $provisioning->buildImapUser($user);
+		$smtpUser = $provisioning->buildSmtpUser($user);
+		$sieveUser = $provisioning->buildSieveUser($user);
+
+		self::assertSame('jane', $imapUser);
+		self::assertSame('jane', $smtpUser);
+		self::assertSame('jane', $sieveUser);
+	}
+
+	public function testEnableMasterPasswordWithoutMasterUser(): void {
+		$provisioning = new Provisioning();
+
+		$provisioning->enableMasterPassword('mypassword', '');
+
+		self::assertTrue($provisioning->getMasterPasswordEnabled());
+		self::assertSame('mypassword', $provisioning->getMasterPassword());
+		self::assertSame('', $provisioning->getMasterUser());
+	}
+
+	public function testEnableMasterPasswordClearsStoredMasterUser(): void {
+		$provisioning = new Provisioning();
+
+		$provisioning->enableMasterPassword('mypassword', '');
+
+		self::assertContains('masterUser', array_keys($provisioning->getUpdatedFields()));
+	}
+
+	public function testEnableMasterPasswordKeepsPlaceholderPassword(): void {
+		$provisioning = new Provisioning();
+		$provisioning->setMasterPassword('stored');
+
+		$provisioning->enableMasterPassword(Provisioning::MASTER_PASSWORD_PLACEHOLDER, '*masteruser');
+
+		self::assertSame('stored', $provisioning->getMasterPassword());
+		self::assertSame('*masteruser', $provisioning->getMasterUser());
+	}
+
+	public function testDisableMasterPasswordMarksFieldsUpdated(): void {
+		$provisioning = new Provisioning();
+
+		$provisioning->disableMasterPassword();
+
+		self::assertFalse($provisioning->getMasterPasswordEnabled());
+		self::assertSame('', $provisioning->getMasterPassword());
+		self::assertSame('', $provisioning->getMasterUser());
+		self::assertEqualsCanonicalizing(
+			['masterPasswordEnabled', 'masterPassword', 'masterUser'],
+			array_keys($provisioning->getUpdatedFields()),
+		);
 	}
 
 }


### PR DESCRIPTION
Local copy of https://github.com/nextcloud/mail/pull/12306 with conflicts resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a Dovecot master user alongside the master password.
  * IMAP, SMTP, and Sieve login previews now show master-user-aware usernames and configuration status.
  * Master-user settings can be enabled or disabled with the master password.

* **Bug Fixes**
  * Improved validation for IMAP port and master-password settings.
  * Prevented empty master passwords from overriding user passwords.

* **Migration**
  * Existing installations are upgraded to store the master user setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->