### PR TITLE
feat(settings): add thread message order preference

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -263,6 +263,7 @@ class PageController extends Controller {
 			'sort-favorites' => $this->preferences->getPreference($this->currentUserId, 'sort-favorites', 'false'),
 			'index-context-chat' => $this->contextChatSettingsService->isIndexingEnabled($this->currentUserId) ? 'true' : 'false',
 			'compact-mode' => $this->preferences->getPreference($this->currentUserId, 'compact-mode', 'false'),
+			'thread-order' => $this->preferences->getPreference($this->currentUserId, 'thread-order', 'oldest'),
 		]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -100,6 +100,14 @@
 					<NcRadioGroupButton :label="t('mail', 'Oldest first')" value="oldest" />
 				</NcRadioGroup>
 
+				<NcRadioGroup
+					:model-value="threadOrder"
+					:label="t('mail', 'Thread message order')"
+					@update:modelValue="onThreadOrderChange">
+					<NcRadioGroupButton :label="t('mail', 'Oldest first')" value="oldest" />
+					<NcRadioGroupButton :label="t('mail', 'Newest first')" value="newest" />
+				</NcRadioGroup>
+
 				<NcAppSettingsSection id="messages" name="Messages">
 					<NcFormBox>
 						<NcFormBoxSwitch
@@ -384,6 +392,7 @@ export default {
 			loadingSortFavorites: false,
 			displaySmimeCertificateModal: false,
 			sortOrder: 'newest',
+			threadOrder: 'oldest',
 			showSettings: false,
 			showAccountSettings: false,
 			showMailSettings: true,
@@ -551,6 +560,7 @@ export default {
 
 	mounted() {
 		this.sortOrder = this.mainStore.getPreference('sort-order', 'newest')
+		this.threadOrder = this.mainStore.getPreference('thread-order', 'oldest')
 		document.addEventListener.call(window, 'mailvelope', () => this.checkMailvelope())
 		if (!this.mainStore.areTextBlocksFetched()) {
 			this.mainStore.fetchMyTextBlocks()
@@ -690,6 +700,21 @@ export default {
 			} catch (error) {
 				Logger.error('could not save preferences', { error })
 				this.sortOrder = previousValue
+				showError(t('mail', 'Could not update preference'))
+			}
+		},
+
+		async onThreadOrderChange(value) {
+			const previousValue = this.threadOrder
+			try {
+				this.threadOrder = value
+				await this.mainStore.savePreference({
+					key: 'thread-order',
+					value,
+				})
+			} catch (error) {
+				Logger.error('could not save thread order preference', { error })
+				this.threadOrder = previousValue
 				showError(t('mail', 'Could not update preference'))
 			}
 		},

--- a/src/init.js
+++ b/src/init.js
@@ -98,6 +98,10 @@ export default function initAfterAppCreation() {
 		key: 'compact-mode',
 		value: preferences['compact-mode'],
 	})
+	mainStore.savePreferenceMutation({
+		key: 'thread-order',
+		value: preferences['thread-order'],
+	})
 
 	mainStore.setQuickActions(loadState('mail', 'quick-actions', []))
 

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -2451,10 +2451,13 @@ export default function mainStoreActions() {
 			return list.map((msgId) => this.envelopes[msgId])
 		},
 		getEnvelopesByThreadRootId(accountId, threadRootId) {
-			return sortBy(
+			const sorted = sortBy(
 				prop('dateInt'),
 				Object.values(this.envelopes).filter((envelope) => envelope.accountId === accountId && envelope.threadRootId === threadRootId),
 			)
+			return this.getPreference('thread-order', 'oldest') === 'newest'
+				? sorted.reverse()
+				: sorted
 		},
 		getMessage(id) {
 			return this.messages[id]

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -180,7 +180,7 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createStub(Mailbox::class);
-		$this->preferences->expects($this->exactly(14))
+		$this->preferences->expects($this->exactly(15))
 			->method('getPreference')
 			->willReturnMap([
 				[$this->userId, 'account-settings', '[]', json_encode([])],
@@ -197,6 +197,7 @@ class PageControllerTest extends TestCase {
 				[$this->userId, 'smime-sign-aliases', '[]', '[]'],
 				[$this->userId, 'sort-favorites', 'false', 'false'],
 				[$this->userId, 'compact-mode', 'false', 'false'],
+				[$this->userId, 'thread-order', 'oldest', 'oldest'],
 			]);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
@@ -359,7 +360,8 @@ class PageControllerTest extends TestCase {
 					'follow-up-reminders' => 'true',
 					'sort-favorites' => 'false',
 					'index-context-chat' => 'true',
-					'compact-mode' => 'false'
+					'compact-mode' => 'false',
+					'thread-order' => 'oldest'
 				]],
 				['prefill_displayName', 'Jane Doe'],
 				['importance_classification_default', true],


### PR DESCRIPTION
Adds a "Thread message order" setting (Oldest first / Newest first) to the Mail appearance settings. The preference is stored under the key 'thread-order' and defaults to 'oldest' (existing behaviour).

- PageController: expose preference via initial state
- init.js: load preference into store on startup
- mainStore: reverse getEnvelopesByThreadRootId when 'newest'
- AppSettingsMenu: add radio group UI below the Sorting setting

Closes #12072