### PR TITLE
fix(imap): log more sync details

### DIFF
--- a/lib/IMAP/Sync/Synchronizer.php
+++ b/lib/IMAP/Sync/Synchronizer.php
@@ -81,6 +81,7 @@ class Synchronizer {
 			throw $e;
 		}
 
+		$logger->debug('Fetching new and changed messages after sync');
 		$newMessages = $this->messageMapper->findByIds($imapClient, $request->getMailbox(), $newUids, $userId);
 		$nNew = count($newMessages);
 		$logger->debug("Found {$nNew} new messages");
@@ -108,6 +109,8 @@ class Synchronizer {
 		$syncData = $imapClient->sync($mailbox, $request->getToken(), [
 			'criteria' => Horde_Imap_Client::SYNC_ALL,
 		]);
+
+		$logger->debug('Combined sync finished');
 
 		return [
 			$syncData->newmsgsuids,


### PR DESCRIPTION
Sync OOMs after `[debug] Performing a combined sync` and I want to find out if it happens in `\Horde_Imap_Client_Base::sync`, while returning or in `\OCA\Mail\IMAP\MessageMapper::findByIds`.