### PR TITLE
test(unit): add coverage for entities, avatar factory and filter state

### DIFF
--- a/tests/Unit/Db/MessageRetentionTest.php
+++ b/tests/Unit/Db/MessageRetentionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\MessageRetention;
+
+class MessageRetentionTest extends TestCase {
+	private MessageRetention $messageRetention;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->messageRetention = new MessageRetention();
+	}
+
+	public function testConstructor(): void {
+		$messageRetention = new MessageRetention();
+
+		$this->assertInstanceOf(MessageRetention::class, $messageRetention);
+	}
+
+	public function testSetAndGetMailboxId(): void {
+		$mailboxId = 123;
+
+		$this->messageRetention->setMailboxId($mailboxId);
+		$result = $this->messageRetention->getMailboxId();
+
+		$this->assertSame($mailboxId, $result);
+	}
+
+	public function testSetAndGetUid(): void {
+		$uid = 456;
+
+		$this->messageRetention->setUid($uid);
+		$result = $this->messageRetention->getUid();
+
+		$this->assertSame($uid, $result);
+	}
+
+	public function testSetAndGetKnownSince(): void {
+		$knownSince = 1234567890;
+
+		$this->messageRetention->setKnownSince($knownSince);
+		$result = $this->messageRetention->getKnownSince();
+
+		$this->assertSame($knownSince, $result);
+	}
+
+	public function testMultipleSettersGetters(): void {
+		$mailboxId1 = 100;
+		$uid1 = 200;
+		$knownSince1 = 1000;
+		$mailboxId2 = 101;
+		$uid2 = 201;
+		$knownSince2 = 2000;
+
+		$this->messageRetention->setMailboxId($mailboxId1);
+		$this->messageRetention->setUid($uid1);
+		$this->messageRetention->setKnownSince($knownSince1);
+		$this->assertSame($mailboxId1, $this->messageRetention->getMailboxId());
+		$this->assertSame($uid1, $this->messageRetention->getUid());
+		$this->assertSame($knownSince1, $this->messageRetention->getKnownSince());
+
+		$this->messageRetention->setMailboxId($mailboxId2);
+		$this->messageRetention->setUid($uid2);
+		$this->messageRetention->setKnownSince($knownSince2);
+		$this->assertSame($mailboxId2, $this->messageRetention->getMailboxId());
+		$this->assertSame($uid2, $this->messageRetention->getUid());
+		$this->assertSame($knownSince2, $this->messageRetention->getKnownSince());
+	}
+
+	public function testSetAndGetMailboxIdZero(): void {
+		$mailboxId = 0;
+
+		$this->messageRetention->setMailboxId($mailboxId);
+		$result = $this->messageRetention->getMailboxId();
+
+		$this->assertSame($mailboxId, $result);
+	}
+
+	public function testSetAndGetUidZero(): void {
+		$uid = 0;
+
+		$this->messageRetention->setUid($uid);
+		$result = $this->messageRetention->getUid();
+
+		$this->assertSame($uid, $result);
+	}
+
+	public function testSetAndGetKnownSinceZero(): void {
+		$knownSince = 0;
+
+		$this->messageRetention->setKnownSince($knownSince);
+		$result = $this->messageRetention->getKnownSince();
+
+		$this->assertSame($knownSince, $result);
+	}
+
+	public function testSetAndGetLargeMailboxId(): void {
+		$mailboxId = 9223372036854775807;
+
+		$this->messageRetention->setMailboxId($mailboxId);
+		$result = $this->messageRetention->getMailboxId();
+
+		$this->assertSame($mailboxId, $result);
+	}
+}

--- a/tests/Unit/Db/MessageTagsTest.php
+++ b/tests/Unit/Db/MessageTagsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\MessageTags;
+
+class MessageTagsTest extends TestCase {
+	private MessageTags $messageTags;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->messageTags = new MessageTags();
+	}
+
+	public function testConstructor(): void {
+		$messageTags = new MessageTags();
+
+		$this->assertInstanceOf(MessageTags::class, $messageTags);
+	}
+
+	public function testSetAndGetImapMessageId(): void {
+		$imapMessageId = 'abc123def456';
+
+		$this->messageTags->setImapMessageId($imapMessageId);
+		$result = $this->messageTags->getImapMessageId();
+
+		$this->assertSame($imapMessageId, $result);
+	}
+
+	public function testSetAndGetTagId(): void {
+		$tagId = 42;
+
+		$this->messageTags->setTagId($tagId);
+		$result = $this->messageTags->getTagId();
+
+		$this->assertSame($tagId, $result);
+	}
+
+	public function testJsonSerialize(): void {
+		$imapMessageId = 'msg123';
+		$tagId = 5;
+
+		$this->messageTags->setImapMessageId($imapMessageId);
+		$this->messageTags->setTagId($tagId);
+
+		$result = $this->messageTags->jsonSerialize();
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertArrayHasKey('imapMessageId', $result);
+		$this->assertArrayHasKey('tagId', $result);
+		$this->assertSame($imapMessageId, $result['imapMessageId']);
+		$this->assertSame($tagId, $result['tagId']);
+	}
+
+	public function testJsonSerializeStructure(): void {
+		$imapMessageId = 'test-msg';
+		$tagId = 99;
+
+		$this->messageTags->setImapMessageId($imapMessageId);
+		$this->messageTags->setTagId($tagId);
+
+		$serialized = $this->messageTags->jsonSerialize();
+
+		$this->assertCount(3, $serialized);
+		$this->assertArrayHasKey('id', $serialized);
+		$this->assertArrayHasKey('imapMessageId', $serialized);
+		$this->assertArrayHasKey('tagId', $serialized);
+		$this->assertSame($imapMessageId, $serialized['imapMessageId']);
+		$this->assertSame($tagId, $serialized['tagId']);
+	}
+
+	public function testSetAndGetImapMessageIdWithEmptyString(): void {
+		$imapMessageId = '';
+
+		$this->messageTags->setImapMessageId($imapMessageId);
+		$result = $this->messageTags->getImapMessageId();
+
+		$this->assertSame($imapMessageId, $result);
+	}
+
+	public function testSetAndGetTagIdZero(): void {
+		$tagId = 0;
+
+		$this->messageTags->setTagId($tagId);
+		$result = $this->messageTags->getTagId();
+
+		$this->assertSame($tagId, $result);
+	}
+
+	public function testMultipleSettersGetters(): void {
+		$imapMessageId1 = 'msg1';
+		$tagId1 = 1;
+		$imapMessageId2 = 'msg2';
+		$tagId2 = 2;
+
+		$this->messageTags->setImapMessageId($imapMessageId1);
+		$this->messageTags->setTagId($tagId1);
+		$this->assertSame($imapMessageId1, $this->messageTags->getImapMessageId());
+		$this->assertSame($tagId1, $this->messageTags->getTagId());
+
+		$this->messageTags->setImapMessageId($imapMessageId2);
+		$this->messageTags->setTagId($tagId2);
+		$this->assertSame($imapMessageId2, $this->messageTags->getImapMessageId());
+		$this->assertSame($tagId2, $this->messageTags->getTagId());
+	}
+}

--- a/tests/Unit/Db/TrustedSenderTest.php
+++ b/tests/Unit/Db/TrustedSenderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\TrustedSender;
+
+class TrustedSenderTest extends TestCase {
+	private TrustedSender $trustedSender;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->trustedSender = new TrustedSender();
+	}
+
+	public function testSetAndGetEmail(): void {
+		$email = 'john@example.com';
+
+		$this->trustedSender->setEmail($email);
+		$result = $this->trustedSender->getEmail();
+
+		$this->assertSame($email, $result);
+	}
+
+	public function testSetAndGetUserId(): void {
+		$userId = 'user123';
+
+		$this->trustedSender->setUserId($userId);
+		$result = $this->trustedSender->getUserId();
+
+		$this->assertSame($userId, $result);
+	}
+
+	public function testSetAndGetType(): void {
+		$type = 'individual';
+
+		$this->trustedSender->setType($type);
+		$result = $this->trustedSender->getType();
+
+		$this->assertSame($type, $result);
+	}
+
+	public function testJsonSerialize(): void {
+		$email = 'alice@example.com';
+		$userId = 'alice';
+		$type = 'trusted';
+
+		$this->trustedSender->setEmail($email);
+		$this->trustedSender->setUserId($userId);
+		$this->trustedSender->setType($type);
+
+		$result = $this->trustedSender->jsonSerialize();
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', $result);
+		$this->assertArrayHasKey('email', $result);
+		$this->assertArrayHasKey('uid', $result);
+		$this->assertArrayHasKey('type', $result);
+		$this->assertSame($email, $result['email']);
+		$this->assertSame($userId, $result['uid']);
+		$this->assertSame($type, $result['type']);
+	}
+
+	public function testJsonSerializeStructure(): void {
+		$email = 'bob@example.com';
+		$userId = 'bob123';
+		$type = 'group';
+
+		$this->trustedSender->setEmail($email);
+		$this->trustedSender->setUserId($userId);
+		$this->trustedSender->setType($type);
+
+		$serialized = $this->trustedSender->jsonSerialize();
+
+		$this->assertCount(4, $serialized);
+		$this->assertArrayHasKey('id', $serialized);
+		$this->assertArrayHasKey('email', $serialized);
+		$this->assertArrayHasKey('uid', $serialized);
+		$this->assertArrayHasKey('type', $serialized);
+	}
+
+	public function testSetAndGetEmailWithMultipleAddresses(): void {
+		$email1 = 'first@example.com';
+		$email2 = 'second@example.com';
+
+		$this->trustedSender->setEmail($email1);
+		$this->assertSame($email1, $this->trustedSender->getEmail());
+
+		$this->trustedSender->setEmail($email2);
+		$this->assertSame($email2, $this->trustedSender->getEmail());
+	}
+
+	public function testSetAndGetUserIdWithVariousIds(): void {
+		$userId1 = 'user_001';
+		$userId2 = 'admin@example.com';
+
+		$this->trustedSender->setUserId($userId1);
+		$this->assertSame($userId1, $this->trustedSender->getUserId());
+
+		$this->trustedSender->setUserId($userId2);
+		$this->assertSame($userId2, $this->trustedSender->getUserId());
+	}
+
+	public function testSetAndGetTypeVariations(): void {
+		$types = ['individual', 'group', 'organization'];
+
+		foreach ($types as $type) {
+			$this->trustedSender->setType($type);
+			$this->assertSame($type, $this->trustedSender->getType());
+		}
+	}
+
+	public function testJsonSerializeWithEmptyEmail(): void {
+		$email = '';
+		$userId = 'testuser';
+		$type = 'trusted';
+
+		$this->trustedSender->setEmail($email);
+		$this->trustedSender->setUserId($userId);
+		$this->trustedSender->setType($type);
+
+		$result = $this->trustedSender->jsonSerialize();
+
+		$this->assertSame($email, $result['email']);
+		$this->assertSame($userId, $result['uid']);
+		$this->assertSame($type, $result['type']);
+	}
+}

--- a/tests/Unit/Service/Avatar/AvatarFactoryTest.php
+++ b/tests/Unit/Service/Avatar/AvatarFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\Avatar;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Service\Avatar\Avatar;
+use OCA\Mail\Service\Avatar\AvatarFactory;
+
+class AvatarFactoryTest extends TestCase {
+	private AvatarFactory $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new AvatarFactory();
+	}
+
+	public function testCreateInternalReturnsAvatarInstance(): void {
+		$url = 'https://internal.example.com/avatar.png';
+
+		$result = $this->factory->createInternal($url);
+
+		$this->assertInstanceOf(Avatar::class, $result);
+	}
+
+	public function testCreateInternalWithUrl(): void {
+		$url = 'https://internal.example.com/avatar.png';
+
+		$result = $this->factory->createInternal($url);
+
+		$this->assertSame($url, $result->getUrl());
+		$this->assertFalse($result->isExternal());
+		$this->assertNull($result->getMime());
+	}
+
+	public function testCreateExternalReturnsAvatarInstance(): void {
+		$url = 'https://external.example.com/avatar.png';
+		$mime = 'image/png';
+
+		$result = $this->factory->createExternal($url, $mime);
+
+		$this->assertInstanceOf(Avatar::class, $result);
+	}
+
+	public function testCreateExternalWithUrlAndMime(): void {
+		$url = 'https://external.example.com/avatar.jpg';
+		$mime = 'image/jpeg';
+
+		$result = $this->factory->createExternal($url, $mime);
+
+		$this->assertSame($url, $result->getUrl());
+		$this->assertTrue($result->isExternal());
+		$this->assertSame($mime, $result->getMime());
+	}
+}

--- a/tests/Unit/Service/MailFilter/FilterStateTest.php
+++ b/tests/Unit/Service/MailFilter/FilterStateTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\MailFilter;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Service\MailFilter\FilterState;
+
+class FilterStateTest extends TestCase {
+	public function testConstructor(): void {
+		$filters = ['filter1' => ['name' => 'Test']];
+
+		$state = new FilterState($filters);
+
+		$this->assertInstanceOf(FilterState::class, $state);
+	}
+
+	public function testFromJson(): void {
+		$data = ['filter1' => ['name' => 'Test Filter']];
+
+		$state = FilterState::fromJson($data);
+
+		$this->assertInstanceOf(FilterState::class, $state);
+		$this->assertSame($data, $state->getFilters());
+	}
+
+	public function testGetFilters(): void {
+		$filters = [
+			'filter1' => ['name' => 'Important'],
+			'filter2' => ['name' => 'Archive'],
+		];
+
+		$state = new FilterState($filters);
+
+		$this->assertSame($filters, $state->getFilters());
+	}
+
+	public function testJsonSerialize(): void {
+		$filters = ['filter1' => ['name' => 'Test']];
+		$state = new FilterState($filters);
+
+		$result = $state->jsonSerialize();
+
+		$this->assertSame($filters, $result);
+	}
+
+	public function testDefaultVersion(): void {
+		$this->assertSame(1, FilterState::DEFAULT_VERSION);
+	}
+
+	public function testEmptyFilters(): void {
+		$filters = [];
+		$state = new FilterState($filters);
+
+		$this->assertSame([], $state->getFilters());
+		$this->assertSame([], $state->jsonSerialize());
+	}
+
+	public function testFromJsonWithEmptyData(): void {
+		$data = [];
+
+		$state = FilterState::fromJson($data);
+
+		$this->assertSame([], $state->getFilters());
+	}
+
+	public function testComplexFilterStructure(): void {
+		$filters = [
+			'filter1' => [
+				'name' => 'Newsletters',
+				'rules' => [
+					['field' => 'from', 'value' => 'newsletter@example.com'],
+				],
+				'actions' => [
+					['type' => 'folder', 'value' => 'Newsletters'],
+				],
+			],
+		];
+		$state = new FilterState($filters);
+
+		$this->assertSame($filters, $state->getFilters());
+		$this->assertSame($filters, $state->jsonSerialize());
+	}
+}


### PR DESCRIPTION
Another batch of easy, straight forward test cases.

AI-assisted: OpenCode + Claude Haiku 4.5 - reviewed manually.