### PR TITLE
fix(phishing): try to catch invalid URL error before Normalizer errors

### DIFF
--- a/lib/Service/PhishingDetection/LinkCheck.php
+++ b/lib/Service/PhishingDetection/LinkCheck.php
@@ -74,6 +74,12 @@ class LinkCheck {
 			];
 		}
 		foreach ($zippedArray as $zipped) {
+			// Skip URLs that cannot be parsed to avoid deprecation errors in URL\Normalizer
+			// with malformed URLs in PHP 8.1+
+			if (parse_url($zipped['href']) === false) {
+				continue;
+			}
+
 			$un = new Normalizer($zipped['href']);
 			$url = $un->normalize();
 			if ($this->textLooksLikeALink($zipped['linkText'])) {

--- a/tests/Unit/Service/PhishingDetection/LinkCheckTest.php
+++ b/tests/Unit/Service/PhishingDetection/LinkCheckTest.php
@@ -87,4 +87,13 @@ class LinkCheckTest extends TestCase {
 
 		$this->assertFalse($result->isPhishing());
 	}
+
+	public function testMalformedUrlReturnsSafe(): void {
+		// Test that malformed URLs don't cause errors but are silently skipped
+		$html = '<html><body><a href="ht!tp://exa mple">Click here</a></body></html>';
+
+		$result = $this->check->run($html);
+
+		$this->assertFalse($result->isPhishing());
+	}
 }


### PR DESCRIPTION
```
ErrorException: Deprecated: Automatic conversion of false to array is deprecated
#0 /mail/vendor/glenscott/url-normalizer/src/URL/Normalizer.php(376): URL\Normalizer::mbParseUrl
#1 /mail/vendor/glenscott/url-normalizer/src/URL/Normalizer.php(85): URL\Normalizer::setUrl
#2 /mail/vendor/glenscott/url-normalizer/src/URL/Normalizer.php(49): URL\Normalizer::__construct
#3 /mail/lib/Service/PhishingDetection/LinkCheck.php(77): OCA\Mail\Service\PhishingDetection\LinkCheck::run
#4 /mail/lib/Service/PhishingDetection/PhishingDetectionService.php(82): OCA\Mail\Service\PhishingDetection\PhishingDetectionService::checkHeadersForPhishing
#5 /mail/lib/IMAP/ImapMessageFetcher.php(535): OCA\Mail\IMAP\ImapMessageFetcher::parseHeaders
#6 /mail/lib/IMAP/ImapMessageFetcher.php(246): OCA\Mail\IMAP\ImapMessageFetcher::fetchMessage
#7 /mail/lib/IMAP/MessageMapper.php(328): OCA\Mail\IMAP\MessageMapper::{closure:OCA\Mail\IMAP\MessageMapper::findByIds():319}
#8 [internal](0): array_map
#9 /mail/lib/IMAP/MessageMapper.php(319): OCA\Mail\IMAP\MessageMapper::findByIds
#10 /mail/lib/IMAP/MessageMapper.php(81): OCA\Mail\IMAP\MessageMapper::find
#11 /mail/lib/Service/MailManager.php(173): OCA\Mail\Service\MailManager::getImapMessage
#12 /mail/lib/Service/Attachment/AttachmentService.php(288): OCA\Mail\Service\Attachment\AttachmentService::getAttachmentNames
#13 /mail/lib/IMAP/PreviewEnhancer.php(75): OCA\Mail\IMAP\PreviewEnhancer::process
#14 /mail/lib/Service/PreprocessingService.php(59): OCA\Mail\Service\PreprocessingService::process
#15 /mail/lib/BackgroundJob/PreviewEnhancementProcessingJob.php(77): OCA\Mail\BackgroundJob\PreviewEnhancementProcessingJob::run
#16 /opt/nextcloud/lib/public/BackgroundJob/Job.php(47): OCP\BackgroundJob\Job::start
#17 /opt/nextcloud/lib/public/BackgroundJob/TimedJob.php(85): OCP\BackgroundJob\TimedJob::start
#18 /opt/nextcloud/core/Service/CronService.php(176): OC\Core\Service\CronService::runCli
#19 /opt/nextcloud/core/Service/CronService.php(98): OC\Core\Service\CronService::run
#20 /opt/nextcloud/cron.php(52)
```

AI-assisted: OpenCode (Claude Haiku 4.5)