### PR TITLE
feat: add ai hint for smart replies

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -56,7 +56,7 @@
 						<NcButton
 							variant="tertiary-no-background"
 							:aria-label="t('mail', 'AI info')"
-							class="button">
+							class="ai-button">
 							<template #icon>
 								<IconInfo :size="20" />
 							</template>


### PR DESCRIPTION
fixes https://github.com/nextcloud/mail/issues/12390

before
<img width="1035" height="221" alt="Screenshot from 2026-03-10 17-48-09" src="https://github.com/user-attachments/assets/a3560c1e-733e-4f85-98e9-9119f7cd5ae6" />
after

<img width="861" height="118" alt="Screenshot from 2026-03-12 16-07-53" src="https://github.com/user-attachments/assets/6c513b74-ed43-4714-94b0-49509dfef13e" />


