### PR TITLE
Forward inline images

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>5.9.0-dev.1</version>
+	<version>5.9.0-dev.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
-		"lint": "find . -name \\*.php -not -path './vendor*/*' -print0 | xargs -0 -n1 php -l",
+		"lint": "find . -name \\*.php -not -path './vendor*/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n1 php -l",
 		"psalm": "psalm.phar",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType",
 		"post-install-cmd": [

--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -23,6 +23,8 @@ class Attachment {
 		string $type,
 		string $content,
 		int $size,
+		public readonly ?string $contentId,
+		public readonly ?string $disposition,
 	) {
 		$this->id = $id;
 		$this->name = $name;
@@ -32,12 +34,19 @@ class Attachment {
 	}
 
 	public static function fromMimePart(Horde_Mime_Part $mimePart): self {
+		$disposition = $mimePart->getDisposition();
+		if ($disposition === '') {
+			$disposition = null;
+		}
+
 		return new Attachment(
 			$mimePart->getMimeId(),
 			$mimePart->getName(),
 			$mimePart->getType(),
 			$mimePart->getContents(),
 			(int)$mimePart->getBytes(),
+			$mimePart->getContentId(),
+			$disposition,
 		);
 	}
 

--- a/lib/Contracts/IAttachmentService.php
+++ b/lib/Contracts/IAttachmentService.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Contracts;
 use OCA\Mail\Db\LocalAttachment;
 use OCA\Mail\Exception\AttachmentNotFoundException;
 use OCA\Mail\Service\Attachment\UploadedFile;
+use OCP\Files\SimpleFS\ISimpleFile;
 
 interface IAttachmentService {
 	/**
@@ -22,8 +23,8 @@ interface IAttachmentService {
 	/**
 	 * Try to get an attachment by id
 	 *
+	 * @return array{0: LocalAttachment, 1: ISimpleFile}
 	 * @throws AttachmentNotFoundException
-	 * @return array of LocalAttachment and ISimpleFile
 	 */
 	public function getAttachment(string $userId, int $id): array;
 

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -259,10 +259,8 @@ class MessagesController extends Controller {
 		if ($itineraries) {
 			$json['itineraries'] = $itineraries;
 		}
-		$json['attachments'] = array_map(fn ($a) => $this->enrichDownloadUrl(
-			$id,
-			$a
-		), $json['attachments']);
+		$json['attachments'] = $this->enrichAttachments($id, $json['attachments']);
+		$json['inlineAttachments'] = $this->enrichAttachments($id, $json['inlineAttachments']);
 		$json['accountId'] = $account->getId();
 		$json['mailboxId'] = $mailbox->getId();
 		$json['databaseId'] = $message->getId();
@@ -648,9 +646,7 @@ class MessagesController extends Controller {
 						$mailbox,
 						$message->getUid(),
 						true
-					)->getHtmlBody(
-						$id
-					);
+					)->getHtmlBody($id);
 				} finally {
 					$client->logout();
 				}
@@ -1056,20 +1052,24 @@ class MessagesController extends Controller {
 		}
 	}
 
+	private function enrichAttachments(int $id, array $attachments): array {
+		return array_map(
+			fn ($attachment) => $this->enrichAttachment($id, $attachment),
+			$attachments
+		);
+	}
+
 	/**
 	 * @param int $id
 	 * @param array $attachment
 	 *
 	 * @return array
 	 */
-	private function enrichDownloadUrl(int $id,
-		array $attachment) {
-		$downloadUrl = $this->urlGenerator->linkToRoute('mail.messages.downloadAttachment',
-			[
-				'id' => $id,
-				'attachmentId' => $attachment['id'],
-			]);
-		$downloadUrl = $this->urlGenerator->getAbsoluteURL($downloadUrl);
+	private function enrichAttachment(int $id, array $attachment): array {
+		$downloadUrl = $this->urlGenerator->linkToRouteAbsolute('mail.messages.downloadAttachment', [
+			'id' => $id,
+			'attachmentId' => $attachment['id'],
+		]);
 		$attachment['downloadUrl'] = $downloadUrl;
 		$attachment['mimeUrl'] = $this->mimeTypeDetector->mimeTypeIcon($attachment['mime']);
 

--- a/lib/Db/LocalAttachment.php
+++ b/lib/Db/LocalAttachment.php
@@ -20,12 +20,20 @@ use ReturnTypeWillChange;
  * @method void setFileName(string $fileName)
  * @method string getMimeType()
  * @method void setMimeType(string $mimeType)
+ * @method string|null getContentId()
+ * @method void setContentId(?string $contentId)
+ * @method string|null getDisposition()
+ * @method void setDisposition(?string $disposition)
  * @method int|null getCreatedAt()
  * @method void setCreatedAt(int $createdAt)
  * @method int|null getLocalMessageId()
  * @method void setLocalMessageId(int $localMessageId)
  */
 class LocalAttachment extends Entity implements JsonSerializable {
+	public const DISPOSITION_ATTACHMENT = 'attachment';
+	public const DISPOSITION_INLINE = 'inline';
+	public const DISPOSITION_OMIT = null;
+
 	/** @var string */
 	protected $userId;
 
@@ -34,6 +42,12 @@ class LocalAttachment extends Entity implements JsonSerializable {
 
 	/** @var string */
 	protected $mimeType;
+
+	/** @var ?string */
+	protected $contentId;
+
+	/** @var ?string */
+	protected $disposition;
 
 	/** @var int|null */
 	protected $createdAt;
@@ -49,8 +63,14 @@ class LocalAttachment extends Entity implements JsonSerializable {
 			'type' => 'local',
 			'fileName' => $this->fileName,
 			'mimeType' => $this->mimeType,
+			'contentId' => $this->contentId,
+			'disposition' => $this->disposition,
 			'createdAt' => $this->createdAt,
 			'localMessageId' => $this->localMessageId
 		];
+	}
+
+	public function isDispositionAttachmentOrInline(): bool {
+		return $this->disposition === self::DISPOSITION_ATTACHMENT || $this->disposition === self::DISPOSITION_INLINE;
 	}
 }

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -369,7 +369,8 @@ class ImapMessageFetcher {
 				'fileName' => $filename,
 				'mime' => $p->getType(),
 				'size' => $p->getBytes(),
-				'cid' => $p->getContentId()
+				'cid' => $p->getContentId(),
+				'disposition' => $p->getDisposition()
 			];
 			return;
 		}

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -33,6 +33,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use function str_starts_with;
 use function strtolower;
 
+/**
+ * @psalm-import-type IMAPAttachment from IMAPMessage
+ */
 class ImapMessageFetcher {
 	/** @var string[] */
 	private array $attachmentsToIgnore = ['signature.asc', 'smime.p7s'];
@@ -50,7 +53,9 @@ class ImapMessageFetcher {
 	private Horde_Imap_Client_Base $client;
 	private string $htmlMessage = '';
 	private string $plainMessage = '';
+	/** @var list<IMAPAttachment> */
 	private array $attachments = [];
+	/** @var list<IMAPAttachment> */
 	private array $inlineAttachments = [];
 	private bool $hasAnyAttachment = false;
 	private array $scheduling = [];

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -20,7 +20,7 @@ use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
 use Horde_Mime_Exception;
 use Horde_Mime_Headers;
-use Horde_Mime_Headers_ContentParam;
+use Horde_Mime_Headers_ContentParam_ContentDisposition;
 use Horde_Mime_Headers_ContentParam_ContentType;
 use Horde_Mime_Headers_ContentTransferEncoding;
 use Horde_Mime_Part;
@@ -804,24 +804,15 @@ class MessageMapper {
 
 		$mimePart = new Horde_Mime_Part();
 
-		// Serve all files with a content-disposition of "attachment" to prevent Cross-Site Scripting
-		$mimePart->setDisposition('attachment');
+		$contentId = $mimeHeaders['content-id']?->value_single;
+		if ($contentId !== null) {
+			$mimePart->setContentId($contentId);
+		}
 
-		// Extract headers from part
-		$cdEl = $mimeHeaders['content-disposition'];
-		$contentDisposition = $cdEl instanceof Horde_Mime_Headers_ContentParam
-			? array_change_key_case($cdEl->params, CASE_LOWER)
-			: null;
-		if (!is_null($contentDisposition) && isset($contentDisposition['filename'])) {
-			$mimePart->setDispositionParameter('filename', $contentDisposition['filename']);
-		} else {
-			$ctEl = $mimeHeaders['content-type'];
-			$contentTypeParams = $ctEl instanceof Horde_Mime_Headers_ContentParam
-				? array_change_key_case($ctEl->params, CASE_LOWER)
-				: null;
-			if (isset($contentTypeParams['name'])) {
-				$mimePart->setContentTypeParameter('name', $contentTypeParams['name']);
-			}
+		$contentDisposition = $mimeHeaders['content-disposition'];
+		if ($contentDisposition instanceof Horde_Mime_Headers_ContentParam_ContentDisposition) {
+			$mimePart->setDisposition($contentDisposition->value_single);
+			$mimePart->setDispositionParameter('filename', $contentDisposition['filename'] ?? null);
 		}
 
 		// Content transfer encoding
@@ -830,17 +821,15 @@ class MessageMapper {
 			$mimePart->setTransferEncoding($tmp);
 		}
 
-		/* Content type */
-		$contentType = $mimeHeaders['content-type']?->value_single;
-		if (!is_null($contentType) && str_contains($contentType, 'text/calendar')) {
-			$mimePart->setType('text/calendar');
-			if ($mimePart->getContentTypeParameter('name') === null) {
-				$mimePart->setContentTypeParameter('name', 'calendar.ics');
+		$contentType = $mimeHeaders['content-type'];
+		if ($contentType instanceof Horde_Mime_Headers_ContentParam_ContentType) {
+			if (str_contains($contentType->value_single, 'text/calendar')) {
+				$mimePart->setType('text/calendar');
+				$mimePart->setContentTypeParameter('name', $contentType['name'] ?? 'calendar.ics');
+			} else {
+				$mimePart->setType($contentType->value_single);
+				$mimePart->setContentTypeParameter('name', $contentType['name'] ?? null);
 			}
-		} else {
-			// To prevent potential problems with the SOP we serve all files but calendar entries with the
-			// MIME type "application/octet-stream"
-			$mimePart->setType('application/octet-stream');
 		}
 
 		$mimePart->setContents($body);

--- a/lib/Migration/Version5008Date20260320125737.php
+++ b/lib/Migration/Version5008Date20260320125737.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\Types;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * @psalm-api
+ */
+#[ModifyColumn(
+	table: 'mail_attachments',
+	description: 'Add column to store content-id and content-disposition', )
+]
+class Version5008Date20260320125737 extends SimpleMigrationStep {
+
+	public function __construct(
+		private IDBConnection $connection,
+	) {
+	}
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('mail_attachments')) {
+			return null;
+		}
+
+		$attachmentsTable = $schema->getTable('mail_attachments');
+		if (!$attachmentsTable->hasColumn('content_id')) {
+			$attachmentsTable->addColumn('content_id', Types::STRING, [
+				'notnull' => false,
+				'length' => 255,
+			]);
+		}
+		if (!$attachmentsTable->hasColumn('disposition')) {
+			$attachmentsTable->addColumn('disposition', Types::STRING, [
+				'notnull' => false,
+				'length' => 10,
+			]);
+		}
+
+		return $schema;
+	}
+
+	#[Override]
+	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
+		$qb = $this->connection->getQueryBuilder();
+		$qb->update('mail_attachments')
+			->set('disposition', $qb->createNamedParameter('attachment', IQueryBuilder::PARAM_STR))
+			->where($qb->expr()->isNull('disposition'));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -33,6 +33,16 @@ use function trim;
 
 /**
  * @psalm-import-type MailIMAPFullMessage from ResponseDefinitions
+ *
+ * @psalm-type IMAPAttachment = array{
+ *      id: string|null,
+ *      messageId: int,
+ *      fileName: string|null,
+ *      mime: string,
+ *      size: int,
+ *      cid: string|null,
+ *      disposition: string,
+ *  }
  */
 class IMAPMessage implements IMessage, JsonSerializable {
 	use ConvertAddresses;
@@ -53,6 +63,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	public string $plainMessage;
 	public string $htmlMessage;
 	public array $attachments;
+	/** @var list<IMAPAttachment> */
 	public array $inlineAttachments;
 	private bool $hasAttachments;
 	public array $scheduling;
@@ -71,6 +82,9 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	private bool $signatureIsValid;
 	private bool $isPgpMimeEncrypted;
 
+	/**
+	 * @param list<IMAPAttachment> $inlineAttachments
+	 */
 	public function __construct(int $uid,
 		string $messageId,
 		array $flags,

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -304,6 +304,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		if ($this->hasHtmlMessage) {
 			$data['hasHtmlBody'] = true;
 			$data['attachments'] = $this->attachments;
+			$data['inlineAttachments'] = $this->inlineAttachments;
 			return $data;
 		}
 
@@ -311,6 +312,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 		[$mailBody, $signature] = $this->htmlService->parseMailBody($mailBody);
 		$data['signature'] = $signature;
 		$data['attachments'] = array_merge($this->attachments, $this->inlineAttachments);
+		$data['inlineAttachments'] = [];
 		if ($loadBody) {
 			$data['body'] = $mailBody;
 		}
@@ -349,15 +351,11 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 * @return string
 	 */
 	public function getHtmlBody(int $id): string {
-		return $this->htmlService->sanitizeHtmlMailBody($this->htmlMessage, $id, function ($cid) {
-			$match = array_filter($this->inlineAttachments,
-				static fn ($a) => $a['cid'] === $cid);
-			$match = array_shift($match);
-			if ($match === null) {
-				return null;
-			}
-			return $match['id'];
-		});
+		return $this->htmlService->sanitizeHtmlMailBody(
+			$id,
+			$this->htmlMessage,
+			$this->inlineAttachments,
+		);
 	}
 
 	/**

--- a/lib/Provider/Command/MessageSend.php
+++ b/lib/Provider/Command/MessageSend.php
@@ -91,11 +91,29 @@ class MessageSend {
 		$attachments = [];
 		try {
 			foreach ($message->getAttachments() as $entry) {
+				/*
+				 * The mail provider API has no disposition field, so we infer it:
+				 * omit the Content-Disposition header (null) when name is null,
+				 * otherwise default to attachment.
+				 *
+				 * See https://github.com/nextcloud/mail/issues/10416 for the original motivation.
+				 *
+				 * Previously handled in TransmissionService::handleAttachment;
+				 * moved here now that LocalAttachment carries a disposition field.
+				 */
+				if ($entry->getName() === null) {
+					$disposition = LocalAttachment::DISPOSITION_OMIT;
+				} else {
+					$disposition = LocalAttachment::DISPOSITION_ATTACHMENT;
+				}
+
 				$attachments[] = $this->attachmentService->addFileFromString(
 					$userId,
 					(string)$entry->getName(),
 					(string)$entry->getType(),
-					(string)$entry->getContents()
+					(string)$entry->getContents(),
+					null,
+					$disposition,
 				);
 			}
 		} catch (UploadException $e) {

--- a/lib/ResponseDefinitions.php
+++ b/lib/ResponseDefinitions.php
@@ -30,7 +30,8 @@ namespace OCA\Mail;
  *     isOneClickUnsubscribe: bool,
  *     unsubscribeMailTo: ?string,
  *     scheduling: list<array{id: ?string, messageId: string, method: string, contents: string}>,
- *     attachments: list<array{id: int<1, max>, messageId: int<1, max>, filename: string, mime: string, size: int<0, max>, cid: ?string, disposition: string, downloadUrl?: string}>
+ *     attachments: list<array{id: int<1, max>, messageId: int<1, max>, filename: string, mime: string, size: int<0, max>, cid: ?string, disposition: string, downloadUrl?: string}>,
+ *     inlineAttachments: list<array{id: int<1, max>, messageId: int<1, max>, filename: string, mime: string, size: int<0, max>, cid: ?string, disposition: string, downloadUrl?: string}>
  * }
  *
  * @psalm-type MailMessageApiResponse = MailIMAPFullMessage&array{

--- a/lib/Service/AntiSpamService.php
+++ b/lib/Service/AntiSpamService.php
@@ -157,10 +157,12 @@ class AntiSpamService {
 		$mimeMessage = new MimeMessage(
 			new DataUriParser()
 		);
+
 		$mimePart = $mimeMessage->build(
 			null,
 			$message->getContent(),
-			$message->getAttachments()
+			false,
+			array_values($message->getAttachments()),
 		);
 
 		$mail->setBasePart($mimePart);

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -94,6 +94,8 @@ class AttachmentService implements IAttachmentService {
 		$attachment->setUserId($userId);
 		$attachment->setFileName($file->getFileName());
 		$attachment->setMimeType($file->getMimeType());
+		$attachment->setContentId(null);
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_ATTACHMENT);
 		$attachment->setCreatedAt($this->timeFactory->getTime());
 
 		$persisted = $this->mapper->insert($attachment);
@@ -108,11 +110,21 @@ class AttachmentService implements IAttachmentService {
 		return $attachment;
 	}
 
-	public function addFileFromString(string $userId, string $name, string $mime, string $fileContents): LocalAttachment {
+	public function addFileFromString(
+		string $userId,
+		string $name,
+		string $mime,
+		string $fileContents,
+		?string $contentId,
+		?string $disposition,
+
+	): LocalAttachment {
 		$attachment = new LocalAttachment();
 		$attachment->setUserId($userId);
 		$attachment->setFileName($name);
 		$attachment->setMimeType($mime);
+		$attachment->setContentId($contentId);
+		$attachment->setDisposition($disposition);
 		$attachment->setCreatedAt($this->timeFactory->getTime());
 
 		$persisted = $this->mapper->insert($attachment);
@@ -252,7 +264,7 @@ class AttachmentService implements IAttachmentService {
 				$attachmentIds[] = $this->handleForwardedMessageAttachment($account, $attachment, $client);
 				continue;
 			}
-			if ($attachment['type'] === 'message-attachment') {
+			if ($attachment['type'] === 'message-attachment' || $attachment['type'] === 'message-attachment-inline') {
 				// Adds an attachment from another email (use case is, eg., a mail forward)
 				$attachmentIds[] = $this->handleForwardedAttachment($account, $attachment, $client);
 				continue;
@@ -345,7 +357,7 @@ class AttachmentService implements IAttachmentService {
 		}
 
 		try {
-			$localAttachment = $this->addFileFromString($account->getUserId(), $attachment['fileName'] ?? $attachmentMessage->getSubject() . '.eml', $mime, $fullText);
+			$localAttachment = $this->addFileFromString($account->getUserId(), $attachment['fileName'] ?? $attachmentMessage->getSubject() . '.eml', $mime, $fullText, null, LocalAttachment::DISPOSITION_ATTACHMENT);
 		} catch (UploadException $e) {
 			$this->logger->error('Could not create attachment', ['exception' => $e]);
 			return null;
@@ -365,32 +377,23 @@ class AttachmentService implements IAttachmentService {
 	private function handleForwardedAttachment(Account $account, array $attachment, \Horde_Imap_Client_Socket $client): ?int {
 		$mailbox = $this->mailManager->getMailbox($account->getUserId(), $attachment['mailboxId']);
 
-		$attachments = $this->messageMapper->getRawAttachments(
+		$imapAttachment = $this->messageMapper->getAttachment(
 			$client,
 			$mailbox->getName(),
 			(int)$attachment['uid'],
+			$attachment['id'],
 			$account->getUserId(),
-			[
-				$attachment['id'] ?? []
-			]
 		);
 
-		if ($attachments === []) {
-			return null;
-		}
-
-		// detect mime type
-		$mime = 'application/octet-stream';
-		if (extension_loaded('fileinfo')) {
-			$finfo = new finfo(FILEINFO_MIME_TYPE);
-			$detectedMime = $finfo->buffer($attachments[0]);
-			if ($detectedMime !== false) {
-				$mime = $detectedMime;
-			}
-		}
-
 		try {
-			$localAttachment = $this->addFileFromString($account->getUserId(), $attachment['fileName'], $mime, $attachments[0]);
+			$localAttachment = $this->addFileFromString(
+				$account->getUserId(),
+				$imapAttachment->getName() ?? 'unknown',
+				$imapAttachment->getType(),
+				$imapAttachment->getContent(),
+				$imapAttachment->contentId,
+				$imapAttachment->disposition,
+			);
 		} catch (UploadException $e) {
 			$this->logger->error('Could not create attachment', ['exception' => $e]);
 			return null;
@@ -439,7 +442,7 @@ class AttachmentService implements IAttachmentService {
 		}
 
 		try {
-			$localAttachment = $this->addFileFromString($account->getUserId(), $file->getName(), $file->getMimeType(), $file->getContent());
+			$localAttachment = $this->addFileFromString($account->getUserId(), $file->getName(), $file->getMimeType(), $file->getContent(), null, LocalAttachment::DISPOSITION_ATTACHMENT);
 		} catch (UploadException $e) {
 			$this->logger->error('Could not create attachment', ['exception' => $e]);
 			return null;

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -32,6 +32,7 @@ use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\ICacheFactory;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
@@ -140,11 +141,9 @@ class AttachmentService implements IAttachmentService {
 	}
 
 	/**
-	 * @param string $userId
-	 * @param int $id
+	 * Try to get an attachment by id
 	 *
-	 * @return array of LocalAttachment and ISimpleFile
-	 *
+	 * @return array{0: LocalAttachment, 1: ISimpleFile}
 	 * @throws AttachmentNotFoundException
 	 */
 	#[\Override]

--- a/lib/Service/DataUri/DataUri.php
+++ b/lib/Service/DataUri/DataUri.php
@@ -10,16 +10,16 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\DataUri;
 
 final class DataUri {
-	private string $mediaType;
-	private array $parameters;
-	private bool $base64;
-	private string $data;
 
-	public function __construct(string $mediaType, array $parameters, bool $base64, $data) {
-		$this->mediaType = $mediaType;
-		$this->parameters = $parameters;
-		$this->base64 = $base64;
-		$this->data = $data;
+	/**
+	 * @param array{charset: string, ...} $parameters
+	 */
+	public function __construct(
+		private readonly string $mediaType,
+		private readonly array $parameters,
+		private readonly bool $base64,
+		private readonly string $data,
+	) {
 	}
 
 	public function getMediaType(): string {

--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -16,6 +16,7 @@ use HTMLPurifier_HTMLDefinition;
 use HTMLPurifier_URIDefinition;
 use HTMLPurifier_URISchemeRegistry;
 use OCA\Mail\Html\ProxyHmacGenerator;
+use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\HtmlPurify\CidURIScheme;
 use OCA\Mail\Service\HtmlPurify\TransformCidDataAttr;
 use OCA\Mail\Service\HtmlPurify\TransformHTMLLinks;
@@ -34,6 +35,9 @@ use Youthweb\UrlLinker\UrlLinker;
 
 require_once __DIR__ . '/../../vendor/cerdic/css-tidy/class.csstidy.php';
 
+/**
+ * @psalm-import-type IMAPAttachment from IMAPMessage
+ */
 class Html {
 	/** @var IURLGenerator */
 	private $urlGenerator;
@@ -108,8 +112,8 @@ class Html {
 	}
 
 	/**
-	 * @param list<array> $inlineAttachments
-	 * @return list<array{id: string, messageId: int, fileName: string|null, mime: string, size: int, cid: string|null, disposition: string|null, url: string}>
+	 * @param list<IMAPAttachment> $inlineAttachments
+	 * @return list<array{id: string|null, messageId: int, fileName: string|null, mime: string, size: int, cid: string|null, disposition: string, url: string}>
 	 */
 	private function addAttachmentUrl(int $messageId, array $inlineAttachments): array {
 		return array_map(function (array $inlineAttachment) use ($messageId) {
@@ -123,6 +127,9 @@ class Html {
 		}, $inlineAttachments);
 	}
 
+	/**
+	 * @param list<IMAPAttachment> $inlineAttachments
+	 */
 	public function sanitizeHtmlMailBody(int $messageId, string $mailBody, array $inlineAttachments): string {
 		$inlineAttachments = $this->addAttachmentUrl($messageId, $inlineAttachments);
 

--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service;
 
-use Closure;
 use HTMLPurifier;
 use HTMLPurifier_Config;
 use HTMLPurifier_HTMLDefinition;
@@ -18,6 +17,7 @@ use HTMLPurifier_URIDefinition;
 use HTMLPurifier_URISchemeRegistry;
 use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Service\HtmlPurify\CidURIScheme;
+use OCA\Mail\Service\HtmlPurify\TransformCidDataAttr;
 use OCA\Mail\Service\HtmlPurify\TransformHTMLLinks;
 use OCA\Mail\Service\HtmlPurify\TransformImageSrc;
 use OCA\Mail\Service\HtmlPurify\TransformNoReferrer;
@@ -78,9 +78,9 @@ class Html {
 		// TODO: Fix this - requires https://github.com/owncloud/core/issues/10767 to be fixed
 		$config->set('Cache.DefinitionImpl', null);
 
-		/** @var HTMLPurifier_HTMLDefinition $uri */
-		$uri = $config->getDefinition('HTML');
-		$uri->info_attr_transform_post['noreferrer'] = new TransformNoReferrer();
+		/** @var HTMLPurifier_HTMLDefinition $def */
+		$def = $config->getHTMLDefinition(true);
+		$def->info_attr_transform_post['noreferrer'] = new TransformNoReferrer();
 
 		$purifier = new HTMLPurifier($config);
 
@@ -107,7 +107,25 @@ class Html {
 		];
 	}
 
-	public function sanitizeHtmlMailBody(string $mailBody, int $id, Closure $mapCidToAttachmentId): string {
+	/**
+	 * @param list<array> $inlineAttachments
+	 * @return list<array{id: string, messageId: int, fileName: string|null, mime: string, size: int, cid: string|null, disposition: string|null, url: string}>
+	 */
+	private function addAttachmentUrl(int $messageId, array $inlineAttachments): array {
+		return array_map(function (array $inlineAttachment) use ($messageId) {
+			$inlineAttachment['url'] = $this->urlGenerator->linkToRouteAbsolute(
+				'mail.messages.downloadAttachment', [
+					'id' => $messageId,
+					'attachmentId' => $inlineAttachment['id']
+				]
+			);
+			return $inlineAttachment;
+		}, $inlineAttachments);
+	}
+
+	public function sanitizeHtmlMailBody(int $messageId, string $mailBody, array $inlineAttachments): string {
+		$inlineAttachments = $this->addAttachmentUrl($messageId, $inlineAttachments);
+
 		$config = HTMLPurifier_Config::createDefault();
 
 		// Append target="_blank" to all link (a) elements
@@ -127,18 +145,21 @@ class Html {
 		$config->set('Cache.DefinitionImpl', null);
 
 		// Rewrite URL for redirection and proxying of content
-		/** @var HTMLPurifier_HTMLDefinition $html */
-		$html = $config->getDefinition('HTML');
-		$html->info_attr_transform_post['imagesrc'] = new TransformImageSrc($this->urlGenerator);
-		$html->info_attr_transform_post['cssbackground'] = new TransformStyleURLs($this->urlGenerator);
-		$html->info_attr_transform_post['htmllinks'] = new TransformHTMLLinks();
+		/** @var HTMLPurifier_HTMLDefinition $def */
+		$def = $config->getHTMLDefinition(true);
+		$def->info_attr_transform_post['imagesrc'] = new TransformImageSrc($this->urlGenerator);
+		$def->info_attr_transform_post['cssbackground'] = new TransformStyleURLs($this->urlGenerator);
+		$def->info_attr_transform_post['htmllinks'] = new TransformHTMLLinks();
+		if (count($inlineAttachments) > 0) {
+			$def->info_attr_transform_post['datacid'] = new TransformCidDataAttr($inlineAttachments);
+		}
 
 		/** @var HTMLPurifier_URIDefinition $uri */
-		$uri = $config->getDefinition('URI');
+		$uri = $config->getURIDefinition(true);
 		$uri->addFilter(
 			new TransformURLScheme(
-				$id,
-				$mapCidToAttachmentId,
+				$messageId,
+				$inlineAttachments,
 				$this->urlGenerator,
 				$this->request,
 				$this->hmacGenerator,

--- a/lib/Service/HtmlPurify/TransformCidDataAttr.php
+++ b/lib/Service/HtmlPurify/TransformCidDataAttr.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Service\HtmlPurify;
+
+use HTMLPurifier_AttrTransform;
+use HTMLPurifier_Config;
+use HTMLPurifier_Context;
+use HTMLPurifier_URIParser;
+
+/**
+ * Sets data-cid on inline image elements after their cid: src has been replaced
+ * with an attachment URL, so the MIME builder can reconstruct inline attachments
+ * when the message is forwarded.
+ */
+class TransformCidDataAttr extends HTMLPurifier_AttrTransform {
+	private HTMLPurifier_URIParser $parser;
+	/** @var array<string, string> path => cid */
+	private array $pathToCid;
+
+	public function __construct(array $inlineAttachments) {
+		$this->parser = new HTMLPurifier_URIParser();
+		$this->pathToCid = [];
+		foreach ($inlineAttachments as $inlineAttachment) {
+			if (isset($inlineAttachment['cid'], $inlineAttachment['url'])) {
+				$url = $this->parser->parse($inlineAttachment['url']);
+				$this->pathToCid[$url->path] = $inlineAttachment['cid'];
+			}
+		}
+	}
+
+	/**
+	 * @param array $attr
+	 * @param HTMLPurifier_Config $config
+	 * @param HTMLPurifier_Context $context
+	 * @return array
+	 */
+	#[\Override]
+	public function transform($attr, $config, $context) {
+		if ($context->get('CurrentToken')->name !== 'img' || !isset($attr['src'])) {
+			return $attr;
+		}
+
+		$url = $this->parser->parse($attr['src']);
+		$cid = $this->pathToCid[$url->path] ?? null;
+
+		if ($cid !== null) {
+			$attr['data-cid'] = $cid;
+		}
+
+		return $attr;
+	}
+}

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service\HtmlPurify;
 
-use Closure;
 use HTMLPurifier_Config;
+use HTMLPurifier_Context;
 use HTMLPurifier_URI;
 use HTMLPurifier_URIFilter;
 use HTMLPurifier_URIParser;
@@ -20,34 +20,15 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 
 class TransformURLScheme extends HTMLPurifier_URIFilter {
-	public $name = 'TransformURLScheme';
-	public $post = true;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var IRequest */
-	private $request;
-
-	/**
-	 * @var \Closure
-	 */
-	private $mapCidToAttachmentId;
-
-	private int $id;
-
-	private ProxyHmacGenerator $hmacGenerator;
-
-	public function __construct(int $id,
-		Closure $mapCidToAttachmentId,
-		IURLGenerator $urlGenerator,
-		IRequest $request,
-		ProxyHmacGenerator $hmacGenerator) {
-		$this->id = $id;
-		$this->mapCidToAttachmentId = $mapCidToAttachmentId;
-		$this->urlGenerator = $urlGenerator;
-		$this->request = $request;
-		$this->hmacGenerator = $hmacGenerator;
+	public function __construct(
+		private int $messageId,
+		private array $inlineAttachments,
+		private IURLGenerator $urlGenerator,
+		private IRequest $request,
+		private ProxyHmacGenerator $hmacGenerator,
+	) {
+		$this->name = 'TransformURLScheme';
+		$this->post = true;
 	}
 
 	/**
@@ -55,7 +36,7 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	 *
 	 * @param \HTMLPurifier_URI $uri
 	 * @param HTMLPurifier_Config $config
-	 * @param \HTMLPurifier_Context $context
+	 * @param HTMLPurifier_Context $context
 	 * @return bool
 	 */
 	#[\Override]
@@ -70,31 +51,13 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 		}
 
 		if ($uri->scheme === 'cid') {
-			$attachmentId = $this->mapCidToAttachmentId->__invoke($uri->path);
-			if (is_null($attachmentId)) {
-				return true;
-			}
-
-			$imgUrl = $this->urlGenerator->linkToRouteAbsolute(
-				'mail.messages.downloadAttachment',
-				[
-					'id' => $this->id,
-					'attachmentId' => $attachmentId,
-				],
-			);
-			$parser = new HTMLPurifier_URIParser();
-			$uri = $parser->parse($imgUrl);
+			$uri = $this->replaceCidWithUrl($uri);
 		}
 
 		return true;
 	}
 
-	/**
-	 * @param HTMLPurifier_URI $uri
-	 * @param \HTMLPurifier_Context $context
-	 * @return HTMLPurifier_URI
-	 */
-	private function filterHttpFtp(&$uri, $context) {
+	private function filterHttpFtp(HTMLPurifier_URI $uri, HTMLPurifier_Context $context): HTMLPurifier_URI {
 		$originalURL = $uri->scheme . '://' . $uri->host;
 
 		// Add the port if it's not a default port
@@ -124,8 +87,8 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 		}
 
 		$proxyUrl = $this->urlGenerator->linkToRoute('mail.proxy.proxy', [
-			'id' => $this->id,
-			'hmac' => $this->hmacGenerator->generate($this->id, $originalURL),
+			'id' => $this->messageId,
+			'hmac' => $this->hmacGenerator->generate($this->messageId, $originalURL),
 			'src' => $originalURL
 		]);
 		$parsedProxyUrl = parse_url($proxyUrl);
@@ -138,5 +101,17 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 			$parsedProxyUrl['query'],
 			null
 		);
+	}
+
+	private function replaceCidWithUrl(HTMLPurifier_URI $uri): HTMLPurifier_URI {
+		$inlineAttachment = array_find($this->inlineAttachments, static function ($attachment) use ($uri) {
+			return $attachment['cid'] === $uri->path;
+		});
+
+		if ($inlineAttachment === null) {
+			return $uri;
+		}
+
+		return (new HTMLPurifier_URIParser())->parse($inlineAttachment['url']);
 	}
 }

--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -138,8 +138,8 @@ class MailTransmission implements IMailTransmission {
 		$mimePart = $mimeMessage->build(
 			$localMessage->getBodyPlain(),
 			$localMessage->getBodyHtml(),
+			$localMessage->isPgpMime() === true,
 			$attachmentParts,
-			$localMessage->isPgpMime() === true
 		);
 
 		// TODO: add smimeEncrypt check if implemented

--- a/lib/Service/MimeMessage.php
+++ b/lib/Service/MimeMessage.php
@@ -26,15 +26,19 @@ class MimeMessage {
 	}
 
 	/**
-	 * generates mime message
+	 * Generates mime message
 	 *
-	 * @param string $contentPlain
-	 * @param string $contentHtml
-	 * @param Horde_Mime_Part[] $attachments
+	 * @param list<Horde_Mime_Part> $attachments
 	 *
 	 * @return Horde_Mime_Part
 	 */
-	public function build(?string $contentPlain, ?string $contentHtml, array $attachments, bool $isPgpEncrypted = false): Horde_Mime_Part {
+	public function build(
+		?string $contentPlain,
+		?string $contentHtml,
+		bool $isPgpEncrypted,
+		array $attachments,
+	): Horde_Mime_Part {
+		[$inlineAttachments, $attachments] = $this->separateAttachments($attachments);
 
 		if ($isPgpEncrypted === true && isset($contentPlain)) {
 			$basePart = $this->buildPgpPart($contentPlain);
@@ -44,12 +48,12 @@ class MimeMessage {
 			*/
 			$basePart = new Horde_Mime_Part();
 			$basePart->setType('multipart/mixed');
-			$basePart[] = $this->buildMessagePart($contentPlain, $contentHtml);
+			$basePart[] = $this->buildMessagePart($contentPlain, $contentHtml, $inlineAttachments);
 			foreach ($attachments as $attachment) {
 				$basePart[] = $attachment;
 			}
 		} else {
-			$basePart = $this->buildMessagePart($contentPlain, $contentHtml);
+			$basePart = $this->buildMessagePart($contentPlain, $contentHtml, $inlineAttachments);
 		}
 
 		$basePart->isBasePart(true);
@@ -60,9 +64,11 @@ class MimeMessage {
 	/**
 	 * generates html/plain message part
 	 *
+	 * @param list<Horde_Mime_Part> $inlineAttachments
+	 *
 	 * @return Horde_Mime_Part
 	 */
-	private function buildMessagePart(?string $contentPlain, ?string $contentHtml): Horde_Mime_Part {
+	private function buildMessagePart(?string $contentPlain, ?string $contentHtml, array $inlineAttachments): Horde_Mime_Part {
 
 		if (isset($contentHtml)) {
 
@@ -73,39 +79,9 @@ class MimeMessage {
 				$source = ' ' . $contentHtml;
 			}
 
-			// determine if content has any embedded images
-			$embeddedParts = [];
 			$doc = Parser::parseToDomDocument($source);
-			foreach ($doc->getElementsByTagName('img') as $id => $image) {
-				if (!($image instanceof DOMElement)) {
-					continue;
-				}
-
-				$src = $image->getAttribute('src');
-				if ($src === '') {
-					continue;
-				}
-				try {
-					$dataUri = $this->uriParser->parse($src);
-				} catch (InvalidDataUriException $e) {
-					continue;
-				}
-
-				$part = new Horde_Mime_Part();
-				$part->setType($dataUri->getMediaType());
-				$part->setCharset($dataUri->getParameters()['charset']);
-				$part->setName('embedded_image_' . $id);
-				$part->setDisposition('inline');
-				if ($dataUri->isBase64()) {
-					$part->setTransferEncoding('base64');
-				}
-				$part->setContents($dataUri->getData());
-
-				$cid = $part->setContentId();
-				$embeddedParts[] = $part;
-
-				$image->setAttribute('src', 'cid:' . $cid);
-			}
+			array_push($inlineAttachments, ...$this->extractDataUriImages($doc));
+			$this->rewriteSrcToCid($doc);
 			$htmlContent = $doc->saveHTML();
 
 			$htmlPart = new Horde_Mime_Part();
@@ -145,14 +121,14 @@ class MimeMessage {
 			$messagePart = new Horde_Mime_Part();
 		}
 
-		if (isset($embeddedParts) && count($embeddedParts) > 0) {
+		if (count($inlineAttachments) > 0) {
 			/*
 			 * Text parts with embedded content (e.g. inline images, etc) need be wrapped in multipart/related part
 			 */
 			$basePart = new Horde_Mime_Part();
 			$basePart->setType('multipart/related');
 			$basePart[] = $messagePart;
-			foreach ($embeddedParts as $part) {
+			foreach ($inlineAttachments as $part) {
 				$basePart[] = $part;
 			}
 		} else {
@@ -160,6 +136,74 @@ class MimeMessage {
 		}
 
 		return $basePart;
+	}
+
+	/**
+	 * Extracts data URI images from the HTML document, converts each to an
+	 * inline MIME part with a generated Content-ID, and rewrites the src
+	 * attribute to the corresponding cid: reference.
+	 *
+	 * @return Horde_Mime_Part[]
+	 */
+	private function extractDataUriImages(DOMDocument $doc): array {
+		$parts = [];
+		foreach ($doc->getElementsByTagName('img') as $id => $image) {
+			if (!($image instanceof DOMElement)) {
+				continue;
+			}
+
+			$src = $image->getAttribute('src');
+			if ($src === '') {
+				continue;
+			}
+
+			try {
+				$dataUri = $this->uriParser->parse($src);
+			} catch (InvalidDataUriException) {
+				continue;
+			}
+
+			if (!str_starts_with($dataUri->getMediaType(), 'image/')) {
+				continue;
+			}
+
+			$part = new Horde_Mime_Part();
+			$part->setType($dataUri->getMediaType());
+			$part->setCharset($dataUri->getParameters()['charset']);
+			$part->setName('embedded_image_' . $id);
+			$part->setDisposition('inline');
+			if ($dataUri->isBase64()) {
+				$part->setTransferEncoding('base64');
+			}
+			$part->setContents($dataUri->getData());
+
+			$cid = $part->setContentId();
+			$parts[] = $part;
+
+			$image->setAttribute('src', 'cid:' . $cid);
+		}
+		return $parts;
+	}
+
+	/**
+	 * Rewrites src attributes of img elements that carry a data-cid attribute
+	 * back to their cid: reference, as required by the MIME structure for
+	 * inline attachments when forwarding messages.
+	 */
+	private function rewriteSrcToCid(DOMDocument $doc): void {
+		foreach ($doc->getElementsByTagName('img') as $image) {
+			if (!($image instanceof DOMElement)) {
+				continue;
+			}
+
+			$cid = $image->getAttribute('data-cid');
+			if ($cid === '') {
+				continue;
+			}
+
+			$image->setAttribute('src', 'cid:' . $cid);
+			$image->removeAttribute('data-cid');
+		}
 	}
 
 	/**
@@ -194,6 +238,25 @@ class MimeMessage {
 
 		return $basePart;
 
+	}
+
+	/**
+	 * @param list<Horde_Mime_Part> $attachments
+	 * @return array{0: list<Horde_Mime_Part>, 1: list<Horde_Mime_Part>}
+	 */
+	private function separateAttachments(array $attachments): array {
+		$inline = [];
+		$normal = [];
+
+		foreach ($attachments as $attachment) {
+			if ($attachment->getDisposition() === 'inline') {
+				$inline[] = $attachment;
+			} else {
+				$normal[] = $attachment;
+			}
+		}
+
+		return [$inline, $normal];
 	}
 
 	/**

--- a/lib/Service/TransmissionService.php
+++ b/lib/Service/TransmissionService.php
@@ -75,10 +75,20 @@ class TransmissionService {
 			[$localAttachment, $file] = $this->attachmentService->getAttachment($account->getMailAccount()->getUserId(), (int)$attachment['id']);
 			$part = new Horde_Mime_Part();
 			$part->setCharset('us-ascii');
-			if (!empty($localAttachment->getFileName())) {
-				$part->setDisposition('attachment');
+
+			if ($localAttachment->isDispositionAttachmentOrInline()) {
+				$part->setDisposition($localAttachment->getDisposition());
+				/*
+				 * Setting a name implicitly adds a Content-Disposition header in Horde,
+				 * which would override the intentional omission. Only set it for attachment/inline dispositions.
+				 */
 				$part->setName($localAttachment->getFileName());
 			}
+
+			if ($localAttachment->getContentId() !== null) {
+				$part->setContentId($localAttachment->getContentId());
+			}
+
 			$part->setContents($file->getContent());
 			/*
 			 * Horde_Mime_Part.setType takes the mimetype (e.g. text/calendar)

--- a/psalm.xml
+++ b/psalm.xml
@@ -24,6 +24,9 @@
 		<directory name="lib/Vendor" />
 		<directory name="vendor-bin/psalm-stubs" />
     </extraFiles>
+	<stubs>
+		<file name="tests/stubs/php-polyfill.php" />
+	</stubs>
 	<issueHandlers>
 		<UndefinedAttributeClass>
 			<errorLevel type="info">
@@ -68,10 +71,5 @@
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 			</errorLevel>
 		</UndefinedDocblockClass>
-		<UndefinedFunction>
-			<errorLevel type="suppress">
-				<referencedFunction name="str_contains" />
-			</errorLevel>
-		</UndefinedFunction>
 	</issueHandlers>
 </psalm>

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -5,9 +5,7 @@
 <template>
 	<li class="composer-attachment" :class="{ 'composer-attachment--with-error': attachment.error }">
 		<div class="attachment-preview">
-			<img v-if="attachment.imageBlobURL !== false" :src="attachment.imageBlobURL" class="attachment-preview-image">
-			<img v-else-if="attachment.hasPreview" :src="previewURL" class="attachment-preview-image">
-			<img v-else :src="getIcon" class="attachment-preview-image">
+			<img :src="previewSrc" class="attachment-preview-image">
 			<span v-if="attachment.type === 'cloud'" class="cloud-attachment-icon">
 				<Cloud :size="20" />
 			</span>
@@ -67,14 +65,16 @@ export default {
 	},
 
 	computed: {
-		previewURL() {
-			if (this.attachment.hasPreview && this.attachment.id > 0) {
+		previewSrc() {
+			if (this.attachment.imageBlobURL) {
+				return this.attachment.imageBlobURL
+			}
+
+			// attachment from cloud
+			if (this.attachment.type === 'cloud' && this.attachment.hasPreview && this.attachment.id > 0) {
 				return generateUrl(`/core/preview?fileId=${this.attachment.id}&x=100&y=100&a=0`)
 			}
-			return ''
-		},
 
-		getIcon() {
 			return OC.MimeType.getIconUrl(this.attachment.fileType)
 		},
 

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -199,6 +199,7 @@ export default {
 				finished: true,
 				sizeString: this.formatBytes(attachment.size),
 				imageBlobURL: attachment.isImage ? attachment.downloadUrl : attachment.mimeUrl,
+				type: attachment.type,
 			})
 			return attachment
 		})
@@ -281,6 +282,7 @@ export default {
 					finished: false,
 					error: false,
 					hasPreview: false,
+					type: 'local',
 					controller,
 				}
 				this.attachments.push(attachment)

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -217,6 +217,17 @@ export default {
 						},
 					],
 				},
+
+				htmlSupport: {
+					allow: [
+						{
+							name: 'img',
+							attributes: {
+								'data-cid': true,
+							},
+						},
+					],
+				},
 			},
 		}
 	},

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -61,7 +61,10 @@ import {
 } from '../../service/caldavService.js'
 import { moveDraft, updateDraft } from '../../service/DraftService.js'
 import * as FollowUpService from '../../service/FollowUpService.js'
-import { addInternalAddress, removeInternalAddress } from '../../service/InternalAddressService.js'
+import {
+	addInternalAddress,
+	removeInternalAddress,
+} from '../../service/InternalAddressService.js'
 import {
 	clearMailbox,
 	create as createMailbox,
@@ -92,14 +95,25 @@ import {
 } from '../../service/MessageService.js'
 import { showNewMessagesNotification } from '../../service/NotificationService.js'
 import { savePreference } from '../../service/PreferenceService.js'
-import { createQuickAction, deleteQuickAction, updateQuickAction } from '../../service/QuickActionsService.js'
+import {
+	createQuickAction,
+	deleteQuickAction,
+	updateQuickAction,
+} from '../../service/QuickActionsService.js'
 import {
 	getActiveScript,
 	updateActiveScript,
 	updateAccount as updateSieveAccount,
 } from '../../service/SieveService.js'
-import * as SmimeCertificateService from '../../service/SmimeCertificateService.js'
-import { createTextBlock, deleteTextBlock, fetchMyTextBlocks, fetchSharedTextBlocks, updateTextBlock } from '../../service/TextBlockService.js'
+import * as SmimeCertificateService
+	from '../../service/SmimeCertificateService.js'
+import {
+	createTextBlock,
+	deleteTextBlock,
+	fetchMyTextBlocks,
+	fetchSharedTextBlocks,
+	updateTextBlock,
+} from '../../service/TextBlockService.js'
 import * as ThreadService from '../../service/ThreadService.js'
 import { normalizedEnvelopeListId } from '../../util/normalization.js'
 import {
@@ -522,6 +536,7 @@ export default function mainStoreActions() {
 								bodyPlain: data.bodyPlain,
 								replyTo: reply.data,
 								smartReply: reply.smartReply,
+								attachments: this.prepareAttachments(original),
 							},
 						})
 						return
@@ -543,6 +558,7 @@ export default function mainStoreActions() {
 								bodyPlain: data.bodyPlain,
 								replyTo: reply.data,
 								smartReply: reply.smartReply,
+								attachments: this.prepareAttachments(original),
 							},
 						})
 						return
@@ -558,13 +574,7 @@ export default function mainStoreActions() {
 								bodyHtml: data.bodyHtml,
 								bodyPlain: data.bodyPlain,
 								forwardFrom: reply.data,
-								attachments: original.attachments.map((attachment) => ({
-									...attachment,
-									mailboxId: original.mailboxId,
-									// messageId for attachments is actually the uid
-									uid: attachment.messageId,
-									type: 'message-attachment',
-								})),
+								attachments: this.prepareAttachments(original, true),
 							},
 						})
 						return
@@ -613,6 +623,35 @@ export default function mainStoreActions() {
 					this.setComposerMessageSavedMutation(true)
 				}
 			})
+		},
+		prepareAttachments(original, forward = false) {
+			const attachments = []
+
+			if (forward && original.attachments) {
+				for (const attachment of original.attachments) {
+					attachments.push({
+						...attachment,
+						mailboxId: original.mailboxId,
+						// messageId for attachments is actually the uid
+						uid: attachment.messageId,
+						type: 'message-attachment',
+					})
+				}
+			}
+
+			if (original.inlineAttachments) {
+				for (const inlineAttachment of original.inlineAttachments) {
+					attachments.push({
+						...inlineAttachment,
+						mailboxId: original.mailboxId,
+						// messageId for attachments is actually the uid
+						uid: inlineAttachment.messageId,
+						type: 'message-attachment-inline',
+					})
+				}
+			}
+
+			return attachments
 		},
 		async stopComposerSession({
 			restoreOriginalSendAt = false,

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -674,4 +674,46 @@ describe('Vuex store actions', () => {
 			'abcdef123', // cache buster
 		)
 	})
+
+	describe('prepareAttachments', () => {
+		const original = {
+			mailboxId: 1,
+			attachments: [{ id: 'att1', messageId: 42, fileName: 'doc.pdf' }],
+			inlineAttachments: [{ id: 'img1', messageId: 42, cid: 'abc@x', fileName: 'logo.png' }],
+		}
+
+		it('reply includes only inline attachments', () => {
+			const result = store.prepareAttachments(original)
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toMatchObject({
+				id: 'img1',
+				type: 'message-attachment-inline',
+				mailboxId: 1,
+				uid: 42,
+			})
+		})
+
+		it('forward includes regular and inline attachments', () => {
+			const result = store.prepareAttachments(original, true)
+
+			expect(result).toHaveLength(2)
+			expect(result[0]).toMatchObject({
+				id: 'att1',
+				type: 'message-attachment',
+				mailboxId: 1,
+				uid: 42,
+			})
+			expect(result[1]).toMatchObject({
+				id: 'img1',
+				type: 'message-attachment-inline',
+				mailboxId: 1,
+				uid: 42,
+			})
+		})
+
+		it('returns empty array when message has no attachments', () => {
+			expect(store.prepareAttachments({})).toEqual([])
+		})
+	})
 })

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -476,6 +476,8 @@ class MessagesControllerTest extends TestCase {
 				'image/png',
 				'abcdefg',
 				7,
+				null,
+				null,
 			),
 		];
 

--- a/tests/Unit/Db/LocalAttachmentTest.php
+++ b/tests/Unit/Db/LocalAttachmentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Db;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\LocalAttachment;
+
+class LocalAttachmentTest extends TestCase {
+	public function testIsDispositionAttachmentOrInlineWithAttachment(): void {
+		$attachment = new LocalAttachment();
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_ATTACHMENT);
+
+		$this->assertTrue($attachment->isDispositionAttachmentOrInline());
+	}
+
+	public function testIsDispositionAttachmentOrInlineWithInline(): void {
+		$attachment = new LocalAttachment();
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_INLINE);
+
+		$this->assertTrue($attachment->isDispositionAttachmentOrInline());
+	}
+
+	public function testIsDispositionAttachmentOrInlineWithNull(): void {
+		$attachment = new LocalAttachment();
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_OMIT);
+
+		$this->assertFalse($attachment->isDispositionAttachmentOrInline());
+	}
+
+	public function testIsDispositionAttachmentOrInlineWithNoDispositionSet(): void {
+		$attachment = new LocalAttachment();
+
+		$this->assertFalse($attachment->isDispositionAttachmentOrInline());
+	}
+}

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -778,7 +778,7 @@ class MessageMapperTest extends TestCase {
 		);
 
 		$this->assertEquals('test.pdf', $attachment->getName());
-		$this->assertEquals('application/octet-stream', $attachment->getType());
+		$this->assertEquals('application/pdf', $attachment->getType());
 		$this->assertEquals($bodyContent, $attachment->getContent());
 	}
 
@@ -807,7 +807,7 @@ class MessageMapperTest extends TestCase {
 		);
 
 		$this->assertEquals('fallback.pdf', $attachment->getName());
-		$this->assertEquals('application/octet-stream', $attachment->getType());
+		$this->assertEquals('application/pdf', $attachment->getType());
 	}
 
 	public function testGetAttachmentTextCalendarContentType(): void {
@@ -908,7 +908,8 @@ class MessageMapperTest extends TestCase {
 		);
 
 		$this->assertEquals('report.pdf', $attachment->getName());
-		$this->assertEquals('application/octet-stream', $attachment->getType());
+		$this->assertEquals('application/pdf', $attachment->getType());
+		$this->assertEquals('attachment', $attachment->disposition);
 	}
 
 	public function testGetAttachmentEncryptedWithInlineImage(): void {
@@ -926,6 +927,7 @@ class MessageMapperTest extends TestCase {
 		);
 
 		$this->assertEquals('nextcloud.png', $attachment->getName());
-		$this->assertEquals('application/octet-stream', $attachment->getType());
+		$this->assertEquals('image/png', $attachment->getType());
+		$this->assertEquals('inline', $attachment->disposition);
 	}
 }

--- a/tests/Unit/Service/Attachment/AttachmentServiceTest.php
+++ b/tests/Unit/Service/Attachment/AttachmentServiceTest.php
@@ -97,6 +97,7 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'createdAt' => 123456,
+			'disposition' => LocalAttachment::DISPOSITION_ATTACHMENT,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -129,12 +130,14 @@ class AttachmentServiceTest extends TestCase {
 		$attachment = LocalAttachment::fromParams([
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
-			'createdAt' => 123456
+			'createdAt' => 123456,
+			'disposition' => LocalAttachment::DISPOSITION_ATTACHMENT,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
+			'disposition' => LocalAttachment::DISPOSITION_ATTACHMENT,
 		]);
 
 		$this->mapper->expects($this->once())
@@ -154,6 +157,8 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'image/jpg',
+			'contentId' => null,
+			'disposition' => null,
 			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
@@ -169,14 +174,14 @@ class AttachmentServiceTest extends TestCase {
 			->willReturn($persistedAttachment);
 		$this->storage->expects($this->once())
 			->method('saveContent')
-			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'))
+			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('Lorem ipsum dolor sit amet'))
 			->willThrowException(new NotPermittedException());
 		$this->mapper->expects($this->once())
 			->method('delete')
 			->with($this->equalTo($persistedAttachment));
 		$this->expectException(UploadException::class);
 
-		$this->service->addFileFromString($userId, 'cat.jpg', 'image/jpg', 'sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds');
+		$this->service->addFileFromString($userId, 'cat.jpg', 'image/jpg', 'Lorem ipsum dolor sit amet', null, null);
 	}
 
 	public function testAddFileFromString() {
@@ -200,9 +205,16 @@ class AttachmentServiceTest extends TestCase {
 			->willReturn($persistedAttachment);
 		$this->storage->expects($this->once())
 			->method('saveContent')
-			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'));
+			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('Lorem ipsum dolor sit amet'));
 
-		$this->service->addFileFromString($userId, 'cat.jpg', 'image/jpg', 'sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds');
+		$this->service->addFileFromString(
+			$userId,
+			'cat.jpg',
+			'image/jpg',
+			'Lorem ipsum dolor sit amet',
+			null,
+			null,
+		);
 	}
 
 	public function testDeleteAttachment(): void {
@@ -302,6 +314,7 @@ class AttachmentServiceTest extends TestCase {
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
 			'createdAt' => 123456,
+			'disposition' => 'attachment'
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -323,6 +336,7 @@ class AttachmentServiceTest extends TestCase {
 			'id' => 123,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+
 		];
 
 		$this->mailManager->expects(self::once())
@@ -336,14 +350,14 @@ class AttachmentServiceTest extends TestCase {
 		$this->messageMapper->expects(self::once())
 			->method('getFullText')
 			->with($client, $mailbox->getName(), $message->getUid(), $userId)
-			->willReturn('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds');
+			->willReturn('Lorem ipsum dolor sit amet');
 		$this->mapper->expects($this->once())
 			->method('insert')
 			->with($this->equalTo($attachment))
 			->willReturn($persistedAttachment);
 		$this->storage->expects($this->once())
 			->method('saveContent')
-			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'));
+			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('Lorem ipsum dolor sit amet'));
 		$this->service->handleAttachments($account, [$attachments], $client);
 	}
 
@@ -353,6 +367,8 @@ class AttachmentServiceTest extends TestCase {
 			'userId' => $userId,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+			'contentId' => null,
+			'disposition' => 'attachment',
 			'createdAt' => 123456,
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
@@ -373,18 +389,27 @@ class AttachmentServiceTest extends TestCase {
 			'type' => 'message-attachment',
 			'mailboxId' => $mailbox->getId(),
 			'uid' => 999,
+			'id' => '2',
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
 		];
-		$imapAttachment = ['sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'];
+		$imapAttachment = new \OCA\Mail\Attachment(
+			'2',
+			'cat.jpg',
+			'text/plain',
+			'Lorem ipsum dolor sit amet',
+			strlen('Lorem ipsum dolor sit amet'),
+			null,
+			'attachment',
+		);
 
 		$this->mailManager->expects(self::once())
 			->method('getMailbox')
 			->with($account->getUserId(), $mailbox->getId())
 			->willReturn($mailbox);
 		$this->messageMapper->expects(self::once())
-			->method('getRawAttachments')
-			->with($client, $mailbox->getName(), 999)
+			->method('getAttachment')
+			->with($client, $mailbox->getName(), 999, '2', $userId)
 			->willReturn($imapAttachment);
 		$this->mapper->expects($this->once())
 			->method('insert')
@@ -392,7 +417,68 @@ class AttachmentServiceTest extends TestCase {
 			->willReturn($persistedAttachment);
 		$this->storage->expects($this->once())
 			->method('saveContent')
-			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'));
+			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('Lorem ipsum dolor sit amet'));
+
+		$this->service->handleAttachments($account, [$attachments], $client);
+	}
+
+	public function testHandleAttachmentsForwardedInlineAttachmentPreservesContentId(): void {
+		$userId = 'linus';
+		$attachment = LocalAttachment::fromParams([
+			'userId' => $userId,
+			'fileName' => 'logo.png',
+			'mimeType' => 'image/png',
+			'contentId' => 'img001@example.com',
+			'disposition' => 'inline',
+			'createdAt' => 123456,
+		]);
+		$persistedAttachment = LocalAttachment::fromParams([
+			'id' => 456,
+			'userId' => $userId,
+			'fileName' => 'logo.png',
+			'mimeType' => 'image/png',
+		]);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getUserId' => $userId
+		]);
+
+		$mailbox = new Mailbox();
+		$mailbox->setId(9);
+		$mailbox->setName('INBOX');
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$attachments = [
+			'type' => 'message-attachment-inline',
+			'mailboxId' => $mailbox->getId(),
+			'uid' => 999,
+			'id' => '3',
+			'fileName' => 'logo.png',
+			'mimeType' => 'image/png',
+		];
+		$imapAttachment = new \OCA\Mail\Attachment(
+			'3',
+			'logo.png',
+			'image/png',
+			'fake png content',
+			strlen('fake png content'),
+			'img001@example.com',
+			'inline',
+		);
+
+		$this->mailManager->expects(self::once())
+			->method('getMailbox')
+			->with($account->getUserId(), $mailbox->getId())
+			->willReturn($mailbox);
+		$this->messageMapper->expects(self::once())
+			->method('getAttachment')
+			->with($client, $mailbox->getName(), 999, '3', $userId)
+			->willReturn($imapAttachment);
+		$this->mapper->expects($this->once())
+			->method('insert')
+			->with($this->equalTo($attachment))
+			->willReturn($persistedAttachment);
+		$this->storage->expects($this->once())
+			->method('saveContent')
+			->with($this->equalTo($userId), $this->equalTo(456), $this->equalTo('fake png content'));
 
 		$this->service->handleAttachments($account, [$attachments], $client);
 	}
@@ -420,7 +506,7 @@ class AttachmentServiceTest extends TestCase {
 		$file = $this->createConfiguredMock(File::class, [
 			'getName' => 'cat.jpg',
 			'getMimeType' => 'text/plain',
-			'getContent' => 'sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds',
+			'getContent' => 'Lorem ipsum dolor sit amet',
 			'getStorage' => $storage
 		]);
 		$account = $this->createConfiguredMock(Account::class, [
@@ -452,7 +538,7 @@ class AttachmentServiceTest extends TestCase {
 		$file = $this->createConfiguredMock(File::class, [
 			'getName' => 'cat.jpg',
 			'getMimeType' => 'text/plain',
-			'getContent' => 'sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds',
+			'getContent' => 'Lorem ipsum dolor sit amet',
 			'getStorage' => $this->createMock(SharedStorage::class)
 		]);
 		$account = $this->createConfiguredMock(Account::class, [
@@ -464,6 +550,7 @@ class AttachmentServiceTest extends TestCase {
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
 			'createdAt' => 123456,
+			'disposition' => 'attachment'
 		]);
 		$persistedAttachment = LocalAttachment::fromParams([
 			'id' => 123,
@@ -476,6 +563,7 @@ class AttachmentServiceTest extends TestCase {
 			'messageId' => 999,
 			'fileName' => 'cat.jpg',
 			'mimeType' => 'text/plain',
+
 		];
 
 		$this->userFolder->expects(self::once())
@@ -492,7 +580,7 @@ class AttachmentServiceTest extends TestCase {
 			->willReturn($persistedAttachment);
 		$this->storage->expects($this->once())
 			->method('saveContent')
-			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('sjdhfkjsdhfkjsdhfkjdshfjhdskfjhds'));
+			->with($this->equalTo($userId), $this->equalTo(123), $this->equalTo('Lorem ipsum dolor sit amet'));
 
 		$this->service->handleAttachments($account, [$attachments], $client);
 	}

--- a/tests/Unit/Service/HtmlPurify/TransformCidDataAttrTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformCidDataAttrTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\HtmlPurify;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use HTMLPurifier_Config;
+use HTMLPurifier_Context;
+use HTMLPurifier_Token_Start;
+use OCA\Mail\Service\HtmlPurify\TransformCidDataAttr;
+
+class TransformCidDataAttrTest extends TestCase {
+	private HTMLPurifier_Config $config;
+
+	private array $inlineAttachments = [
+		[
+			'cid' => 'image001@example.com',
+			'url' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7',
+		],
+		[
+			'cid' => 'image002@example.com',
+			'url' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/8',
+		],
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = HTMLPurifier_Config::createDefault();
+	}
+
+	private function makeContext(string $tagName = 'img'): HTMLPurifier_Context {
+		$context = new HTMLPurifier_Context();
+		$token = new HTMLPurifier_Token_Start($tagName);
+		$context->register('CurrentToken', $token);
+		return $context;
+	}
+
+	public function testNonImgTagIsUnchanged(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('div');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testImgWithoutSrcIsUnchanged(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = ['alt' => 'image'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testMatchingSrcSetsCidAttribute(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertSame('image001@example.com', $result['data-cid']);
+	}
+
+	public function testSecondAttachmentMatches(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/8'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertSame('image002@example.com', $result['data-cid']);
+	}
+
+	public function testNonMatchingSrcLeavesNoCidAttribute(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/99'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testPathComparisonIgnoresSchemeAndHost(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		// Same path, different scheme/host (e.g. behind a reverse proxy)
+		$attr = ['src' => 'http://internal.proxy/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertSame('image001@example.com', $result['data-cid']);
+	}
+
+	public function testAttachmentWithoutCidIsSkipped(): void {
+		$attachments = [
+			['url' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'],
+		];
+		$transform = new TransformCidDataAttr($attachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testAttachmentWithoutUrlIsSkipped(): void {
+		$attachments = [
+			['cid' => 'image001@example.com'],
+		];
+		$transform = new TransformCidDataAttr($attachments);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testEmptyInlineAttachments(): void {
+		$transform = new TransformCidDataAttr([]);
+		$attr = ['src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7'];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertArrayNotHasKey('data-cid', $result);
+	}
+
+	public function testExistingAttributesArePreserved(): void {
+		$transform = new TransformCidDataAttr($this->inlineAttachments);
+		$attr = [
+			'src' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7',
+			'alt' => 'inline image',
+			'width' => '100',
+		];
+		$context = $this->makeContext('img');
+
+		$result = $transform->transform($attr, $this->config, $context);
+
+		$this->assertSame('inline image', $result['alt']);
+		$this->assertSame('100', $result['width']);
+		$this->assertSame('image001@example.com', $result['data-cid']);
+	}
+}

--- a/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Service\HtmlPurify;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use Closure;
 use HTMLPurifier_Config;
 use HTMLPurifier_Context;
 use HTMLPurifier_URI;
@@ -25,7 +24,10 @@ class TransformURLSchemeTest extends TestCase {
 	private IURLGenerator|MockObject $urlGenerator;
 	private IRequest|MockObject $request;
 	private ProxyHmacGenerator|MockObject $hmacGenerator;
-	private Closure $mapCidToAttachmentId;
+
+	private array $inlineAttachments = [
+		['cid' => 'valid-cid', 'url' => 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/123'],
+	];
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -33,16 +35,9 @@ class TransformURLSchemeTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
 
-		$this->mapCidToAttachmentId = function (string $cid) {
-			if ($cid === 'valid-cid') {
-				return 123;
-			}
-			return null;
-		};
-
 		$this->filter = new TransformURLScheme(
 			42,
-			$this->mapCidToAttachmentId,
+			$this->inlineAttachments,
 			$this->urlGenerator,
 			$this->request,
 			$this->hmacGenerator,
@@ -221,11 +216,6 @@ class TransformURLSchemeTest extends TestCase {
 		$config = HTMLPurifier_Config::createDefault();
 		$context = new HTMLPurifier_Context();
 
-		$this->urlGenerator->expects($this->once())
-			->method('linkToRouteAbsolute')
-			->with('mail.messages.downloadAttachment', $this->anything())
-			->willReturn('https://mail.example.com/download/123');
-
 		$result = $this->filter->filter($uri, $config, $context);
 
 		$this->assertTrue($result);
@@ -325,27 +315,17 @@ class TransformURLSchemeTest extends TestCase {
 		$this->assertStringContainsString('%23section', $uri->query);
 	}
 
-	public function testCidSchemeMapsCidToAttachmentId(): void {
-		$filter = new TransformURLScheme(
-			42,
-			$this->mapCidToAttachmentId,
-			$this->urlGenerator,
-			$this->request,
-			$this->hmacGenerator,
-		);
-
+	public function testCidSchemeRewritesUriFromUrl(): void {
 		$uri = new HTMLPurifier_URI('cid', null, null, null, 'valid-cid', null, null);
 		$config = HTMLPurifier_Config::createDefault();
 		$context = new HTMLPurifier_Context();
 
-		$this->urlGenerator->expects($this->once())
-			->method('linkToRouteAbsolute')
-			->with('mail.messages.downloadAttachment', [
-				'id' => 42,
-				'attachmentId' => 123,
-			])
-			->willReturn('https://mail.example.com/download/123');
+		$this->urlGenerator->expects($this->never())->method('linkToRouteAbsolute');
 
-		$filter->filter($uri, $config, $context);
+		$this->filter->filter($uri, $config, $context);
+
+		$this->assertSame('https', $uri->scheme);
+		$this->assertSame('mail.example.com', $uri->host);
+		$this->assertStringContainsString('/apps/mail/api/messages/42/attachment/123', $uri->path);
 	}
 }

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -81,6 +81,43 @@ class HtmlTest extends TestCase {
 		];
 	}
 
+	public function testSanitizeHtmlMailBodyRewritesCidToUrl(): void {
+		$attachmentUrl = 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7';
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('mail.messages.downloadAttachment', ['id' => 42, 'attachmentId' => '7'])
+			->willReturn($attachmentUrl);
+		$request = $this->createMock(IRequest::class);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$inlineAttachments = [['id' => '7', 'cid' => 'image001@example.com']];
+
+		$result = $html->sanitizeHtmlMailBody(42, '<img src="cid:image001@example.com">', $inlineAttachments);
+
+		$this->assertStringContainsString($attachmentUrl, $result);
+		$this->assertStringNotContainsString('src="cid:', $result);
+	}
+
+	public function testSanitizeHtmlMailBodySetsDataCidOnInlineImage(): void {
+		$attachmentUrl = 'https://mail.example.com/index.php/apps/mail/api/messages/42/attachment/7';
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$urlGenerator->expects(self::once())
+			->method('linkToRouteAbsolute')
+			->with('mail.messages.downloadAttachment', ['id' => 42, 'attachmentId' => '7'])
+			->willReturn($attachmentUrl);
+		$request = $this->createMock(IRequest::class);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$inlineAttachments = [['id' => '7', 'cid' => 'image001@example.com']];
+
+		$result = $html->sanitizeHtmlMailBody(42, '<img src="cid:image001@example.com">', $inlineAttachments);
+
+		$this->assertStringContainsString('data-cid="image001@example.com"', $result);
+	}
+
 	public function testSanitizeStyleSheet() {
 		$blockedUrl = '/apps/mail/img/blocked-image.png';
 		$urlGenerator = self::createMock(IURLGenerator::class);

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -537,7 +537,9 @@ class MailManagerTest extends TestCase {
 				'cat.png',
 				'image/png',
 				'abcdefg',
-				7
+				7,
+				null,
+				null,
 			),
 		];
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);

--- a/tests/Unit/Service/MimeMessageTest.php
+++ b/tests/Unit/Service/MimeMessageTest.php
@@ -47,6 +47,7 @@ class MimeMessageTest extends TestCase {
 		$part = $this->mimeMessage->build(
 			$messageData->getBody(),
 			null,
+			false,
 			[],
 		);
 
@@ -69,6 +70,7 @@ class MimeMessageTest extends TestCase {
 		$part = $this->mimeMessage->build(
 			$messageData->getBody(),
 			$messageData->getBody(),
+			false,
 			[],
 		);
 
@@ -97,6 +99,7 @@ class MimeMessageTest extends TestCase {
 		$part = $this->mimeMessage->build(
 			$messageData->getBody(),
 			$messageData->getBody(),
+			false,
 			[],
 		);
 
@@ -122,15 +125,17 @@ class MimeMessageTest extends TestCase {
 			false
 		);
 
-		$attachment1 = $this->createAttachmentDetails(
+		$attachment1 = $this->createAttachmentPart(
 			'nextcloud logo',
 			file_get_contents(__DIR__ . '/../../../tests/data/nextcloud.png'),
-			'image/png'
+			'image/png',
+			'attachment',
 		);
 
 		$part = $this->mimeMessage->build(
 			$messageData->getBody(),
 			$messageData->getBody(),
+			false,
 			[$attachment1],
 		);
 
@@ -167,21 +172,24 @@ class MimeMessageTest extends TestCase {
 			false
 		);
 
-		$attachment1 = $this->createAttachmentDetails(
+		$attachment1 = $this->createAttachmentPart(
 			'nextcloud logo',
 			file_get_contents(__DIR__ . '/../../../tests/data/nextcloud.png'),
-			'image/png'
+			'image/png',
+			'attachment',
 		);
 
-		$attachment2 = $this->createAttachmentDetails(
+		$attachment2 = $this->createAttachmentPart(
 			'sensitive animals logo',
 			file_get_contents(__DIR__ . '/../../../tests/data/test.txt'),
-			'text/plain'
+			'text/plain',
+			'attachment',
 		);
 
 		$part = $this->mimeMessage->build(
 			$messageData->getBody(),
 			$messageData->getBody(),
+			false,
 			[$attachment1, $attachment2],
 		);
 
@@ -224,6 +232,106 @@ class MimeMessageTest extends TestCase {
 		$this->assertEquals('attachment', $attachmentPart2->getDisposition());
 	}
 
+	public function testInlineAttachmentGoesIntoMultipartRelated(): void {
+		$inlinePart = $this->createAttachmentPart(
+			'inline image',
+			file_get_contents(__DIR__ . '/../../../tests/data/nextcloud.png'),
+			'image/png',
+			'inline',
+		);
+		$inlinePart->setContentId('test-inline-image@example.com');
+
+		$part = $this->mimeMessage->build(
+			'Hello',
+			'<p>Hello</p>',
+			false,
+			[$inlinePart],
+		);
+
+		$this->assertEquals('multipart/related', $part->getType());
+
+		/** @var Horde_Mime_Part[] $subParts */
+		$subParts = $part->getParts();
+		$this->assertCount(2, $subParts);
+		$this->assertEquals('inline', $subParts[1]->getDisposition());
+		$this->assertEquals('image/png', $subParts[1]->getType());
+		$this->assertEquals('test-inline-image@example.com', $subParts[1]->getContentId());
+	}
+
+	public function testInlineAndNormalAttachmentsSeparated(): void {
+		$inlinePart = $this->createAttachmentPart(
+			'inline image',
+			file_get_contents(__DIR__ . '/../../../tests/data/nextcloud.png'),
+			'image/png',
+			'inline',
+		);
+		$inlinePart->setContentId('test-inline-image@example.com');
+
+		$normalPart = $this->createAttachmentPart(
+			'document.txt',
+			'some content',
+			'text/plain',
+			'attachment',
+		);
+
+		$part = $this->mimeMessage->build(
+			'Hello',
+			'<p>Hello</p>',
+			false,
+			[$inlinePart, $normalPart],
+		);
+
+		// multipart/mixed wraps (multipart/related + normal attachment)
+		$this->assertEquals('multipart/mixed', $part->getType());
+
+		/** @var Horde_Mime_Part[] $subParts */
+		$subParts = $part->getParts();
+		$this->assertCount(2, $subParts);
+
+		$this->assertEquals('multipart/related', $subParts[0]->getType());
+		$this->assertEquals('attachment', $subParts[1]->getDisposition());
+
+		$relatedSubParts = $subParts[0]->getParts();
+		$this->assertEquals('inline', $relatedSubParts[1]->getDisposition());
+		$this->assertEquals('test-inline-image@example.com', $relatedSubParts[1]->getContentId());
+	}
+
+	public function testRewriteSrcToCidFromDataCidAttribute(): void {
+		$inlinePart = $this->createAttachmentPart(
+			'inline image',
+			file_get_contents(__DIR__ . '/../../../tests/data/nextcloud.png'),
+			'image/png',
+			'inline',
+		);
+		$inlinePart->setContentId('test-inline-image@example.com');
+
+		$html = '<p><img src="https://example.com/image.png" data-cid="test-inline-image@example.com" /></p>';
+
+		$part = $this->mimeMessage->build(
+			null,
+			$html,
+			false,
+			[$inlinePart],
+		);
+
+		$this->assertEquals('multipart/related', $part->getType());
+
+		$relatedSubParts = $part->getParts();
+		$this->assertCount(2, $relatedSubParts);
+
+		$alternativePart = $relatedSubParts[0];
+		$this->assertEquals('multipart/alternative', $alternativePart->getType());
+
+		$alternativeSubParts = $alternativePart->getParts();
+		$this->assertCount(2, $alternativeSubParts);
+		$this->assertEquals('text/plain', $alternativeSubParts[0]->getType());
+		$this->assertEquals('text/html', $alternativeSubParts[1]->getType());
+
+		$htmlBody = $alternativeSubParts[1]->getContents();
+		$this->assertStringContainsString('cid:test-inline-image@example.com', $htmlBody);
+		$this->assertStringNotContainsString('data-cid', $htmlBody);
+	}
+
 	public function testMultipartAlternativeGreek() {
 		$messageData = new NewMessageData(
 			$this->account,
@@ -240,6 +348,7 @@ class MimeMessageTest extends TestCase {
 		$part = $this->mimeMessage->build(
 			null,
 			$messageData->getBody(),
+			false,
 			[],
 		);
 
@@ -267,18 +376,47 @@ class MimeMessageTest extends TestCase {
 		);
 	}
 
-	/**
-	 * OCA\Mail\Model\Message::createAttachmentDetails
-	 *
-	 * @param string $name
-	 * @param string $content
-	 * @param string $mime
-	 * @return void
-	 */
-	private function createAttachmentDetails(string $name, string $content, string $mime): Horde_Mime_Part {
+	public function testEmbeddedImageSkipNonImages(): void {
+		$body = file_get_contents(__DIR__ . '/../../../tests/data/mime-html-image.txt');
+		// replace image/png type with a non-image type to trigger the skip.
+		$body = str_replace('data:image/png;base64,', 'data:text/html;base64,', $body);
+
+		$messageData = new NewMessageData(
+			$this->account,
+			new AddressList(),
+			new AddressList(),
+			new AddressList(),
+			'Text, HTML but invalid inline image',
+			$body,
+			[],
+			true,
+			false
+		);
+
+		$part = $this->mimeMessage->build(
+			$messageData->getBody(),
+			$messageData->getBody(),
+			false,
+			[],
+		);
+
+		$this->assertEquals('multipart/alternative', $part->getType());
+
+		/** @var Horde_Mime_Part[] $alternativeSubParts */
+		$alternativeSubParts = $part->getParts();
+		$this->assertCount(2, $alternativeSubParts);
+		$this->assertEquals('text/plain', $alternativeSubParts[0]->getType());
+		$this->assertEquals('text/html', $alternativeSubParts[1]->getType());
+
+		$htmlBody = $alternativeSubParts[1]->getContents();
+		$this->assertStringContainsString('data:text/html;base64,', $htmlBody);
+		$this->assertStringNotContainsString('data-cid', $htmlBody);
+	}
+
+	private function createAttachmentPart(string $name, string $content, string $mime, string $disposition): Horde_Mime_Part {
 		$part = new Horde_Mime_Part();
 		$part->setCharset('us-ascii');
-		$part->setDisposition('attachment');
+		$part->setDisposition($disposition);
 		$part->setName($name);
 		$part->setContents($content);
 		$part->setType($mime);

--- a/tests/Unit/Service/TransmissionServiceTest.php
+++ b/tests/Unit/Service/TransmissionServiceTest.php
@@ -91,6 +91,7 @@ class TransmissionServiceTest extends TestCase {
 		$attachment = new LocalAttachment();
 		$attachment->setFileName('test.txt');
 		$attachment->setMimeType('text/plain');
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_ATTACHMENT);
 
 		$file = new InMemoryFile(
 			'test.txt',
@@ -106,6 +107,30 @@ class TransmissionServiceTest extends TestCase {
 		$part = $this->transmissionService->handleAttachment($account, ['id' => 1, 'type' => 'local']);
 
 		$this->assertEquals('test.txt', $part->getContentTypeParameter('name'));
+	}
+
+	public function testHandleAttachmentInlineWithContentId(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setUserId('bob');
+		$account = new Account($mailAccount);
+
+		$attachment = new LocalAttachment();
+		$attachment->setFileName('logo.png');
+		$attachment->setMimeType('image/png');
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_INLINE);
+		$attachment->setContentId('img001@example.com');
+
+		$file = new InMemoryFile('logo.png', 'fake png content');
+
+		$this->attachmentService->expects(self::once())
+			->method('getAttachment')
+			->willReturn([$attachment, $file]);
+
+		$part = $this->transmissionService->handleAttachment($account, ['id' => 1, 'type' => 'local']);
+
+		$this->assertEquals('inline', $part->getDisposition());
+		$this->assertEquals('img001@example.com', $part->getContentId());
+		$this->assertEquals('logo.png', $part->getContentTypeParameter('name'));
 	}
 
 	public function testHandleAttachmentNoId(): void {
@@ -355,23 +380,48 @@ class TransmissionServiceTest extends TestCase {
 		$mailAccount = new MailAccount();
 		$mailAccount->setUserId('bob');
 		$account = new Account($mailAccount);
-
 		$attachment = new LocalAttachment();
-		$attachment->setFileName('event.ics');
-		$attachment->setMimeType('text/calendar; method=REQUEST');
-
+		$attachment->setFileName(null);
+		$attachment->setMimeType('text/calendar; method=REQUEST; charset="utf-8"; name=event.ics');
+		// iMIP attachments must not carry a Content-Disposition header.
+		// See https://github.com/nextcloud/mail/issues/10416
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_OMIT);
 		$file = new InMemoryFile(
 			'event.ics',
 			"BEGIN:VCALENDAR\nEND:VCALENDAR"
 		);
-
 		$this->attachmentService->expects(self::once())
 			->method('getAttachment')
 			->willReturn([$attachment, $file]);
 
 		$part = $this->transmissionService->handleAttachment($account, ['id' => 1, 'type' => 'local']);
 
-		$this->assertEquals('event.ics', $part->getContentTypeParameter('name'));
+		$this->assertEquals('text/calendar', $part->getType());
 		$this->assertEquals('REQUEST', $part->getContentTypeParameter('method'));
+		$this->assertEquals('utf-8', $part->getContentTypeParameter('charset'));
+		$this->assertEquals('event.ics', $part->getContentTypeParameter('name'));
+	}
+
+	public function testHandleAttachmentImipOmitsContentDisposition(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setUserId('bob');
+		$account = new Account($mailAccount);
+		$attachment = new LocalAttachment();
+		$attachment->setFileName(null);
+		$attachment->setMimeType('text/calendar; method=REQUEST; charset="utf-8"; name=event.ics');
+		// iMIP attachments must not carry a Content-Disposition header.
+		// See https://github.com/nextcloud/mail/issues/10416
+		$attachment->setDisposition(LocalAttachment::DISPOSITION_OMIT);
+		$file = new InMemoryFile(
+			'event.ics',
+			"BEGIN:VCALENDAR\nEND:VCALENDAR"
+		);
+		$this->attachmentService->expects(self::once())
+			->method('getAttachment')
+			->willReturn([$attachment, $file]);
+
+		$part = $this->transmissionService->handleAttachment($account, ['id' => 1, 'type' => 'local']);
+
+		$this->assertEquals('', $part->getDisposition());
 	}
 }

--- a/tests/stubs/php-polyfill.php
+++ b/tests/stubs/php-polyfill.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * SPDX-FileCopyrightText: None
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+// PHP 8.4
+function array_find(array $array, callable $callback) {
+}
+
+// PHP 8.5
+function array_any(array $array, callable $callback): bool {
+}


### PR DESCRIPTION
Fix #8351

### Todo

- [x] Merge https://github.com/nextcloud/mail/pull/12676
- [x] Enable also for replies?

### Findings

- `MessageMapper::getAttachment()` previously forced the Content-Type of all attachments to application/octet-stream, except for text/calendar. I assume this was originally introduced as a security hardening.
For forwarding messages with inline attachments, however, preserving the original Content-Type is necessary. Mail clients generally do not render inline parts correctly when they are marked as application/octet-stream, so forwarded inline images would no longer be displayed inline.
- In `AttachmentService::handleForwardedAttachment()`, we previously tried to guess the Content-Type` from the attachment payload. Now that the original MIME metadata is preserved, this is no longer necessary. The trade-off is that we now rely on the provider-supplied MIME headers instead of re-deriving the type from the content, so this effectively trusts the original message metadata without additional validation.
- I added type annotations for attachments and inline attachments, but for now they are only applied to inlineAttachments. Applying the same annotations to attachments currently triggers Psalm warnings because the existing attachment shape is less precise and not yet fully aligned. I think it is better to address that cleanup in a follow-up PR rather than expanding the scope of this change (see also https://github.com/nextcloud/mail/issues/12530).

### getAttachment() consumers

| Consumer | Assesment |
|--------|--------|
| `AttachmentService.handleForwardedAttachment` | No direct browser exposure |
| `MessageController.downloadAttachment` | DownloadResponse forces Content-Disposition: attachment |
| `MessageController.saveAttachment` | No direct browser exposure in Mail |
| `MessageApiController.getAttachment` | Returns attachment data embedded in JSON | 

### Test cases

1. Forward email with attachment (not inline)
2. Forward email with at least two inline images
3. Calendar invitations via mail provider are shown in evolution (The workaround added for https://github.com/nextcloud/mail/issues/10416 was moved)
4. Download attachment
5. Download inline attachment
6. Store attachments to cloud
7. Fetch attachment via api