### PR TITLE
feat: Add route to open messages via Message-ID

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,6 +11,11 @@ declare(strict_types=1);
 return [
 	'routes' => [
 		[
+			'name' => 'deep_link#open',
+			'url' => '/open/{messageId}',
+			'verb' => 'GET',
+		],
+		[
 			'name' => 'page#index',
 			'url' => '/',
 			'verb' => 'GET'

--- a/lib/Controller/DeepLinkController.php
+++ b/lib/Controller/DeepLinkController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Controller;
+
+use Horde_Mail_Rfc822_Identification;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+class DeepLinkController extends Controller {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private MailAccountMapper $mailAccountMapper,
+		private AccountService $accountService,
+		private MessageMapper $messageMapper,
+		private IURLGenerator $urlGenerator,
+		private IUserSession $userSession,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param string $messageId
+	 * @return RedirectResponse
+	 */
+	public function open(string $messageId): RedirectResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.page.login'));
+		}
+
+		$userId = $user->getUID();
+
+		try {
+			$id = '<' . trim(trim($messageId), '<>') . '>';
+			$parsed = new Horde_Mail_Rfc822_Identification($id);
+			$cleanedId = $parsed->ids[0] ?? null;
+
+			if ($cleanedId === null) {
+				return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('mail.page.index', []));
+			}
+
+			$lightAccounts = $this->mailAccountMapper->findByUserId($userId);
+
+			foreach ($lightAccounts as $lightAccount) {
+				$accountId = $lightAccount->getId();
+				$account = $this->accountService->find($userId, $accountId);
+				$messages = $this->messageMapper->findByMessageId($account, $cleanedId);
+
+				if (!empty($messages)) {
+					$message = $messages[0];
+					$targetId = $message->getId();
+
+					// IMPORTANT FIX: Use 'mail.page.thread' instead of 'mail.page#thread'
+					$url = $this->urlGenerator->linkToRouteAbsolute(
+						'mail.page.thread',
+						['mailboxId' => $message->getMailboxId(), 'id' => $targetId]
+					);
+
+					return new RedirectResponse($url);
+				}
+			}
+		} catch (\Exception $e) {
+			$this->logger->error('DeepLinkController: An unexpected error occurred.', [
+				'exception' => $e,
+				'messageId' => $messageId,
+			]);
+		}
+
+		// Fallback
+		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('mail.page.index', []));
+	}
+}

--- a/tests/Unit/Controller/DeepLinkControllerTest.php
+++ b/tests/Unit/Controller/DeepLinkControllerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Controller;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Controller\DeepLinkController;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+class DeepLinkControllerTest extends TestCase {
+	private string $appName;
+	private IRequest $request;
+	private MailAccountMapper $mailAccountMapper;
+	private AccountService $accountService;
+	private MessageMapper $messageMapper;
+	private IURLGenerator $urlGenerator;
+	private IUserSession $userSession;
+	private LoggerInterface $logger;
+	private DeepLinkController $controller;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appName = 'mail';
+		$this->request = $this->createMock(IRequest::class);
+		$this->mailAccountMapper = $this->createMock(MailAccountMapper::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->messageMapper = $this->createMock(MessageMapper::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->controller = new DeepLinkController(
+			$this->appName,
+			$this->request,
+			$this->mailAccountMapper,
+			$this->accountService,
+			$this->messageMapper,
+			$this->urlGenerator,
+			$this->userSession,
+			$this->logger
+		);
+	}
+
+	public function testOpenNotLoggedIn(): void {
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn(null);
+
+		$this->urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('core.page.login')
+			->willReturn('http://localhost/login');
+
+		$response = $this->controller->open('test-message-id');
+
+		self::assertInstanceOf(RedirectResponse::class, $response);
+		self::assertSame('http://localhost/login', $response->getRedirectURL());
+	}
+
+	public function testOpenMessageFound(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user123');
+
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+
+		$lightAccount = new MailAccount();
+		$lightAccount->setId(1);
+
+		$this->mailAccountMapper->expects(self::once())
+			->method('findByUserId')
+			->with('user123')
+			->willReturn([$lightAccount]);
+
+		$account = $this->createMock(Account::class);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with('user123', 1)
+			->willReturn($account);
+
+		$message = new Message();
+		$message->setId(42);
+		$message->setMailboxId(5);
+
+		$this->messageMapper->expects(self::once())
+			->method('findByMessageId')
+			->with($account, '<test-message-id>')
+			->willReturn([$message]);
+
+		$this->urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('mail.page.thread', ['mailboxId' => 5, 'id' => 42])
+			->willReturn('http://localhost/apps/mail/box/5/thread/42');
+
+		$response = $this->controller->open('test-message-id');
+
+		self::assertInstanceOf(RedirectResponse::class, $response);
+		self::assertSame('http://localhost/apps/mail/box/5/thread/42', $response->getRedirectURL());
+	}
+
+	public function testOpenMessageNotFound(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user123');
+
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+
+		$lightAccount = new MailAccount();
+		$lightAccount->setId(1);
+
+		$this->mailAccountMapper->expects(self::once())
+			->method('findByUserId')
+			->with('user123')
+			->willReturn([$lightAccount]);
+
+		$account = $this->createMock(Account::class);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with('user123', 1)
+			->willReturn($account);
+
+		$this->messageMapper->expects(self::once())
+			->method('findByMessageId')
+			->with($account, '<test-message-id>')
+			->willReturn([]);
+
+		$this->urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('mail.page.index', [])
+			->willReturn('http://localhost/apps/mail/');
+
+		$response = $this->controller->open('test-message-id');
+
+		self::assertInstanceOf(RedirectResponse::class, $response);
+		self::assertSame('http://localhost/apps/mail/', $response->getRedirectURL());
+	}
+
+	public function testOpenException(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user123');
+
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($user);
+
+		$exception = new \RuntimeException('Database error');
+		$this->mailAccountMapper->expects(self::once())
+			->method('findByUserId')
+			->with('user123')
+			->willThrowException($exception);
+
+		$this->logger->expects(self::once())
+			->method('error')
+			->with('DeepLinkController: An unexpected error occurred.', [
+				'exception' => $exception,
+				'messageId' => 'test-message-id',
+			]);
+
+		$this->urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('mail.page.index', [])
+			->willReturn('http://localhost/apps/mail/');
+
+		$response = $this->controller->open('test-message-id');
+
+		self::assertInstanceOf(RedirectResponse::class, $response);
+		self::assertSame('http://localhost/apps/mail/', $response->getRedirectURL());
+	}
+}


### PR DESCRIPTION
Related to #2269

Hi @ChristophWurst, this is the first part of the deep-linking feature.

## What this PR does

This PR introduces a new frontend route `/apps/mail/open/<message-id>` that allows opening a specific email directly if the Message-ID is known.

The app will search for a message with the given ID across all accounts and mailboxes of the user and open it if found.

This is the foundational work for a future UI element that will allow users to copy such a link. The button for generating the link is not part of this PR and will follow in a separate one.

## How to test

1.  Find a `Message-ID` of an existing email (e.g., from the email source).
2.  Manually construct a URL like `http://<your-nextcloud-instance>/index.php/apps/mail/open/<your-message-id>`.
3.  Make sure to URL-encode the Message-ID (e.g., `<` becomes `%3C`).
4.  Navigate to the URL.
5.  The Mail app should open and display the corresponding email directly.