### PR TITLE
fix: Broken encryption with Mailvelope

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1261,6 +1261,8 @@ export default {
 
 			if (data.isHtml) {
 				data.bodyHtml = this.bodyVal
+			} else if (data.isPgpMime) {
+				data.bodyPlain = this.bodyVal
 			} else {
 				data.bodyPlain = toPlain(html(this.bodyVal)).value
 			}


### PR DESCRIPTION
Fix #11495 

Regression from https://github.com/nextcloud/mail/pull/10754

Piping the encrypted message through `toPlain(html(...)).value` breaks it.

Main: `-----BEGIN PGP MESSAGE-----Version: Mailvelope v6.2.1Comment: https://mailvelope.com\` (bad)
Here: `-----BEGIN PGP MESSAGE-----\nVersion: Mailvelope v6.2.1\nComment: https://mailvelope.com\n\` (good)
