### PR TITLE
fix: compact view UI fixes

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1719,7 +1719,8 @@ export default {
 .hovering-status {
 	// Needs to be the same width as the check-icon and the avatar to prevent automatic resizing
 	// and height differences between hover state and normal state
-	height: 34px;
+	height: calc(var(--default-grid-baseline) * 10);
+	padding-top: 3px;
 }
 
 .check-icon {
@@ -1780,12 +1781,10 @@ export default {
 		display: none;
 	}
 }
-</style>
-
-<style>
-.list-item__wrapper--active .compact-checkbox .checkbox-radio-switch__content,
-.list-item__wrapper.active .compact-checkbox .checkbox-radio-switch__content {
+.list-item__wrapper--active :deep(.compact-checkbox .checkbox-radio-switch__content),
+.list-item__wrapper.active :deep(.compact-checkbox .checkbox-radio-switch__content) {
 	background-color: var(--color-primary-element-text) !important;
 	color: var(--color-primary-element) !important;
 }
 </style>
+

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1717,7 +1717,7 @@ export default {
 }
 
 .hovering-status {
-	// Needs to be the same width as the check-icon and the avatar to prevent automatic resizing
+	// Needs to be the same height as the check-icon and the avatar to prevent automatic resizing
 	// and height differences between hover state and normal state
 	height: calc(var(--default-grid-baseline) * 10);
 	padding-top: 3px;

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -1787,4 +1787,3 @@ export default {
 	color: var(--color-primary-element) !important;
 }
 </style>
-

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -69,6 +69,7 @@
 						<NcCheckboxRadioSwitch
 							type="checkbox"
 							class="compact-checkbox"
+							:class="{ 'compact-checkbox--active': selected }"
 							:model-value="selected"
 							@update:checked="toggleSelected" />
 					</div>
@@ -164,9 +165,9 @@
 
 					<span
 						class="envelope__subtitle__subject"
-						:class="{ 'one-line': oneLineLayout }"
+						:class="{ 'one-line': oneLineLayout && !compactMode }"
 						dir="auto">
-						<span class="envelope__subtitle__subject__text" :class="{ 'one-line': oneLineLayout, draft }" v-html="subjectForSubtitle" />
+						<span class="envelope__subtitle__subject__text" :class="{ 'one-line': oneLineLayout && !compactMode, draft }" v-html="subjectForSubtitle" />
 					</span>
 				</div>
 				<div
@@ -1505,7 +1506,8 @@ export default {
 }
 
 .list-item__wrapper--active {
-	div, :deep(.list-item-content__inner__details__details) {
+	div:not(.compact-checkbox-wrapper, .compact-checkbox-wrapper *),
+	:deep(.list-item-content__inner__details__details) {
 		color: var(--color-primary-element-text) !important;
 	}
 }
@@ -1686,11 +1688,6 @@ export default {
 	display: flex;
 	align-items: center;
 	height: calc(var(--default-font-size) * var(--default-line-height));
-
-	&::after {
-		content: '\00B7';
-		margin: 12px;
-	}
 }
 
 .envelope__subtitle__subject__text.one-line {
@@ -1720,9 +1717,9 @@ export default {
 }
 
 .hovering-status {
-	// Needs to be the same height as the check-icon and the avatar to prevent automatic resizing
+	// Needs to be the same width as the check-icon and the avatar to prevent automatic resizing
 	// and height differences between hover state and normal state
-	height: calc(var(--default-grid-baseline) * 10);
+	height: 34px;
 }
 
 .check-icon {
@@ -1739,9 +1736,6 @@ export default {
 		margin-inline-start: 0;
 		flex: 1;
 		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 }
 
@@ -1759,13 +1753,11 @@ export default {
 .compact-subject-icons {
 	display: flex;
 	align-items: center;
-	gap: 4px;
 	flex-shrink: 0;
-	margin-inline-end: 4px;
 }
 
 .envelope__recipient-row {
-	display: inline-flex;
+	display: flex;
 	align-items: center;
 	min-width: 0;
 }
@@ -1787,5 +1779,13 @@ export default {
 	.icon-important {
 		display: none;
 	}
+}
+</style>
+
+<style>
+.list-item__wrapper--active .compact-checkbox .checkbox-radio-switch__content,
+.list-item__wrapper.active .compact-checkbox .checkbox-radio-switch__content {
+	background-color: var(--color-primary-element-text) !important;
+	color: var(--color-primary-element) !important;
 }
 </style>

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -69,6 +69,7 @@
 						<NcCheckboxRadioSwitch
 							type="checkbox"
 							class="compact-checkbox"
+							:class="{ 'compact-checkbox--active': selected }"
 							:model-value="selected"
 							@update:checked="toggleSelected" />
 					</div>
@@ -164,9 +165,9 @@
 
 					<span
 						class="envelope__subtitle__subject"
-						:class="{ 'one-line': oneLineLayout }"
+						:class="{ 'one-line': oneLineLayout && !compactMode }"
 						dir="auto">
-						<span class="envelope__subtitle__subject__text" :class="{ 'one-line': oneLineLayout, draft }" v-html="subjectForSubtitle" />
+						<span class="envelope__subtitle__subject__text" :class="{ 'one-line': oneLineLayout && !compactMode, draft }" v-html="subjectForSubtitle" />
 					</span>
 				</div>
 				<div
@@ -1505,7 +1506,8 @@ export default {
 }
 
 .list-item__wrapper--active {
-	div, :deep(.list-item-content__inner__details__details) {
+	div:not(.compact-checkbox-wrapper, .compact-checkbox-wrapper *),
+	:deep(.list-item-content__inner__details__details) {
 		color: var(--color-primary-element-text) !important;
 	}
 }
@@ -1686,11 +1688,6 @@ export default {
 	display: flex;
 	align-items: center;
 	height: calc(var(--default-font-size) * var(--default-line-height));
-
-	&::after {
-		content: '\00B7';
-		margin: 12px;
-	}
 }
 
 .envelope__subtitle__subject__text.one-line {
@@ -1723,6 +1720,7 @@ export default {
 	// Needs to be the same height as the check-icon and the avatar to prevent automatic resizing
 	// and height differences between hover state and normal state
 	height: calc(var(--default-grid-baseline) * 10);
+	padding-top: 3px;
 }
 
 .check-icon {
@@ -1739,9 +1737,6 @@ export default {
 		margin-inline-start: 0;
 		flex: 1;
 		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 	}
 }
 
@@ -1759,13 +1754,11 @@ export default {
 .compact-subject-icons {
 	display: flex;
 	align-items: center;
-	gap: 4px;
 	flex-shrink: 0;
-	margin-inline-end: 4px;
 }
 
 .envelope__recipient-row {
-	display: inline-flex;
+	display: flex;
 	align-items: center;
 	min-width: 0;
 }
@@ -1787,5 +1780,11 @@ export default {
 	.icon-important {
 		display: none;
 	}
+}
+
+.list-item__wrapper--active :deep(.compact-checkbox .checkbox-radio-switch__content),
+.list-item__wrapper.active :deep(.compact-checkbox .checkbox-radio-switch__content) {
+	background-color: var(--color-primary-element-text) !important;
+	color: var(--color-primary-element) !important;
 }
 </style>

--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -73,7 +73,7 @@
 								<!-- Counter and indicator -->
 								<div
 									v-if="counterNumber || hasIndicator"
-									v-show="showAdditionalElements"
+									:class="{ 'extra--hidden': !showAdditionalElements }"
 									class="list-item-content__inner__details__extra">
 									<NcCounterBubble
 										v-if="counterNumber"
@@ -553,6 +553,11 @@ export default {
 				&--bold {
 					font-weight: 500;
 				}
+				.list-item--compact.list-item--multiline & {
+					white-space: normal;
+					overflow: visible;
+					text-overflow: unset;
+				}
 			}
 
 			&__tags {
@@ -726,5 +731,8 @@ export default {
 :deep(.app-content-list-item-icon), :deep(.avatardiv), :deep(.avatardiv__initials-wrapper) {
 	height: calc(var(--header-menu-item-height) - 4px);
 	width: calc(var(--header-menu-item-height) - 4px);
+}
+.extra--hidden {
+	visibility: hidden;
 }
 </style>

--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -73,7 +73,7 @@
 								<!-- Counter and indicator -->
 								<div
 									v-if="counterNumber || hasIndicator"
-									v-show="showAdditionalElements"
+									:class="{ 'extra--hidden': !showAdditionalElements }"
 									class="list-item-content__inner__details__extra">
 									<NcCounterBubble
 										v-if="counterNumber"
@@ -553,6 +553,11 @@ export default {
 				&--bold {
 					font-weight: 500;
 				}
+				.list-item--compact.list-item--multiline & {
+					white-space: normal;
+					overflow: visible;
+					text-overflow: unset;
+				}
 			}
 
 			&__tags {
@@ -726,5 +731,9 @@ export default {
 :deep(.app-content-list-item-icon), :deep(.avatardiv), :deep(.avatardiv__initials-wrapper) {
 	height: calc(var(--header-menu-item-height) - 4px);
 	width: calc(var(--header-menu-item-height) - 4px);
+}
+
+.extra--hidden {
+	visibility: hidden;
 }
 </style>


### PR DESCRIPTION
fixes #12583 
fixes #12582 
fixes #12581
i also removed the *(dot) in the end of the subject and removed the max-width for list view, so it uses the whole space

after
<img width="335" height="165" alt="Screenshot from 2026-04-08 19-51-33" src="https://github.com/user-attachments/assets/b9268023-1401-4606-b252-e800328ef266" />
<img width="1008" height="153" alt="Screenshot from 2026-04-08 19-49-48" src="https://github.com/user-attachments/assets/226a36b2-ea30-4bc1-befb-27e1e3c30421" />
