### PR TITLE
refactor(imap): replace Horde's deprecated magic header getValue method

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -20,6 +20,7 @@ use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
 use Horde_Mime_Exception;
 use Horde_Mime_Headers;
+use Horde_Mime_Headers_ContentParam;
 use Horde_Mime_Headers_ContentParam_ContentType;
 use Horde_Mime_Headers_ContentTransferEncoding;
 use Horde_Mime_Part;
@@ -582,8 +583,9 @@ class MessageMapper {
 			/** @var Horde_Imap_Client_Data_Fetch $part */
 			$body = $part->getBodyPart($htmlPartId);
 			if ($body !== null) {
+				/** @var Horde_Mime_Headers $mimeHeaders */
 				$mimeHeaders = $part->getMimeHeader($htmlPartId, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
-				if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
+				if ($enc = $mimeHeaders['content-transfer-encoding']?->value_single) {
 					$structure->setTransferEncoding($enc);
 				}
 				$structure->setContents($body);
@@ -695,8 +697,9 @@ class MessageMapper {
 			// Encrypted parts were already decoded and their content can be used directly
 			if (!$isEncrypted) {
 				$stream = $messageData->getBodyPart($key, true);
+				/** @var Horde_Mime_Headers $mimeHeaders */
 				$mimeHeaders = $messageData->getMimeHeader($key, Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
-				if ($enc = $mimeHeaders->getValue('content-transfer-encoding')) {
+				if ($enc = $mimeHeaders['content-transfer-encoding']?->value_single) {
 					$part->setTransferEncoding($enc);
 				}
 
@@ -802,24 +805,30 @@ class MessageMapper {
 		$mimePart->setDisposition('attachment');
 
 		// Extract headers from part
-		$contentDisposition = $mimeHeaders->getValue('content-disposition', Horde_Mime_Headers::VALUE_PARAMS);
+		$cdEl = $mimeHeaders['content-disposition'];
+		$contentDisposition = $cdEl instanceof Horde_Mime_Headers_ContentParam
+			? array_change_key_case($cdEl->params, CASE_LOWER)
+			: null;
 		if (!is_null($contentDisposition) && isset($contentDisposition['filename'])) {
 			$mimePart->setDispositionParameter('filename', $contentDisposition['filename']);
 		} else {
-			$contentDisposition = $mimeHeaders->getValue('content-type', Horde_Mime_Headers::VALUE_PARAMS);
-			if (isset($contentDisposition['name'])) {
-				$mimePart->setContentTypeParameter('name', $contentDisposition['name']);
+			$ctEl = $mimeHeaders['content-type'];
+			$contentTypeParams = $ctEl instanceof Horde_Mime_Headers_ContentParam
+				? array_change_key_case($ctEl->params, CASE_LOWER)
+				: null;
+			if (isset($contentTypeParams['name'])) {
+				$mimePart->setContentTypeParameter('name', $contentTypeParams['name']);
 			}
 		}
 
 		// Content transfer encoding
 		// Decrypted parts are already decoded because they went through the MIME parser
-		if (!$isEncrypted && $tmp = $mimeHeaders->getValue('content-transfer-encoding')) {
+		if (!$isEncrypted && $tmp = $mimeHeaders['content-transfer-encoding']?->value_single) {
 			$mimePart->setTransferEncoding($tmp);
 		}
 
 		/* Content type */
-		$contentType = $mimeHeaders->getValue('content-type');
+		$contentType = $mimeHeaders['content-type']?->value_single;
 		if (!is_null($contentType) && str_contains($contentType, 'text/calendar')) {
 			$mimePart->setType('text/calendar');
 			if ($mimePart->getContentTypeParameter('name') === null) {

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Tests\Unit\IMAP;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Imap_Client;
+use Horde_Imap_Client_Base;
 use Horde_Imap_Client_Data_Fetch;
 use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Fetch_Query;
@@ -748,5 +749,119 @@ class MessageMapperTest extends TestCase {
 			'google request' => ['request_google', true],
 			'outlook.com request' => ['request_outlook_com', true],
 		];
+	}
+
+	public function testGetAttachmentFilenameFromContentDisposition(): void {
+		$messageUid = 1;
+		$attachmentId = '2';
+		$bodyContent = 'attachment body content';
+		$headerText = "Content-Disposition: attachment; filename=\"test.pdf\"\r\n"
+			. "Content-Type: application/pdf\r\n"
+			. "Content-Transfer-Encoding: 7bit\r\n";
+		$fetchData = new Horde_Imap_Client_Data_Fetch();
+		$fetchData->setMimeHeader($attachmentId, $headerText);
+		$fetchData->setBodyPart($attachmentId, $bodyContent);
+		$fetchData->setUid($messageUid);
+		$fetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult[$messageUid] = $fetchData;
+		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
+		$imapClient->method('fetch')->willReturn($fetchResult);
+		$this->sMimeService->method('isEncrypted')->willReturn(false);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals('test.pdf', $attachment->getName());
+		$this->assertEquals('application/octet-stream', $attachment->getType());
+		$this->assertEquals($bodyContent, $attachment->getContent());
+	}
+
+	public function testGetAttachmentFilenameFromContentTypeName(): void {
+		$messageUid = 1;
+		$attachmentId = '2';
+		$bodyContent = 'attachment body content';
+		$headerText = "Content-Type: application/pdf; name=\"fallback.pdf\"\r\n"
+			. "Content-Transfer-Encoding: 7bit\r\n";
+		$fetchData = new Horde_Imap_Client_Data_Fetch();
+		$fetchData->setMimeHeader($attachmentId, $headerText);
+		$fetchData->setBodyPart($attachmentId, $bodyContent);
+		$fetchData->setUid($messageUid);
+		$fetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult[$messageUid] = $fetchData;
+		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
+		$imapClient->method('fetch')->willReturn($fetchResult);
+		$this->sMimeService->method('isEncrypted')->willReturn(false);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals('fallback.pdf', $attachment->getName());
+		$this->assertEquals('application/octet-stream', $attachment->getType());
+	}
+
+	public function testGetAttachmentTextCalendarContentType(): void {
+		$messageUid = 1;
+		$attachmentId = '2';
+		$bodyContent = 'BEGIN:VCALENDAR';
+		$headerText = "Content-Type: text/calendar; charset=utf-8\r\n"
+			. "Content-Transfer-Encoding: 7bit\r\n";
+		$fetchData = new Horde_Imap_Client_Data_Fetch();
+		$fetchData->setMimeHeader($attachmentId, $headerText);
+		$fetchData->setBodyPart($attachmentId, $bodyContent);
+		$fetchData->setUid($messageUid);
+		$fetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult[$messageUid] = $fetchData;
+		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
+		$imapClient->method('fetch')->willReturn($fetchResult);
+		$this->sMimeService->method('isEncrypted')->willReturn(false);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals('text/calendar', $attachment->getType());
+		$this->assertEquals('calendar.ics', $attachment->getName());
+	}
+
+	public function testGetAttachmentAppliesContentTransferEncoding(): void {
+		$messageUid = 1;
+		$attachmentId = '2';
+		$originalContent = 'hello world';
+		$bodyContent = base64_encode($originalContent);
+		$headerText = "Content-Type: application/octet-stream\r\n"
+			. "Content-Transfer-Encoding: base64\r\n";
+		$fetchData = new Horde_Imap_Client_Data_Fetch();
+		$fetchData->setMimeHeader($attachmentId, $headerText);
+		$fetchData->setBodyPart($attachmentId, $bodyContent);
+		$fetchData->setUid($messageUid);
+		$fetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult[$messageUid] = $fetchData;
+		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
+		$imapClient->method('fetch')->willReturn($fetchResult);
+		$this->sMimeService->method('isEncrypted')->willReturn(false);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals($originalContent, $attachment->getContent());
 	}
 }


### PR DESCRIPTION
For https://github.com/nextcloud/mail/pull/11224

```
Error: lib/IMAP/MessageMapper.php:805:39: UndefinedMagicMethod: Magic method Horde_Mime_Headers::getvalue does not exist (see https://psalm.dev/219)
Error: lib/IMAP/MessageMapper.php:809:40: UndefinedMagicMethod: Magic method Horde_Mime_Headers::getvalue does not exist (see https://psalm.dev/219)
Error: lib/IMAP/MessageMapper.php:817:45: UndefinedMagicMethod: Magic method Horde_Mime_Headers::getvalue does not exist (see https://psalm.dev/219)
Error: lib/IMAP/MessageMapper.php:822:32: UndefinedMagicMethod: Magic method Horde_Mime_Headers::getvalue does not exist (see https://psalm.dev/219)
```

`\Horde_Mime_Headers_Deprecated::getValue` is deprecated. This replaces the code with the "new" access pattern.

Tests pass before the actual changes and after, verifying that the change is safe.

AI-assisted: OpenCode + Claude Sonnet 4.6