### PR TITLE
fix(phishing): change header property accessor

### DIFF
--- a/lib/Service/PhishingDetection/PhishingDetectionService.php
+++ b/lib/Service/PhishingDetection/PhishingDetectionService.php
@@ -58,7 +58,7 @@ class PhishingDetectionService {
 			}
 		}
 
-		$date = $headers->getHeader('Date')?->value;
+		$date = $headers->getHeader('Date')?->value_single;
 
 		$list = new PhishingDetectionList();
 		if ($fromEmail !== null) {


### PR DESCRIPTION
For https://github.com/nextcloud/mail/pull/11224

`\Horde_Mime_Headers::getHeader` returns a `\Horde_Mime_Headers_Element`, which only has a magic property `value_single`.
Practically the accessor worked because `\Horde_Mime_Headers_Date` is a subclass of `\Horde_Mime_Headers_Element_Single`, which has `value`.

Both accessors return `$this->_value`, so this is just a small refactoring to make our tools happy :)

 AI-assisted: OpenCode + Claude Sonnet 4.6