### PR TITLE
test: Add tests for getAttachment and S/MIME

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -102,6 +102,12 @@ SPDX-FileCopyrightText = "2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "AGPL-3.0-or-later"
 
 [[annotations]]
+path = "tests/data/decrypted-message-body-with-attachment.txt"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
 path = ["tests/data/mail-filter/*"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 Nextcloud GmbH and Nextcloud contributors"

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -26,6 +26,7 @@ use OCA\Mail\IMAP\ImapMessageFetcher;
 use OCA\Mail\IMAP\ImapMessageFetcherFactory;
 use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Model\IMAPMessage;
+use OCA\Mail\Model\SmimeDecryptionResult;
 use OCA\Mail\Service\SmimeService;
 use OCA\Mail\Support\PerformanceLoggerTask;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -863,5 +864,68 @@ class MessageMapperTest extends TestCase {
 		);
 
 		$this->assertEquals($originalContent, $attachment->getContent());
+	}
+
+	private function mockEncryptedFetch(int $messageUid, string $decryptedMime): Horde_Imap_Client_Base {
+		$fetchData = new Horde_Imap_Client_Data_Fetch();
+		$fetchData->setUid($messageUid);
+		$fetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fetchResult[$messageUid] = $fetchData;
+
+		$fullTextFetchData = new Horde_Imap_Client_Data_Fetch();
+		$fullTextFetchData->setUid($messageUid);
+		$fullTextFetchResult = new Horde_Imap_Client_Fetch_Results();
+		$fullTextFetchResult[$messageUid] = $fullTextFetchData;
+
+		$imapClient = $this->createMock(Horde_Imap_Client_Base::class);
+		$imapClient->method('fetch')
+			->willReturnOnConsecutiveCalls($fetchResult, $fullTextFetchResult);
+
+		$this->sMimeService->method('isEncrypted')->willReturn(true);
+		$this->sMimeService->method('addDecryptQueries')->willReturnCallback(
+			static function (Horde_Imap_Client_Fetch_Query $query): void {
+			}
+		);
+		$this->sMimeService->method('decryptDataFetch')
+			->with($fullTextFetchData, 'alice')
+			->willReturn(new SmimeDecryptionResult($decryptedMime, true, false, false));
+
+		return $imapClient;
+	}
+
+	public function testGetAttachmentEncryptedWithRegularAttachment(): void {
+		$messageUid = 1;
+		$attachmentId = '1.2';
+		$decryptedMime = file_get_contents(__DIR__ . '/../../data/decrypted-message-body-with-attachment.txt');
+		$imapClient = $this->mockEncryptedFetch($messageUid, $decryptedMime);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals('report.pdf', $attachment->getName());
+		$this->assertEquals('application/octet-stream', $attachment->getType());
+	}
+
+	public function testGetAttachmentEncryptedWithInlineImage(): void {
+		$messageUid = 1;
+		$attachmentId = '1.1.2.2';
+		$decryptedMime = file_get_contents(__DIR__ . '/../../data/decrypted-message-body-with-attachment.txt');
+		$imapClient = $this->mockEncryptedFetch($messageUid, $decryptedMime);
+
+		$attachment = $this->mapper->getAttachment(
+			$imapClient,
+			'INBOX',
+			$messageUid,
+			$attachmentId,
+			'alice',
+		);
+
+		$this->assertEquals('nextcloud.png', $attachment->getName());
+		$this->assertEquals('application/octet-stream', $attachment->getType());
 	}
 }

--- a/tests/data/decrypted-message-body-with-attachment.txt
+++ b/tests/data/decrypted-message-body-with-attachment.txt
@@ -1,0 +1,81 @@
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg=sha-512; boundary="------------ms090602070103080803000804"
+
+--------------ms090602070103080803000804
+Content-Type: multipart/mixed; boundary="------------qAYOrn93kRwkODOppBlz0hPa"
+
+--------------qAYOrn93kRwkODOppBlz0hPa
+Content-Type: multipart/alternative;
+ boundary="------------khRKVoYMOnH1fDekoKVmWtCU"
+
+--------------khRKVoYMOnH1fDekoKVmWtCU
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+Hi Bob,
+
+please take a look at the report.
+
+
+Best
+
+Alice
+
+
+--------------khRKVoYMOnH1fDekoKVmWtCU
+Content-Type: multipart/related;
+ boundary="------------XTvL9ftLXAsOr07D7RnGhT8k"
+
+--------------XTvL9ftLXAsOr07D7RnGhT8k
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE html>
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  </head>
+  <body>
+    <p>Hi Bob,</p>
+    <p>please take a look at the report.</p>
+    <p><br>
+    </p>
+    <p>Best</p>
+    <p>Alice</p>
+    <p><br>
+    </p>
+    <p><img moz-do-not-send="false"
+        src="cid:part1.rSMDTUJE.c3rWVu9G@mail.example.com" alt="" width="195"
+        height="130"></p>
+  </body>
+</html>
+--------------XTvL9ftLXAsOr07D7RnGhT8k
+Content-Type: image/png; name="nextcloud.png"
+Content-Disposition: inline; filename="nextcloud.png"
+Content-Id: <part1.rSMDTUJE.c3rWVu9G@mail.example.com>
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9ffpkAAAAASUVORK5CYII=
+
+--------------XTvL9ftLXAsOr07D7RnGhT8k--
+
+
+--------------khRKVoYMOnH1fDekoKVmWtCU--
+
+--------------qAYOrn93kRwkODOppBlz0hPa
+Content-Type: application/pdf; name="report.pdf"
+Content-Disposition: attachment; filename="report.pdf"
+Content-Transfer-Encoding: base64
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=
+
+--------------qAYOrn93kRwkODOppBlz0hPa--
+
+--------------ms090602070103080803000804
+Content-Type: application/pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+Content-Description: S/MIME Cryptographic Signature
+
+JVBERi0xLjcK
+--------------ms090602070103080803000804--


### PR DESCRIPTION
 I need to change getAttachment for  https://github.com/nextcloud/mail/issues/8351 to return the actual content type and hence, some coverage for this path would be good. 

AI-assisted: Claude Sonnet 4.6