### PR TITLE
fix(deps): bump ckeditor from v45 to v46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@pinia/testing": "^0.1.7",
         "@riophae/vue-treeselect": "^0.4.0",
         "address-rfc2822": "^2.2.3",
-        "ckeditor5": "^45.2.2",
+        "ckeditor5": "^46",
         "color-convert": "^2.0.1",
         "core-js": "^3.48.0",
         "debounce-promise": "^3.1.2",
@@ -1862,817 +1862,865 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-45.2.2.tgz",
-      "integrity": "sha512-RayO7CdX+b51ZhHuJQBBUbZ9QtZICI17zm7e8WX4ZjsZXRoZNP6SNZeGn9Ku47+WdUYfAz8SUDNTW0ryUoDmnw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-46.1.1.tgz",
+      "integrity": "sha512-7wq9WdYyq0jabUZOlnq/vOa/WQO6jXKQ01QCsx6Y7WZ00mxOQ0AmwzLEusHf9VEvXx25yH7jZa07axyEvjM+RQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-upload": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-upload": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-45.2.2.tgz",
-      "integrity": "sha512-5Xb1DStKEu8Hy6tT6P6a8MGpAiEuQwS2s7FWGgTUzw9mnVOIjdOtC0srO4ZRJ3UeJ4yLxW3KdWQFK2HmkJVZSw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-46.1.1.tgz",
+      "integrity": "sha512-LD9XMo0lqZw8Nm4Rdsd3b19rjVNLInAUrlbuJpXxgHTOP3CcrE1+kklosow3KreUZkWSxui0tszp45jRmGL1qQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-45.2.2.tgz",
-      "integrity": "sha512-I+5T3Inuoonf2SbJQ7Se8mr0uLF8rwWNgRiou10u+kJ3o66BSCXIDYty/VpjVt7GAwT6Utg/7tH1X3IpMCnluQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-46.1.1.tgz",
+      "integrity": "sha512-D2gC9NMd73BAszrP7GdwEqv5YAb+k/EMSIzlcyeUn8gYslGE+SrZHcgj4VCWaGWS+iu/G80ZskiXMBbNgC4NAw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-heading": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-heading": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-45.2.2.tgz",
-      "integrity": "sha512-fhlbBXcq65uYGPPYqIJM+LglzcAusQYWrNByITwronxUuLONXbIUkzdNzt3aDSIW8LhsRXzD63qP0KyKis3igA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-46.1.1.tgz",
+      "integrity": "sha512-VJ2U0P0ybuIF92fU1rSL9jkqOnywKek7ANR+B9Gc3vs3JdNEkN078pF5KS9xvnAkcrEt1KZBmqwghSDiiI91Wg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-45.2.2.tgz",
-      "integrity": "sha512-iaRWXoGWC06NZBED9Ds4fcKohK7o1AHxchHG01ec0v4g1yq+pL3jycg/70AlhFBiIJMXndmgcg5WButhKkjv8A==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-46.1.1.tgz",
+      "integrity": "sha512-NiCugPGmaCIHc4ivvJRUq/hcfchaChksWyRK6i5xbjj5NSlASjXt0fe4717pQVTN6lZxiJ9CaX6btCAYlmu5BQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-45.2.2.tgz",
-      "integrity": "sha512-R3Fii9P3yQtjRZpmuoWSqpTA0auYIqNQw8UQtwofXYtJkl1ARCFNqYRrNm68d8Duoh23n75zYWZjTkNu4r8eRQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-46.1.1.tgz",
+      "integrity": "sha512-m9MhmntW8cZBfhqluaDE4sJaMjks36ClxzxQwuz7Br+YhUXNhhtUrvpFggeZvgZ/IuII+OG6DolnD1WRHJlMEg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-45.2.2.tgz",
-      "integrity": "sha512-xbFEnBYsVO1oOpYJO+3i4D7d4kEfQOtqxXir2UY2Lx+eRNjgrAkfafu3OOOtv+U2t7j48Q0s6/gHi/ADuTfhzQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-46.1.1.tgz",
+      "integrity": "sha512-TiCO6F9uHiHOuGGfR+t7a5i93bJqPEoBpX67qQYV7EkhNIa7roa0PTkPXw6RFBGFv6LNgt0cNle/f7O94qhfcQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-link": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-link": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-45.2.2.tgz",
-      "integrity": "sha512-opJBlS86WbRIcxKaT47bAIo8cPp69VxXyAG4un861MxSm2PlbqjmPkveJbNIKpGCEQFrGocKfYVsqwZnI5bIcA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-46.1.1.tgz",
+      "integrity": "sha512-ngKJf1doQFp0FExF7skmtzHcD1H6cxkFFWH5ipRm8t5AcxivZIkbaMlNQMZTGKhMKtLmT77dQ7oGI4HT1XV4bA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-image": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-upload": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
+        "@ckeditor/ckeditor5-cloud-services": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-image": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-upload": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
         "blurhash": "2.0.5",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-45.2.2.tgz",
-      "integrity": "sha512-cEoo4dWJWYtWB2QoiCSQqpEr+yWObzQN/vW1OnzX5OHtmbyO33MJrDYejaEyrYO44Z4OefTeZt33VSAsg5lkrQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-46.1.1.tgz",
+      "integrity": "sha512-u096IDCS/9R7DhUUgHhP7ED5pjIP5JPE1SMRZ3UcfipVUveqT9Qqgm892Rsm4VfouoXw3f3pwoK68KIVjdxMlw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-image": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-image": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-45.2.2.tgz",
-      "integrity": "sha512-9D2x2Dk+UCl9e4DYRE0SuxQ9UMOOAjOai3slNDuAEm6tllTYRjsvf/pXfsFYNOKNbVXtjZIYlmhwzQ4qBd+X4Q==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-46.1.1.tgz",
+      "integrity": "sha512-YaFYBPdOIBqkYY1e7RYzZlicldmkM251WoWVAjbSwY7EWQY/tmLrnVmBZ31B/TqwvSBy6txQYBtuRZvozQ3F0w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-45.2.2.tgz",
-      "integrity": "sha512-RGoQDktkYIuw/C4hNdCGw5xUspxO2o8k1egCTy2M1Pz6Lpph5PIJSJWfHchU/4zpaVvaYddVp08uFgwGODQITw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-46.1.1.tgz",
+      "integrity": "sha512-YBBklzman8taer22uehNxeehDKaGbwnAaI8h7JIxaf0EpvaldjDnswg1hvJTHpLYDZiiEoI3pHmtdatuNWMlrg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-45.2.2.tgz",
-      "integrity": "sha512-UyDzNgSYvwlzkZa77yBJLnxqEplZgRXa+RCCsAcDkfSjFXJ10B8uQOeN3tbyUxMy0KauEkYcdcCox7Q842Avjg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-46.1.1.tgz",
+      "integrity": "sha512-YG1YOKHV/zHsSS/CcQJUx/Y8virChUG7JB7HbS3WgkFccvMEZLusx5GkeKXQHRZp0yUxbcAKO+woeVIwylrbCw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-45.2.2.tgz",
-      "integrity": "sha512-PhC3gakw+E1hyh2U5gdilcrH7/Pd1abKNO0g6qSlFgb2IuWKc5rm3xDvggXu7cOKlxbrhGckDsWUlJaFE4gfxQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.1.1.tgz",
+      "integrity": "sha512-J1WsQxxnbzgbG+xz669+bzfJ+jRbaMdYsdxZZAHlGjaKaOOMXMVrmsAesxy9OoV2LEuMed3BMu7BnICKIoD/aw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-watchdog": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-watchdog": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-45.2.2.tgz",
-      "integrity": "sha512-fq/+/JydXWJtLbatRjRfPP/zlAM2NsYDjzgO+MdUyYqonnYQ6d5tGiYoXTTVTykUrUeevyp9q0Rujo18+3fHEg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-46.1.1.tgz",
+      "integrity": "sha512-1UbSdmRuGoYhtAlYUeZlttLBblfYJbmIXE5iGVgi+2rGLEHucqQ0zBh84di+TCdqbjkp/S+T6G4sopQMM3xmbA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-upload": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-cloud-services": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-upload": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-45.2.2.tgz",
-      "integrity": "sha512-H6p2IelE9AdC6mLLyrGjNwGcBAxa66QQfB6CLC7qCYI3V82w8DiqWyOQNA23WJ162Aromz114HUAd1IZK+vX4A==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-46.1.1.tgz",
+      "integrity": "sha512-RGqrEWy50j8TbQeE8dNg+EIuuX5lef2fciiUO7wNyKQO5HahQS5BVbVy8+Uo24p/VHishp2Dzf4tqX6ZtnzRdA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-45.2.2.tgz",
-      "integrity": "sha512-0u5WfakjFzE+e84CyK7Qu+ksVwHMh3NAPv4JfAAecy1aI/6DZwK64U8uPCeDM3T2K5wiw6wpPCZV/IFboY3QlA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.1.1.tgz",
+      "integrity": "sha512-5WrFP+YUTwjQN/0f1TfzDNqgd0tK50Gw1YNPXav1AQHYnQUaFUxJEZgesV2Z3w77LIYVguoOlCEMk2yDhA+7aw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-45.2.2.tgz",
-      "integrity": "sha512-pGBd6sNFQt1eGyxc9ie+yeloQuTEWoWxi+F0f+uHn2msjHrfxB9z/w7tN+zFtm4zaMXjA5/vVfmMH+qDHILN1g==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-46.1.1.tgz",
+      "integrity": "sha512-ony/8uvWj7zFCPQ9GdsntT247WQShcNdNsG+M7bmaVNh8VjMyUMPY8vGL42eqR72I95vzhcnO19yqqqoa4bT/A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-45.2.2.tgz",
-      "integrity": "sha512-w7MzJLlZmw1riBCwEMkq/8tZJG5gMxum+plWC0X2JLPJBH4Pr8liDcLeW0kDe0mMS31gD3Ji2wkaIeyuxiz0pA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-46.1.1.tgz",
+      "integrity": "sha512-/paul3r1JgKp588tswE0yBfjpUT8U1/VLLo9RweAzQmtV1/XvG/Ua3YtGAV9eyvLQ5R7PKBJ0+Wq4fjNE8yVgw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-45.2.2.tgz",
-      "integrity": "sha512-XM0q+RxoR0HLvdDvxTRq+BWJ+R8JVCi3xfGnNfeJn3AmeBkxZ803UL4qP2eEodYYMknt0W0rCko3ToQjH5PpKg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-46.1.1.tgz",
+      "integrity": "sha512-UBqQPDtWpoPd+LJ/45MW2DTykYMc6Qg3QcNto81cRBGj5pbhnCaCIkzCDpT9A7r9XS8+pmfFw9xEajFZiUkdTw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-45.2.2.tgz",
-      "integrity": "sha512-3RYWLur7nJ/WXYSRQxIS7UK/eE/XafNnlm57SSQ7BjHZPXrhECXDHkWQ1ATi0GX1dFT1mC0bdXetc1XiP+ePUQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.1.1.tgz",
+      "integrity": "sha512-RTyl0LdPBi7um6WjV0tbrVZ9sg/ZqDPTglMbWPmgnPaoZzGs+BJgv6B8cPi9RIl6klOfKWzupGSdHynjI680eg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-mention": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-mention": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5",
         "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-45.2.2.tgz",
-      "integrity": "sha512-zkdNuqdXjCa2R3zQFmGdkPVAtVAx1ZfjD4O7fYJ5P1e999sqL9AA+8yLvyJ+fch0QHcLW9zOMuPp09c+hwnzQw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.1.1.tgz",
+      "integrity": "sha512-5kKbVnsE1PC1T+4kXOlHa6u+shCFKVPLEDjo4gWOwxDr1qPVPVQ9ytvXenQtx/k/wtVNuy3s+uq/nbiMoUXSlA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-45.2.2.tgz",
-      "integrity": "sha512-ICux3aGUmQqWZBGviD9FPJunZDVXqQIc7xJTaci/yA9Nt5B6gzNNmpLXz6Hifv6943KU8e17uSmCttfTiF+KXw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-46.1.1.tgz",
+      "integrity": "sha512-VqnHR5X2vGPcdpmWsyp9OW7O0kl+avFAjSICz1JJ6cPKW8yCHTCxSWxuVEq1bLqS8I2v4imQ+fqM20HYwii2vQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-45.2.2.tgz",
-      "integrity": "sha512-tjcWFMXdhDHDniuLJTA3CB5TLXHqdaSNdRbJe2evQDk10hxAapSMtO2pmElWx7s3g6bxQRPuS4AFlp4QVtmAzA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-46.1.1.tgz",
+      "integrity": "sha512-QyX+DPFDdPgBGRU2LeeMYJUqJ9MGDeCnG19lw4kwfA6PwrIamErTMEI9bLAXr9ZD5SxOVr8U+A+1MtFdQzdBxQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-select-all": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-undo": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-select-all": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-undo": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-45.2.2.tgz",
-      "integrity": "sha512-BqMnN0XvhmEEW999czAqyQgBKWpt18neoGHVfAkYXpiFkS0g2TcCf88ari0OFgtb30WuFR+aFmj3lKHv4g6R+w==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-46.1.1.tgz",
+      "integrity": "sha512-xQn3jt2BVw/NOY0QhfTnjKqiv40ahJ6VLGp8DPi/0bmHcgDRqD9QEKg5TFPY99Fi7Oh0OJL81UlQJnulc2hSlg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-45.2.2.tgz",
-      "integrity": "sha512-babdM2QN6LTgoBwx/NghExl8bWugQUUCvMs0KhGVtCVNrYwtFXBRv1IbSmO5YplMmOQnq6YYBAcWQm+qA3fTIg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-46.1.1.tgz",
+      "integrity": "sha512-TqIoOUUChwN9cEKCIn30m9Y95VZU7PQyn20mIbG4/iQItI8IyzlToFAdb+xPaL2ozUcyzTFTGqx0nz9zqKNtWQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-fullscreen": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-45.2.2.tgz",
-      "integrity": "sha512-cgdZ22QW7EruY71ZplMSOXJnDKjfQ2qjOef3e/67kGADc0nG9iz+c1oXnAjr7aVEkc2cNxOx4BHvhEAM+vkG3Q==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-46.1.1.tgz",
+      "integrity": "sha512-lpIG6YIw5KjehuTTX3MiAPBULzei8Pw+wfkpaP/NgyHLaUkN0x2wsoDRf3NWsdg+BMMDbR0ejGRJ8q+sD8d6ZQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-editor-classic": "45.2.2",
-        "@ckeditor/ckeditor5-editor-decoupled": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-editor-classic": "46.1.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-45.2.2.tgz",
-      "integrity": "sha512-ZtKDDQj2BdnOYglVD+tKgM2ciY3ur8AWV2DhdZPHKmkXFVFRRZ8avM6NmKYMXNbTykAz2dSR4rUZ2Yyb3hb04w==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.1.1.tgz",
+      "integrity": "sha512-ACneDx+HP3Nm/f2zFrRkUzpbG0CNNMGI4FS242eu0AQqE/vwwLvSD7HmiEzN2Z0HRLVFoY5EWa6kSZpJx6z/WA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-paragraph": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-paragraph": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-45.2.2.tgz",
-      "integrity": "sha512-GHgCc2kYWccQ0iUYGKsx0IfmfbWPlJMjrT+h6QYfVl+5TJw7KZT1FQHvK31BCuLN8GM9UOWeBlJe/IIQs6PojA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-46.1.1.tgz",
+      "integrity": "sha512-eNZ4BWF98mux26X/UOh+SyMTfMgvCOq4+T6lbqLB9TbN2i5/seKxIM9IV5ynag//bNd1ZwaqUczt05e3xFpYUg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-45.2.2.tgz",
-      "integrity": "sha512-fhX2mHh5kWGZTGWieJeBYxt1hj4AiFFqaTYgba+1PTlSyBS0L8iJbx1+QvAw2Owa2bNozABYo22CTWwkRRYprg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-46.1.1.tgz",
+      "integrity": "sha512-2PtEKoGQm6OYFDk1kjlIluCsuFVGPP7rU+KXOBBmOSku4rP1cIYyV+wFlerCGaH7hlzEyiuH1arR8va21IBprA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-45.2.2.tgz",
-      "integrity": "sha512-AxZIaCA2kgOqRXGOKsMsdqqUlarlOMGdawK1PW8Yhc/LhnTWu9fwRnWvHKSmkVR+GVHklIsC9Lh/oGCKnx1upQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-46.1.1.tgz",
+      "integrity": "sha512-rD1AlVOAKeNH0wdBedJFOyWF8dIx5tOJFV+ao36hbtHvXlEDXyXpeal58pbd3Z1QVIdfQ65NF0yZL2leQqOQZA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-45.2.2.tgz",
-      "integrity": "sha512-+1F7pmarn7NP1+5YrLXPHBNimf5814cbqZ/HIgQ7bBY5AeRAPm2xTyZ26R1ZgyALNdSMMABYXi37/O5shtOnPg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-46.1.1.tgz",
+      "integrity": "sha512-wG3cYNhzc5MAaFVbE+xjMMDDMtXwMUYiZ1Tjwo4YkSdBGRrOYShbktal5H/Snvj+pIgAgc5tOetmk5+izRKVSw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-heading": "45.2.2",
-        "@ckeditor/ckeditor5-image": "45.2.2",
-        "@ckeditor/ckeditor5-list": "45.2.2",
-        "@ckeditor/ckeditor5-table": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-heading": "46.1.1",
+        "@ckeditor/ckeditor5-image": "46.1.1",
+        "@ckeditor/ckeditor5-list": "46.1.1",
+        "@ckeditor/ckeditor5-remove-format": "46.1.1",
+        "@ckeditor/ckeditor5-table": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-icons": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-45.2.2.tgz",
-      "integrity": "sha512-QGPfkKZdWc5S2kpsFHCivfByNTqBtAL/prrMAQ8hhM5vLvA3xWVh45RAYYtCN3eGKA5LuY/JUTes2evQuGsaCg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-46.1.1.tgz",
+      "integrity": "sha512-BeJaBmXxg/R2cvGpL0oeLToDX2zIjLm/UejK0qsiO/eYxTJmveCabUWhcigpk19ciAcSjUdiariZUxCvpTyL5g==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-45.2.2.tgz",
-      "integrity": "sha512-TqUTBon5HoxVzKLiMVC7cL82PplMxtmz11P0c3V5H5u3bigBRyh0wepYFP8NKeA/n68+DZd1cWf90RaSpD64WQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.1.1.tgz",
+      "integrity": "sha512-292BrygMMXAvrcCxXxRUHC7rfxYqG6Fjf+/QhPXybOb1MFIzGnCkBh7zckUH6oQ4GlQ8kE+mwIthgmc8xvVYGw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-undo": "45.2.2",
-        "@ckeditor/ckeditor5-upload": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-undo": "46.1.1",
+        "@ckeditor/ckeditor5-upload": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-45.2.2.tgz",
-      "integrity": "sha512-y9cnJHgsrQkKjvQk1a1AK18CmIKswEpIQO2eNkXq7Qm0CSanHzS9hYYZdiei0pFk14ZlPgAUKDzFU9oGh12d8g==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-46.1.1.tgz",
+      "integrity": "sha512-JKLcCcKo20scOvEuKu09d6og+ECia6QKGOOaTfmy2QJx6CqkbkgC3NQKVF+ixmeGYERfL6X14VZURD7APXVJTA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-heading": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-list": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-heading": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-list": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-45.2.2.tgz",
-      "integrity": "sha512-SbNL8eNDUG869e+zfh4W+42VfYsfez6PxFuEYYxeswuBQfDJRmagJ551E9dsvo3QaC1Kgnr5x2VoKXoHdmBXbw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-46.1.1.tgz",
+      "integrity": "sha512-g8atx87RRSypjnnvthpMMSykLN6cgoNAQRvABdxYJTHARRrpjcIKNqWup9SW02QPUKRk/dmsnFEQVH6gkTTzTQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-45.2.2.tgz",
-      "integrity": "sha512-kBnvV4+QwNhGhnaSqyRD4mAzqLjR+gnaPzP10XUYxY6zDptM/EpQEY8dbtd3+12p0Q2N6doTonYdFu5QE/+SVQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.1.1.tgz",
+      "integrity": "sha512-dXsLFdL9VvU8VB4EK4qZk7TVSHCOmaAPoxorGy053Wg29ngEhpMHYiYWZQcLZB5VZSNYlc/mW2Hdv1cr2VEwFQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-image": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-image": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-45.2.2.tgz",
-      "integrity": "sha512-HmhurDxVIi5UDSOSJb6NR0iP0p1Gp94MnCAiHxxfCtOkgh/h37MG1UmxxaKZB44iaL3EsWm7d3wCZ97y0+KGQA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.1.1.tgz",
+      "integrity": "sha512-TlO8xiZHEoyy5nJSeBWSiu7oZjhBXFzm/3CT2jvBZPer/mWnPV0r6BTrw7GK+Pki0PtQCJUNhyxWafUN9rnKqQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-font": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-45.2.2.tgz",
-      "integrity": "sha512-2yR1LYMbSUDptT/39xj9NmrVgddmRMcCAqp2XuSk4F5uGXZCQcNIEEM7CX8jYrBixnYdMvRdhmcgwHdIHbudxQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-46.1.1.tgz",
+      "integrity": "sha512-nFPeW+EmkFuvAxp7wqJvXZlqUcVsoVH2s77785DR90iOzb2+zYHzanJ2bWkuC8b+7im7U6h2+6Ghahtz5Y/VVQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@types/marked": "4.3.2",
-        "@types/turndown": "5.0.5",
-        "ckeditor5": "45.2.2",
-        "marked": "4.0.12",
-        "turndown": "7.2.0",
-        "turndown-plugin-gfm": "1.0.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "46.1.1",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-45.2.2.tgz",
-      "integrity": "sha512-dDeHFoZzjn54eMdmxddXfuDaPycnvDQ9xKg6+AjrJdgc2NZC7VixvwR0SCCZtqOE523g1rRbXEEogM6YOMbKxw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-46.1.1.tgz",
+      "integrity": "sha512-1gkrTOlXu0Ptag429I/+sNPeefuLm4ATa0jjaVqM4Mtu/3JRGndkYqVTzmQQeRRn6jEJljqgngNMnlccMRKEmw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-undo": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-undo": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-45.2.2.tgz",
-      "integrity": "sha512-Di3JW/aiAKfmOTo7rUbrQcmua/h69qMFu8sl6d0LrKMGKTuZEfSeCCtmc/1TYmiYCyXQGTsenwOJq3+E3E7khw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-46.1.1.tgz",
+      "integrity": "sha512-NOyYUBW+bCrr5TSIHxTuoHe1H7YRjDChq396n+XAtreRICRKRloOWhzklI5RMJ5dfmQ7llS1eafi8uu7mzB2zQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-45.2.2.tgz",
-      "integrity": "sha512-wsVDndKeecRcgU+FYvna+xJPPq6uEzAown7SVEf/ijHHdfHOpIh4hqYKN6a7a8ahczuV/3Ebzpo0I/gRF7yg3w==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.1.1.tgz",
+      "integrity": "sha512-6tj1PhzVSWbkJYI0+v5TQTKwWfUAeTyZsDXQgaMZeH3ZIZ40wzXRI+ly380msu9t3mBS/qgzuKnsZpc7qNpbaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-45.2.2.tgz",
-      "integrity": "sha512-iNmH9kBH+vD/cQNkJ4B61KN3RF8E04NiW4nCrvpwfHHc50cvDWNWadV+g8j8oHjKyUNbu5tU4+ljBaXoJhQADA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-46.1.1.tgz",
+      "integrity": "sha512-c6TjuwTxeuYCloCdLLrjOURrhKyI3iLWuAZhoQ1XLxLpp0k/BIX9G7tRVEr7xzXzk2T8ibnZVHgegx/ImWkGLg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-45.2.2.tgz",
-      "integrity": "sha512-xvVbZDd+d6pz/w9rvcuQeF+hytqAuOYoY2iEaeTKEZwG8CElCuKujAu2OHhoGNOvfPV68/SVXd859INIWCSHcg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.1.1.tgz",
+      "integrity": "sha512-7SC78DYDrFiBTOVHBajxzAUdSoTiM85I8M11QLCrKDoGR1zGgRGjQH8NUMMUOekAjh8SxRN25Alm2Gn27IgCUw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-45.2.2.tgz",
-      "integrity": "sha512-CcAX3EdCHlqySIpjVP0gCJg7AgpOWfXXuez0FOCahKDxkosbFtS1tc/btEmyRZs2HS7AEECL+56xWXRf6Jd8dw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-46.1.1.tgz",
+      "integrity": "sha512-W7v4LAc3EJyXXmOCQtnCwjiK9ZhphhBIgLHz1jF/cE6WjS0nQDeXLxHqHnOaD8awR4oqcDyaUNvuBx4ipcUwzA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-45.2.2.tgz",
-      "integrity": "sha512-BTlSndkS0AXiK3G0l27Kfj7uLHCNByy3gWF8tTF/M2B/svNkV70IE/fKbyWDOA49Ian5wxLG0cpZkXEaL3hTVw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-46.1.1.tgz",
+      "integrity": "sha512-WdFyMzIEHqIrGAhq0NPQhDuKbRvpIOgr87r9IjefRQC0a5mbEdGLNQSE7l0JF0mmNEKQbSi520yJLGZo4EJ7Sg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-45.2.2.tgz",
-      "integrity": "sha512-7EzPSVvsbYuFzTudwmgAcAAuzRT2MJFK2sGXuT57VWGn2sZy/JHIawnUiGcNSBsbbhj+BaJhxXfOdq6dbb+J9Q==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-46.1.1.tgz",
+      "integrity": "sha512-lODjvDEbTTG//EZQ2yqgmOL2NRzljpAULscanh2eY4km+AVNCPu7181txvnUMtEaWVwEG6Aja9ys3AJlcs3TsQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-45.2.2.tgz",
-      "integrity": "sha512-oC8h3mUPWYdImHBYCuRjzEyqA1zLsg8kgocLzthtASBgkQLbmIkbiB8qTvKGZJU/WieKEPwRWZADe3+amm1N4w==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-46.1.1.tgz",
+      "integrity": "sha512-+h+28FPJKL59SESQzh4mvqEXkKrPyL3SnQI4wPC+ZMcBUqd3+0U0OCff0gClucNszgZcHbT83aODmKrQwUdQiw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-45.2.2.tgz",
-      "integrity": "sha512-iQ4bfTlhHQ2qghB7Rf4BblgjtGUz/gzJ4S8zZgYaZ23fL2LGC9zk50A4+BquAgpOnWDYK1lH6L3qQpA71Ecwwg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-46.1.1.tgz",
+      "integrity": "sha512-kiwceBqz5cMUrVp1iVJ+RoRhZRDGhhRHJo3pUeNG2+oYV+xxXvGdrMitDTXBbKnvoEHmI8xOWmh6E+wwHsIiNw==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-45.2.2.tgz",
-      "integrity": "sha512-DEUAPhBBaU5gYngtBjVgfxx7nuB/sE2WrxXGPTGAcA6ENgwip1sNfu06jUuTA9LKv2ucutwK1genf+iccuUmAw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-46.1.1.tgz",
+      "integrity": "sha512-Z5Y/s49athQku0wBc6H8DOWAdCYfAOUJtjPaOjkmWuUF6b/WT5GJbEp2ZEGH1EXfZxIY98JEQypjH3fMNb6fAA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-theme-lark": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-theme-lark": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-45.2.2.tgz",
-      "integrity": "sha512-a8iEtP89eTy7hwWA4+fgQycAgd4PF8xXXt50/D3Q8S1ni6ju6YAHq/QLAJ8isUPGyWoLXCWl757WO1zb2zmSJg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-46.1.1.tgz",
+      "integrity": "sha512-6U99q15iGgb28hNTh7xYw8lbwtajyv/6Z9aVpnlkDXLHAdgkXyfo/5Z65hpPjlMoHwxnZd2xtzYaK1Aaz22MbQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-45.2.2.tgz",
-      "integrity": "sha512-4uZDSMfEo4g6RGynGR1ejMJbCyYLv8WQpEDllUMjYW1aaWxh9WzAAKrITskdaBuCbqJw2zXTi/JDVUPUfOCzGg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-46.1.1.tgz",
+      "integrity": "sha512-42ghJrxnRA32MMAtgdAxAI5NmMdpp8mVpOAs6SIfzfzPyJ7flNorNdjjeD8QIAGvaYz4Vj1G9Y0se2FKR9PCtA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-html-support": "45.2.2",
-        "@ckeditor/ckeditor5-list": "45.2.2",
-        "@ckeditor/ckeditor5-table": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-html-support": "46.1.1",
+        "@ckeditor/ckeditor5-list": "46.1.1",
+        "@ckeditor/ckeditor5-table": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-45.2.2.tgz",
-      "integrity": "sha512-4Cz37AYJbH5K0zkWBkQlRiodxYEVrCVKF1WYzcm2j9yXxU1JKabTsynk2woh/S0o3ZgDFf9jgeVLY3tSUefOFg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.1.1.tgz",
+      "integrity": "sha512-tV2PBXvnw5znqF0riVjPwbstSU35oP/WPGEPzS6iHEWF21+efRgNKA05PSdQp9NQt58uMPOa3vz+1DSDozO5rQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-45.2.2.tgz",
-      "integrity": "sha512-K5auWRMtAAo5cSuJ/qc/YCq9A56ztX49EnAE+2fonWJ1i1zByh6xNwVyoG6VwZ3ZhyC+HjDV/aRQN/FLjccS9A==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-46.1.1.tgz",
+      "integrity": "sha512-W7U3a6JUGXbnd5kCBySrGei57Uh9Vs6FFlD0/nP7D9FdHKi5IRcnLOXQ2s/sAkztfmIXSKvvcGqGwnZVQCQxNQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "45.2.2"
+        "@ckeditor/ckeditor5-ui": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-45.2.2.tgz",
-      "integrity": "sha512-okLdKC4a6fKEiTm+jUfI7KMuS71xIZH+HDhYpQTqQhOcRdvLfT1j35HKTX+w+3damTNJF3uTrl7uKiN/EHaaUg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.1.1.tgz",
+      "integrity": "sha512-+lhzvyHj8Ao/qPHCuufiiBO68pCuynumI8oxfE/UBp9oPO25sqyW4FBgKeGZN6MR+4WKAMjI7tRtNrYEm0FM5Q==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-45.2.2.tgz",
-      "integrity": "sha512-8Nfm6uICsdHH3Cyw9EAE1lcd9N4V5mTVYcPMF5PPo3OuLdj6W3Y0FwnnNiTCYzuMZaaQFvAAcRjbj7o3+NDCcg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.1.1.tgz",
+      "integrity": "sha512-GWUH41WqzoS5OaXDLWtpr6SN8nQ9Iq4hvGXPp/ajWilyoX5Ar/1LA5v/sRIzlyekjVglzvOxrSZvRB5BQyz1Rg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-editor-multi-root": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
         "@types/color-convert": "2.0.4",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "es-toolkit": "1.32.0",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.39.5",
         "vanilla-colorful": "0.7.2"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-45.2.2.tgz",
-      "integrity": "sha512-n/5IRhZwQECc4GdTVXPNnigJR2j4tHJIDYLFF9kF+0hgOQ6tLnhPownqCjQeRniSylDtvQFp4K7liGXevmiVpw==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-46.1.1.tgz",
+      "integrity": "sha512-xM1Zv4oBGP5UVeXeSEma+n3DBY86zqs+HpyqUaDGYu1ELo5IHc+/mX4vmF06cAOepgLYKgD/Cn+4/PYuxSplZQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-45.2.2.tgz",
-      "integrity": "sha512-RFD3Y3s9G3RELnIUbaek88+EJm/jmxO197eibPOF84ApBhTTF14/axiPTiKyqwZVtxGQTLBuDiRyZH9hSG7gCA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-46.1.1.tgz",
+      "integrity": "sha512-aP0p4nP5ttx8pLV0SEtg7zEfk2xxyvbUZGIHvRoCIFUOXEoWsBgeP+Q9RK3RrbkWZ8vh2YSI8CeePtzGfFTLTg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-45.2.2.tgz",
-      "integrity": "sha512-X4e+amzYsOwPeD5de8ODBSAoPjDQhHQCzWNYvln3QTevoDPcobf0oZybCo1+1qiTnvWi/FJ/5+SxMjRP+zi0bg==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.1.1.tgz",
+      "integrity": "sha512-Be6IfHXQVEY0yQ42lnPAhNu805SaccmUSoOCFgcmZFtzqzhQN8OP50VDX7R40G3EMvhEdBKX5T7DASr10VPiJg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-vue2": {
@@ -2687,45 +2735,45 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-45.2.2.tgz",
-      "integrity": "sha512-M6aDY3q3jDJUmZhmPzq7xVjNlWQed5imTNWZdmvJyYE/sxnJaz4wLtxtx8RMzi92TWrNzBelYm1lxjNeMu5bvA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-46.1.1.tgz",
+      "integrity": "sha512-kBUsBIJ8eBIfbpLRHG0UGUvzYVD2dYpwP3cHQaSbFvEc9dnq2EgJ+LTDlysNM+ci+Z3fAeMC1KYskOO6oGGMXA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-editor-multi-root": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-45.2.2.tgz",
-      "integrity": "sha512-+Rfnbh0htgp2j9j1l74nlUo9wHgBcaZJ7xu9yJBWVJdF0phUtjy/fcTCBjjaUKmPE+ddbVY1zcwGqIlj3mm+sQ==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-46.1.1.tgz",
+      "integrity": "sha512-kBOVN1Iu9oTvk7bbgHXg70ZIVbsUm1U4XQF+knZ1bmI5M+wrOxh2HWSpigX/niOOcsIUo3TtYSPienEKxvxD6g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-45.2.2.tgz",
-      "integrity": "sha512-sY1WqcP1toGx+RDgLcyUKNiv/RVdcRR8S1wuLiW5lMV3EyFNY9CVxvNhxKX3r4tCqFy/VHhPy7bb3o8P9eR/sA==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-46.1.1.tgz",
+      "integrity": "sha512-F5+PEunszKRIHgXh1oOKpsQdUaCRSEXmkceAmKuAAE3a/7K5xbmno43N+36rVQApqE5oejLOYqd/hGg5d6Ei8g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "ckeditor5": "45.2.2",
-        "es-toolkit": "1.32.0"
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "ckeditor5": "46.1.1",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -4001,12 +4049,6 @@
       "version": "7.4.47",
       "resolved": "https://registry.npmjs.org/@mdi/svg/-/svg-7.4.47.tgz",
       "integrity": "sha512-WQ2gDll12T9WD34fdRFgQVgO8bag3gavrAgJ0frN4phlwdJARpE6gO1YvLEMJR0KKgoc+/Ea/A0Pp11I00xBvw=="
-    },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/@nextcloud/auth": {
       "version": "2.5.3",
@@ -5656,12 +5698,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/marked": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
-      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
-      "license": "MIT"
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -5721,12 +5757,6 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "optional": true
-    },
-    "node_modules/@types/turndown": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
-      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
-      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -7519,6 +7549,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -7565,6 +7605,26 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -7641,72 +7701,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "45.2.2",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-45.2.2.tgz",
-      "integrity": "sha512-UPv6pIix2+m/hezZE5LDNjgSE0nexrf18ccUdtkTNEctJ181vu4wQFnAJ4X5cCTomKWWcPaE4Ee7OpDZ37+g8Q==",
+      "version": "46.1.1",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-46.1.1.tgz",
+      "integrity": "sha512-6EdHMjm3I+23rVmkOMY5nvS+DpiKbAbbZjY7NIvtCwsDa0333/852raCXbLCUyKL6FRHiYowbjY+8LUvVBuZ8w==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "45.2.2",
-        "@ckeditor/ckeditor5-alignment": "45.2.2",
-        "@ckeditor/ckeditor5-autoformat": "45.2.2",
-        "@ckeditor/ckeditor5-autosave": "45.2.2",
-        "@ckeditor/ckeditor5-basic-styles": "45.2.2",
-        "@ckeditor/ckeditor5-block-quote": "45.2.2",
-        "@ckeditor/ckeditor5-bookmark": "45.2.2",
-        "@ckeditor/ckeditor5-ckbox": "45.2.2",
-        "@ckeditor/ckeditor5-ckfinder": "45.2.2",
-        "@ckeditor/ckeditor5-clipboard": "45.2.2",
-        "@ckeditor/ckeditor5-cloud-services": "45.2.2",
-        "@ckeditor/ckeditor5-code-block": "45.2.2",
-        "@ckeditor/ckeditor5-core": "45.2.2",
-        "@ckeditor/ckeditor5-easy-image": "45.2.2",
-        "@ckeditor/ckeditor5-editor-balloon": "45.2.2",
-        "@ckeditor/ckeditor5-editor-classic": "45.2.2",
-        "@ckeditor/ckeditor5-editor-decoupled": "45.2.2",
-        "@ckeditor/ckeditor5-editor-inline": "45.2.2",
-        "@ckeditor/ckeditor5-editor-multi-root": "45.2.2",
-        "@ckeditor/ckeditor5-emoji": "45.2.2",
-        "@ckeditor/ckeditor5-engine": "45.2.2",
-        "@ckeditor/ckeditor5-enter": "45.2.2",
-        "@ckeditor/ckeditor5-essentials": "45.2.2",
-        "@ckeditor/ckeditor5-find-and-replace": "45.2.2",
-        "@ckeditor/ckeditor5-font": "45.2.2",
-        "@ckeditor/ckeditor5-fullscreen": "45.2.2",
-        "@ckeditor/ckeditor5-heading": "45.2.2",
-        "@ckeditor/ckeditor5-highlight": "45.2.2",
-        "@ckeditor/ckeditor5-horizontal-line": "45.2.2",
-        "@ckeditor/ckeditor5-html-embed": "45.2.2",
-        "@ckeditor/ckeditor5-html-support": "45.2.2",
-        "@ckeditor/ckeditor5-icons": "45.2.2",
-        "@ckeditor/ckeditor5-image": "45.2.2",
-        "@ckeditor/ckeditor5-indent": "45.2.2",
-        "@ckeditor/ckeditor5-language": "45.2.2",
-        "@ckeditor/ckeditor5-link": "45.2.2",
-        "@ckeditor/ckeditor5-list": "45.2.2",
-        "@ckeditor/ckeditor5-markdown-gfm": "45.2.2",
-        "@ckeditor/ckeditor5-media-embed": "45.2.2",
-        "@ckeditor/ckeditor5-mention": "45.2.2",
-        "@ckeditor/ckeditor5-minimap": "45.2.2",
-        "@ckeditor/ckeditor5-page-break": "45.2.2",
-        "@ckeditor/ckeditor5-paragraph": "45.2.2",
-        "@ckeditor/ckeditor5-paste-from-office": "45.2.2",
-        "@ckeditor/ckeditor5-remove-format": "45.2.2",
-        "@ckeditor/ckeditor5-restricted-editing": "45.2.2",
-        "@ckeditor/ckeditor5-select-all": "45.2.2",
-        "@ckeditor/ckeditor5-show-blocks": "45.2.2",
-        "@ckeditor/ckeditor5-source-editing": "45.2.2",
-        "@ckeditor/ckeditor5-special-characters": "45.2.2",
-        "@ckeditor/ckeditor5-style": "45.2.2",
-        "@ckeditor/ckeditor5-table": "45.2.2",
-        "@ckeditor/ckeditor5-theme-lark": "45.2.2",
-        "@ckeditor/ckeditor5-typing": "45.2.2",
-        "@ckeditor/ckeditor5-ui": "45.2.2",
-        "@ckeditor/ckeditor5-undo": "45.2.2",
-        "@ckeditor/ckeditor5-upload": "45.2.2",
-        "@ckeditor/ckeditor5-utils": "45.2.2",
-        "@ckeditor/ckeditor5-watchdog": "45.2.2",
-        "@ckeditor/ckeditor5-widget": "45.2.2",
-        "@ckeditor/ckeditor5-word-count": "45.2.2"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "46.1.1",
+        "@ckeditor/ckeditor5-alignment": "46.1.1",
+        "@ckeditor/ckeditor5-autoformat": "46.1.1",
+        "@ckeditor/ckeditor5-autosave": "46.1.1",
+        "@ckeditor/ckeditor5-basic-styles": "46.1.1",
+        "@ckeditor/ckeditor5-block-quote": "46.1.1",
+        "@ckeditor/ckeditor5-bookmark": "46.1.1",
+        "@ckeditor/ckeditor5-ckbox": "46.1.1",
+        "@ckeditor/ckeditor5-ckfinder": "46.1.1",
+        "@ckeditor/ckeditor5-clipboard": "46.1.1",
+        "@ckeditor/ckeditor5-cloud-services": "46.1.1",
+        "@ckeditor/ckeditor5-code-block": "46.1.1",
+        "@ckeditor/ckeditor5-core": "46.1.1",
+        "@ckeditor/ckeditor5-easy-image": "46.1.1",
+        "@ckeditor/ckeditor5-editor-balloon": "46.1.1",
+        "@ckeditor/ckeditor5-editor-classic": "46.1.1",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.1.1",
+        "@ckeditor/ckeditor5-editor-inline": "46.1.1",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.1.1",
+        "@ckeditor/ckeditor5-emoji": "46.1.1",
+        "@ckeditor/ckeditor5-engine": "46.1.1",
+        "@ckeditor/ckeditor5-enter": "46.1.1",
+        "@ckeditor/ckeditor5-essentials": "46.1.1",
+        "@ckeditor/ckeditor5-find-and-replace": "46.1.1",
+        "@ckeditor/ckeditor5-font": "46.1.1",
+        "@ckeditor/ckeditor5-fullscreen": "46.1.1",
+        "@ckeditor/ckeditor5-heading": "46.1.1",
+        "@ckeditor/ckeditor5-highlight": "46.1.1",
+        "@ckeditor/ckeditor5-horizontal-line": "46.1.1",
+        "@ckeditor/ckeditor5-html-embed": "46.1.1",
+        "@ckeditor/ckeditor5-html-support": "46.1.1",
+        "@ckeditor/ckeditor5-icons": "46.1.1",
+        "@ckeditor/ckeditor5-image": "46.1.1",
+        "@ckeditor/ckeditor5-indent": "46.1.1",
+        "@ckeditor/ckeditor5-language": "46.1.1",
+        "@ckeditor/ckeditor5-link": "46.1.1",
+        "@ckeditor/ckeditor5-list": "46.1.1",
+        "@ckeditor/ckeditor5-markdown-gfm": "46.1.1",
+        "@ckeditor/ckeditor5-media-embed": "46.1.1",
+        "@ckeditor/ckeditor5-mention": "46.1.1",
+        "@ckeditor/ckeditor5-minimap": "46.1.1",
+        "@ckeditor/ckeditor5-page-break": "46.1.1",
+        "@ckeditor/ckeditor5-paragraph": "46.1.1",
+        "@ckeditor/ckeditor5-paste-from-office": "46.1.1",
+        "@ckeditor/ckeditor5-remove-format": "46.1.1",
+        "@ckeditor/ckeditor5-restricted-editing": "46.1.1",
+        "@ckeditor/ckeditor5-select-all": "46.1.1",
+        "@ckeditor/ckeditor5-show-blocks": "46.1.1",
+        "@ckeditor/ckeditor5-source-editing": "46.1.1",
+        "@ckeditor/ckeditor5-special-characters": "46.1.1",
+        "@ckeditor/ckeditor5-style": "46.1.1",
+        "@ckeditor/ckeditor5-table": "46.1.1",
+        "@ckeditor/ckeditor5-theme-lark": "46.1.1",
+        "@ckeditor/ckeditor5-typing": "46.1.1",
+        "@ckeditor/ckeditor5-ui": "46.1.1",
+        "@ckeditor/ckeditor5-undo": "46.1.1",
+        "@ckeditor/ckeditor5-upload": "46.1.1",
+        "@ckeditor/ckeditor5-utils": "46.1.1",
+        "@ckeditor/ckeditor5-watchdog": "46.1.1",
+        "@ckeditor/ckeditor5-widget": "46.1.1",
+        "@ckeditor/ckeditor5-word-count": "46.1.1"
       }
     },
     "node_modules/clamp": {
@@ -7774,12 +7834,21 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
       "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/colord": {
@@ -8878,9 +8947,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.32.0.tgz",
-      "integrity": "sha512-ZfSfHP1l6ubgW/B/FRtqb9bYdMvI6jizbOSfbwwJNcOQ1QE6TFsC3jpQkZ900uUPSR3t3SU5Ds7UWKnYz+uP8Q==",
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -10439,10 +10508,235 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast/node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -10473,6 +10767,33 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript/node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/he": {
@@ -10567,6 +10888,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -11741,6 +12072,16 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -11782,16 +12123,14 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/material-colors": {
@@ -11901,6 +12240,107 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-newline-to-break": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
@@ -11908,6 +12348,20 @@
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11929,6 +12383,27 @@
         "unist-util-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12060,6 +12535,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -14054,6 +14650,28 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
     "node_modules/rehype-external-links": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
@@ -14082,6 +14700,20 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14200,6 +14832,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -14207,6 +14856,24 @@
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -14230,15 +14897,31 @@
       }
     },
     "node_modules/remark-rehype": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.1.tgz",
-      "integrity": "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15244,6 +15927,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -16131,6 +16828,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -16235,21 +16942,6 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
-    },
-    "node_modules/turndown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
-      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      }
-    },
-    "node_modules/turndown-plugin-gfm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
-      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17849,6 +18541,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@pinia/testing": "^0.1.7",
     "@riophae/vue-treeselect": "^0.4.0",
     "address-rfc2822": "^2.2.3",
-    "ckeditor5": "^45.2.2",
+    "ckeditor5": "^46",
     "color-convert": "^2.0.1",
     "core-js": "^3.48.0",
     "debounce-promise": "^3.1.2",

--- a/src/tests/virtualtesteditor.js
+++ b/src/tests/virtualtesteditor.js
@@ -5,11 +5,11 @@
  * For licensing, see https://github.com/ckeditor/ckeditor5/blob/master/LICENSE.md
  * or https://ckeditor.com/legal/ckeditor-oss-license
  */
-import { DataApiMixin, Editor, mix } from 'ckeditor5'
+import { Editor } from 'ckeditor5'
 
 /**
  * A simple editor implementation useful for testing the engine part of the features.
- * It contains full data pipepilne and the engine pipeline but without rendering to DOM.
+ * It contains full data pipeline and the engine pipeline but without rendering to DOM.
  *
  * Should work in Node.js. If not now, then in the future :).
  */
@@ -34,5 +34,3 @@ export default class VirtualTestEditor extends Editor {
 		})
 	}
 }
-
-mix(VirtualTestEditor, DataApiMixin)


### PR DESCRIPTION
Because jumping to 47 gives red CI I'm trying to make a smaller step than https://github.com/nextcloud/mail/pull/12518.

Tested and works :smoking: :+1: 

https://ckeditor.com/docs/ckeditor5/latest/updating/guides/update-to-46.html

* [core](https://www.npmjs.com/package/@ckeditor/ckeditor5-core): Removed the deprecated DataApiMixin function and DataApi interface. Their functionality is the part of the Editor class.
* [utils](https://www.npmjs.com/package/@ckeditor/ckeditor5-utils): Removed the deprecated mix function.