### PR TITLE
fix(textblocks): guard removal of non existing text block

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -2324,6 +2324,9 @@ export default function mainStoreActions() {
 		},
 		deleteTextBlockLocally(id) {
 			const index = this.myTextBlocks.findIndex((textBlock) => textBlock.id === id)
+			if (index === -1) {
+				return
+			}
 			this.myTextBlocks.splice(index, 1)
 		},
 		patchTextBlockLocally(textBlock) {


### PR DESCRIPTION
findIndex returns -1 when it can't find an element. -1 in splice will return the last element of the array.