### PR TITLE
fix(db): add missing messages table index for Postgres

### DIFF
--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Listener;
 
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -108,7 +108,7 @@ class OptionalIndicesListener implements IEventListener {
 		 * This index may be missing on Postgres - we add it back on all DBs nevertheless
 		 * @see \OCA\Mail\Migration\Version1130Date20220412111833::changeSchema for the different lengths
 		 */
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
 			$event->addMissingIndex(
 				'mail_messages',
 				'mail_msg_thrd_root_snt_idx',

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Migration;
 
 use Closure;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Types\Type;
 use OCP\DB\ISchemaWrapper;
@@ -165,7 +165,7 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 		);
 
 		// Postgres doesn't need shortened indices
-		if ($this->connection->getDatabasePlatform() instanceof PostgreSQL94Platform) {
+		if ($this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
 			$messagesTable->addIndex(['mailbox_id', 'thread_root_id', 'sent_at'], 'mail_msg_thrd_root_snt_idx');
 		} else {
 			$messagesTable->addIndex(['mailbox_id', 'thread_root_id', 'sent_at'], 'mail_msg_thrd_root_snt_idx', [], ['lengths' => [null, 64, null]]);

--- a/psalm.xml
+++ b/psalm.xml
@@ -33,6 +33,7 @@
 		<UndefinedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform" />
+				<referencedClass name="Doctrine\DBAL\Platforms\PostgreSQLPlatform" />
 				<referencedClass name="Doctrine\DBAL\Platforms\PostgreSQL94Platform" />
 				<referencedClass name="Doctrine\DBAL\Platforms\SqlitePlatform" />
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />


### PR DESCRIPTION
It's true that Postrges doesn't support prefix indices. But it can just work with the full width. This adds the index also for Postgres, allowing it to run messages table self-join (when listing threads) efficiently.

Fixes https://github.com/nextcloud/mail/issues/12490