### PR TITLE
fix(imap): log details of the sync to debug OOMs

### DIFF
--- a/lib/IMAP/Sync/Synchronizer.php
+++ b/lib/IMAP/Sync/Synchronizer.php
@@ -18,6 +18,7 @@ use Horde_Imap_Client_Mailbox;
 use OCA\Mail\Exception\MailboxDoesNotSupportModSequencesException;
 use OCA\Mail\Exception\UidValidityChangedException;
 use OCA\Mail\IMAP\MessageMapper;
+use Psr\Log\LoggerInterface;
 use function array_merge;
 use function OCA\Mail\chunk_uid_sequence;
 
@@ -42,10 +43,6 @@ class Synchronizer {
 	}
 
 	/**
-	 * @param Horde_Imap_Client_Base $imapClient
-	 * @param Request $request
-	 * @param int $criteria
-	 *
 	 * @return Response
 	 * @throws Horde_Imap_Client_Exception
 	 * @throws Horde_Imap_Client_Exception_Sync
@@ -56,9 +53,11 @@ class Synchronizer {
 		Request $request,
 		string $userId,
 		bool $hasQresync, // TODO: query client directly, but could be unsafe because login has to happen prior
+		LoggerInterface $logger,
 		int $criteria = Horde_Imap_Client::SYNC_NEWMSGSUIDS | Horde_Imap_Client::SYNC_FLAGSUIDS | Horde_Imap_Client::SYNC_VANISHEDUIDS): Response {
 		// Return cached response from last full sync when QRESYNC is enabled
 		if ($hasQresync && $this->response !== null && $request->getId() === $this->requestId) {
+			$logger->debug('Reusing cached sync response');
 			return $this->response;
 		}
 
@@ -66,10 +65,11 @@ class Synchronizer {
 		try {
 			// Do a full sync and cache the response when QRESYNC is enabled
 			[$newUids, $changedUids, $vanishedUids] = match ($hasQresync) {
-				true => $this->doCombinedSync($imapClient, $mailbox, $request),
-				false => $this->doSplitSync($imapClient, $mailbox, $request, $criteria),
+				true => $this->doCombinedSync($imapClient, $mailbox, $request, $logger),
+				false => $this->doSplitSync($imapClient, $mailbox, $request, $criteria, $logger),
 			};
 		} catch (Horde_Imap_Client_Exception_Sync $e) {
+			$logger->info('UID validity changed');
 			if ($e->getCode() === Horde_Imap_Client_Exception_Sync::UIDVALIDITY_CHANGED) {
 				throw new UidValidityChangedException();
 			}
@@ -82,7 +82,11 @@ class Synchronizer {
 		}
 
 		$newMessages = $this->messageMapper->findByIds($imapClient, $request->getMailbox(), $newUids, $userId);
+		$nNew = count($newMessages);
+		$logger->debug("Found {$nNew} new messages");
 		$changedMessages = $this->messageMapper->findByIds($imapClient, $request->getMailbox(), $changedUids, $userId);
+		$nChanged = count($changedMessages);
+		$logger->debug("Found {$nChanged} changed messages");
 		$vanishedMessageUids = $vanishedUids;
 
 		$this->requestId = $request->getId();
@@ -95,7 +99,12 @@ class Synchronizer {
 	 * @throws Horde_Imap_Client_Exception
 	 * @throws Horde_Imap_Client_Exception_Sync
 	 */
-	private function doCombinedSync(Horde_Imap_Client_Base $imapClient, Horde_Imap_Client_Mailbox $mailbox, Request $request): array {
+	private function doCombinedSync(Horde_Imap_Client_Base $imapClient,
+		Horde_Imap_Client_Mailbox $mailbox,
+		Request $request,
+		LoggerInterface $logger): array {
+		$logger->debug('Performing a combined sync');
+
 		$syncData = $imapClient->sync($mailbox, $request->getToken(), [
 			'criteria' => Horde_Imap_Client::SYNC_ALL,
 		]);
@@ -112,7 +121,13 @@ class Synchronizer {
 	 * @throws Horde_Imap_Client_Exception
 	 * @throws Horde_Imap_Client_Exception_Sync
 	 */
-	private function doSplitSync(Horde_Imap_Client_Base $imapClient, Horde_Imap_Client_Mailbox $mailbox, Request $request, int $criteria): array {
+	private function doSplitSync(Horde_Imap_Client_Base $imapClient,
+		Horde_Imap_Client_Mailbox $mailbox,
+		Request $request,
+		int $criteria,
+		LoggerInterface $logger): array {
+		$logger->debug('Performing a split sync');
+
 		if ($criteria & Horde_Imap_Client::SYNC_NEWMSGSUIDS) {
 			$newUids = $this->getNewMessageUids($imapClient, $mailbox, $request);
 		} else {

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -420,7 +420,8 @@ class ImapToDbSynchronizer {
 				),
 				$account->getUserId(),
 				$hasQresync,
-				Horde_Imap_Client::SYNC_NEWMSGSUIDS
+				$logger,
+				Horde_Imap_Client::SYNC_NEWMSGSUIDS,
 			);
 			$perf->step('get new messages via Horde');
 
@@ -485,7 +486,8 @@ class ImapToDbSynchronizer {
 				),
 				$account->getUserId(),
 				$hasQresync,
-				Horde_Imap_Client::SYNC_FLAGSUIDS
+				$logger,
+				Horde_Imap_Client::SYNC_FLAGSUIDS,
 			);
 			$perf->step('get changed messages via Horde');
 
@@ -515,7 +517,8 @@ class ImapToDbSynchronizer {
 				),
 				$account->getUserId(),
 				$hasQresync,
-				Horde_Imap_Client::SYNC_VANISHEDUIDS
+				$logger,
+				Horde_Imap_Client::SYNC_VANISHEDUIDS,
 			);
 			$perf->step('get vanished messages via Horde');
 

--- a/tests/Unit/IMAP/Sync/SynchronizerTest.php
+++ b/tests/Unit/IMAP/Sync/SynchronizerTest.php
@@ -20,11 +20,15 @@ use OCA\Mail\IMAP\Sync\Request;
 use OCA\Mail\IMAP\Sync\Response;
 use OCA\Mail\IMAP\Sync\Synchronizer;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use function range;
 
 class SynchronizerTest extends TestCase {
 	/** @var MessageMapper|MockObject */
 	private $mapper;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
 
 	/** @var Synchronizer */
 	private $synchronizer;
@@ -33,6 +37,7 @@ class SynchronizerTest extends TestCase {
 		parent::setUp();
 
 		$this->mapper = $this->createMock(MessageMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->synchronizer = new Synchronizer($this->mapper);
 	}
@@ -62,6 +67,7 @@ class SynchronizerTest extends TestCase {
 			$request,
 			'user',
 			true,
+			$this->logger,
 			Horde_Imap_Client::SYNC_NEWMSGSUIDS,
 		);
 		$changedResponse = $this->synchronizer->sync(
@@ -69,6 +75,7 @@ class SynchronizerTest extends TestCase {
 			$request,
 			'user',
 			true,
+			$this->logger,
 			Horde_Imap_Client::SYNC_FLAGSUIDS,
 		);
 		$vanishedResponse = $this->synchronizer->sync(
@@ -76,6 +83,7 @@ class SynchronizerTest extends TestCase {
 			$request,
 			'user',
 			true,
+			$this->logger,
 			Horde_Imap_Client::SYNC_VANISHEDUIDS
 		);
 
@@ -108,6 +116,7 @@ class SynchronizerTest extends TestCase {
 			$request,
 			'user',
 			false,
+			$this->logger,
 			Horde_Imap_Client::SYNC_VANISHEDUIDS
 		);
 


### PR DESCRIPTION
```
[debug] Syncing 8468
[debug] Locking mailbox 8468 for new messages sync
[debug] Locking mailbox 8468 for changed messages sync
[debug] Locking mailbox 8468 for vanished messages sync
[debug] Running partial sync for 8468 with criteria 42
[debug] partial sync 4634:Sent - get all known UIDs took 0s. 14/16MB memory used
[debug] Performing a split sync
[debug] Found 0 new messages
[debug] Found 0 changed messages
[debug] partial sync 4634:Sent - get new messages via Horde took 0s. 14/16MB memory used
[debug] partial sync 4634:Sent - persist new messages took 0s. 14/16MB memory used
[debug] Performing a split sync
[debug] Found 0 new messages
[debug] Found 96 changed messages
[debug] partial sync 4634:Sent - get changed messages via Horde took 0s. 15/16MB memory used
[debug] partial sync 4634:Sent - persist changed messages took 0s. 15/16MB memory used
[debug] Performing a split sync
[debug] Found 0 new messages
[debug] Found 0 changed messages
[debug] partial sync 4634:Sent - get vanished messages via Horde took 1s. 15/16MB memory used
[debug] partial sync 4634:Sent - delete vanished messages took 0s. 15/16MB memory used
[debug] partial sync 4634:Sent took 1s
[debug] Unlocking mailbox 8468 from vanished messages sync
[debug] Unlocking mailbox 8468 from changed messages sync
[debug] Unlocking mailbox 8468 from new messages sync
```

A sync job is crashing with OOM on prod. This allows us to run the job with loglevel=0 via CLI and see how far it gets before the crash.