### PR TITLE
refactor: replace moment.js LLL format with Intl

### DIFF
--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import moment from '@nextcloud/moment'
 import negate from 'lodash/fp/negate.js'
+import { formatDateTimeFromUnix } from './util/formatDateTime.js'
 import { html } from './util/text.js'
 
 /**
@@ -24,7 +24,7 @@ export function buildReplyBody(original, from, date, replyOnTop = true) {
 	switch (original.format) {
 		case 'plain':
 			if (from) {
-				const dateString = moment.unix(date).format('LLL')
+				const dateString = formatDateTimeFromUnix(date)
 				return replyOnTop
 					? html(`${startEnd}${quoteStart}"${from.label}" ${from.email} – ${dateString}` + plainBody + quoteEnd)
 					: html(`${quoteStart}"${from.label}" ${from.email} – ${dateString}` + plainBody + quoteEnd + startEnd)
@@ -35,7 +35,7 @@ export function buildReplyBody(original, from, date, replyOnTop = true) {
 			}
 		case 'html':
 			if (from) {
-				const dateString = moment.unix(date).format('LLL')
+				const dateString = formatDateTimeFromUnix(date)
 				return replyOnTop
 					? html(`${startEnd}${quoteStart}"${from.label}" ${from.email} – ${dateString}<br>${htmlBody}${quoteEnd}`)
 					: html(`${quoteStart}"${from.label}" ${from.email} – ${dateString}<br>${htmlBody}${quoteEnd}${startEnd}`)

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -546,6 +546,7 @@ import { findRecipient } from '../service/AutocompleteService.js'
 import { savePreference } from '../service/PreferenceService.js'
 import { EDITOR_MODE_HTML, EDITOR_MODE_TEXT } from '../store/constants.js'
 import useMainStore from '../store/mainStore.js'
+import { formatDateTime } from '../util/formatDateTime.js'
 import { detect, html, toHtml, toPlain } from '../util/text.js'
 import textBlockSvg from './../../img/text_snippet.svg'
 
@@ -760,11 +761,11 @@ export default {
 			firstDayDatetimePicker: getFirstDay() === 0 ? 7 : getFirstDay(),
 			formatter: {
 				stringify: (date) => {
-					return date ? moment(date).format('LLL') : ''
+					return date ? formatDateTime(date) : ''
 				},
 
 				parse: (value) => {
-					return value ? moment(value, 'LLL').toDate() : null
+					return value ? new Date(value) : null
 				},
 			},
 

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -73,7 +73,6 @@
 <script>
 import { showError } from '@nextcloud/dialogs'
 import { loadState } from '@nextcloud/initial-state'
-import moment from '@nextcloud/moment'
 import { NcAppContentDetails as AppContentDetails, NcPopover } from '@nextcloud/vue'
 import debounce from 'lodash/fp/debounce.js'
 import { mapStores } from 'pinia'
@@ -87,6 +86,7 @@ import logger from '../logger.js'
 import { summarizeThread } from '../service/AiIntergrationsService.js'
 import useMainStore from '../store/mainStore.js'
 import { getRandomMessageErrorMessage } from '../util/ErrorMessageFactory.js'
+import { formatDateTimeFromUnix } from '../util/formatDateTime.js'
 
 export default {
 	name: 'Thread',
@@ -466,7 +466,7 @@ export default {
 
 			const dateSpan = virtualIframeDocument.createElement('p')
 			dateSpan.style.fontWeight = 'bold'
-			dateSpan.textContent = t('mail', 'Date') + ': ' + moment.unix(this.thread[index].dateInt).format('LLL')
+			dateSpan.textContent = t('mail', 'Date') + ': ' + formatDateTimeFromUnix(this.thread[index].dateInt)
 
 			const recipientSpan = virtualIframeDocument.createElement('p')
 			recipientSpan.style.fontWeight = 'bold'

--- a/src/util/formatDateTime.js
+++ b/src/util/formatDateTime.js
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getCanonicalLocale } from '@nextcloud/l10n'
+
+/**
+ * Format a date as a localized long date with time (equivalent to moment's LLL format).
+ *
+ * @param {Date} date The date to format
+ * @return {string} Formatted date string (e.g. "September 4, 1986, 8:30 PM")
+ */
+export function formatDateTime(date) {
+	return new Intl.DateTimeFormat(getCanonicalLocale(), {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: 'numeric',
+	}).format(date)
+}
+
+/**
+ * Format a Unix timestamp as a localized long date with time.
+ *
+ * @param {number} timestamp Unix timestamp in seconds
+ * @return {string} Formatted date string
+ */
+export function formatDateTimeFromUnix(timestamp) {
+	return formatDateTime(new Date(timestamp * 1000))
+}


### PR DESCRIPTION
In preparation for https://github.com/nextcloud/mail/issues/8573

The output format changes slightly (Intl produces "November 5, 2018 at 2:17 PM" vs moment's "November 5, 2018 2:17 PM"), but this is the standard Intl style. All existing tests pass.