### PR TITLE
Minor UI fixes

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -113,7 +113,7 @@
 						{{ n('mail', 'Forward {number} as attachment', 'Forward {number} as attachment', selection.length, { number: selection.length }) }}
 					</ActionButton>
 				</Actions>
-				</div>
+			</div>
 		</transition>
 
 		<transition-group :name="listTransitionName">

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -173,6 +173,7 @@ import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import IconSelect from 'vue-material-design-icons/CloseThick.vue'
 import EmailRead from 'vue-material-design-icons/EmailOpenOutline.vue'
 import EmailUnread from 'vue-material-design-icons/EmailOutline.vue'
+import ImportantIcon from 'vue-material-design-icons/LabelVariant.vue'
 import ImportantOutlineIcon from 'vue-material-design-icons/LabelVariantOutline.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import AddIcon from 'vue-material-design-icons/Plus.vue'
@@ -205,6 +206,7 @@ export default {
 		ActionButton,
 		Envelope,
 		IconDelete,
+		ImportantIcon,
 		ImportantOutlineIcon,
 		IconFavorite,
 		IconSelect,

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -113,13 +113,7 @@
 						{{ n('mail', 'Forward {number} as attachment', 'Forward {number} as attachment', selection.length, { number: selection.length }) }}
 					</ActionButton>
 				</Actions>
-				<MoveModal
-					v-if="showMoveModal"
-					:account="account"
-					:envelopes="selectedEnvelopes"
-					:move-thread="true"
-					@close="onCloseMoveModal" />
-			</div>
+				</div>
 		</transition>
 
 		<transition-group :name="listTransitionName">
@@ -153,6 +147,13 @@
 			:account="account"
 			:envelopes="selectedEnvelopes"
 			@close="onCloseTagModal" />
+
+		<MoveModal
+			v-if="showMoveModal"
+			:account="account"
+			:envelopes="selectedEnvelopes"
+			:move-thread="true"
+			@close="onCloseMoveModal" />
 
 		<NcDialog
 			v-if="showQuickActionsSettings"


### PR DESCRIPTION
### MoveModal reappearing after bulk move (#12661) 
fixes https://github.com/nextcloud/mail/issues/12661
The MoveModal was nested inside the v-if="selectMode" div. During a bulk move, envelopes are removed from the store, which empties the selection, which flips selectMode to false — destroying the MoveModal before it can emit @close. The showMoveModal flag stays true, so the modal reappears on the next selection. Fixed by moving the MoveModal component to the root level of the template (matching how TagModal is already placed), so its lifecycle depends only on its own v-if="showMoveModal".

Closes #12661

### Missing "important" icon in multi-select quick actions (#12149)                                                    

The template used `<ImportantIcon>` but the component was never imported or registered. Added the missing import of  LabelVariant.vue and registered it in the components block.

Closes #12149