### PR TITLE
docs: update external link about l10n contributions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,5 @@ Usage of AI agents has to be made transparent. Therefore, the commit message's l
 
 ## Translations
 
-Please submit translations via [Transifex][transifex].
+See [our website](https://nextcloud.com/translation/) for how translations of this repository work and how you can get started.
 
-[transifex]: https://www.transifex.com/projects/p/nextcloud/


### PR DESCRIPTION
The Transifex landing page redirects to login. I chose to send people to the website instead because it has some explanation of the process and best practices.

Fixes https://github.com/nextcloud/mail/issues/12710