### PR TITLE
[stable5.7] fix(dns): Update public suffix list

### DIFF
--- a/resources/public_suffix_list.dat
+++ b/resources/public_suffix_list.dat
@@ -5,8 +5,8 @@
 // Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
 // rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
 
-// VERSION: 2026-03-09_08-24-09_UTC
-// COMMIT: 3c5eb8e70837e15570608f2cb5abe8579e09c9b9
+// VERSION: 2026-03-26_14-47-43_UTC
+// COMMIT: d333b72b39575da1ce6932b01d7c421a4107c620
 
 // Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
 
@@ -13452,6 +13452,10 @@ us-4.evennode.com
 // Submitted by Hannah Neary <engineering@evervault.com>
 relay.evervault.app
 relay.evervault.dev
+
+// Exe : https://exe.dev
+// Submitted by Josh Bleecher Snyder <security@exe.dev>
+exe.xyz
 
 // Expo : https://expo.dev/
 // Submitted by Phil Pluckthun <psl@expo.dev>


### PR DESCRIPTION
Auto-generated update of https://publicsuffix.org/