### PR TITLE
perf(imap): reuse existing IMAP client/connection for mailbox sync

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -79,13 +79,19 @@ class MailboxSync {
 	 */
 	public function sync(Account $account,
 		LoggerInterface $logger,
-		bool $force = false): void {
+		bool $force = false,
+		?Horde_Imap_Client_Socket $client = null): void {
 		if (!$force && $account->getMailAccount()->getLastMailboxSync() >= ($this->timeFactory->getTime() - 7200)) {
 			$logger->debug('account is up to date, skipping mailbox sync');
 			return;
 		}
 
-		$client = $this->imapClientFactory->getClient($account);
+		if ($client === null) {
+			$client = $this->imapClientFactory->getClient($account);
+			$ownClient = true;
+		} else {
+			$ownClient = false;
+		}
 		try {
 			try {
 				$namespaces = $client->getNamespaces([], [
@@ -131,7 +137,9 @@ class MailboxSync {
 				new MailboxesSynchronizedEvent($account)
 			);
 		} finally {
-			$client->logout();
+			if ($ownClient) {
+				$client->logout();
+			}
 		}
 	}
 

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -147,6 +147,8 @@ class MailManager implements IMailManager {
 		try {
 			$folder = $this->folderMapper->createFolder($client, $name, $specialUse);
 			$this->folderMapper->fetchFolderAcls([$folder], $client);
+			$this->folderMapper->detectFolderSpecialUse([$folder]);
+			$this->mailboxSync->sync($account, $this->logger, true, $client);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				'Could not get mailbox status: ' . $e->getMessage(),
@@ -156,9 +158,6 @@ class MailManager implements IMailManager {
 		} finally {
 			$client->logout();
 		}
-		$this->folderMapper->detectFolderSpecialUse([$folder]);
-
-		$this->mailboxSync->sync($account, $this->logger, true);
 
 		return $this->mailboxMapper->find($account, $name);
 	}
@@ -413,6 +412,11 @@ class MailManager implements IMailManager {
 		$client = $this->imapClientFactory->getClient($account);
 		try {
 			$client->subscribeMailbox($mailbox->getName(), $subscribed);
+
+			/**
+			 * 2. Pull changes into the mailbox database cache
+			 */
+			$this->mailboxSync->sync($account, $this->logger, true, $client);
 		} catch (Horde_Imap_Client_Exception $e) {
 			throw new ServiceException(
 				'Could not set subscription status for mailbox ' . $mailbox->getId() . ' on IMAP: ' . $e->getMessage(),
@@ -422,11 +426,6 @@ class MailManager implements IMailManager {
 		} finally {
 			$client->logout();
 		}
-
-		/**
-		 * 2. Pull changes into the mailbox database cache
-		 */
-		$this->mailboxSync->sync($account, $this->logger, true);
 
 		/**
 		 * 3. Return the updated object
@@ -615,14 +614,14 @@ class MailManager implements IMailManager {
 				$mailbox->getName(),
 				$name
 			);
+
+			/**
+			 * 2. Get the IMAP changes into our database cache
+			 */
+			$this->mailboxSync->sync($account, $this->logger, true, $client);
 		} finally {
 			$client->logout();
 		}
-
-		/**
-		 * 2. Get the IMAP changes into our database cache
-		 */
-		$this->mailboxSync->sync($account, $this->logger, true);
 
 		/**
 		 * 3. Return the cached object with the new ID


### PR DESCRIPTION
I've tested new account creation, sync at reload and sync via CLI - works as expected.