### PR TITLE
refactor(ui): migrate from scss @import to @use

### DIFF
--- a/src/directives/drag-and-drop/styles/drag-and-drop.scss
+++ b/src/directives/drag-and-drop/styles/drag-and-drop.scss
@@ -2,5 +2,5 @@
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-@import 'draggable-envelope';
-@import 'droppable-mailbox';
+@use 'draggable-envelope';
+@use 'droppable-mailbox';


### PR DESCRIPTION
The build yields two warnings that are easy to fix:

```
WARNING in ./src/directives/drag-and-drop/styles/drag-and-drop.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/directives/drag-and-drop/styles/drag-and-drop.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 4, column 8 of file:///nextcloud/apps/mail/src/directives/drag-and-drop/styles/drag-and-drop.scss:4:8:
Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

4 | @import 'draggable-envelope';


src/directives/drag-and-drop/styles/drag-and-drop.scss 5:9  root stylesheet

 @ ./src/directives/drag-and-drop/styles/drag-and-drop.scss 8:6-166 20:17-24 25:22-29 25:33-47 25:50-64 24:0-136 24:0-136
 @ ./src/main.js 17:0-62

WARNING in ./src/directives/drag-and-drop/styles/drag-and-drop.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/sass-loader/dist/cjs.js!./src/directives/drag-and-drop/styles/drag-and-drop.scss)
Module Warning (from ./node_modules/sass-loader/dist/cjs.js):
Deprecation Warning on line 5, column 8 of file:///nextcloud/apps/mail/src/directives/drag-and-drop/styles/drag-and-drop.scss:5:8:
Sass @import rules are deprecated and will be removed in Dart Sass 3.0.0.

More info and automated migrator: https://sass-lang.com/d/import

5 | @import 'droppable-mailbox';


src/directives/drag-and-drop/styles/drag-and-drop.scss 6:9  root stylesheet

 @ ./src/directives/drag-and-drop/styles/drag-and-drop.scss 8:6-166 20:17-24 25:22-29 25:33-47 25:50-64 24:0-136 24:0-136
 @ ./src/main.js 17:0-62
```