### PR TITLE
style: move flat styles to nested SCSS BEM

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -788,9 +788,7 @@ export default {
 .tabs-component-panels select {
 	margin-bottom: calc(var(--default-grid-baseline) * 2);
 }
-</style>
 
-<style scoped>
 h4 {
 	font-size: 17px;
 	text-align: start;
@@ -813,34 +811,36 @@ input[type='radio'][disabled] + label {
 	opacity: 0.5;
 }
 
-.account-form__label--required:after {
-	content:" *";
-}
+.account-form {
+	&__label--required:after {
+		content:" *";
+	}
 
-.account-form__heading--required:after {
-	content:" *";
-}
+	&__heading--required:after {
+		content:" *";
+	}
 
-.account-form__submit-buttons {
-	display: flex;
-	justify-content: center;
-	margin-top: var(--default-grid-baseline);
-}
+	&__submit-buttons {
+		display: flex;
+		justify-content: center;
+		margin-top: var(--default-grid-baseline);
+	}
 
-.account-form__submit-button {
-	display: flex;
-	align-items: center;
-}
+	&__submit-button {
+		display: flex;
+		align-items: center;
+	}
 
-.account-form--feedback {
-	color: var(--color-text-maxcontrast);
-	margin-top: var(--default-grid-baseline);
-	text-align: center;
-}
+	&--feedback {
+		color: var(--color-text-maxcontrast);
+		margin-top: var(--default-grid-baseline);
+		text-align: center;
+	}
 
-.account-form--error {
-	text-align: start;
-	font-size: 14px;
+	&--error {
+		text-align: start;
+		font-size: 14px;
+	}
 }
 
 #account-form {

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1898,6 +1898,40 @@ export default {
 .composer-actions {
 	position: sticky;
 	background: linear-gradient(rgba(255, 255, 255, 0), var(--color-main-background-translucent) 50%);
+
+	&-right {
+		display: flex;
+		align-items: center;
+		flex-direction: row;
+		justify-content: space-between;
+		bottom: var(--default-grid-baseline);
+	}
+
+	&--primary-actions {
+		display: flex;
+		flex-direction: row;
+		padding-inline-start: calc(var(--default-grid-baseline) * 2);
+		align-items: center;
+
+		.button {
+			padding: 2px;
+		}
+	}
+
+	&--secondary-actions {
+		display: flex;
+		flex-direction: row;
+		padding: calc(var(--default-grid-baseline) * 2);
+		gap: 5px;
+
+		.button {
+			flex-shrink: 0;
+		}
+	}
+
+	&-draft-status {
+		padding-inline-start: 0;
+	}
 }
 
 .composer-fields {
@@ -1921,7 +1955,7 @@ export default {
 		border-radius: 0;
 	}
 
-	.composer-fields--custom {
+	&--custom {
 		flex: 1;
 		min-width: 0;
 		display: flex;
@@ -2132,55 +2166,23 @@ export default {
 	margin-top: 0 !important;
 }
 
-.composer-actions-right {
-	display: flex;
-	align-items: center;
-	flex-direction: row;
-	justify-content: space-between;
-	bottom: var(--default-grid-baseline);
-}
-
-.composer-actions--primary-actions {
-	display: flex;
-	flex-direction: row;
-	padding-inline-start: calc(var(--default-grid-baseline) * 2);
-	align-items: center;
-}
-
-.composer-actions--secondary-actions {
-	display: flex;
-	flex-direction: row;
-	padding: calc(var(--default-grid-baseline) * 2);
-	gap: 5px;
-}
-
-.composer-actions--primary-actions .button {
-	padding: 2px;
-}
-
-.composer-actions--secondary-actions .button{
-	flex-shrink: 0;
-}
-
-.composer-actions-draft-status {
-	padding-inline-start: 0;
-}
-
 :deep(.vs__selected-options .vs__dropdown-toggle .vs--multiple ){
 	width: 100%;
 }
 
 @media only screen and (max-width: 580px) {
-	.composer-actions-right {
-		align-items: end;
-		flex-direction: column-reverse;
-	}
-	.composer-actions-draft-status {
-		text-align: end;
-		padding-inline-end: 15px;
-	}
-	.composer-actions--primary-actions {
-		padding-inline-end: 5px;
+	.composer-actions {
+		&-right {
+			align-items: end;
+			flex-direction: column-reverse;
+		}
+		&-draft-status {
+			text-align: end;
+			padding-inline-end: 15px;
+		}
+		&--primary-actions {
+			padding-inline-end: 5px;
+		}
 	}
 }
 

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1545,6 +1545,10 @@ export default {
 				}
 			}
 		}
+		&--compact-wrapper {
+			display: flex;
+			align-items: center;
+		}
 	}
 	&__preview-text {
 		color: var(--color-text-maxcontrast);
@@ -1567,12 +1571,40 @@ export default {
 			display: inline;
 		}
 	}
+
+	&__recipient-row {
+		display: flex;
+		align-items: center;
+		min-width: 0;
+	}
+
+	&__recipient-text {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&--compact.envelope--one-line {
+		.favorite-icon-style,
+		.icon-important {
+			display: none;
+		}
+	}
 }
 
-.list-item__wrapper--active {
-	div:not(.compact-checkbox-wrapper, .compact-checkbox-wrapper *),
-	:deep(.list-item-content__inner__details__details) {
-		color: var(--color-primary-element-text) !important;
+.list-item {
+	&__wrapper {
+		&--active {
+			div:not(.compact-checkbox-wrapper, .compact-checkbox-wrapper *),
+			:deep(.list-item-content__inner__details__details) {
+				color: var(--color-primary-element-text) !important;
+			}
+		}
+
+		&:deep() {
+			list-style: none;
+		}
 	}
 }
 
@@ -1649,24 +1681,6 @@ export default {
 	}
 }
 
-.tag-group__label {
-	margin: 0 7px;
-	z-index: 2;
-	font-size: calc(var(--default-font-size) * 0.8);
-	font-weight: bold;
-	padding-inline: 2px;
-	white-space: nowrap;
-}
-
-.tag-group__bg {
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	inset-inline-start: 0;
-	opacity: 15%;
-}
-
 .tag-group {
 	display: inline-block;
 	border-radius: var(--border-radius-pill);
@@ -1674,10 +1688,24 @@ export default {
 	margin-inline-end: 1px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-}
 
-.list-item__wrapper:deep() {
-	list-style: none;
+	&__label {
+		margin: 0 7px;
+		z-index: 2;
+		font-size: calc(var(--default-font-size) * 0.8);
+		font-weight: bold;
+		padding-inline: 2px;
+		white-space: nowrap;
+	}
+
+	&__bg {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		top: 0;
+		inset-inline-start: 0;
+		opacity: 15%;
+	}
 }
 
 .icon-important.app-content-list-item-star:deep() {
@@ -1802,17 +1830,12 @@ export default {
 		flex: 1;
 		min-width: 0;
 	}
-}
 
-.list-item--compact .envelope__subtitle {
-	display: flex;
-	align-items: center;
-	padding-inline-start: 0;
-}
-
-.envelope__subtitle--compact-wrapper {
-	display: flex;
-	align-items: center;
+	.envelope__subtitle {
+		display: flex;
+		align-items: center;
+		padding-inline-start: 0;
+	}
 }
 
 .compact-subject-icons {
@@ -1821,29 +1844,9 @@ export default {
 	flex-shrink: 0;
 }
 
-.envelope__recipient-row {
-	display: flex;
-	align-items: center;
-	min-width: 0;
-}
-
 .recipient-icon {
 	flex: 0 0 auto;
 	margin-inline-end: 6px;
-}
-
-.envelope__recipient-text {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.envelope--compact.envelope--one-line {
-	.favorite-icon-style,
-	.icon-important {
-		display: none;
-	}
 }
 
 .list-item__wrapper--active :deep(.compact-checkbox .checkbox-radio-switch__content),

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -682,28 +682,30 @@ export default {
 	margin: 0 !important;
 }
 
-.tag-group__search {
-	box-sizing: border-box;
-	position: relative;
-	margin: 3px 3px;
-	padding: 0 6px;
-}
+.tag-group {
+	&__search {
+		box-sizing: border-box;
+		position: relative;
+		margin: 3px 3px;
+		padding: 0 6px;
+	}
 
-.tag-group__bg {
-	position: absolute;
-	inset-inline: 0;
-	bottom: 0;
-	top: 0;
-	opacity: 0.4;
-	border-radius: 14px;
-	z-index: 1;
-}
+	&__bg {
+		position: absolute;
+		inset-inline: 0;
+		bottom: 0;
+		top: 0;
+		opacity: 0.4;
+		border-radius: 14px;
+		z-index: 1;
+	}
 
-.tag-group__label {
-	font-weight: bold;
-	font-size: 12px;
-	position: relative;
-	z-index: 2;
+	&__label {
+		font-weight: bold;
+		font-size: 12px;
+		position: relative;
+		z-index: 2;
+	}
 }
 
 .search-modal {
@@ -754,38 +756,40 @@ export default {
 	flex-wrap: wrap !important;
 }
 
-.modal-inner-field--right {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	padding: 0 33px;
-	margin-top: 15px;
-}
-
-.modal-inner--field {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	margin-bottom: 15px;
-	padding: 0 12px 0 30px;
-
-	.checkbox-radio-switch {
-		margin: 0 8px 0 0;
-	}
-
-	& > label {
-		font-weight: bold;
-		width: 120px;
-	}
-
-	.modal-inner--container {
-		width: calc(100% - 120px);
+.modal-inner {
+	&-field--right {
 		display: flex;
-		flex-wrap: wrap;
+		align-items: center;
+		justify-content: flex-end;
+		padding: 0 33px;
+		margin-top: 15px;
+	}
 
-		.select {
-			width: 100%;
+	&--field {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		margin-bottom: 15px;
+		padding: 0 12px 0 30px;
+
+		.checkbox-radio-switch {
+			margin: 0 8px 0 0;
+		}
+
+		& > label {
+			font-weight: bold;
+			width: 120px;
+		}
+
+		.modal-inner--container {
+			width: calc(100% - 120px);
+			display: flex;
+			flex-wrap: wrap;
+
+			.select {
+				width: 100%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This moves some existing BEM classes to the usual nested SCSS structure.

Not all classes have great names, but that's for another clean-up …

Smoke test was successful: no visual regressions for the account form, envelopes and searching :broom: 