### PR TITLE
fix: Return proper error message for ManageSieve auth failures

### DIFF
--- a/lib/Http/Middleware/ErrorMiddleware.php
+++ b/lib/Http/Middleware/ErrorMiddleware.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace OCA\Mail\Http\Middleware;
 
 use Exception;
+use Horde\ManageSieve\Exception as ManageSieveException;
 use Horde_Imap_Client_Exception;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\CouldNotConnectException;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Http\JsonResponse;
@@ -61,6 +63,20 @@ class ErrorMiddleware extends Middleware {
 
 		if ($exception instanceof ClientException) {
 			return JsonResponse::failWith($exception);
+		}
+
+		if ($exception instanceof CouldNotConnectException) {
+			return JsonResponse::fail([
+				'message' => $exception->getMessage(),
+				'type' => get_class($exception),
+			], Http::STATUS_SERVICE_UNAVAILABLE);
+		}
+
+		if ($exception instanceof ManageSieveException) {
+			return JsonResponse::fail([
+				'message' => $exception->getMessage(),
+				'type' => get_class($exception),
+			], Http::STATUS_SERVICE_UNAVAILABLE);
 		}
 
 		if ($exception instanceof DoesNotExistException) {


### PR DESCRIPTION
When ManageSieve authentication fails (e.g., due to an outdated password stored in Nextcloud), the error was silently swallowed in production mode, returning only a generic "Server error" message.

This fix ensures that both `ManageSieveException` and `CouldNotConnectException` return proper error messages to the frontend so users can see why their out-of-office settings failed to save.

**Root cause:** The `ErrorMiddleware` was only handling `ClientException`, `DoesNotExistException`, and `NotImplemented` exceptions specifically. Other exceptions like `ManageSieveException` (from Horde) and `CouldNotConnectException` were falling through to the generic error handler, which in production mode only returns "Server error" without the actual message.

**Fix:** Added explicit handling for `ManageSieveException` and `CouldNotConnectException` to return the actual error message to the frontend.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*