### PR TITLE
refactor(ui): make the directives Vue 3 compatible

### DIFF
--- a/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
+++ b/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js
@@ -6,7 +6,7 @@ import defer from 'lodash/defer.js'
 import dragEventBus from '../util/dragEventBus.js'
 
 export class DraggableEnvelope {
-	constructor(el, componentInstance, options) {
+	constructor(el, options) {
 		this.el = el
 		this.options = options
 		this.registerListeners.bind(this)(el)
@@ -44,7 +44,7 @@ export class DraggableEnvelope {
 		const envelopes = []
 		if (selectedEnvelopes.length) {
 			// handle dragged selection mode items
-			selectedEnvelopes.forEach((envelope, index) => {
+			selectedEnvelopes.forEach((envelope) => {
 				envelopes.push({
 					accountId,
 					mailboxId,
@@ -68,7 +68,7 @@ export class DraggableEnvelope {
 		})
 	}
 
-	onDragEnd(event) {
+	onDragEnd() {
 		dragEventBus.emit('drag-end', { accountId: this.options.accountId })
 	}
 

--- a/src/directives/drag-and-drop/draggable-envelope/index.js
+++ b/src/directives/drag-and-drop/draggable-envelope/index.js
@@ -6,23 +6,34 @@ import { DraggableEnvelope } from './draggable-envelope.js'
 
 let instances = []
 
-export const DraggableEnvelopeDirective = {
-	bind(el, binding, vnode) {
-		const instance = new DraggableEnvelope(el, vnode.context, binding.value)
-		instances.push(instance)
-	},
-	componentUpdated(el, binding) {
-		const options = binding.value
-		setTimeout(() => {
-			instances.forEach((instance) => {
-				instance.options.selectedEnvelopes = options.selectedEnvelopes
-				instance.update(el, instance)
-			})
+function onBind(el, binding) {
+	const instance = new DraggableEnvelope(el, binding.value)
+	instances.push(instance)
+}
+
+function onUpdate(el, binding) {
+	const options = binding.value
+	setTimeout(() => {
+		instances.forEach((instance) => {
+			instance.options.selectedEnvelopes = options.selectedEnvelopes
+			instance.update(el, instance)
 		})
-	},
-	unbind(el) {
-		instances = instances.filter((instance) => instance.el !== el)
-	},
+	})
+}
+
+function onUnbind(el) {
+	instances = instances.filter((instance) => instance.el !== el)
+}
+
+export const DraggableEnvelopeDirective = {
+	// Vue 2
+	bind: onBind,
+	componentUpdated: onUpdate,
+	unbind: onUnbind,
+	// Vue 3
+	mounted: onBind,
+	updated: onUpdate,
+	unmounted: onUnbind,
 }
 
 export default DraggableEnvelope

--- a/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
@@ -6,7 +6,7 @@ import logger from '../../../logger.js'
 import dragEventBus from '../util/dragEventBus.js'
 
 export class DroppableMailbox {
-	constructor(el, componentInstance, options) {
+	constructor(el, options) {
 		this.el = el
 		this.options = options
 		this.mainStore = options.mainStore

--- a/src/directives/drag-and-drop/droppable-mailbox/index.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/index.js
@@ -6,14 +6,22 @@ import { DroppableMailbox } from './droppable-mailbox.js'
 
 let instance
 
+function onBind(el, binding) {
+	instance = new DroppableMailbox(el, binding.value)
+}
+
+function onUpdate(el, binding) {
+	instance.options = binding.value
+	instance.update(el, instance)
+}
+
 export const DroppableMailboxDirective = {
-	bind(el, binding, vnode) {
-		instance = new DroppableMailbox(el, vnode.context, binding.value)
-	},
-	componentUpdated(el, binding) {
-		instance.options = binding.value
-		instance.update(el, instance)
-	},
+	// Vue 2
+	bind: onBind,
+	componentUpdated: onUpdate,
+	// Vue 3
+	mounted: onBind,
+	updated: onUpdate,
 }
 
 export default DroppableMailbox

--- a/src/directives/infinite-scroll.js
+++ b/src/directives/infinite-scroll.js
@@ -4,222 +4,218 @@
  * SPDX-License-Identifier: MIT
  *
  * Vendored and fixed version of the abandoned https://github.com/ElemeFE/vue-infinite-scroll lib
+ * Refactored for Vue 2.7 / Vue 3 dual compatibility.
  */
-/* eslint-disable */
-const ctx = '@@InfiniteScroll';
 
-var throttle = function (fn, delay) {
-  var now, lastExec, timer, context, args;  
+import { nextTick } from 'vue'
 
-  var execute = function () {
-    fn.apply(context, args);
-    lastExec = now;
-  };
+const ctx = '@@InfiniteScroll'
 
-  return function () {
-    context = this;
-    args = arguments;
+function throttle(fn, delay) {
+	let now, lastExec, timer, context, args
 
-    now = Date.now();
+	const execute = function() {
+		fn.apply(context, args)
+		lastExec = now
+	}
 
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
+	return function() {
+		context = this
+		args = arguments
 
-    if (lastExec) {
-      var diff = delay - (now - lastExec);
-      if (diff < 0) {
-        execute();
-      } else {
-        timer = setTimeout(() => {
-          execute();
-        }, diff);
-      }
-    } else {
-      execute();
-    }
-  };
-};
+		now = Date.now()
 
-var getScrollTop = function (element) {
-  if (element === window) {
-    return Math.max(window.pageYOffset || 0, document.documentElement.scrollTop);
-  }
+		if (timer) {
+			clearTimeout(timer)
+			timer = null
+		}
 
-  return element.scrollTop;
-};
+		if (lastExec) {
+			const diff = delay - (now - lastExec)
+			if (diff < 0) {
+				execute()
+			} else {
+				timer = setTimeout(() => {
+					execute()
+				}, diff)
+			}
+		} else {
+			execute()
+		}
+	}
+}
 
-var getComputedStyle = document.defaultView.getComputedStyle;
+function getScrollTop(element) {
+	if (element === window) {
+		return Math.max(window.pageYOffset || 0, document.documentElement.scrollTop)
+	}
 
-var getScrollEventTarget = function (element) {
-  var currentNode = element;
-  // bugfix, see http://w3help.org/zh-cn/causes/SD9013 and http://stackoverflow.com/questions/17016740/onscroll-function-is-not-working-for-chrome
-  while (currentNode && currentNode.tagName !== 'HTML' && currentNode.tagName !== 'BODY' && currentNode.nodeType === 1) {
-    var overflowY = getComputedStyle(currentNode).overflowY;
-    if (overflowY === 'scroll' || overflowY === 'auto') {
-      return currentNode;
-    }
-    currentNode = currentNode.parentNode;
-  }
-  return window;
-};
+	return element.scrollTop
+}
 
-var getVisibleHeight = function (element) {
-  if (element === window) {
-    return document.documentElement.clientHeight;
-  }
+const getComputedStyle = document.defaultView.getComputedStyle
 
-  return element.clientHeight;
-};
+function getScrollEventTarget(element) {
+	let currentNode = element
+	while (currentNode && currentNode.tagName !== 'HTML' && currentNode.tagName !== 'BODY' && currentNode.nodeType === 1) {
+		const overflowY = getComputedStyle(currentNode).overflowY
+		if (overflowY === 'scroll' || overflowY === 'auto') {
+			return currentNode
+		}
+		currentNode = currentNode.parentNode
+	}
+	return window
+}
 
-var getElementTop = function (element) {
-  if (element === window) {
-    return getScrollTop(window);
-  }
-  return element.getBoundingClientRect().top + getScrollTop(window);
-};
+function getVisibleHeight(element) {
+	if (element === window) {
+		return document.documentElement.clientHeight
+	}
 
-var isAttached = function (element) {
-  var currentNode = element.parentNode;
-  while (currentNode) {
-    if (currentNode.tagName === 'HTML') {
-      return true;
-    }
-    if (currentNode.nodeType === 11) {
-      return false;
-    }
-    currentNode = currentNode.parentNode;
-  }
-  return false;
-};
+	return element.clientHeight
+}
 
-var doBind = function () {
-  if (this.binded) return;  
-  this.binded = true;
+function getElementTop(element) {
+	if (element === window) {
+		return getScrollTop(window)
+	}
+	return element.getBoundingClientRect().top + getScrollTop(window)
+}
 
-  var directive = this;
-  var element = directive.el;
+function isAttached(element) {
+	let currentNode = element.parentNode
+	while (currentNode) {
+		if (currentNode.tagName === 'HTML') {
+			return true
+		}
+		if (currentNode.nodeType === 11) {
+			return false
+		}
+		currentNode = currentNode.parentNode
+	}
+	return false
+}
 
-  var throttleDelayExpr = element.getAttribute('infinite-scroll-throttle-delay');
-  var throttleDelay = 200;
-  if (throttleDelayExpr) {
-    throttleDelay = Number(directive.vm[throttleDelayExpr] || throttleDelayExpr);
-    if (isNaN(throttleDelay) || throttleDelay < 0) {
-      throttleDelay = 200;
-    }
-  }
-  directive.throttleDelay = throttleDelay;
+function doBind() {
+	if (this.binded) {
+		return
+	}
+	this.binded = true
 
-  directive.scrollEventTarget = getScrollEventTarget(element);
-  directive.scrollListener = throttle(doCheck.bind(directive), directive.throttleDelay);
-  directive.scrollEventTarget.addEventListener('scroll', directive.scrollListener);
+	const directive = this
+	const element = directive.el
 
-  // TODO: refactor to use directive hooks from vue 3
-  //       https://vuejs.org/guide/reusability/custom-directives.html#directive-hooks
-  this.vm.$on('hook:beforeDestroy', function () {
-    directive.scrollEventTarget.removeEventListener('scroll', directive.scrollListener);
-  });
+	const throttleDelayExpr = element.getAttribute('infinite-scroll-throttle-delay')
+	let throttleDelay = 200
+	if (throttleDelayExpr) {
+		throttleDelay = Number(directive.vm[throttleDelayExpr] || throttleDelayExpr)
+		if (isNaN(throttleDelay) || throttleDelay < 0) {
+			throttleDelay = 200
+		}
+	}
+	directive.throttleDelay = throttleDelay
 
-  var disabledExpr = element.getAttribute('infinite-scroll-disabled');
-  var disabled = false;
+	directive.scrollEventTarget = getScrollEventTarget(element)
+	directive.scrollListener = throttle(doCheck.bind(directive), directive.throttleDelay)
+	directive.scrollEventTarget.addEventListener('scroll', directive.scrollListener)
 
-  if (disabledExpr) {
-    this.vm.$watch(disabledExpr, function(value) {
-      directive.disabled = value;
-      if (!value && directive.immediateCheck) {
-        doCheck.call(directive);
-      }
-    });
-    disabled = Boolean(directive.vm[disabledExpr]);
-  }
-  directive.disabled = disabled;
+	const disabledExpr = element.getAttribute('infinite-scroll-disabled')
+	let disabled = false
 
-  var distanceExpr = element.getAttribute('infinite-scroll-distance');
-  var distance = 0;
-  if (distanceExpr) {
-    distance = Number(directive.vm[distanceExpr] || distanceExpr);
-    if (isNaN(distance)) {
-      distance = 0;
-    }
-  }
-  directive.distance = distance;
+	if (disabledExpr) {
+		disabled = Boolean(directive.vm[disabledExpr])
+	}
+	directive.disabled = disabled
 
-  var immediateCheckExpr = element.getAttribute('infinite-scroll-immediate-check');
-  var immediateCheck = true;
-  if (immediateCheckExpr) {
-    immediateCheck = Boolean(directive.vm[immediateCheckExpr]);
-  }
-  directive.immediateCheck = immediateCheck;
+	const distanceExpr = element.getAttribute('infinite-scroll-distance')
+	let distance = 0
+	if (distanceExpr) {
+		distance = Number(directive.vm[distanceExpr] || distanceExpr)
+		if (isNaN(distance)) {
+			distance = 0
+		}
+	}
+	directive.distance = distance
 
-  if (immediateCheck) {
-    doCheck.call(directive);
-  }
+	const immediateCheckExpr = element.getAttribute('infinite-scroll-immediate-check')
+	let immediateCheck = true
+	if (immediateCheckExpr) {
+		immediateCheck = Boolean(directive.vm[immediateCheckExpr])
+	}
+	directive.immediateCheck = immediateCheck
 
-  var eventName = element.getAttribute('infinite-scroll-listen-for-event');
-  if (eventName) {
-    directive.vm.$on(eventName, function() {
-      doCheck.call(directive);
-    });
-  }
-};
+	if (immediateCheck) {
+		doCheck.call(directive)
+	}
+}
 
-var doCheck = function (force) {
-  var scrollEventTarget = this.scrollEventTarget;
-  var element = this.el;
-  var distance = this.distance;
+function doCheck(force) {
+	const scrollEventTarget = this.scrollEventTarget
+	const element = this.el
+	const distance = this.distance
 
-  if (force !== true && this.disabled) return;  
-  var viewportScrollTop = getScrollTop(scrollEventTarget);
-  var viewportBottom = viewportScrollTop + getVisibleHeight(scrollEventTarget);
+	if (force !== true && this.disabled) {
+		return
+	}
+	const viewportScrollTop = getScrollTop(scrollEventTarget)
+	const viewportBottom = viewportScrollTop + getVisibleHeight(scrollEventTarget)
 
-  var shouldTrigger = false;
+	let shouldTrigger = false
 
-  if (scrollEventTarget === element) {
-    shouldTrigger = scrollEventTarget.scrollHeight - viewportBottom <= distance;
-  } else {
-    var elementBottom = getElementTop(element) - getElementTop(scrollEventTarget) + element.offsetHeight + viewportScrollTop;
+	if (scrollEventTarget === element) {
+		shouldTrigger = scrollEventTarget.scrollHeight - viewportBottom <= distance
+	} else {
+		const elementBottom = getElementTop(element) - getElementTop(scrollEventTarget) + element.offsetHeight + viewportScrollTop
 
-    shouldTrigger = viewportBottom + distance >= elementBottom;
-  }
+		shouldTrigger = viewportBottom + distance >= elementBottom
+	}
 
-  if (shouldTrigger && this.expression) {
-    this.expression();
-  }
-};
+	if (shouldTrigger && this.expression) {
+		this.expression()
+	}
+}
+
+function onBind(el, binding, vnode) {
+	el[ctx] = {
+		el,
+		vm: binding.instance ?? vnode.context,
+		expression: binding.value,
+	}
+
+	nextTick(function() {
+		if (isAttached(el)) {
+			doBind.call(el[ctx])
+		}
+
+		el[ctx].bindTryCount = 0
+
+		const tryBind = function() {
+			if (el[ctx].bindTryCount > 10) {
+				return
+			}
+			el[ctx].bindTryCount++
+			if (isAttached(el)) {
+				doBind.call(el[ctx])
+			} else {
+				setTimeout(tryBind, 50)
+			}
+		}
+
+		tryBind()
+	})
+}
+
+function onUnbind(el) {
+	if (el && el[ctx] && el[ctx].scrollEventTarget) {
+		el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener)
+	}
+}
 
 export default {
-  bind(el, binding, vnode) {
-    el[ctx] = {
-      el,
-      vm: vnode.context,
-      expression: binding.value
-    };
-    const args = arguments;
-    console.info('binding', el, binding, vnode)
-    el[ctx].vm.$nextTick(function () {
-      if (isAttached(el)) {
-        doBind.call(el[ctx], args);
-      }
-
-      el[ctx].bindTryCount = 0;
-
-      var tryBind = function () {
-        if (el[ctx].bindTryCount > 10) return;  
-        el[ctx].bindTryCount++;
-        if (isAttached(el)) {
-          doBind.call(el[ctx], args);
-        } else {
-          setTimeout(tryBind, 50);
-        }
-      };
-
-      tryBind();
-    });
-  },
-
-  unbind(el) {
-    if (el && el[ctx] && el[ctx].scrollEventTarget)
-      el[ctx].scrollEventTarget.removeEventListener('scroll', el[ctx].scrollListener);
-  }
-};
+	// Vue 2
+	bind: onBind,
+	unbind: onUnbind,
+	// Vue 3
+	mounted: onBind,
+	unmounted: onUnbind,
+}


### PR DESCRIPTION
For https://github.com/nextcloud/groupware/issues/64

Drag-and-drop and infinite scroll still works and this way it's compatible with Vue 2.7 and Vue 3.

AI-assisted: Claude Code + Opus 4.6