### PR TITLE
refactor(ui): replace Vue2-only click outside mixin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "vue-dndrop": "^1.3.4",
         "vue-frag": "^1.4.3",
         "vue-material-design-icons": "^5.3.1",
-        "vue-on-click-outside": "^1.0.3",
         "vue-router": "^3.6.5",
         "vue-shortkey": "^3.1.7",
         "vue-tabs-component": "^1.5.0",
@@ -17139,11 +17138,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.3.1.tgz",
       "integrity": "sha512-6UNEyhlTzlCeT8ZeX5WbpUGFTTPSbOoTQeoASTv7X4Ylh0pe8vltj+36VMK56KM0gG8EQVoMK/Qw/6evalg8lA=="
-    },
-    "node_modules/vue-on-click-outside": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/vue-on-click-outside/-/vue-on-click-outside-1.0.3.tgz",
-      "integrity": "sha512-eaL3ORsSGl9L1kyZe6Dw6geqzhdJfjrWdm6VGyNey7+0irABZIKILlQbm4nis1ScMB60HHqDC8XwzskcpYWuXQ=="
     },
     "node_modules/vue-resize": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "vue-dndrop": "^1.3.4",
     "vue-frag": "^1.4.3",
     "vue-material-design-icons": "^5.3.1",
-    "vue-on-click-outside": "^1.0.3",
     "vue-router": "^3.6.5",
     "vue-shortkey": "^3.1.7",
     "vue-tabs-component": "^1.5.0",

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -84,7 +84,6 @@ import { FilePickerVue as FilePicker } from '@nextcloud/dialogs/filepicker.js'
 import { formatFileSize } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
 import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading } from '@nextcloud/vue'
-import { mixin as onClickOutside } from 'vue-on-click-outside'
 import IconArrow from 'vue-material-design-icons/ArrowLeft.vue'
 import IconSave from 'vue-material-design-icons/FolderOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -106,7 +105,6 @@ export default {
 		IconDownload,
 	},
 
-	mixins: [onClickOutside],
 	props: {
 		id: {
 			type: String,
@@ -173,6 +171,14 @@ export default {
 		}
 	},
 
+	mounted() {
+		document.addEventListener('click', this.handleClickOutside)
+	},
+
+	beforeUnmount() {
+		document.removeEventListener('click', this.handleClickOutside)
+	},
+
 	computed: {
 		name() {
 			if (this.mime === 'message/rfc822') {
@@ -203,6 +209,16 @@ export default {
 	},
 
 	methods: {
+		handleClickOutside(event) {
+			if (!this.showCalendarPopover) {
+				return
+			}
+
+			if (this.$el && !this.$el.contains(event.target)) {
+				this.closeCalendarPopover()
+			}
+		},
+
 		humanReadable(size) {
 			return formatFileSize(size)
 		},


### PR DESCRIPTION
For https://github.com/nextcloud/groupware/issues/64

The custom event handler is simple enough - tested and works

AI-assisted: Claude Code + Claude Sonnet 4.5