### PR TITLE
fix(imap): handle korean Windows encoding ks_c_5601-1987/ks_c_5601-1989

### DIFF
--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -84,11 +84,13 @@ class Converter {
 			return $data;
 		}
 
-		$normalizedCharset = $this->normalizeCharset($charset ?? '');
+		$normalizedCharset = $charset !== null ? $this->normalizeCharset($charset) : null;
 		$converted = @mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
 		if ($converted === false) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
-			$converted = iconv($normalizedCharset, 'UTF-8', $data);
+			if ($normalizedCharset !== null) {
+				$converted = iconv($normalizedCharset, 'UTF-8', $data);
+			}
 		}
 
 		if (!is_string($converted)) {

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\IMAP\Charset;
 
 use Horde_Mime_Part;
 use OCA\Mail\Exception\ServiceException;
+use ValueError;
 use function in_array;
 use function is_string;
 
@@ -66,10 +67,15 @@ class Converter {
 		// The part specifies a charset
 		if ($charset !== null) {
 			$normalizedCharset = $this->normalizeCharset($charset);
-			if (in_array($normalizedCharset, mb_list_encodings(), true)) {
-				$converted = mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
-			} else {
-				$converted = iconv($normalizedCharset, 'UTF-8', $data);
+			try {
+				if (in_array($normalizedCharset, mb_list_encodings(), true)) {
+					$converted = mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
+				} else {
+					$converted = @iconv($normalizedCharset, 'UTF-8', $data);
+				}
+			} catch (ValueError) {
+				// Invalid charset name, fall through to auto-detection
+				$converted = null;
 			}
 
 			if (is_string($converted)) {
@@ -89,11 +95,20 @@ class Converter {
 		}
 
 		$normalizedCharset = $charset !== null ? $this->normalizeCharset($charset) : null;
-		$converted = @mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
+		try {
+			$converted = @mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
+		} catch (ValueError) {
+			$converted = false;
+		}
 		if ($converted === false) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
 			if ($normalizedCharset !== null) {
-				$converted = iconv($normalizedCharset, 'UTF-8', $data);
+				try {
+					$converted = @iconv($normalizedCharset, 'UTF-8', $data);
+				} catch (ValueError) {
+					// Invalid charset, conversion not possible
+					$converted = null;
+				}
 			}
 		}
 

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -22,8 +22,14 @@ class Converter {
 	 * Maps unsupported charset names to their mbstring equivalents.
 	 * Notably, handles Korean encodings used by Outlook:
 	 * - ks_c_5601-1987 and ks_c_5601-1989 are mapped to UHC (Windows-949/CP949)
+	 *
+	 * Charset tokens are case-insensitive in email headers (RFC 2046),
+	 * so we normalize to lowercase for lookup.
 	 */
 	private function normalizeCharset(string $charset): string {
+		$charset = trim($charset);
+		$lowerCharset = strtolower($charset);
+
 		// Map unsupported charsets to compatible alternatives
 		// See: http://lists.w3.org/Archives/Public/ietf-charsets/2001AprJun/0030.html
 		$charsetMap = [
@@ -31,8 +37,7 @@ class Converter {
 			'ks_c_5601-1989' => 'UHC',
 		];
 
-		$normalizedCharset = $charsetMap[$charset] ?? $charset;
-		return $normalizedCharset;
+		return $charsetMap[$lowerCharset] ?? $charset;
 	}
 
 	/**

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -17,6 +17,25 @@ use function is_string;
 class Converter {
 
 	/**
+	 * Normalize charset names for mbstring compatibility.
+	 *
+	 * Maps unsupported charset names to their mbstring equivalents.
+	 * Notably, handles Korean encodings used by Outlook:
+	 * - ks_c_5601-1987 and ks_c_5601-1989 are mapped to UHC (Windows-949/CP949)
+	 */
+	private function normalizeCharset(string $charset): string {
+		// Map unsupported charsets to compatible alternatives
+		// See: http://lists.w3.org/Archives/Public/ietf-charsets/2001AprJun/0030.html
+		$charsetMap = [
+			'ks_c_5601-1987' => 'UHC',
+			'ks_c_5601-1989' => 'UHC',
+		];
+
+		$normalizedCharset = $charsetMap[$charset] ?? $charset;
+		return $normalizedCharset;
+	}
+
+	/**
 	 * @param Horde_Mime_Part $p
 	 * @return string
 	 * @throws ServiceException
@@ -37,10 +56,11 @@ class Converter {
 
 		// The part specifies a charset
 		if ($charset !== null) {
-			if (in_array($charset, mb_list_encodings(), true)) {
-				$converted = mb_convert_encoding($data, 'UTF-8', $charset);
+			$normalizedCharset = $this->normalizeCharset($charset);
+			if (in_array($normalizedCharset, mb_list_encodings(), true)) {
+				$converted = mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
 			} else {
-				$converted = iconv($charset, 'UTF-8', $data);
+				$converted = iconv($normalizedCharset, 'UTF-8', $data);
 			}
 
 			if (is_string($converted)) {
@@ -59,10 +79,11 @@ class Converter {
 			return $data;
 		}
 
-		$converted = @mb_convert_encoding($data, 'UTF-8', $charset);
+		$normalizedCharset = $this->normalizeCharset($charset ?? '');
+		$converted = @mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
 		if ($converted === false) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
-			$converted = iconv($charset, 'UTF-8', $data);
+			$converted = iconv($normalizedCharset, 'UTF-8', $data);
 		}
 
 		if (!is_string($converted)) {

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -87,34 +87,42 @@ class Converter {
 		// No charset specified, let's ask mb if this could be UTF-8
 		$detectedCharset = mb_detect_encoding($data, 'UTF-8', true);
 		if ($detectedCharset === false) {
-			// Fallback, non UTF-8
-			$detectedCharset = mb_detect_encoding($data, null, true);
+			// Fallback, try common charsets (the default mb_detect_encoding order may miss some)
+			$detectedCharset = mb_detect_encoding($data, 'ISO-8859-1,ISO-8859-2,UTF-8,ASCII', true);
 		}
 		// Still UTF8, no need to convert
 		if ($detectedCharset !== false && strtoupper($detectedCharset) === 'UTF-8') {
 			return $data;
 		}
 
-		$normalizedCharset = $charset !== null ? $this->normalizeCharset($charset) : null;
+		// Use detected charset when available, otherwise use original/normalized charset
+		if ($detectedCharset !== false) {
+			$sourceCharset = $detectedCharset;
+		} elseif ($charset !== null) {
+			$sourceCharset = $this->normalizeCharset($charset);
+		} else {
+			$sourceCharset = null;
+		}
+
+		// Attempt conversion with the source charset
 		try {
-			$converted = @mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
+			$converted = @mb_convert_encoding($data, 'UTF-8', $sourceCharset);
 		} catch (ValueError) {
 			$converted = false;
 		}
+
 		if ($converted === false) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
-			if ($normalizedCharset !== null) {
-				try {
-					$converted = @iconv($normalizedCharset, 'UTF-8', $data);
-				} catch (ValueError) {
-					// Invalid charset, conversion not possible
-					$converted = null;
-				}
+			try {
+				$converted = @iconv($sourceCharset, 'UTF-8', $data);
+			} catch (ValueError) {
+				// Invalid charset, conversion not possible
+				$converted = null;
 			}
 		}
 
 		if (!is_string($converted)) {
-			throw new ServiceException('Could not detect message charset');
+			throw new ServiceException('Could not convert message charset');
 		}
 		return $converted;
 	}

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -17,27 +17,31 @@ use function is_string;
 class Converter {
 
 	/**
+	 * Map of unsupported charset names to their mbstring equivalents.
+	 * Keys must be lowercase for case-insensitive lookup.
+	 *
+	 * @see http://lists.w3.org/Archives/Public/ietf-charsets/2001AprJun/0030.html
+	 */
+	private const CHARSET_MAP = [
+		'ks_c_5601-1987' => 'UHC',
+		'ks_c_5601-1989' => 'UHC',
+	];
+
+	/**
 	 * Normalize charset names for mbstring compatibility.
 	 *
 	 * Maps unsupported charset names to their mbstring equivalents.
 	 * Notably, handles Korean encodings used by Outlook:
 	 * - ks_c_5601-1987 and ks_c_5601-1989 are mapped to UHC (Windows-949/CP949)
 	 *
-	 * Charset tokens are case-insensitive in email headers (RFC 2046),
+	 * Charset tokens are case-insensitive in email headers (RFC 2045),
 	 * so we normalize to lowercase for lookup.
 	 */
 	private function normalizeCharset(string $charset): string {
 		$charset = trim($charset);
 		$lowerCharset = strtolower($charset);
 
-		// Map unsupported charsets to compatible alternatives
-		// See: http://lists.w3.org/Archives/Public/ietf-charsets/2001AprJun/0030.html
-		$charsetMap = [
-			'ks_c_5601-1987' => 'UHC',
-			'ks_c_5601-1989' => 'UHC',
-		];
-
-		return $charsetMap[$lowerCharset] ?? $charset;
+		return self::CHARSET_MAP[$lowerCharset] ?? $charset;
 	}
 
 	/**

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -74,7 +74,8 @@ class Converter {
 					$converted = @iconv($normalizedCharset, 'UTF-8', $data);
 				}
 			} catch (ValueError) {
-				// Invalid charset name, fall through to auto-detection
+				// Invalid charset name, treat as null to use auto-detection below
+				$charset = null;
 				$converted = null;
 			}
 

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -11,10 +11,45 @@ namespace OCA\Mail\IMAP\Charset;
 
 use Horde_Mime_Part;
 use OCA\Mail\Exception\ServiceException;
+use ValueError;
 use function in_array;
 use function is_string;
 
 class Converter {
+
+	/**
+	 * Korean charset aliases used by Outlook/Windows that mbstring does not
+	 * accept verbatim, mapped to UHC. Keys are lowercase because charset tokens
+	 * are case-insensitive.
+	 *
+	 * @see http://lists.w3.org/Archives/Public/ietf-charsets/2001AprJun/0030.html
+	 */
+	private const CHARSET_MAP = [
+		'ks_c_5601-1987' => 'UHC',
+		'ks_c_5601-1989' => 'UHC',
+		'cp949' => 'UHC',
+		'windows-949' => 'UHC',
+	];
+
+	private function normalizeCharset(string $charset): string {
+		$charset = trim($charset);
+		$lowerCharset = strtolower($charset);
+
+		return self::CHARSET_MAP[$lowerCharset] ?? $charset;
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function mbEncodings(): array {
+		/** @var list<string>|null $encodings */
+		static $encodings = null;
+		if ($encodings === null) {
+			$encodings = mb_list_encodings();
+		}
+
+		return $encodings;
+	}
 
 	/**
 	 * @param Horde_Mime_Part $p
@@ -37,10 +72,17 @@ class Converter {
 
 		// The part specifies a charset
 		if ($charset !== null) {
-			if (in_array($charset, mb_list_encodings(), true)) {
-				$converted = mb_convert_encoding($data, 'UTF-8', $charset);
-			} else {
-				$converted = iconv($charset, 'UTF-8', $data);
+			$normalizedCharset = $this->normalizeCharset($charset);
+			try {
+				if (in_array($normalizedCharset, $this->mbEncodings(), true)) {
+					$converted = mb_convert_encoding($data, 'UTF-8', $normalizedCharset);
+				} else {
+					$converted = @iconv($normalizedCharset, 'UTF-8', $data);
+				}
+			} catch (ValueError) {
+				// Invalid charset name, treat as null to use auto-detection below
+				$charset = null;
+				$converted = null;
 			}
 
 			if (is_string($converted)) {
@@ -51,22 +93,44 @@ class Converter {
 		// No charset specified, let's ask mb if this could be UTF-8
 		$detectedCharset = mb_detect_encoding($data, 'UTF-8', true);
 		if ($detectedCharset === false) {
-			// Fallback, non UTF-8
-			$detectedCharset = mb_detect_encoding($data, null, true);
+			// Fallback, try common charsets (the default mb_detect_encoding order may miss some)
+			$detectedCharset = mb_detect_encoding($data, 'ISO-8859-1,ISO-8859-2,UTF-8,ASCII', true);
 		}
 		// Still UTF8, no need to convert
 		if ($detectedCharset !== false && strtoupper($detectedCharset) === 'UTF-8') {
 			return $data;
 		}
 
-		$converted = @mb_convert_encoding($data, 'UTF-8', $charset);
-		if ($converted === false && $charset !== null) {
+		// Use detected charset when available, otherwise use original/normalized charset
+		if ($detectedCharset !== false) {
+			$sourceCharset = $detectedCharset;
+		} elseif ($charset !== null) {
+			$sourceCharset = $this->normalizeCharset($charset);
+		} else {
+			// Converting from an unknown source encoding would silently produce
+			// garbage, so give up instead of guessing.
+			throw new ServiceException('Could not determine message charset');
+		}
+
+		// Attempt conversion with the source charset
+		try {
+			$converted = @mb_convert_encoding($data, 'UTF-8', $sourceCharset);
+		} catch (ValueError) {
+			$converted = false;
+		}
+
+		if ($converted === false) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
-			$converted = iconv($charset, 'UTF-8', $data);
+			try {
+				$converted = @iconv($sourceCharset, 'UTF-8', $data);
+			} catch (ValueError) {
+				// Invalid charset, conversion not possible
+				$converted = null;
+			}
 		}
 
 		if (!is_string($converted)) {
-			throw new ServiceException('Could not detect message charset');
+			throw new ServiceException('Could not convert message charset');
 		}
 		return $converted;
 	}

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -104,12 +104,13 @@ class ConverterTest extends TestCase {
 	}
 
 	/**
-	 * Test that conversion works when no charset is specified and content
-	 * is not valid UTF-8, triggering the fallback auto-detection path.
+	 * Test that conversion completes without error when no charset is specified,
+	 * triggering the fallback auto-detection path.
 	 *
 	 * This tests the code path where $charset is null and we reach the
 	 * fallback mb_convert_encoding() call. With null, mbstring should
-	 * auto-detect the encoding rather than receiving an empty string.
+	 * auto-detect the encoding rather than receiving an empty string
+	 * (which would cause a ValueError).
 	 */
 	public function testConvertWithNullCharsetFallback(): void {
 		// Create a mock that returns null for getCharset() to test the null charset path
@@ -119,9 +120,11 @@ class ConverterTest extends TestCase {
 		$mimePart->method('getCharset')
 			->willReturn(null);
 
+		// Should complete without ValueError and return valid UTF-8
+		// (auto-detection may not produce perfect results, but should not throw)
 		$result = $this->converter->convert($mimePart);
 
-		// Should successfully convert (via auto-detection) and return valid UTF-8
 		$this->assertTrue(mb_check_encoding($result, 'UTF-8'));
+		$this->assertNotEmpty($result);
 	}
 }

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -103,13 +103,13 @@ class ConverterTest extends TestCase {
 	}
 
 	/**
-	 * Test that conversion completes without error when no charset is specified,
-	 * triggering the fallback auto-detection path.
+	 * Test that conversion succeeds when no charset is specified in the MIME header.
 	 *
-	 * This tests the code path where $charset is null and we reach the
-	 * fallback mb_convert_encoding() call. With null, mbstring should
-	 * auto-detect the encoding rather than receiving an empty string
-	 * (which would cause a ValueError).
+	 * This tests the code path where $charset is null. The Converter should:
+	 * 1. Use mb_detect_encoding() to detect the source encoding
+	 * 2. Use the detected charset for conversion to UTF-8
+	 *
+	 * Without detection, conversion would fail or produce garbled output.
 	 */
 	public function testConvertWithNullCharsetFallback(): void {
 		// Create a mock that returns null for getCharset() to test the null charset path
@@ -119,12 +119,13 @@ class ConverterTest extends TestCase {
 		$mimePart->method('getCharset')
 			->willReturn(null);
 
-		// Should complete without ValueError and return valid UTF-8
-		// (auto-detection may not produce perfect results, but should not throw)
+		// Should complete without ValueError and return the correctly converted text
 		$result = $this->converter->convert($mimePart);
 
+		// Verify actual conversion correctness, not just UTF-8 validity
+		$this->assertEquals('Tëst', $result);
+		// Also verify it's valid UTF-8
 		$this->assertTrue(mb_check_encoding($result, 'UTF-8'));
-		$this->assertNotEmpty($result);
 	}
 
 	/**

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -102,4 +102,26 @@ class ConverterTest extends TestCase {
 			[$windowsMimePart, 'قام زهاء أوراقهم ما,']
 		];
 	}
+
+	/**
+	 * Test that conversion works when no charset is specified and content
+	 * is not valid UTF-8, triggering the fallback auto-detection path.
+	 *
+	 * This tests the code path where $charset is null and we reach the
+	 * fallback mb_convert_encoding() call. With null, mbstring should
+	 * auto-detect the encoding rather than receiving an empty string.
+	 */
+	public function testConvertWithNullCharsetFallback(): void {
+		// Create a mock that returns null for getCharset() to test the null charset path
+		$mimePart = $this->createMock(Horde_Mime_Part::class);
+		$mimePart->method('getContents')
+			->willReturn(mb_convert_encoding('Tëst', 'ISO-8859-1', 'UTF-8'));
+		$mimePart->method('getCharset')
+			->willReturn(null);
+
+		$result = $this->converter->convert($mimePart);
+
+		// Should successfully convert (via auto-detection) and return valid UTF-8
+		$this->assertTrue(mb_check_encoding($result, 'UTF-8'));
+	}
 }

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -60,8 +60,6 @@ class ConverterTest extends TestCase {
 		$iso2022jpMimePart->setType('text/plain');
 		$iso2022jpMimePart->setCharset('ISO-2022-JP');
 		$iso2022jpMimePart->setContents(mb_convert_encoding('外せ園査リツハワ題', 'ISO-2022-JP', 'UTF-8'));
-		$iso2022jpMimePart_noCharset = new Horde_Mime_Part();
-		$iso2022jpMimePart_noCharset->setContents('外せ園査リツハワ題');
 		// Korean (Outlook) - ks_c_5601-1987 is mapped to UHC (CP949)
 		// Use iconv for encoding to avoid dependency on mbstring's UHC support
 		$koreanKsc56011987MimePart = new Horde_Mime_Part();
@@ -130,20 +128,28 @@ class ConverterTest extends TestCase {
 	}
 
 	/**
-	 * Test that an invalid/unknown charset name throws ServiceException
-	 * instead of letting ValueError bubble up, when the content cannot
-	 * be auto-detected as UTF-8.
+	 * Test that an invalid/unknown charset name does not let ValueError bubble up.
+	 *
+	 * When an invalid charset is provided, Converter catches the ValueError
+	 * and falls back to mbstring auto-detection. The result depends on
+	 * mb_detect_order, but the important behavior is that no ValueError escapes.
 	 */
-	public function testConvertWithInvalidCharsetThrowsServiceException(): void {
+	public function testConvertWithInvalidCharsetDoesNotThrowValueError(): void {
 		$mimePart = $this->createMock(Horde_Mime_Part::class);
-		// Use content that is NOT valid UTF-8 (raw ISO-8859-1 bytes)
 		$mimePart->method('getContents')
 			->willReturn(mb_convert_encoding('Tëst with spëcial chärs', 'ISO-8859-1', 'UTF-8'));
 		$mimePart->method('getCharset')
 			->willReturn('INVALID-CHARSET-NAME-12345');
 
-		$this->expectException(\OCA\Mail\Exception\ServiceException::class);
+		$thrown = null;
+		try {
+			$this->converter->convert($mimePart);
+		} catch (\ValueError $e) {
+			$thrown = $e;
+		} catch (\OCA\Mail\Exception\ServiceException) {
+			// ServiceException is acceptable (auto-detection failed)
+		}
 
-		$this->converter->convert($mimePart);
+		$this->assertNull($thrown, 'ValueError should not bubble up from convert()');
 	}
 }

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -62,27 +62,28 @@ class ConverterTest extends TestCase {
 		$iso2022jpMimePart->setContents(mb_convert_encoding('外せ園査リツハワ題', 'ISO-2022-JP', 'UTF-8'));
 		$iso2022jpMimePart_noCharset = new Horde_Mime_Part();
 		$iso2022jpMimePart_noCharset->setContents('外せ園査リツハワ題');
-		// Korean (Outlook) - ks_c_5601-1987 is mapped to UHC
+		// Korean (Outlook) - ks_c_5601-1987 is mapped to UHC (CP949)
+		// Use iconv for encoding to avoid dependency on mbstring's UHC support
 		$koreanKsc56011987MimePart = new Horde_Mime_Part();
 		$koreanKsc56011987MimePart->setType('text/plain');
 		$koreanKsc56011987MimePart->setCharset('ks_c_5601-1987');
 		$koreanText = '안녕하세요';
-		$koreanKsc56011987MimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
-		// Korean (Outlook) - ks_c_5601-1989 is also mapped to UHC
+		$koreanKsc56011987MimePart->setContents(iconv('UTF-8', 'CP949', $koreanText));
+		// Korean (Outlook) - ks_c_5601-1989 is also mapped to UHC (CP949)
 		$koreanKsc56011989MimePart = new Horde_Mime_Part();
 		$koreanKsc56011989MimePart->setType('text/plain');
 		$koreanKsc56011989MimePart->setCharset('ks_c_5601-1989');
-		$koreanKsc56011989MimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		$koreanKsc56011989MimePart->setContents(iconv('UTF-8', 'CP949', $koreanText));
 		// Korean (Outlook) - uppercase variant KS_C_5601-1987 (case-insensitive)
 		$koreanKsc56011987UpperMimePart = new Horde_Mime_Part();
 		$koreanKsc56011987UpperMimePart->setType('text/plain');
 		$koreanKsc56011987UpperMimePart->setCharset('KS_C_5601-1987');
-		$koreanKsc56011987UpperMimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		$koreanKsc56011987UpperMimePart->setContents(iconv('UTF-8', 'CP949', $koreanText));
 		// Korean (Outlook) - mixed case variant Ks_C_5601-1987 (case-insensitive)
 		$koreanKsc56011987MixedMimePart = new Horde_Mime_Part();
 		$koreanKsc56011987MixedMimePart->setType('text/plain');
 		$koreanKsc56011987MixedMimePart->setCharset('Ks_C_5601-1987');
-		$koreanKsc56011987MixedMimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		$koreanKsc56011987MixedMimePart->setContents(iconv('UTF-8', 'CP949', $koreanText));
 		// Arabic - not in mb
 		$windowsMimePart = new Horde_Mime_Part();
 		$windowsMimePart->setType('text/plain');
@@ -126,5 +127,23 @@ class ConverterTest extends TestCase {
 
 		$this->assertTrue(mb_check_encoding($result, 'UTF-8'));
 		$this->assertNotEmpty($result);
+	}
+
+	/**
+	 * Test that an invalid/unknown charset name throws ServiceException
+	 * instead of letting ValueError bubble up, when the content cannot
+	 * be auto-detected as UTF-8.
+	 */
+	public function testConvertWithInvalidCharsetThrowsServiceException(): void {
+		$mimePart = $this->createMock(Horde_Mime_Part::class);
+		// Use content that is NOT valid UTF-8 (raw ISO-8859-1 bytes)
+		$mimePart->method('getContents')
+			->willReturn(mb_convert_encoding('Tëst with spëcial chärs', 'ISO-8859-1', 'UTF-8'));
+		$mimePart->method('getCharset')
+			->willReturn('INVALID-CHARSET-NAME-12345');
+
+		$this->expectException(\OCA\Mail\Exception\ServiceException::class);
+
+		$this->converter->convert($mimePart);
 	}
 }

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -62,11 +62,17 @@ class ConverterTest extends TestCase {
 		$iso2022jpMimePart->setContents(mb_convert_encoding('外せ園査リツハワ題', 'ISO-2022-JP', 'UTF-8'));
 		$iso2022jpMimePart_noCharset = new Horde_Mime_Part();
 		$iso2022jpMimePart_noCharset->setContents('外せ園査リツハワ題');
-		// Korean - not in mb nor iconv
-		// $iso106461MimePart = new Horde_Mime_Part();
-		// $iso106461MimePart->setType('text/plain');
-		// $iso106461MimePart->setCharset('ISO 10646-1');
-		//$iso106461MimePart->setContents(iconv('UTF-8', 'ISO 10646-1', '언론·출판은 타인의 명'));
+		// Korean (Outlook) - ks_c_5601-1987 is mapped to UHC
+		$koreanKsc56011987MimePart = new Horde_Mime_Part();
+		$koreanKsc56011987MimePart->setType('text/plain');
+		$koreanKsc56011987MimePart->setCharset('ks_c_5601-1987');
+		$koreanText = '안녕하세요';
+		$koreanKsc56011987MimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		// Korean (Outlook) - ks_c_5601-1989 is also mapped to UHC
+		$koreanKsc56011989MimePart = new Horde_Mime_Part();
+		$koreanKsc56011989MimePart->setType('text/plain');
+		$koreanKsc56011989MimePart->setCharset('ks_c_5601-1989');
+		$koreanKsc56011989MimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
 		// Arabic - not in mb
 		$windowsMimePart = new Horde_Mime_Part();
 		$windowsMimePart->setType('text/plain');
@@ -79,7 +85,8 @@ class ConverterTest extends TestCase {
 			[$iso88591MimePart, 'Ümlaut'],
 			[$iso2022jpMimePart, '外せ園査リツハワ題'],
 			[$iso88591MimePart_noCharset, 'בה בדף לחבר ממונרכיה, בקר בגרסה ואמנות דת'],
-			// [$iso106461MimePart, '언론·출판은 타인의 명'],
+			[$koreanKsc56011987MimePart, $koreanText],
+			[$koreanKsc56011989MimePart, $koreanText],
 			[$windowsMimePart, 'قام زهاء أوراقهم ما,']
 		];
 	}

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -73,6 +73,16 @@ class ConverterTest extends TestCase {
 		$koreanKsc56011989MimePart->setType('text/plain');
 		$koreanKsc56011989MimePart->setCharset('ks_c_5601-1989');
 		$koreanKsc56011989MimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		// Korean (Outlook) - uppercase variant KS_C_5601-1987 (case-insensitive)
+		$koreanKsc56011987UpperMimePart = new Horde_Mime_Part();
+		$koreanKsc56011987UpperMimePart->setType('text/plain');
+		$koreanKsc56011987UpperMimePart->setCharset('KS_C_5601-1987');
+		$koreanKsc56011987UpperMimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
+		// Korean (Outlook) - mixed case variant Ks_C_5601-1987 (case-insensitive)
+		$koreanKsc56011987MixedMimePart = new Horde_Mime_Part();
+		$koreanKsc56011987MixedMimePart->setType('text/plain');
+		$koreanKsc56011987MixedMimePart->setCharset('Ks_C_5601-1987');
+		$koreanKsc56011987MixedMimePart->setContents(mb_convert_encoding($koreanText, 'UHC', 'UTF-8'));
 		// Arabic - not in mb
 		$windowsMimePart = new Horde_Mime_Part();
 		$windowsMimePart->setType('text/plain');
@@ -87,6 +97,8 @@ class ConverterTest extends TestCase {
 			[$iso88591MimePart_noCharset, 'בה בדף לחבר ממונרכיה, בקר בגרסה ואמנות דת'],
 			[$koreanKsc56011987MimePart, $koreanText],
 			[$koreanKsc56011989MimePart, $koreanText],
+			[$koreanKsc56011987UpperMimePart, $koreanText],
+			[$koreanKsc56011987MixedMimePart, $koreanText],
 			[$windowsMimePart, 'قام زهاء أوراقهم ما,']
 		];
 	}

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -60,27 +60,80 @@ class ConverterTest extends TestCase {
 		$iso2022jpMimePart->setType('text/plain');
 		$iso2022jpMimePart->setCharset('ISO-2022-JP');
 		$iso2022jpMimePart->setContents(mb_convert_encoding('外せ園査リツハワ題', 'ISO-2022-JP', 'UTF-8'));
-		$iso2022jpMimePart_noCharset = new Horde_Mime_Part();
-		$iso2022jpMimePart_noCharset->setContents('外せ園査リツハワ題');
-		// Korean - not in mb nor iconv
-		// $iso106461MimePart = new Horde_Mime_Part();
-		// $iso106461MimePart->setType('text/plain');
-		// $iso106461MimePart->setCharset('ISO 10646-1');
-		//$iso106461MimePart->setContents(iconv('UTF-8', 'ISO 10646-1', '언론·출판은 타인의 명'));
+		// Korean (Outlook) - all ks_c_5601 spellings map to UHC (CP949). Encode
+		// with iconv to avoid depending on mbstring's UHC support, and cover the
+		// case-insensitive charset spellings.
+		$koreanText = '안녕하세요';
+		$koreanBytes = iconv('UTF-8', 'CP949', $koreanText);
+		$koreanCharsets = ['ks_c_5601-1987', 'ks_c_5601-1989', 'KS_C_5601-1987', 'Ks_C_5601-1987', 'cp949', 'windows-949'];
+		$koreanCases = [];
+		foreach ($koreanCharsets as $koreanCharset) {
+			$koreanMimePart = new Horde_Mime_Part();
+			$koreanMimePart->setType('text/plain');
+			$koreanMimePart->setCharset($koreanCharset);
+			$koreanMimePart->setContents($koreanBytes);
+			$koreanCases[] = [$koreanMimePart, $koreanText];
+		}
 		// Arabic - not in mb
 		$windowsMimePart = new Horde_Mime_Part();
 		$windowsMimePart->setType('text/plain');
 		$windowsMimePart->setCharset('Windows-1256');
 		$windowsMimePart->setContents(iconv('UTF-8', 'Windows-1256', 'قام زهاء أوراقهم ما,'));
 
-		return[
+		return array_merge([
 			[$utfMimePart, '😊'],
 			[$utfMimeStreamPart, '💦'],
 			[$iso88591MimePart, 'Ümlaut'],
 			[$iso2022jpMimePart, '外せ園査リツハワ題'],
 			[$iso88591MimePart_noCharset, 'בה בדף לחבר ממונרכיה, בקר בגרסה ואמנות דת'],
-			// [$iso106461MimePart, '언론·출판은 타인의 명'],
-			[$windowsMimePart, 'قام زهاء أوراقهم ما,']
-		];
+		], $koreanCases, [
+			[$windowsMimePart, 'قام زهاء أوراقهم ما,'],
+		]);
+	}
+
+	/**
+	 * A part without a charset header must still decode via detection.
+	 */
+	public function testConvertWithNullCharsetFallback(): void {
+		$mimePart = $this->createMock(Horde_Mime_Part::class);
+		$mimePart->method('getContents')
+			->willReturn(mb_convert_encoding('Tëst', 'ISO-8859-1', 'UTF-8'));
+		$mimePart->method('getCharset')
+			->willReturn(null);
+
+		$result = $this->converter->convert($mimePart);
+
+		$this->assertEquals('Tëst', $result);
+		$this->assertTrue(mb_check_encoding($result, 'UTF-8'));
+	}
+
+	/**
+	 * Test that an invalid/unknown charset name does not let ValueError bubble up.
+	 *
+	 * When an invalid charset is provided, Converter catches the ValueError
+	 * and falls back to mbstring auto-detection. The result depends on
+	 * mb_detect_order, but the important behavior is that no ValueError escapes.
+	 */
+	public function testConvertWithInvalidCharsetDoesNotThrowValueError(): void {
+		$mimePart = $this->createMock(Horde_Mime_Part::class);
+		$mimePart->method('getContents')
+			->willReturn(mb_convert_encoding('Tëst with spëcial chärs', 'ISO-8859-1', 'UTF-8'));
+		$mimePart->method('getCharset')
+			->willReturn('INVALID-CHARSET-NAME-12345');
+
+		$thrown = null;
+		$result = null;
+		try {
+			$result = $this->converter->convert($mimePart);
+		} catch (\ValueError $e) {
+			$thrown = $e;
+		} catch (\OCA\Mail\Exception\ServiceException) {
+			// ServiceException is acceptable (auto-detection failed)
+		}
+
+		$this->assertNull($thrown, 'ValueError should not bubble up from convert()');
+		if ($result !== null) {
+			$this->assertTrue(mb_check_encoding($result, 'UTF-8'), 'A successful conversion must yield valid UTF-8');
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/11416

Trick borrowed from https://github.com/bytestream/Util/blob/45a9c3c14e70eec9df5d117a2d4941b097872672/lib/Horde/String.php#L847-L867.

Tested with the email from the ticket - threw ValueException before, is converted now :heavy_check_mark: 

AI-assisted: OpenCode (Claude Haiku 4.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Korean charset variants, including `ks_c_5601-1987` and `ks_c_5601-1989`.
  * Improved automatic charset detection when the source charset is unavailable.
* **Bug Fixes**
  * Prevented invalid or unsupported charset names from causing unexpected conversion errors.
  * Improved error handling when message charset conversion cannot be completed.
* **Tests**
  * Added coverage for Korean text conversion, automatic detection, and invalid charset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->