### PR TITLE
refactor: inject $userId instead of $UserId

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -106,7 +106,7 @@ final class Application extends App implements IBootstrap {
 
 		$context->registerService('userFolder', static function (ContainerInterface $c) {
 			$userContainer = $c->get(IServerContainer::class);
-			$uid = $c->get('UserId');
+			$uid = $c->get('userId');
 
 			return $userContainer->getUserFolder($uid);
 		});

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -57,7 +57,7 @@ class AccountsController extends Controller {
 		string $appName,
 		IRequest $request,
 		AccountService $accountService,
-		$UserId,
+		$userId,
 		LoggerInterface $logger,
 		IL10N $l10n,
 		AliasesService $aliasesService,
@@ -72,7 +72,7 @@ class AccountsController extends Controller {
 	) {
 		parent::__construct($appName, $request);
 		$this->accountService = $accountService;
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->logger = $logger;
 		$this->l10n = $l10n;
 		$this->aliasesService = $aliasesService;

--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -27,10 +27,10 @@ class AliasesController extends Controller {
 	public function __construct(string $appName,
 		IRequest $request,
 		AliasesService $aliasesService,
-		string $UserId) {
+		string $userId) {
 		parent::__construct($appName, $request);
 		$this->aliasService = $aliasesService;
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 	}
 
 	/**

--- a/lib/Controller/AvatarsController.php
+++ b/lib/Controller/AvatarsController.php
@@ -27,11 +27,11 @@ class AvatarsController extends Controller {
 	public function __construct(string $appName,
 		IRequest $request,
 		IAvatarService $avatarService,
-		string $UserId) {
+		string $userId) {
 		parent::__construct($appName, $request);
 
 		$this->avatarService = $avatarService;
-		$this->uid = $UserId;
+		$this->uid = $userId;
 	}
 
 	/**

--- a/lib/Controller/ContactIntegrationController.php
+++ b/lib/Controller/ContactIntegrationController.php
@@ -30,12 +30,12 @@ class ContactIntegrationController extends Controller {
 		IRequest $request,
 		ContactIntegrationService $service,
 		ICacheFactory $cacheFactory,
-		string $UserId) {
+		string $userId) {
 		parent::__construct($appName, $request);
 
 		$this->service = $service;
 		$this->cache = $cacheFactory->createLocal('mail.contacts');
-		$this->uid = $UserId;
+		$this->uid = $userId;
 	}
 
 	/**

--- a/lib/Controller/DraftsController.php
+++ b/lib/Controller/DraftsController.php
@@ -33,14 +33,14 @@ class DraftsController extends Controller {
 
 
 	public function __construct(string $appName,
-		$UserId,
+		$userId,
 		IRequest $request,
 		DraftsService $service,
 		AccountService $accountService,
 		ITimeFactory $timeFactory,
 		SmimeService $smimeService) {
 		parent::__construct($appName, $request);
-		$this->userId = $UserId;
+		$this->userId = $userId;
 		$this->service = $service;
 		$this->accountService = $accountService;
 		$this->timeFactory = $timeFactory;

--- a/lib/Controller/GoogleIntegrationController.php
+++ b/lib/Controller/GoogleIntegrationController.php
@@ -38,13 +38,13 @@ class GoogleIntegrationController extends Controller {
 
 
 	public function __construct(IRequest $request,
-		?string $UserId,
+		?string $userId,
 		GoogleIntegration $googleIntegration,
 		AccountService $accountService,
 		LoggerInterface $logger,
 		MailboxSync $mailboxSync) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->userId = $UserId;
+		$this->userId = $userId;
 		$this->googleIntegration = $googleIntegration;
 		$this->accountService = $accountService;
 		$this->logger = $logger;

--- a/lib/Controller/LocalAttachmentsController.php
+++ b/lib/Controller/LocalAttachmentsController.php
@@ -31,10 +31,10 @@ class LocalAttachmentsController extends Controller {
 	 * @param string $UserId
 	 */
 	public function __construct(string $appName, IRequest $request,
-		IAttachmentService $attachmentService, $UserId) {
+		IAttachmentService $attachmentService, $userId) {
 		parent::__construct($appName, $request);
 		$this->attachmentService = $attachmentService;
-		$this->userId = $UserId;
+		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -43,7 +43,7 @@ class MailboxesController extends Controller {
 		string $appName,
 		IRequest $request,
 		AccountService $accountService,
-		?string $UserId,
+		?string $userId,
 		IMailManager $mailManager,
 		SyncService $syncService,
 		private readonly IConfig $config,
@@ -52,7 +52,7 @@ class MailboxesController extends Controller {
 		parent::__construct($appName, $request);
 
 		$this->accountService = $accountService;
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->mailManager = $mailManager;
 		$this->syncService = $syncService;
 	}

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -83,7 +83,7 @@ class MessagesController extends Controller {
 		IMailManager $mailManager,
 		IMailSearch $mailSearch,
 		ItineraryService $itineraryService,
-		?string $UserId,
+		?string $userId,
 		$userFolder,
 		LoggerInterface $logger,
 		IL10N $l10n,
@@ -105,7 +105,7 @@ class MessagesController extends Controller {
 		$this->mailManager = $mailManager;
 		$this->mailSearch = $mailSearch;
 		$this->itineraryService = $itineraryService;
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->userFolder = $userFolder;
 		$this->logger = $logger;
 		$this->l10n = $l10n;

--- a/lib/Controller/MicrosoftIntegrationController.php
+++ b/lib/Controller/MicrosoftIntegrationController.php
@@ -31,12 +31,12 @@ class MicrosoftIntegrationController extends Controller {
 	private LoggerInterface $logger;
 
 	public function __construct(IRequest $request,
-		?string $UserId,
+		?string $userId,
 		AccountService $accountService,
 		MicrosoftIntegration $microsoftIntegration,
 		LoggerInterface $logger) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->userId = $UserId;
+		$this->userId = $userId;
 		$this->accountService = $accountService;
 		$this->microsoftIntegration = $microsoftIntegration;
 		$this->logger = $logger;

--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -31,13 +31,13 @@ class OutboxController extends Controller {
 	private SmimeService $smimeService;
 
 	public function __construct(string $appName,
-		$UserId,
+		$userId,
 		IRequest $request,
 		OutboxService $service,
 		AccountService $accountService,
 		SmimeService $smimeService) {
 		parent::__construct($appName, $request);
-		$this->userId = $UserId;
+		$this->userId = $userId;
 		$this->service = $service;
 		$this->accountService = $accountService;
 		$this->smimeService = $smimeService;

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -83,7 +83,7 @@ class PageController extends Controller {
 		IConfig $config,
 		AccountService $accountService,
 		AliasesService $aliasesService,
-		?string $UserId,
+		?string $userId,
 		IUserSession $userSession,
 		IUserPreferences $preferences,
 		IMailManager $mailManager,
@@ -109,7 +109,7 @@ class PageController extends Controller {
 		$this->config = $config;
 		$this->accountService = $accountService;
 		$this->aliasesService = $aliasesService;
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->userSession = $userSession;
 		$this->preferences = $preferences;
 		$this->mailManager = $mailManager;

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -27,11 +27,11 @@ class PreferencesController extends Controller {
 	 * @param IUserPreferences $userPreference
 	 * @param string $UserId
 	 */
-	public function __construct(IRequest $request, IUserPreferences $userPreference, string $UserId) {
+	public function __construct(IRequest $request, IUserPreferences $userPreference, string $userId) {
 		parent::__construct('mail', $request);
 
 		$this->userPreference = $userPreference;
-		$this->userId = $UserId;
+		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/SieveController.php
+++ b/lib/Controller/SieveController.php
@@ -39,7 +39,7 @@ class SieveController extends Controller {
 
 	public function __construct(
 		IRequest $request,
-		string $UserId,
+		string $userId,
 		MailAccountMapper $mailAccountMapper,
 		SieveClientFactory $sieveClientFactory,
 		ICrypto $crypto,
@@ -48,7 +48,7 @@ class SieveController extends Controller {
 		private SieveService $sieveService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->mailAccountMapper = $mailAccountMapper;
 		$this->sieveClientFactory = $sieveClientFactory;
 		$this->crypto = $crypto;

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -30,12 +30,12 @@ class TagsController extends Controller {
 
 
 	public function __construct(IRequest $request,
-		string $UserId,
+		string $userId,
 		IMailManager $mailManager,
 		AccountService $accountService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->mailManager = $mailManager;
 		$this->accountService = $accountService;
 	}

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -36,14 +36,14 @@ class ThreadController extends Controller {
 
 	public function __construct(string $appName,
 		IRequest $request,
-		string $UserId,
+		string $userId,
 		AccountService $accountService,
 		IMailManager $mailManager,
 		SnoozeService $snoozeService,
 		AiIntegrationsService $aiIntergrationsService,
 		LoggerInterface $logger) {
 		parent::__construct($appName, $request);
-		$this->currentUserId = $UserId;
+		$this->currentUserId = $userId;
 		$this->accountService = $accountService;
 		$this->mailManager = $mailManager;
 		$this->snoozeService = $snoozeService;

--- a/lib/Controller/TrustedSendersController.php
+++ b/lib/Controller/TrustedSendersController.php
@@ -24,11 +24,11 @@ class TrustedSendersController extends Controller {
 	private ITrustedSenderService $trustedSenderService;
 
 	public function __construct(IRequest $request,
-		?string $UserId,
+		?string $userId,
 		ITrustedSenderService $trustedSenderService) {
 		parent::__construct(Application::APP_ID, $request);
 
-		$this->uid = $UserId;
+		$this->uid = $userId;
 		$this->trustedSenderService = $trustedSenderService;
 	}
 

--- a/tests/Unit/Controller/SieveControllerTest.php
+++ b/tests/Unit/Controller/SieveControllerTest.php
@@ -40,7 +40,7 @@ class SieveControllerTest extends TestCase {
 			SieveController::class,
 			[
 				'hostValidator' => $this->remoteHostValidator,
-				'UserId' => '1',
+				'userId' => '1',
 			]
 		);
 		$this->sieveController = $this->serviceMock->getService();

--- a/tests/Unit/Controller/TagsControllerTest.php
+++ b/tests/Unit/Controller/TagsControllerTest.php
@@ -29,7 +29,7 @@ class TagsControllerTest extends TestCase {
 		parent::setUp();
 		$this->serviceMock = $this->createServiceMock(
 			TagsController::class,
-			['UserId' => '1']
+			['userId' => '1']
 		);
 		$this->mailManager = $this->serviceMock->getParameter('mailManager');
 		$this->tagsController = $this->serviceMock->getService();

--- a/tests/Unit/Controller/TrustedSendersControllerTest.php
+++ b/tests/Unit/Controller/TrustedSendersControllerTest.php
@@ -16,7 +16,7 @@ use OCP\AppFramework\Http;
 class TrustedSendersControllerTest extends TestCase {
 	public function testSetTrustedNullUser(): void {
 		$serviceMock = $this->createServiceMock(TrustedSendersController::class, [
-			'UserId' => null,
+			'userId' => null,
 		]);
 
 		$response = $serviceMock->getService()->setTrusted('sender@example.com', 'individual');
@@ -26,7 +26,7 @@ class TrustedSendersControllerTest extends TestCase {
 
 	public function testRemoveTrustNullUser(): void {
 		$serviceMock = $this->createServiceMock(TrustedSendersController::class, [
-			'UserId' => null,
+			'userId' => null,
 		]);
 
 		$response = $serviceMock->getService()->removeTrust('sender@example.com', 'individual');
@@ -36,7 +36,7 @@ class TrustedSendersControllerTest extends TestCase {
 
 	public function testListNullUser(): void {
 		$serviceMock = $this->createServiceMock(TrustedSendersController::class, [
-			'UserId' => null,
+			'userId' => null,
 		]);
 
 		$response = $serviceMock->getService()->list();


### PR DESCRIPTION
Fixes ``[mail] The requested alias "UserId" is deprecated. Please request "userId" directly. This alias will be removed in a future Nextcloud version.`` from Sentry.

Also submit https://github.com/nextcloud-libraries/rector/pull/72 because our shared rector rule should have refactored this already.

AI-assisted: OpenCode (Claude Haiku 4.5)
