### PR TITLE
fix(php): use type-safe string concatenation

### DIFF
--- a/lib/BackgroundJob/ContextChat/ScheduleJob.php
+++ b/lib/BackgroundJob/ContextChat/ScheduleJob.php
@@ -65,7 +65,7 @@ class ScheduleJob extends TimedJob {
 		try {
 			$mailboxes = $this->mailManager->getMailboxes($account);
 		} catch (ServiceException $e) {
-			$this->logger->debug('Could not find mailboxes for account <' . $accountId . '>');
+			$this->logger->debug("Could not find mailboxes for account <{$accountId}>");
 			return;
 		}
 
@@ -74,7 +74,7 @@ class ScheduleJob extends TimedJob {
 				$this->taskService->findByMailboxId($mailbox->getId());
 				$this->taskService->updateOrCreate($mailbox->getId(), 0);
 			} catch (DoesNotExistException|MultipleObjectsReturnedException|Exception $e) {
-				$this->logger->warning('Could not schedule context chat indexing tasks for mailbox <' . $mailbox->getId() . '>');
+				$this->logger->warning("Could not schedule context chat indexing tasks for mailbox <{$mailbox->getId()}>");
 			}
 		}
 	}

--- a/lib/BackgroundJob/ContextChat/SubmitContentJob.php
+++ b/lib/BackgroundJob/ContextChat/SubmitContentJob.php
@@ -139,7 +139,7 @@ class SubmitContentJob extends TimedJob {
 
 
 				$items[] = new ContentItem(
-					$mailbox->getId() . ':' . $message->getId(),
+					"{$mailbox->getId()}:{$message->getId()}",
 					$this->contextChatProvider->getId(),
 					$imapMessage->getSubject(),
 					$fullMessage['body'] ?? '',

--- a/lib/BackgroundJob/FollowUpClassifierJob.php
+++ b/lib/BackgroundJob/FollowUpClassifierJob.php
@@ -94,7 +94,7 @@ class FollowUpClassifierJob extends QueuedJob {
 			return;
 		}
 
-		$this->logger->debug('Message requires follow-up: ' . $message->getId());
+		$this->logger->debug("Message requires follow-up: {$message->getId()}");
 		$tag = $this->mailManager->createTag('Follow up', '#d77000', $userId);
 		$this->mailManager->tagMessage(
 			$account,

--- a/lib/BackgroundJob/MigrateImportantJob.php
+++ b/lib/BackgroundJob/MigrateImportantJob.php
@@ -58,7 +58,7 @@ class MigrateImportantJob extends QueuedJob {
 		try {
 			$mailbox = $this->mailboxMapper->findById($mailboxId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find mailbox <' . $mailboxId . '>');
+			$this->logger->debug("Could not find mailbox <{$mailboxId}>");
 			return;
 		}
 
@@ -66,7 +66,7 @@ class MigrateImportantJob extends QueuedJob {
 		try {
 			$mailAccount = $this->mailAccountMapper->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '>');
+			$this->logger->debug("Could not find account <{$accountId}>");
 			return;
 		}
 
@@ -75,20 +75,20 @@ class MigrateImportantJob extends QueuedJob {
 
 		try {
 			if ($this->mailManager->isPermflagsEnabled($client, $account, $mailbox->getName()) === false) {
-				$this->logger->debug('Permflags not enabled for <' . $accountId . '>');
+				$this->logger->debug("Permflags not enabled for <{$accountId}>");
 				return;
 			}
 
 			try {
 				$this->migration->migrateImportantOnImap($client, $account, $mailbox);
 			} catch (ServiceException $e) {
-				$this->logger->debug('Could not flag messages on IMAP for mailbox <' . $mailboxId . '>.');
+				$this->logger->debug("Could not flag messages on IMAP for mailbox <{$mailboxId}>.");
 			}
 
 			try {
 				$this->migration->migrateImportantFromDb($client, $account, $mailbox);
 			} catch (ServiceException $e) {
-				$this->logger->debug('Could not flag messages from DB on IMAP for mailbox <' . $mailboxId . '>.');
+				$this->logger->debug("Could not flag messages from DB on IMAP for mailbox <{$mailboxId}>.");
 			}
 		} finally {
 			$client->logout();

--- a/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
+++ b/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
@@ -53,13 +53,13 @@ class PreviewEnhancementProcessingJob extends TimedJob {
 		try {
 			$account = $this->accountService->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->logger->debug("Could not find account <{$accountId}> removing from jobs");
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}
 
 		if (!$account->getMailAccount()->canAuthenticateImap()) {
-			$this->logger->info('Ignoring preprocessing job for provisioned account as athentication on IMAP not possible');
+			$this->logger->info('Ignoring preprocessing job for provisioned account as authentication on IMAP not possible');
 			return;
 		}
 

--- a/lib/BackgroundJob/QuotaJob.php
+++ b/lib/BackgroundJob/QuotaJob.php
@@ -56,7 +56,7 @@ class QuotaJob extends TimedJob {
 		try {
 			$account = $this->accountService->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->logger->debug("Could not find account <{$accountId}> removing from jobs");
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}
@@ -78,7 +78,7 @@ class QuotaJob extends TimedJob {
 
 		$quota = $this->mailManager->getQuota($account);
 		if ($quota === null) {
-			$this->logger->debug('Could not get quota information for account <' . $account->getEmail() . '>', ['app' => 'mail']);
+			$this->logger->debug("Could not get quota information for account <{$account->getEmail()}>", ['app' => 'mail']);
 			return;
 		}
 		$mailAccount = $account->getMailAccount();
@@ -93,7 +93,7 @@ class QuotaJob extends TimedJob {
 
 		// Only notify if we've reached the rising edge
 		if ($previous < $current && $previous <= 90 && $current > 90) {
-			$this->logger->debug('New quota information for <' . $account->getEmail() . '> - previous: ' . $previous . ', current: ' . $current);
+			$this->logger->debug("New quota information for <{$account->getEmail()}> - previous: {$previous}, current: {$current}");
 			$time = $this->time->getDateTime('now');
 			$notification = $this->notificationManager->createNotification();
 			$notification

--- a/lib/BackgroundJob/RepairSyncJob.php
+++ b/lib/BackgroundJob/RepairSyncJob.php
@@ -45,7 +45,7 @@ class RepairSyncJob extends TimedJob {
 		try {
 			$account = $this->accountService->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->logger->debug("Could not find account <{$accountId}> removing from jobs");
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}

--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -78,7 +78,7 @@ class SyncJob extends TimedJob {
 		try {
 			$account = $this->accountService->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->logger->debug("Could not find account <{$accountId}> removing from jobs");
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -50,7 +50,7 @@ class TrainImportanceClassifierJob extends TimedJob {
 		try {
 			$account = $this->accountService->findById($accountId);
 		} catch (DoesNotExistException $e) {
-			$this->logger->debug('Could not find account <' . $accountId . '> removing from jobs');
+			$this->logger->debug("Could not find account <{$accountId}> removing from jobs");
 			$this->jobList->remove(self::class, $argument);
 			return;
 		}

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -459,7 +459,7 @@ class AccountsController extends Controller {
 			try {
 				$previousDraft = $this->mailManager->getMessage($this->currentUserId, $draftId);
 			} catch (ClientException $e) {
-				$this->logger->info('Draft ' . $draftId . ' could not be loaded: ' . $e->getMessage());
+				$this->logger->info("Draft {$draftId} could not be loaded: {$e->getMessage()}");
 			}
 		}
 		$messageData = NewMessageData::fromRequest($account, $subject, $body, $to, $cc, $bcc, [], $isHtml);


### PR DESCRIPTION
Psalm doesn't like us concatenating int with strings. So I use the string interpolation.

Extracted from https://github.com/nextcloud/mail/pull/11224