### PR TITLE
fix: Normalize message IDs via RFC822 parser to handle malformed input

### DIFF
--- a/lib/Db/Message.php
+++ b/lib/Db/Message.php
@@ -181,7 +181,7 @@ class Message extends Entity implements JsonSerializable {
 	 * before setting it, or sets null if it is not valid.
 	 */
 	public function setMessageId(?string $messageId): void {
-		$this->setMessageIdFieldIfNotEmpty('messageId', $messageId);
+		$this->setter('messageId', [$this->parseMessageId($messageId)]);
 	}
 
 	public function setRawReferences(?string $references): void {
@@ -190,19 +190,23 @@ class Message extends Entity implements JsonSerializable {
 	}
 
 	public function setInReplyTo(?string $inReplyTo): void {
-		$this->setMessageIdFieldIfNotEmpty('inReplyTo', $inReplyTo);
+		$this->setter('inReplyTo', [$this->parseMessageId($inReplyTo)]);
 	}
 
-	public function setThreadRootId(?string $messageId): void {
-		$threadRootId = (!empty($messageId)) ? '<' . rtrim(ltrim($messageId, '<'), '>') . '>' : $this->getMessageId();
-		$parsed = new Horde_Mail_Rfc822_Identification($threadRootId);
-		$this->setter('threadRootId', [$parsed->ids[0] ?? $this->getMessageId()]);
+	public function setThreadRootId(?string $threadRootId): void {
+		$this->setter('threadRootId', [$this->parseMessageId($threadRootId) ?? $this->messageId]);
 	}
 
-	private function setMessageIdFieldIfNotEmpty(string $field, ?string $id): void {
-		$id = (!empty($id)) ? '<' . rtrim(ltrim($id, '<'), '>') . '>' : null;
+	private function parseMessageId(?string $id): ?string {
+		if (empty($id)) {
+			return null;
+		}
+
+		// trim whitespace and <>
+		$id = '<' . trim(trim($id), '<>') . '>';
+
 		$parsed = new Horde_Mail_Rfc822_Identification($id);
-		$this->setter($field, [$parsed->ids[0] ?? null]);
+		return $parsed->ids[0] ?? null;
 	}
 
 	/**

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -17,6 +17,7 @@ use Horde_Imap_Client_Exception_NoSupportExtension;
 use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Ids;
 use Horde_ListHeaders;
+use Horde_Mail_Rfc822_Identification;
 use Horde_Mime_Exception;
 use Horde_Mime_Headers;
 use Horde_Mime_Part;
@@ -246,9 +247,13 @@ class ImapMessageFetcher {
 		$this->parseHeaders($fetch);
 
 		$envelope = $fetch->getEnvelope();
+
+		$messageId = new Horde_Mail_Rfc822_Identification($envelope->message_id);
+		$inReplyTo = new Horde_Mail_Rfc822_Identification($envelope->in_reply_to);
+
 		return new IMAPMessage(
 			$this->uid,
-			$envelope->message_id,
+			$messageId->ids[0] ?? '',
 			$fetch->getFlags(),
 			AddressList::fromHorde($envelope->from),
 			AddressList::fromHorde($envelope->to),
@@ -271,7 +276,7 @@ class ImapMessageFetcher {
 			$this->unsubscribeUrl,
 			$this->isOneClickUnsubscribe,
 			$this->unsubscribeMailto,
-			$envelope->in_reply_to,
+			$inReplyTo->ids[0] ?? '',
 			$isEncrypted,
 			$isSigned,
 			$signatureIsValid,

--- a/tests/Unit/Db/MessageTest.php
+++ b/tests/Unit/Db/MessageTest.php
@@ -7,15 +7,13 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\Mail\Tests\Integration\Db;
+namespace OCA\Mail\Tests\Unit\Db;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Service\Avatar\Avatar;
 
 class MessageTest extends TestCase {
-	protected function setUp(): void {
-	}
 
 	public function testNewForMessageId(): void {
 		$expected = '<abc@123.com>';
@@ -42,23 +40,48 @@ class MessageTest extends TestCase {
 
 	public function testNewWithMessageIdOneAngleBrackets(): void {
 		$expected = '<abc@123.com>';
-		$noBrackets = '<abc@123.com';
 		$message = new Message();
 
-		$message->setMessageId($noBrackets);
-		$message->setThreadRootId($noBrackets);
+		$message->setMessageId('abc@123.com>');
+		$message->setThreadRootId('abc@123.com>');
 
 		$this->assertEquals($expected, $message->getMessageId());
 		$this->assertEquals($expected, $message->getThreadRootId());
+	}
 
-		$noBrackets = 'abc@123.com>';
+	public function testLeadingNewlineOutlook(): void {
 		$message = new Message();
+		$message->setMessageId("\n <abc@123.com>");
 
-		$message->setMessageId($noBrackets);
-		$message->setThreadRootId($noBrackets);
+		$this->assertEquals('<abc@123.com>', $message->getMessageId());
+	}
 
-		$this->assertEquals($expected, $message->getMessageId());
-		$this->assertEquals($expected, $message->getThreadRootId());
+	public function testLeadingCrLfFoldedHeader(): void {
+		$message = new Message();
+		$message->setMessageId("\r\n <abc@123.com>");
+
+		$this->assertEquals('<abc@123.com>', $message->getMessageId());
+	}
+
+	public function testLeadingWhitespace(): void {
+		$message = new Message();
+		$message->setMessageId('   <abc@123.com>');
+
+		$this->assertEquals('<abc@123.com>', $message->getMessageId());
+	}
+
+	public function testTrailingWhitespace(): void {
+		$message = new Message();
+		$message->setMessageId('<abc@123.com>   ');
+
+		$this->assertEquals('<abc@123.com>', $message->getMessageId());
+	}
+
+	public function testOutlookMultipleAtSigns(): void {
+		$message = new Message();
+		$message->setMessageId('<abc@@example.com>');
+
+		$this->assertEquals('<abc@@example.com>', $message->getMessageId());
 	}
 
 	public function testThreadrootIdNull(): void {


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/12558

AI-assisted: Claude Sonnet 4.6