### PR TITLE
ci: split codecov status for unit and integration test coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,17 @@
 # SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 comment: false
+coverage:
+  status:
+    project:
+      unit:
+        target: auto
+        flags:
+          - unittests
+      integration:
+        target: auto
+        flags:
+          - integrationtests
 ignore:
   - "tests"
   - "lib/Vendor"


### PR DESCRIPTION
We separately upload unit and integration test coverage. I just enabled flags at https://app.codecov.io/gh/nextcloud/mail/flags/new to have a split report. With the config change we should be able to also get two distinct PR checks.