### PR TITLE
fix(outbox): Skip messages with status error

### DIFF
--- a/lib/Service/OutboxService.php
+++ b/lib/Service/OutboxService.php
@@ -228,6 +228,12 @@ class OutboxService {
 				// Ignore message of non-existent account
 				continue;
 			}
+
+			if ($message->getStatus() === LocalMessage::STATUS_ERROR) {
+				// Skip messages with status error
+				continue;
+			}
+
 			try {
 				$this->sendChain->process($account, $message);
 				$this->logger->debug('Outbox message {id} sent', [


### PR DESCRIPTION
Messages in the outbox with status error are currently stuck.

To avoid spamming the logs, we skip them for now. 

As mentioned by copilot in the first review, there's indeed a bit of weirdness around the status (e.g. status can be final or temporary, the initial state is null, etc). 

I will try to rework that in a follow up.