### PR TITLE
test(js): use mock router for composer tests

### DIFF
--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -15,6 +15,12 @@ localVue.mixin(Nextcloud)
 localVue.use(PiniaVuePlugin)
 const pinia = createPinia()
 
+const $route = {
+	params: {
+		mailboxId: '123', // String because it comes from URL params
+	},
+}
+
 describe('Composer', () => {
 	let store
 
@@ -23,16 +29,41 @@ describe('Composer', () => {
 			value: 0,
 		})
 
+		const defaultAccount = {
+			id: 123,
+			editorMode: 'plaintext',
+			isUnified: false,
+			aliases: [],
+			connectionStatus: true,
+			emailAddress: 'test@example.com',
+			name: 'Test Account',
+		}
+
 		shallowMount(Composer, {
 			propsData: {
 				isFirstOpen: true,
-				accounts: [],
+				accounts: [defaultAccount],
+			},
+			mocks: {
+				$route,
 			},
 			localVue,
 			pinia,
 			store,
 		})
 		store = useMainStore()
+
+		// Add a mailbox to the store for the route param to reference
+		store.mailboxes[123] = {
+			id: 123,
+			databaseId: 123,
+			accountId: 123,
+			name: 'INBOX',
+			attributes: [],
+			specialUse: ['inbox'],
+			envelopeLists: {},
+			mailboxes: [],
+		}
 	})
 
 	it('does not drop the reply message ID', () => {
@@ -48,6 +79,9 @@ describe('Composer', () => {
 						aliases: [],
 					},
 				],
+			},
+			mocks: {
+				$route,
 			},
 			store,
 			localVue,
@@ -71,6 +105,9 @@ describe('Composer', () => {
 						aliases: [],
 					},
 				],
+			},
+			mocks: {
+				$route,
 			},
 			store,
 			localVue,
@@ -98,6 +135,9 @@ describe('Composer', () => {
 					},
 				],
 			},
+			mocks: {
+				$route,
+			},
 			store,
 			localVue,
 		})
@@ -119,6 +159,9 @@ describe('Composer', () => {
 						aliases: [],
 					},
 				],
+			},
+			mocks: {
+				$route,
 			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
@@ -149,6 +192,9 @@ describe('Composer', () => {
 					},
 				],
 			},
+			mocks: {
+				$route,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
@@ -178,6 +224,9 @@ describe('Composer', () => {
 					},
 				],
 			},
+			mocks: {
+				$route,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return undefined
@@ -206,6 +255,9 @@ describe('Composer', () => {
 						aliases: [],
 					},
 				],
+			},
+			mocks: {
+				$route,
 			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
@@ -239,6 +291,9 @@ describe('Composer', () => {
 					},
 				],
 			},
+			mocks: {
+				$route,
+			},
 			computed: {
 				smimeCertificateForCurrentAlias() {
 					return { foo: 'bar' }
@@ -271,6 +326,9 @@ describe('Composer', () => {
 					},
 				],
 			},
+			mocks: {
+				$route,
+			},
 			store,
 			localVue,
 		})
@@ -299,6 +357,9 @@ describe('Composer', () => {
 						aliases: [],
 					},
 				],
+			},
+			mocks: {
+				$route,
 			},
 			store,
 			localVue,


### PR DESCRIPTION
Frontend tests pass but leave a lot of warnings like

```
[Vue warn]: Error in beforeMount hook (Promise/async): "TypeError: Cannot read properties of undefined (reading 'params')"

found in

---> <Composer> at /nextcloud/apps/mail/src/components/Composer.vue
       <Root>
TypeError: Cannot read properties of undefined (reading 'params')
    at VueComponent.setAlias (/nextcloud/apps/mail/src/components/Composer.vue:1192:1)
    at VueComponent.beforeMount (/nextcloud/apps/mail/src/components/Composer.vue:1073:1)
    at invokeWithErrorHandling (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:2931:61)
    at callHook$1 (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:3996:13)
    at mountComponent (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:3819:5)
    at VueComponent.Vue.$mount (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:8708:12)
    at init (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:4369:19)
    at createComponent (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:6509:17)
    at createElm (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:6463:13)
    at VueComponent.patch [as __patch__] (/nextcloud/apps/mail/node_modules/vue/dist/vue.runtime.common.dev.js:7011:13)
```

AI-assisted: OpenCode (Claude Haiku 4.5)