### PR TITLE
chore: add commit guidelines for agents and users

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,32 +1,48 @@
 <!--
-  - SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-FileCopyrightText: 2016-2026 Nextcloud GmbH and Nextcloud contributors
   - SPDX-FileCopyrightText: 2013-2016 ownCloud, Inc.
   - SPDX-License-Identifier: AGPL-3.0-only
 -->
 ## Submitting issues
-
-### Short version
-
- * The [**issue template can be found here**][template] but be aware of the different repositories! See list below. Please always use the issue template when reporting issues.
 
 ### Guidelines
 * Please search the existing issues first, it's likely that your issue was already reported or even fixed.
   - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
   - You can also filter by appending e. g. "state:open" to the search string.
   - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
-* Report the issue using our [template][template], it includes all the informations we need to track down the issue.
+* Report issues using our [issue templates](ISSUE_TEMPLATE/); they include all the information we need to track down the issue.
 
 If your issue appears to be a bug, and hasn't been reported, open a new issue.
 
 Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
 
-[template]: https://raw.github.com/nextcloud/mail/master/.github/issue_template.md
-
 ## Contributing to Source Code
 
 Thanks for wanting to contribute source code to the Mail app. That's great!
 
+### Commit messages
+
+This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary). The commit types used are
+
+* **feat**: for new features
+* **fix**: for bug fixes and production dependency updates
+* **perf**: for performance improvements
+* **refactor**: for structural code changes with no changed features nor fixed bugs
+* **test**: for modified test files
+* **docs**: for documentation changes
+* **style**: for coding style changes (formatting only)
+* **ci**: for changes to our CI setup, like workflow files
+* **chore**: for any change that doesn't fit the rest, like development dependency updates
+
+You can also use scopes. Try to have them broad and not specific to a file or ticket. Here are common scopes used:
+
+* **imap**: for changes in the IMAP client
+* **ui**: for changes to the web UI
+
+Usage of AI agents has to be made transparent. Therefore, the commit message's last line before sign-off has to be `AI-assisted: <agent> (model)` for agenting contributions. For example: `AI-assisted: Claude Code (Claude Haiku 4.5)`
+
 ## Translations
+
 Please submit translations via [Transifex][transifex].
 
 [transifex]: https://www.transifex.com/projects/p/nextcloud/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,3 +69,18 @@ composer test:unit                                    # Run all unit tests
 composer test:unit -- tests/Unit/Service/HtmlTest.php # Run specific test file
 composer test:unit -- --filter="TestClassName"        # Run tests matching filter
 ```
+
+## Git Workflow
+
+Do NOT commit changes unless explicitly asked to do so.
+
+After completing code changes:
+1. Verify your work is complete and tests pass
+2. Make sure there is no trailing whitespace
+3. Leave changes in working directory or staged (do not commit)
+4. Provide a summary of what was changed and why
+5. Suggest a commit message using Conventional Commits format
+   - There is a [contributing doc](./.github/CONTRIBUTING.md) with suggestions
+6. The user will review and commit when ready
+
+The commit message's last line before sign-off should be `AI-assisted: <agent> (model)`. For example: `AI-assisted: Claude Code (Claude Haiku 4.5)`


### PR DESCRIPTION
We don't want to make changes in autopilot mode. Even with agents the user has to review the changes. IMO this is best achieved when the agent only makes the changes and the user handles git.