### PR TITLE
fix(composer): Forwarding emails with attachments

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1093,19 +1093,6 @@ export default {
 			})
 		}
 
-		// Add attachments in case of forward
-		if (this.forwardFrom?.attachments !== undefined) {
-			this.forwardFrom.attachments.forEach((att) => {
-				this.attachments.push({
-					fileName: att.fileName,
-					displayName: trimStart('/', att.fileName),
-					id: att.id,
-					messageId: this.forwardFrom.databaseId,
-					type: 'message-attachment',
-				})
-			})
-		}
-
 		// Add messages forwarded as attachments
 		for (const id of this.forwardedMessages) {
 			const env = this.mainStore.getEnvelope(id)


### PR DESCRIPTION
Fix #12374 

**STR:**

- Take an email with an attachment
- Forward

The code path was never executed on Mail 5.6, because the response from the messages api doesn't include any details about attachments. 

Since Mail 5.7 (c.f. https://github.com/nextcloud/mail/pull/11596) the api response does include a list of attachments again, making code path active again.

However, the composer already set the attachments and the backend is not able to process the given list of attachments because information are missing. 