### PR TITLE
fix(contactsIntegration): avoid incorrect cache results

### DIFF
--- a/lib/Controller/ContactIntegrationController.php
+++ b/lib/Controller/ContactIntegrationController.php
@@ -85,7 +85,7 @@ class ContactIntegrationController extends Controller {
 	 */
 	#[TrapError]
 	public function autoComplete(string $term): JSONResponse {
-		$cached = $this->cache->get($this->uid . $term);
+		$cached = $this->cache->get("{$this->uid}:$term");
 		if ($cached !== null) {
 			$decoded = json_decode($cached, true);
 			if ($decoded !== null) {
@@ -93,7 +93,7 @@ class ContactIntegrationController extends Controller {
 			}
 		}
 		$res = $this->service->autoComplete($term);
-		$this->cache->set($this->uid . $term, json_encode($res), 24 * 3600);
+		$this->cache->set("{$this->uid}:$term", json_encode($res), 24 * 3600);
 		return new JSONResponse($res);
 	}
 }


### PR DESCRIPTION
Avoid case like   userId = 'ab' and term ='c' / userId = 'a' and term ='bc'
caught by copilot in https://github.com/nextcloud/mail/pull/12457#discussion_r2828350795