### PR TITLE
fix: Pass error message from response to error object

### DIFF
--- a/src/errors/convert.js
+++ b/src/errors/convert.js
@@ -44,5 +44,5 @@ export function convertAxiosError(axiosError) {
 		return axiosError
 	}
 
-	return new map[response.data.data.type](response.data.message)
+	return new map[response.data.data.type](response.data.data.message)
 }


### PR DESCRIPTION
For some errors `response.data.message` is undefined.

