### PR TITLE
fix: Added the missing "@" character in the default IMAP/SMTP username

### DIFF
--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -348,11 +348,11 @@ export default {
 				emailTemplate: '',
 				imapHost: 'mx.domain.com',
 				imapPort: 993,
-				imapUser: '%USERID%domain.com',
+				imapUser: '%USERID%@domain.com',
 				imapSslMode: 'ssl',
 				smtpHost: 'mx.domain.com',
 				smtpPort: 587,
-				smtpUser: '%USERID%domain.com',
+				smtpUser: '%USERID%@domain.com',
 				smtpSslMode: 'tls',
 				previewData1: {
 					uid: 'user123',


### PR DESCRIPTION
Hi,

When you go `Groupware` -> `Provisioning Configurations` -> `Add new config` IMAP user and SMTP user missing `@` character.

Here is a patch.

<img width="652" height="805" alt="image" src="https://github.com/user-attachments/assets/e702660c-66c5-45f3-a8c5-3e9c565d73a2" />