### PR TITLE
fix(db): widen recipients table index for email+type+message_id

### DIFF
--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -122,6 +122,14 @@ class OptionalIndicesListener implements IEventListener {
 				['lengths' => [null, 64, null]],
 			);
 		}
+
+		$event->replaceIndex(
+			'mail_recipients',
+			['mail_recipient_email_idx'],
+			'mail_recip_eml_type_mid_idx',
+			['email', 'type', 'message_id'],
+			false,
+		);
 	}
 
 }

--- a/lib/Migration/Version1020Date20191002091035.php
+++ b/lib/Migration/Version1020Date20191002091035.php
@@ -127,7 +127,10 @@ class Version1020Date20191002091035 extends SimpleMigrationStep {
 		]);
 		$recipientsTable->setPrimaryKey(['id']);
 		$recipientsTable->addIndex(['message_id'], 'mail_recipient_msg_id_idx');
-		$recipientsTable->addIndex(['email'], 'mail_recipient_email_idx');
+
+		// Converted to wider index later on - installations might have the old one until replacement
+		// $recipientsTable->addIndex(['email'], 'mail_recipient_email_idx');
+		$recipientsTable->addIndex(['email', 'type', 'message_id'], 'mail_recip_eml_type_mid_idx');
 
 		$mailboxTable = $schema->getTable('mail_mailboxes');
 		$mailboxTable->addColumn('sync_new_lock', Types::INTEGER, [


### PR DESCRIPTION
This adds a covering index for classification statistics queries like these:

```sql
SELECT 
  "r"."email" AS "email", 
  COUNT(*) AS "count" 
FROM 
  "oc_mail_recipients" "r" 
  INNER JOIN "oc_mail_messages" "m" ON "m"."id" = "r"."message_id" 
WHERE 
  ("r"."type" = $1) 
  AND (
    "m"."mailbox_id" IN ($2)
  ) 
  AND (
    "r"."email" IN ($3)
  ) 
GROUP BY 
  "r"."email"
```

-> the db can filter purely on the index. It already gets the join column `message_id` too so no table lookup is necessary.

New installations will receive the new index right away. Existing installations will be converted with the optional indices command – use it for testing.

Fixes https://github.com/nextcloud/mail/issues/12492

This branch is based on https://github.com/nextcloud/mail/pull/12496 to avoid conflicts.