### PR TITLE
feat: add sidecar forwarding for mailbox listing

### DIFF
--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -19,6 +19,7 @@ use OCA\Mail\Exception\IncompleteSyncException;
 use OCA\Mail\Exception\MailboxNotCachedException;
 use OCA\Mail\Exception\NotImplemented;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Http\SidecarClient;
 use OCA\Mail\Http\TrapError;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\Sync\SyncService;
@@ -31,6 +32,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\Security\ICrypto;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MailboxesController extends Controller {
@@ -48,6 +50,8 @@ class MailboxesController extends Controller {
 		SyncService $syncService,
 		private readonly IConfig $config,
 		private readonly ITimeFactory $timeFactory,
+		private readonly SidecarClient $sidecarClient,
+		private readonly ICrypto $crypto,
 	) {
 		parent::__construct($appName, $request);
 
@@ -76,6 +80,16 @@ class MailboxesController extends Controller {
 
 		$account = $this->accountService->find($this->currentUserId, $accountId);
 
+		// Try sidecar first, fall back to Horde
+		if ($this->sidecarClient->isAvailable()) {
+			try {
+				return $this->indexViaSidecar($account, $accountId);
+			} catch (\Exception $e) {
+				// Sidecar failed, fall through to Horde
+			}
+		}
+
+		// Original Horde path (fallback)
 		$mailboxes = $this->mailManager->getMailboxes($account, $forceSync);
 		return new JSONResponse([
 			'id' => $accountId,
@@ -83,6 +97,29 @@ class MailboxesController extends Controller {
 			'mailboxes' => $mailboxes,
 			'delimiter' => $mailboxes[0]?->getDelimiter(),
 		]);
+	}
+
+	/**
+	 * Forward mailbox listing to the Go sidecar.
+	 */
+	private function indexViaSidecar(\OCA\Mail\Account $account, int $accountId): JSONResponse {
+		$mailAccount = $account->getMailAccount();
+		$password = $mailAccount->getInboundPassword() !== null
+			? $this->crypto->decrypt($mailAccount->getInboundPassword())
+			: '';
+
+		$result = $this->sidecarClient->forward('POST', '/mailboxes', [
+			'accountId' => $accountId,
+			'imap' => SidecarClient::buildImapCredentials(
+				$mailAccount->getInboundHost(),
+				$mailAccount->getInboundPort(),
+				$mailAccount->getInboundUser(),
+				$password,
+				$mailAccount->getInboundSslMode(),
+			),
+		]);
+
+		return new JSONResponse($result);
 	}
 
 	/**

--- a/lib/Http/SidecarClient.php
+++ b/lib/Http/SidecarClient.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 ncmail-turbo contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Http;
+
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use Psr\Log\LoggerInterface;
+
+/**
+ * HTTP client for communicating with the ncmail-turbo Go sidecar.
+ *
+ * The sidecar runs as a separate process (e.g., sidecar:3000 in Docker)
+ * and handles IMAP operations with persistent connections and caching.
+ */
+class SidecarClient {
+	private IClientService $clientService;
+	private IConfig $config;
+	private LoggerInterface $logger;
+
+	public function __construct(
+		IClientService $clientService,
+		IConfig $config,
+		LoggerInterface $logger,
+	) {
+		$this->clientService = $clientService;
+		$this->config = $config;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Forward a request to the Go sidecar.
+	 *
+	 * @param string $method HTTP method (GET, POST, PUT, DELETE)
+	 * @param string $path API path (e.g., /mailboxes)
+	 * @param array $data Request data (sent as JSON body)
+	 * @return array Decoded JSON response
+	 * @throws \Exception If the sidecar is unreachable or returns an error
+	 */
+	public function forward(string $method, string $path, array $data = []): array {
+		$baseUrl = $this->config->getSystemValueString(
+			'app.mail.sidecar_url',
+			'http://sidecar:3000'
+		);
+
+		$url = rtrim($baseUrl, '/') . '/' . ltrim($path, '/');
+		$client = $this->clientService->newClient();
+
+		$options = [
+			'headers' => [
+				'Content-Type' => 'application/json',
+				'Accept' => 'application/json',
+			],
+			'timeout' => 10,
+		];
+
+		if (!empty($data)) {
+			$options['body'] = json_encode($data);
+		}
+
+		try {
+			$response = match (strtoupper($method)) {
+				'GET' => $client->get($url, $options),
+				'POST' => $client->post($url, $options),
+				'PUT' => $client->put($url, $options),
+				'DELETE' => $client->delete($url, $options),
+				default => throw new \InvalidArgumentException("Unsupported method: $method"),
+			};
+
+			return json_decode($response->getBody(), true) ?? [];
+		} catch (\Exception $e) {
+			$this->logger->warning('Sidecar request failed: {error}', [
+				'error' => $e->getMessage(),
+				'path' => $path,
+			]);
+			throw $e;
+		}
+	}
+
+	/**
+	 * Check if the sidecar is reachable.
+	 */
+	public function isAvailable(): bool {
+		try {
+			$result = $this->forward('GET', '/health');
+			return ($result['status'] ?? '') === 'ok';
+		} catch (\Exception $e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Build the IMAP credentials array to pass to the sidecar.
+	 */
+	public static function buildImapCredentials(
+		string $host,
+		int $port,
+		string $user,
+		string $password,
+		string $sslMode,
+	): array {
+		return [
+			'host' => $host,
+			'port' => $port,
+			'user' => $user,
+			'password' => $password,
+			'ssl' => $sslMode,
+		];
+	}
+}


### PR DESCRIPTION
- SidecarClient: HTTP client for Go sidecar communication
  - Configurable URL via app.mail.sidecar_url (default: http://sidecar:3000)
  - Health check, credential builder
  - Timeout handling and error logging

- MailboxesController: forward index() to sidecar with Horde fallback
  - Check sidecar availability first
  - Forward IMAP credentials (decrypted) to Go
  - Fall back to original Horde path if sidecar is down

No changes to routes, Vue frontend, or other controllers.