### PR TITLE
chore: Log account id for oauth refresh

### DIFF
--- a/lib/Integration/GoogleIntegration.php
+++ b/lib/Integration/GoogleIntegration.php
@@ -152,8 +152,9 @@ class GoogleIntegration {
 				], JSON_THROW_ON_ERROR)
 			]);
 		} catch (Exception $e) {
-			$this->logger->warning('Could not refresh oauth token: ' . $e->getMessage(), [
+			$this->logger->warning('Could not refresh Google OAuth token for account {accountId}: ' . $e->getMessage(), [
 				'exception' => $e,
+				'accountId' => $account->getId(),
 			]);
 			return $account;
 		}

--- a/lib/Integration/MicrosoftIntegration.php
+++ b/lib/Integration/MicrosoftIntegration.php
@@ -167,8 +167,9 @@ class MicrosoftIntegration {
 				],
 			]);
 		} catch (Exception $e) {
-			$this->logger->warning('Could not refresh oauth token: ' . $e->getMessage(), [
+			$this->logger->warning('Could not refresh Microsoft OAuth token for account {accountId}: ' . $e->getMessage(), [
 				'exception' => $e,
+				'accountId' => $account->getId(),
 			]);
 			return $account;
 		}


### PR DESCRIPTION
**Main change: Log the account id when refreshing the oauth token fails**

---

Why adding google/microsoft to the log message.

I suspect, that using the same log message confuses logsmash. So, let's see if that makes it work ;)

<img width="1475" height="49" alt="Screenshot From 2026-03-23 11-46-56" src="https://github.com/user-attachments/assets/ad222ccb-858e-4fd2-974c-a485fd5216ca" />

<img width="712" height="623" alt="Screenshot From 2026-03-23 11-47-14" src="https://github.com/user-attachments/assets/db9c6d95-2cc3-42fa-a3ef-cce240e9cbf7" />
