### PR TITLE
fix: replace deprecated and removed OC\Server getters

### DIFF
--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -121,7 +121,7 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 			null, $this->request->getServerHost(),
 			null,
 			$this->urlGenerator->linkToRoute('mail.proxy.proxy'),
-			'src=' . $originalURL . '&requesttoken=' . \OC::$server->getSession()->get('requesttoken'),
+			'src=' . $originalURL . '&requesttoken=' . \OCP\Server::get(\OCP\ISession::class)->get('requesttoken'),
 			null
 		);
 	}

--- a/tests/Integration/Db/AliasMapperTest.php
+++ b/tests/Integration/Db/AliasMapperTest.php
@@ -11,7 +11,6 @@ namespace OCA\Mail\Tests\Integration\Db;
 
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC;
 use OCA\Mail\Db\Alias;
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\MailAccount;
@@ -38,7 +37,7 @@ class AliasMapperTest extends TestCase {
 	 */
 	public function setup(): void {
 		parent::setUp();
-		$this->db = OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->mapper = new AliasMapper($this->db);
 	}
 

--- a/tests/Integration/Db/CollectedAddressMapperTest.php
+++ b/tests/Integration/Db/CollectedAddressMapperTest.php
@@ -10,7 +10,6 @@ namespace OCA\Mail\Tests\Integration\Db;
 
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC;
 use OCA\Mail\Db\CollectedAddress;
 use OCA\Mail\Db\CollectedAddressMapper;
 use OCP\IDBConnection;
@@ -42,7 +41,7 @@ class CollectedAddressMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->mapper = new CollectedAddressMapper($this->db);
 
 		// Empty DB

--- a/tests/Integration/Db/LocalAttachmentMapperTest.php
+++ b/tests/Integration/Db/LocalAttachmentMapperTest.php
@@ -53,7 +53,7 @@ class LocalAttachmentMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->mapper = new LocalAttachmentMapper(
 			$this->db
 		);

--- a/tests/Integration/Db/LocalMessageMapperTest.php
+++ b/tests/Integration/Db/LocalMessageMapperTest.php
@@ -45,7 +45,7 @@ class LocalMessageMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$recipientMapper = new RecipientMapper(
 			$this->db
 		);

--- a/tests/Integration/Db/MailAccountMapperTest.php
+++ b/tests/Integration/Db/MailAccountMapperTest.php
@@ -12,7 +12,6 @@ namespace OCA\Mail\Tests\Integration\Db;
 
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\MailAccountMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -40,7 +39,7 @@ class MailAccountMapperTest extends TestCase {
 	 */
 	public function setup(): void {
 		parent::setUp();
-		$this->db = OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->mapper = new MailAccountMapper($this->db);
 
 		$this->account = new MailAccount();

--- a/tests/Integration/Db/MailboxMapperTest.php
+++ b/tests/Integration/Db/MailboxMapperTest.php
@@ -34,7 +34,7 @@ class MailboxMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->mapper = new MailboxMapper(
 			$this->db,

--- a/tests/Integration/Db/MessageMapperTest.php
+++ b/tests/Integration/Db/MessageMapperTest.php
@@ -41,7 +41,7 @@ class MessageMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')->willReturnCallback(fn () => $this->timestamp);
 		$tagMapper = $this->createMock(TagMapper::class);

--- a/tests/Integration/Db/ProvisioningMapperTest.php
+++ b/tests/Integration/Db/ProvisioningMapperTest.php
@@ -11,7 +11,6 @@ namespace OCA\Mail\Tests\Integration\Db;
 
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC;
 use OCA\Mail\Db\Provisioning;
 use OCA\Mail\Db\ProvisioningMapper;
 use OCA\Mail\Exception\ValidationException;
@@ -44,7 +43,7 @@ class ProvisioningMapperTest extends TestCase {
 	 */
 	public function setup(): void {
 		parent::setUp();
-		$this->db = OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->mapper = new ProvisioningMapper($this->db, $this->logger);
 

--- a/tests/Integration/Db/RecipientMapperTest.php
+++ b/tests/Integration/Db/RecipientMapperTest.php
@@ -48,7 +48,7 @@ class RecipientMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
 		$this->mapper = new RecipientMapper(
 			$this->db
 		);

--- a/tests/Integration/Framework/ImapTestAccount.php
+++ b/tests/Integration/Framework/ImapTestAccount.php
@@ -7,7 +7,6 @@
 
 namespace OCA\Mail\Tests\Integration\Framework;
 
-use OC;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\IMAP\MailboxSync;
@@ -40,12 +39,12 @@ trait ImapTestAccount {
 		$mailAccount->setInboundPort(993);
 		$mailAccount->setInboundSslMode('ssl');
 		$mailAccount->setInboundUser('user@domain.tld');
-		$mailAccount->setInboundPassword(OC::$server->getCrypto()->encrypt('mypassword'));
+		$mailAccount->setInboundPassword(\OCP\Server::get(\OCP\Security\ICrypto::class)->encrypt('mypassword'));
 
 		$mailAccount->setOutboundHost('127.0.0.1');
 		$mailAccount->setOutboundPort(25);
 		$mailAccount->setOutboundUser('user@domain.tld');
-		$mailAccount->setOutboundPassword(OC::$server->getCrypto()->encrypt('mypassword'));
+		$mailAccount->setOutboundPassword(\OCP\Server::get(\OCP\Security\ICrypto::class)->encrypt('mypassword'));
 		$mailAccount->setOutboundSslMode('none');
 		$mailAccount->setDebug(false);
 		$acc = $accountService->save($mailAccount);

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -76,7 +76,7 @@ class MailTransmissionIntegrationTest extends TestCase {
 		$this->user = $this->createTestUser();
 
 		/** @var ICrypto $crypo */
-		$crypo = OC::$server->getCrypto();
+		$crypo = \OCP\Server::get(\OCP\Security\ICrypto::class);
 		/** @var MailAccountMapper $mapper */
 		$mapper = Server::get(MailAccountMapper::class);
 		$mailAccount = MailAccount::fromParams([

--- a/tests/Integration/Service/Phishing/PhishingDetectionServiceIntegrationTest.php
+++ b/tests/Integration/Service/Phishing/PhishingDetectionServiceIntegrationTest.php
@@ -42,7 +42,7 @@ class PhishingDetectionServiceIntegrationTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->contactCheck = new ContactCheck($this->contactsIntegration, $this->l10n);
 		$this->customEmailCheck = new CustomEmailCheck($this->l10n);
-		$this->dateCheck = new DateCheck($this->l10n, \OC::$server->get(ITimeFactory::class));
+		$this->dateCheck = new DateCheck($this->l10n, \OCP\Server::get(ITimeFactory::class));
 		$this->replyToCheck = new ReplyToCheck($this->l10n);
 		$this->linkCheck = new LinkCheck($this->l10n);
 		$this->imapFlagCheck = new ImapFlagCheck($this->l10n);

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use OC;
 use OCA\Mail\Service\Html;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -62,8 +61,8 @@ class HtmlTest extends TestCase {
 	 * @param $text
 	 */
 	public function testParseMailBody($expectedBody, $expectedSignature, $text) {
-		$urlGenerator = OC::$server->getURLGenerator();
-		$request = OC::$server->getRequest();
+		$urlGenerator = \OCP\Server::get(\OCP\IURLGenerator::class);
+		$request = \OCP\Server::get(\OCP\IRequest::class);
 		$html = new Html($urlGenerator, $request);
 		[$b, $s] = $html->parseMailBody($text);
 		$this->assertSame($expectedBody, $b);

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -493,6 +493,13 @@
       <code><![CDATA[$value]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>
+  <file src="lib/Service/HtmlPurify/TransformURLScheme.php">
+    <NullArgument>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+      <code><![CDATA[null]]></code>
+    </NullArgument>
+  </file>
   <file src="lib/Service/IMipService.php">
     <PossiblyNullArgument>
       <code><![CDATA[$sender]]></code>

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -6,6 +6,6 @@
 		"sort-packages": true
 	},
 	"require-dev": {
-		"christophwurst/nextcloud_testing": "^1.1.1"
+		"christophwurst/nextcloud_testing": "^1.1.3"
 	}
 }

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6a2e01254383be37831691ebceed7a7",
+    "content-hash": "8df47d40b09bad037b778cdb33a0b4ec",
     "packages": [],
     "packages-dev": [
         {
             "name": "christophwurst/nextcloud_testing",
-            "version": "v1.1.1",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_testing.git",
-                "reference": "152df875b0533e720fc20a77a33fecbd9d408588"
+                "reference": "2428fddb15caeb025fa0bb37638e7756aae2a1f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/152df875b0533e720fc20a77a33fecbd9d408588",
-                "reference": "152df875b0533e720fc20a77a33fecbd9d408588",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/2428fddb15caeb025fa0bb37638e7756aae2a1f1",
+                "reference": "2428fddb15caeb025fa0bb37638e7756aae2a1f1",
                 "shasum": ""
             },
             "require": {
@@ -45,9 +45,9 @@
             "description": "Simple and fast unit and integration testing framework for Nextcloud, based on PHPUnit",
             "support": {
                 "issues": "https://github.com/ChristophWurst/nextcloud_testing/issues",
-                "source": "https://github.com/ChristophWurst/nextcloud_testing/tree/v1.1.1"
+                "source": "https://github.com/ChristophWurst/nextcloud_testing/tree/v1.1.3"
             },
-            "time": "2026-02-17T08:39:26+00:00"
+            "time": "2026-03-10T18:18:16+00:00"
         },
         {
             "name": "doctrine/instantiator",


### PR DESCRIPTION
Fixes currently red CI like

```
1) OCA\Mail\Tests\Unit\Model\IMAPMessageTest::testIconvHtmlMessage
Error: Call to undefined method OC\Server::getSession()

/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Service/HtmlPurify/TransformURLScheme.php:124
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Service/HtmlPurify/TransformURLScheme.php:66
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier/URIDefinition.php:104
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier/AttrDef/URI.php:92
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier/AttrValidator.php:95
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Strategy/RemoveForeignElements.php:89
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Strategy/Composite.php:24
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/ezyang/htmlpurifier/library/HTMLPurifier.php:209
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Service/Html.php:146
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/lib/Model/IMAPMessage.php:352
/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Unit/Model/IMAPMessageTest.php:85

2) OCA\Mail\Tests\Unit\Service\HtmlTest::testParseMailBody with data set #0 ('abc', null, 'abc')
Error: Call to undefined method OC\Server::getURLGenerator()

/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Unit/Service/HtmlTest.php:65

3) OCA\Mail\Tests\Unit\Service\HtmlTest::testParseMailBody with data set #1 ('abc', 'def', 'abc-- \r\ndef')
Error: Call to undefined method OC\Server::getURLGenerator()

/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Unit/Service/HtmlTest.php:65

4) OCA\Mail\Tests\Unit\Service\HtmlTest::testParseMailBody with data set #2 ('abc-- \r\ndef', 'ghi', 'abc-- \r\ndef-- \r\nghi')
Error: Call to undefined method OC\Server::getURLGenerator()

/home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/tests/Unit/Service/HtmlTest.php:65
```

Changes made with Rector