### PR TITLE
fix(http): prevent NPE by non-null controller parameters

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -119,37 +119,21 @@ class AccountsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
-	 * @param int $id
-	 * @param string $accountName
-	 * @param string $emailAddress
-	 * @param string $imapHost
-	 * @param int $imapPort
-	 * @param string $imapSslMode
-	 * @param string $imapUser
-	 * @param string $imapPassword
-	 * @param string $smtpHost
-	 * @param int $smtpPort
-	 * @param string $smtpSslMode
-	 * @param string $smtpUser
-	 * @param string $smtpPassword
-	 * @param string $authMethod
-	 *
-	 * @return JSONResponse
 	 * @throws ClientException
 	 */
 	#[TrapError]
 	public function update(int $id,
 		string $accountName,
 		string $emailAddress,
-		?string $imapHost = null,
-		?int $imapPort = null,
-		?string $imapSslMode = null,
-		?string $imapUser = null,
+		string $imapHost,
+		int $imapPort,
+		string $imapSslMode,
+		string $imapUser,
+		string $smtpHost,
+		int $smtpPort,
+		string $smtpSslMode,
+		string $smtpUser,
 		?string $imapPassword = null,
-		?string $smtpHost = null,
-		?int $smtpPort = null,
-		?string $smtpSslMode = null,
-		?string $smtpUser = null,
 		?string $smtpPassword = null,
 		string $authMethod = 'password'): JSONResponse {
 		try {
@@ -329,36 +313,19 @@ class AccountsController extends Controller {
 
 	/**
 	 * @NoAdminRequired
-	 *
-	 * @param string $accountName
-	 * @param string $emailAddress
-	 * @param string|null $imapHost
-	 * @param int|null $imapPort
-	 * @param string|null $imapSslMode
-	 * @param string|null $imapUser
-	 * @param string|null $imapPassword
-	 * @param string|null $smtpHost
-	 * @param int|null $smtpPort
-	 * @param string|null $smtpSslMode
-	 * @param string|null $smtpUser
-	 * @param string|null $smtpPassword
-	 * @param string $authMethod
-	 * @param bool|null $classificationEnabled
-	 *
-	 * @return JSONResponse
 	 */
 	#[TrapError]
 	public function create(string $accountName,
 		string $emailAddress,
-		?string $imapHost = null,
-		?int $imapPort = null,
-		?string $imapSslMode = null,
-		?string $imapUser = null,
+		string $imapHost,
+		int $imapPort,
+		string $imapSslMode,
+		string $imapUser,
+		string $smtpHost,
+		int $smtpPort,
+		string $smtpSslMode,
+		string $smtpUser,
 		?string $imapPassword = null,
-		?string $smtpHost = null,
-		?int $smtpPort = null,
-		?string $smtpSslMode = null,
-		?string $smtpUser = null,
 		?string $smtpPassword = null,
 		string $authMethod = 'password',
 		?bool $classificationEnabled = null): JSONResponse {

--- a/lib/Controller/ContactIntegrationController.php
+++ b/lib/Controller/ContactIntegrationController.php
@@ -57,7 +57,7 @@ class ContactIntegrationController extends Controller {
 	 * @return JSONResponse
 	 */
 	#[TrapError]
-	public function addMail(?string $uid = null, ?string $mail = null): JSONResponse {
+	public function addMail(string $uid, string $mail): JSONResponse {
 		$res = $this->service->addEMailToContact($uid, $mail);
 		if ($res === null) {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
@@ -69,7 +69,7 @@ class ContactIntegrationController extends Controller {
 	 * @NoAdminRequired
 	 */
 	#[TrapError]
-	public function newContact(?string $contactName = null, ?string $mail = null): JSONResponse {
+	public function newContact(string $contactName, string $mail): JSONResponse {
 		$res = $this->service->newContact($contactName, $mail);
 		if ($res === null) {
 			return new JSONResponse([], Http::STATUS_NOT_ACCEPTABLE);

--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -146,7 +146,7 @@ class OutboxController extends Controller {
 	 * @return JsonResponse
 	 */
 	#[TrapError]
-	public function createFromDraft(DraftsService $draftsService, int $id, ?int $sendAt = null): JsonResponse {
+	public function createFromDraft(DraftsService $draftsService, int $id, int $sendAt): JsonResponse {
 		$draftMessage = $draftsService->getMessage($id, $this->userId);
 		// Locate the account to check authorization
 		$this->accountService->find($this->userId, $draftMessage->getAccountId());

--- a/lib/Db/LocalMessage.php
+++ b/lib/Db/LocalMessage.php
@@ -42,11 +42,11 @@ use function array_filter;
  * @method bool|null isPgpMime()
  * @method setPgpMime(bool $pgpMime)
  * @method bool|null getSmimeSign()
- * @method setSmimeSign(bool $smimeSign)
+ * @method setSmimeSign(?bool $smimeSign)
  * @method int|null getSmimeCertificateId()
  * @method setSmimeCertificateId(?int $smimeCertificateId)
  * @method bool|null getSmimeEncrypt()
- * @method setSmimeEncrypt(bool $smimeEncryt)
+ * @method setSmimeEncrypt(?bool $smimeEncrypt)
  * @method int|null getStatus();
  * @method setStatus(?int $status);
  * @method string|null getRaw()

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -245,7 +245,7 @@ class AccountsControllerTest extends TestCase {
 			->with($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->userId, 'password')
 			->willReturn($account);
 
-		$response = $this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword);
+		$response = $this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $imapPassword, $smtpPassword);
 
 		$expectedResponse = \OCA\Mail\Http\JsonResponse::success($account, Http::STATUS_CREATED);
 
@@ -274,7 +274,7 @@ class AccountsControllerTest extends TestCase {
 			->method('createNewAccount');
 
 		$expectedResponse = \OCA\Mail\Http\JsonResponse::error('Could not create account');
-		$response = $this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword);
+		$response = $this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $imapPassword, $smtpPassword);
 
 		self::assertEquals($expectedResponse, $response);
 	}
@@ -299,7 +299,7 @@ class AccountsControllerTest extends TestCase {
 			->willThrowException(new ClientException());
 		$this->expectException(ClientException::class);
 
-		$this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, 'password');
+		$this->controller->create($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $imapPassword, $smtpPassword, 'password');
 	}
 
 	public function testUpdateManualSuccess(): void {
@@ -322,7 +322,7 @@ class AccountsControllerTest extends TestCase {
 			->with($accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->userId, 'password', $id)
 			->willReturn($account);
 
-		$response = $this->controller->update($id, $accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword);
+		$response = $this->controller->update($id, $accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $imapPassword, $smtpPassword);
 
 		$expectedResponse = \OCA\Mail\Http\JsonResponse::success($account);
 
@@ -349,7 +349,7 @@ class AccountsControllerTest extends TestCase {
 			->willThrowException(new ClientException());
 		$this->expectException(ClientException::class);
 
-		$this->controller->update($id, $accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword);
+		$this->controller->update($id, $accountName, $email, $imapHost, $imapPort, $imapSslMode, $imapUser, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $imapPassword, $smtpPassword);
 	}
 
 	public function draftDataProvider(): array {

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -18,26 +18,6 @@
       <code><![CDATA[$slicemap = &$this->_slicemap[$mailbox]]]></code>
     </UnsupportedPropertyReferenceUsage>
   </file>
-  <file src="lib/Controller/AccountsController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$imapHost]]></code>
-      <code><![CDATA[$imapHost]]></code>
-      <code><![CDATA[$imapPort]]></code>
-      <code><![CDATA[$imapPort]]></code>
-      <code><![CDATA[$imapSslMode]]></code>
-      <code><![CDATA[$imapSslMode]]></code>
-      <code><![CDATA[$imapUser]]></code>
-      <code><![CDATA[$imapUser]]></code>
-      <code><![CDATA[$smtpHost]]></code>
-      <code><![CDATA[$smtpHost]]></code>
-      <code><![CDATA[$smtpPort]]></code>
-      <code><![CDATA[$smtpPort]]></code>
-      <code><![CDATA[$smtpSslMode]]></code>
-      <code><![CDATA[$smtpSslMode]]></code>
-      <code><![CDATA[$smtpUser]]></code>
-      <code><![CDATA[$smtpUser]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="lib/Controller/AvatarsController.php">
     <PossiblyNullArgument>
       <code><![CDATA[$image]]></code>
@@ -50,22 +30,6 @@
       <code><![CDATA[getMime]]></code>
       <code><![CDATA[isExternal]]></code>
     </PossiblyNullReference>
-  </file>
-  <file src="lib/Controller/ContactIntegrationController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$contactName]]></code>
-      <code><![CDATA[$mail]]></code>
-      <code><![CDATA[$mail]]></code>
-      <code><![CDATA[$uid]]></code>
-    </PossiblyNullArgument>
-  </file>
-  <file src="lib/Controller/DraftsController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$smimeEncrypt]]></code>
-      <code><![CDATA[$smimeEncrypt]]></code>
-      <code><![CDATA[$smimeSign]]></code>
-      <code><![CDATA[$smimeSign]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="lib/Controller/InternalAddressController.php">
     <PossiblyNullArgument>
@@ -158,12 +122,6 @@
       <code><![CDATA[$fileParts['extension']]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
-  <file src="lib/Controller/OutboxController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$editorBody]]></code>
-      <code><![CDATA[$sendAt]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="lib/Controller/PageController.php">
     <PossiblyNullArgument>
       <code><![CDATA[$this->currentUserId]]></code>
@@ -181,11 +139,6 @@
     <PossiblyInvalidArgument>
       <code><![CDATA[$content]]></code>
     </PossiblyInvalidArgument>
-  </file>
-  <file src="lib/Controller/SieveController.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$sievePassword]]></code>
-    </PossiblyNullArgument>
   </file>
   <file src="lib/Controller/SmimeCertificatesController.php">
     <PossiblyNullArgument>


### PR DESCRIPTION
Some controller params were nullable but only in the controller method and not the method passed into. This can lead to a NPE when the param is actually missing from a HTTP request.

For https://github.com/nextcloud/mail/pull/11224