### PR TITLE
fix: use HMAC for proxied HTML iframe content

### DIFF
--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -11,10 +11,15 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use Exception;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Http\ProxyDownloadResponse;
+use OCA\Mail\Service\MailManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\UserRateLimit;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\LocalServerException;
@@ -24,6 +29,7 @@ use OCP\IURLGenerator;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Log\LoggerInterface;
 use function file_get_contents;
+use function hash_equals;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ProxyController extends Controller {
@@ -31,19 +37,28 @@ class ProxyController extends Controller {
 	private ISession $session;
 	private IClientService $clientService;
 	private LoggerInterface $logger;
+	private ProxyHmacGenerator $hmacGenerator;
+	private MailManager $mailManager;
+	private ?string $userId;
 
 	public function __construct(string $appName,
 		IRequest $request,
 		IURLGenerator $urlGenerator,
 		ISession $session,
 		IClientService $clientService,
-		LoggerInterface $logger) {
+		ProxyHmacGenerator $hmacGenerator,
+		LoggerInterface $logger,
+		MailManager $mailManager,
+		?string $userId) {
 		parent::__construct($appName, $request);
 		$this->request = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
 		$this->clientService = $clientService;
 		$this->logger = $logger;
+		$this->hmacGenerator = $hmacGenerator;
+		$this->mailManager = $mailManager;
+		$this->userId = $userId;
 	}
 
 	/**
@@ -89,10 +104,10 @@ class ProxyController extends Controller {
 	 *       The caching should also already happen in a cronjob so that the sender of the
 	 *       mail does not know whether the mail has been opened.
 	 *
-	 * @return ProxyDownloadResponse
+	 * @return Response|ProxyDownloadResponse
 	 */
 	#[UserRateLimit(limit: 50, period: 60)]
-	public function proxy(string $src): ProxyDownloadResponse {
+	public function proxy(string $src, ?int $id, ?string $hmac): Response {
 		// close the session to allow parallel downloads
 		$this->session->close();
 
@@ -100,6 +115,20 @@ class ProxyController extends Controller {
 		if (!$this->request->passesStrictCookieCheck()) {
 			$content = file_get_contents(__DIR__ . '/../../img/blocked-image.png');
 			return new ProxyDownloadResponse($content, $src, 'application/octet-stream');
+		}
+
+		// HMAC check
+		if ($this->userId === null || $id === null || $hmac === null) {
+			return new Response(Http::STATUS_BAD_REQUEST);
+		}
+		try {
+			$this->mailManager->getMessage($this->userId, $id);
+		} catch (DoesNotExistException $e) {
+			return new Response(Http::STATUS_BAD_REQUEST);
+		}
+		if (!hash_equals($this->hmacGenerator->generate($id, $src), $hmac)) {
+			$this->logger->info('Proxied email content blocked due to invalid HMAC');
+			return new Response(Http::STATUS_UNAUTHORIZED);
 		}
 
 		$client = $this->clientService->newClient();

--- a/lib/Html/ProxyHmacGenerator.php
+++ b/lib/Html/ProxyHmacGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Html;
+
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+
+class ProxyHmacGenerator {
+
+	public function __construct(
+		private IConfig $config,
+		private ICrypto $crypto,
+	) {
+	}
+
+	public function generate(int $id, string $src): string {
+		return bin2hex($this->crypto->calculateHMAC(
+			$src,
+			implode('|', [
+				$this->config->getSystemValueString('secret'),
+				$id,
+			]),
+		));
+	}
+
+}

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -349,9 +349,7 @@ class IMAPMessage implements IMessage, JsonSerializable {
 	 * @return string
 	 */
 	public function getHtmlBody(int $id): string {
-		return $this->htmlService->sanitizeHtmlMailBody($this->htmlMessage, [
-			'id' => $id,
-		], function ($cid) {
+		return $this->htmlService->sanitizeHtmlMailBody($this->htmlMessage, $id, function ($cid) {
 			$match = array_filter($this->inlineAttachments,
 				static fn ($a) => $a['cid'] === $cid);
 			$match = array_shift($match);

--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -16,6 +16,7 @@ use HTMLPurifier_Config;
 use HTMLPurifier_HTMLDefinition;
 use HTMLPurifier_URIDefinition;
 use HTMLPurifier_URISchemeRegistry;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Service\HtmlPurify\CidURIScheme;
 use OCA\Mail\Service\HtmlPurify\TransformHTMLLinks;
 use OCA\Mail\Service\HtmlPurify\TransformImageSrc;
@@ -39,10 +40,14 @@ class Html {
 
 	/** @var IRequest */
 	private $request;
+	private ProxyHmacGenerator $hmacGenerator;
 
-	public function __construct(IURLGenerator $urlGenerator, IRequest $request) {
+	public function __construct(IURLGenerator $urlGenerator,
+		IRequest $request,
+		ProxyHmacGenerator $hmacGenerator) {
 		$this->urlGenerator = $urlGenerator;
 		$this->request = $request;
+		$this->hmacGenerator = $hmacGenerator;
 	}
 
 	/**
@@ -102,7 +107,7 @@ class Html {
 		];
 	}
 
-	public function sanitizeHtmlMailBody(string $mailBody, array $messageParameters, Closure $mapCidToAttachmentId): string {
+	public function sanitizeHtmlMailBody(string $mailBody, int $id, Closure $mapCidToAttachmentId): string {
 		$config = HTMLPurifier_Config::createDefault();
 
 		// Append target="_blank" to all link (a) elements
@@ -130,7 +135,16 @@ class Html {
 
 		/** @var HTMLPurifier_URIDefinition $uri */
 		$uri = $config->getDefinition('URI');
-		$uri->addFilter(new TransformURLScheme($messageParameters, $mapCidToAttachmentId, $this->urlGenerator, $this->request), $config);
+		$uri->addFilter(
+			new TransformURLScheme(
+				$id,
+				$mapCidToAttachmentId,
+				$this->urlGenerator,
+				$this->request,
+				$this->hmacGenerator,
+			),
+			$config
+		);
 
 		$uriSchemeRegistry = HTMLPurifier_URISchemeRegistry::instance();
 		$uriSchemeRegistry->register('cid', new CidURIScheme());

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -15,6 +15,7 @@ use HTMLPurifier_Config;
 use HTMLPurifier_URI;
 use HTMLPurifier_URIFilter;
 use HTMLPurifier_URIParser;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 
@@ -33,17 +34,20 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	 */
 	private $mapCidToAttachmentId;
 
-	/** @var array */
-	private $messageParameters;
+	private int $id;
 
-	public function __construct(array $messageParameters,
+	private ProxyHmacGenerator $hmacGenerator;
+
+	public function __construct(int $id,
 		Closure $mapCidToAttachmentId,
 		IURLGenerator $urlGenerator,
-		IRequest $request) {
-		$this->messageParameters = $messageParameters;
+		IRequest $request,
+		ProxyHmacGenerator $hmacGenerator) {
+		$this->id = $id;
 		$this->mapCidToAttachmentId = $mapCidToAttachmentId;
 		$this->urlGenerator = $urlGenerator;
 		$this->request = $request;
+		$this->hmacGenerator = $hmacGenerator;
 	}
 
 	/**
@@ -56,7 +60,6 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	 */
 	#[\Override]
 	public function filter(&$uri, $config, $context) {
-
 		if ($uri->scheme === null) {
 			$uri->scheme = 'https';
 		}
@@ -71,10 +74,14 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 			if (is_null($attachmentId)) {
 				return true;
 			}
-			$this->messageParameters['attachmentId'] = $attachmentId;
 
-			$imgUrl = $this->urlGenerator->linkToRouteAbsolute('mail.messages.downloadAttachment',
-				$this->messageParameters);
+			$imgUrl = $this->urlGenerator->linkToRouteAbsolute(
+				'mail.messages.downloadAttachment',
+				[
+					'id' => $this->id,
+					'attachmentId' => $attachmentId,
+				],
+			);
 			$parser = new HTMLPurifier_URIParser();
 			$uri = $parser->parse($imgUrl);
 		}
@@ -88,23 +95,23 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	 * @return HTMLPurifier_URI
 	 */
 	private function filterHttpFtp(&$uri, $context) {
-		$originalURL = urlencode($uri->scheme . '://' . $uri->host);
+		$originalURL = $uri->scheme . '://' . $uri->host;
 
 		// Add the port if it's not a default port
 		if ($uri->port !== null
 			&& !($uri->scheme === 'http' && $uri->port === 80)
 			&& !($uri->scheme === 'https' && $uri->port === 443)
 			&& !($uri->scheme === 'ftp' && $uri->port === 21)) {
-			$originalURL = $originalURL . urlencode(':' . $uri->port);
+			$originalURL = $originalURL . ':' . $uri->port;
 		}
 
-		$originalURL = $originalURL . urlencode($uri->path);
+		$originalURL = $originalURL . $uri->path;
 
 		if ($uri->query !== null) {
-			$originalURL = $originalURL . urlencode('?' . $uri->query);
+			$originalURL = $originalURL . '?' . $uri->query;
 		}
 		if ($uri->fragment !== null) {
-			$originalURL = $originalURL . urlencode('#' . $uri->fragment);
+			$originalURL = $originalURL . '#' . $uri->fragment;
 		}
 
 		// Get the HTML attribute
@@ -116,12 +123,19 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 			return $uri;
 		}
 
+		$proxyUrl = $this->urlGenerator->linkToRoute('mail.proxy.proxy', [
+			'id' => $this->id,
+			'hmac' => $this->hmacGenerator->generate($this->id, $originalURL),
+			'src' => $originalURL
+		]);
+		$parsedProxyUrl = parse_url($proxyUrl);
+		/** @var array{path: string, query: string} $parsedProxyUrl */
 		return new \HTMLPurifier_URI(
 			$this->request->getServerProtocol(),
 			null, $this->request->getServerHost(),
 			null,
-			$this->urlGenerator->linkToRoute('mail.proxy.proxy'),
-			'src=' . $originalURL . '&requesttoken=' . \OCP\Server::get(\OCP\ISession::class)->get('requesttoken'),
+			$parsedProxyUrl['path'],
+			$parsedProxyUrl['query'],
 			null
 		);
 	}

--- a/tests/Unit/Controller/ProxyControllerTest.php
+++ b/tests/Unit/Controller/ProxyControllerTest.php
@@ -13,7 +13,12 @@ namespace OCA\Mail\Tests\Unit\Controller;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Exception;
 use OCA\Mail\Controller\ProxyController;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Http\ProxyDownloadResponse;
+use OCA\Mail\Service\MailManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
@@ -44,6 +49,14 @@ class ProxyControllerTest extends TestCase {
 	/** @var LoggerInterface */
 	private $logger;
 
+	/** @var ProxyHmacGenerator|MockObject */
+	private $hmacGenerator;
+
+	/** @var MailManager|MockObject */
+	private $mailManager;
+
+	private string $userId = 'user';
+
 	/** @var ProxyController */
 	private $controller;
 
@@ -55,6 +68,8 @@ class ProxyControllerTest extends TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->clientService = $this->createMock(IClientService::class);
+		$this->hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+		$this->mailManager = $this->createMock(MailManager::class);
 		$this->logger = new NullLogger();
 	}
 
@@ -112,7 +127,10 @@ class ProxyControllerTest extends TestCase {
 			$this->urlGenerator,
 			$this->session,
 			$this->clientService,
-			$this->logger
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
 		);
 		$expected = new TemplateResponse(
 			$this->appName,
@@ -138,7 +156,10 @@ class ProxyControllerTest extends TestCase {
 			$this->urlGenerator,
 			$this->session,
 			$this->clientService,
-			$this->logger
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
 		);
 		$this->expectException(Exception::class);
 
@@ -147,41 +168,48 @@ class ProxyControllerTest extends TestCase {
 
 	public function testProxyWithoutCookies(): void {
 		$src = 'http://example.com';
-		$content = '🐵🐵🐵';
+		$this->request->expects($this->once())
+			->method('passesStrictCookieCheck')
+			->willReturn(false);
 		$this->session->expects($this->once())
 			->method('close');
-		$client = $this->getMockBuilder(IClient::class)->getMock();
 		$this->clientService->expects(self::never())
-			->method('newClient')
-			->willReturn($client);
-		$unexpected = new ProxyDownloadResponse(
-			$content,
-			$src,
-			'application/octet-stream'
-		);
+			->method('newClient');
 		$this->controller = new ProxyController(
 			$this->appName,
 			$this->request,
 			$this->urlGenerator,
 			$this->session,
 			$this->clientService,
-			$this->logger
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
 		);
 
-		$response = $this->controller->proxy($src);
+		$response = $this->controller->proxy($src, null, null);
 
-		$this->assertNotEquals($unexpected, $response);
+		$this->assertInstanceOf(ProxyDownloadResponse::class, $response);
 	}
 
 	public function testProxy(): void {
 		$src = 'http://example.com';
-		$httpResponse = $this->createMock(IResponse::class);
+		$id = 1;
+		$validHmac = 'valid-hmac-hash';
 		$content = '🐵🐵🐵';
+		$httpResponse = $this->createMock(IResponse::class);
 		$this->request->expects(self::once())
 			->method('passesStrictCookieCheck')
 			->willReturn(true);
 		$this->session->expects($this->once())
 			->method('close');
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with($id, $src)
+			->willReturn($validHmac);
+		$this->mailManager->expects($this->once())
+			->method('getMessage')
+			->with($this->userId, $id);
 		$client = $this->getMockBuilder(IClient::class)->getMock();
 		$this->clientService->expects($this->once())
 			->method('newClient')
@@ -193,23 +221,116 @@ class ProxyControllerTest extends TestCase {
 		$httpResponse->expects($this->once())
 			->method('getBody')
 			->willReturn($content);
-
-		$expected = new ProxyDownloadResponse(
-			$content,
-			$src,
-			'application/octet-stream'
-		);
 		$this->controller = new ProxyController(
 			$this->appName,
 			$this->request,
 			$this->urlGenerator,
 			$this->session,
 			$this->clientService,
-			$this->logger
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
 		);
 
-		$response = $this->controller->proxy($src);
+		$response = $this->controller->proxy($src, $id, $validHmac);
 
-		$this->assertEquals($expected, $response);
+		$this->assertInstanceOf(ProxyDownloadResponse::class, $response);
+	}
+
+	public function testProxyWithInvalidHmac(): void {
+		$src = 'http://example.com';
+		$id = 1;
+		$invalidHmac = 'invalid-hmac';
+		$expectedHmac = 'expected-hmac';
+		$this->request->expects(self::once())
+			->method('passesStrictCookieCheck')
+			->willReturn(true);
+		$this->session->expects($this->once())
+			->method('close');
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with($id, $src)
+			->willReturn($expectedHmac);
+		$this->mailManager->expects($this->once())
+			->method('getMessage')
+			->with($this->userId, $id);
+		$this->clientService->expects(self::never())
+			->method('newClient');
+		$this->controller = new ProxyController(
+			$this->appName,
+			$this->request,
+			$this->urlGenerator,
+			$this->session,
+			$this->clientService,
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
+		);
+
+		$response = $this->controller->proxy($src, $id, $invalidHmac);
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+	public function testProxyWithMissingHmacParameters(): void {
+		$src = 'http://example.com';
+		$this->request->expects(self::once())
+			->method('passesStrictCookieCheck')
+			->willReturn(true);
+		$this->session->expects($this->once())
+			->method('close');
+		$this->clientService->expects(self::never())
+			->method('newClient');
+		$this->controller = new ProxyController(
+			$this->appName,
+			$this->request,
+			$this->urlGenerator,
+			$this->session,
+			$this->clientService,
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
+		);
+
+		$response = $this->controller->proxy($src, null, null);
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testProxyWithMessageNotOwnedByUser(): void {
+		$src = 'http://example.com';
+		$id = 1;
+		$this->request->expects(self::once())
+			->method('passesStrictCookieCheck')
+			->willReturn(true);
+		$this->session->expects($this->once())
+			->method('close');
+		$this->mailManager->expects($this->once())
+			->method('getMessage')
+			->with($this->userId, $id)
+			->willThrowException(new DoesNotExistException('not found'));
+		$this->clientService->expects(self::never())
+			->method('newClient');
+		$this->controller = new ProxyController(
+			$this->appName,
+			$this->request,
+			$this->urlGenerator,
+			$this->session,
+			$this->clientService,
+			$this->hmacGenerator,
+			$this->logger,
+			$this->mailManager,
+			$this->userId,
+		);
+
+		$response = $this->controller->proxy($src, $id, 'some-hmac');
+
+		$this->assertInstanceOf(Response::class, $response);
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 }

--- a/tests/Unit/Html/ProxyHmacGeneratorTest.php
+++ b/tests/Unit/Html/ProxyHmacGeneratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Html;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Html\ProxyHmacGenerator;
+use OCP\IConfig;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProxyHmacGeneratorTest extends TestCase {
+	private ProxyHmacGenerator $generator;
+	private IConfig|MockObject $config;
+	private ICrypto|MockObject $crypto;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->generator = new ProxyHmacGenerator($this->config, $this->crypto);
+	}
+
+	public function testGenerateCreatesConsistentHmac(): void {
+		$id = 123;
+		$src = 'https://example.com/image.png';
+		$secret = 'app-secret-key';
+		$hmacBinary = 'binary-hmac-data';
+		$this->config->expects($this->exactly(2))
+			->method('getSystemValueString')
+			->with('secret')
+			->willReturn($secret);
+		$this->crypto->expects($this->exactly(2))
+			->method('calculateHMAC')
+			->with(
+				$src,
+				$secret . '|' . $id
+			)
+			->willReturn($hmacBinary);
+
+		$result1 = $this->generator->generate($id, $src);
+		$result2 = $this->generator->generate($id, $src);
+
+		$this->assertSame($result1, $result2);
+	}
+
+	public function testGenerateDifferentForDifferentId(): void {
+		$src = 'https://example.com/image.png';
+		$secret = 'app-secret-key';
+		$this->config->expects($this->exactly(2))
+			->method('getSystemValueString')
+			->with('secret')
+			->willReturn($secret);
+		$this->crypto->expects($this->exactly(2))
+			->method('calculateHMAC')
+			->withConsecutive(
+				[$src, $secret . '|' . 123],
+				[$src, $secret . '|' . 456]
+			)
+			->willReturnOnConsecutiveCalls('hmac-123', 'hmac-456');
+
+		$result1 = $this->generator->generate(123, $src);
+		$result2 = $this->generator->generate(456, $src);
+
+		$this->assertNotSame($result1, $result2);
+	}
+
+	public function testGenerateDifferentForDifferentSrc(): void {
+		$id = 123;
+		$secret = 'app-secret-key';
+		$src1 = 'https://example.com/image1.png';
+		$src2 = 'https://example.com/image2.png';
+		$this->config->expects($this->exactly(2))
+			->method('getSystemValueString')
+			->with('secret')
+			->willReturn($secret);
+		$this->crypto->expects($this->exactly(2))
+			->method('calculateHMAC')
+			->withConsecutive(
+				[$src1, $secret . '|' . $id],
+				[$src2, $secret . '|' . $id]
+			)
+			->willReturnOnConsecutiveCalls('hmac-src1', 'hmac-src2');
+
+		$result1 = $this->generator->generate($id, $src1);
+		$result2 = $this->generator->generate($id, $src2);
+
+		$this->assertNotSame($result1, $result2);
+	}
+}

--- a/tests/Unit/Model/IMAPMessageTest.php
+++ b/tests/Unit/Model/IMAPMessageTest.php
@@ -17,6 +17,7 @@ use Horde_Imap_Client_DateTime;
 use Horde_Mime_Part;
 use OCA\Mail\AddressList;
 use OCA\Mail\Db\Tag;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\Html;
 use OCP\IRequest;
@@ -41,7 +42,8 @@ class IMAPMessageTest extends TestCase {
 		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$htmlService = new Html($urlGenerator, $request);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+		$htmlService = new Html($urlGenerator, $request, $hmacGenerator);
 
 		$part = Horde_Mime_Part::parseMessage(file_get_contents(__DIR__ . '/../../data/mail-message-123.txt'),
 			['level' => 1]);

--- a/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
@@ -14,6 +14,7 @@ use Closure;
 use HTMLPurifier_Config;
 use HTMLPurifier_Context;
 use HTMLPurifier_URI;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Service\HtmlPurify\TransformURLScheme;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -23,12 +24,14 @@ class TransformURLSchemeTest extends TestCase {
 	private TransformURLScheme $filter;
 	private IURLGenerator|MockObject $urlGenerator;
 	private IRequest|MockObject $request;
+	private ProxyHmacGenerator|MockObject $hmacGenerator;
 	private Closure $mapCidToAttachmentId;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->request = $this->createMock(IRequest::class);
+		$this->hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
 
 		$this->mapCidToAttachmentId = function (string $cid) {
 			if ($cid === 'valid-cid') {
@@ -37,17 +40,12 @@ class TransformURLSchemeTest extends TestCase {
 			return null;
 		};
 
-		$messageParameters = [
-			'accountId' => 1,
-			'folderId' => 'INBOX',
-			'id' => 42,
-		];
-
 		$this->filter = new TransformURLScheme(
-			$messageParameters,
+			42,
 			$this->mapCidToAttachmentId,
 			$this->urlGenerator,
 			$this->request,
+			$this->hmacGenerator,
 		);
 	}
 
@@ -187,6 +185,14 @@ class TransformURLSchemeTest extends TestCase {
 		$attr = 'src';
 		$context->register('CurrentAttr', $attr);
 
+		$originalURL = 'https://example.com/image.png';
+		$hmac = 'abc123';
+
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with(42, $originalURL)
+			->willReturn($hmac);
+
 		$this->request->expects($this->once())
 			->method('getServerProtocol')
 			->willReturn('https');
@@ -195,15 +201,19 @@ class TransformURLSchemeTest extends TestCase {
 			->willReturn('mail.example.com');
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
-			->with('mail.proxy.proxy')
-			->willReturn('/apps/mail/proxy');
+			->with('mail.proxy.proxy', [
+				'id' => 42,
+				'hmac' => $hmac,
+				'src' => $originalURL,
+			])
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fimage.png');
 
 		$this->filter->filter($uri, $config, $context);
 
 		$this->assertSame('https', $uri->scheme);
 		$this->assertSame('mail.example.com', $uri->host);
 		$this->assertSame('/apps/mail/proxy', $uri->path);
-		$this->assertStringContainsString('src=', $uri->query);
+		$this->assertStringContainsString('id=42', $uri->query);
 	}
 
 	public function testCidSchemeWithValidAttachment(): void {
@@ -252,6 +262,14 @@ class TransformURLSchemeTest extends TestCase {
 		$attr = 'src';
 		$context->register('CurrentAttr', $attr);
 
+		$originalURL = 'https://example.com/page?id=123&name=test';
+		$hmac = 'abc123';
+
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with(42, $originalURL)
+			->willReturn($hmac);
+
 		$this->request->expects($this->once())
 			->method('getServerProtocol')
 			->willReturn('https');
@@ -260,8 +278,12 @@ class TransformURLSchemeTest extends TestCase {
 			->willReturn('mail.example.com');
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
-			->with('mail.proxy.proxy')
-			->willReturn('/apps/mail/proxy');
+			->with('mail.proxy.proxy', [
+				'id' => 42,
+				'hmac' => $hmac,
+				'src' => $originalURL,
+			])
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fpage%3Fid%3D123%26name%3Dtest');
 
 		$this->filter->filter($uri, $config, $context);
 
@@ -275,6 +297,14 @@ class TransformURLSchemeTest extends TestCase {
 		$attr = 'src';
 		$context->register('CurrentAttr', $attr);
 
+		$originalURL = 'https://example.com/page#section';
+		$hmac = 'abc123';
+
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with(42, $originalURL)
+			->willReturn($hmac);
+
 		$this->request->expects($this->once())
 			->method('getServerProtocol')
 			->willReturn('https');
@@ -283,8 +313,12 @@ class TransformURLSchemeTest extends TestCase {
 			->willReturn('mail.example.com');
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
-			->with('mail.proxy.proxy')
-			->willReturn('/apps/mail/proxy');
+			->with('mail.proxy.proxy', [
+				'id' => 42,
+				'hmac' => $hmac,
+				'src' => $originalURL,
+			])
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fpage%23section');
 
 		$this->filter->filter($uri, $config, $context);
 
@@ -292,17 +326,12 @@ class TransformURLSchemeTest extends TestCase {
 	}
 
 	public function testCidSchemeMapsCidToAttachmentId(): void {
-		$messageParameters = [
-			'accountId' => 1,
-			'folderId' => 'INBOX',
-			'id' => 42,
-		];
-
 		$filter = new TransformURLScheme(
-			$messageParameters,
+			42,
 			$this->mapCidToAttachmentId,
 			$this->urlGenerator,
 			$this->request,
+			$this->hmacGenerator,
 		);
 
 		$uri = new HTMLPurifier_URI('cid', null, null, null, 'valid-cid', null, null);
@@ -312,8 +341,6 @@ class TransformURLSchemeTest extends TestCase {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRouteAbsolute')
 			->with('mail.messages.downloadAttachment', [
-				'accountId' => 1,
-				'folderId' => 'INBOX',
 				'id' => 42,
 				'attachmentId' => 123,
 			])

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Html\ProxyHmacGenerator;
 use OCA\Mail\Service\Html;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -25,8 +26,9 @@ class HtmlTest extends TestCase {
 	public function testLinkDetection(string $expected, string $text) {
 		$urlGenerator = Server::get(IURLGenerator::class);
 		$request = Server::get(IRequest::class);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
 
-		$html = new Html($urlGenerator, $request);
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
 		$withLinks = $html->convertLinks($text);
 
 		self::assertSame($expected, $withLinks);
@@ -63,7 +65,9 @@ class HtmlTest extends TestCase {
 	public function testParseMailBody($expectedBody, $expectedSignature, $text) {
 		$urlGenerator = \OCP\Server::get(\OCP\IURLGenerator::class);
 		$request = \OCP\Server::get(\OCP\IRequest::class);
-		$html = new Html($urlGenerator, $request);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
 		[$b, $s] = $html->parseMailBody($text);
 		$this->assertSame($expectedBody, $b);
 		$this->assertSame($expectedSignature, $s);
@@ -85,6 +89,7 @@ class HtmlTest extends TestCase {
 			->with('mail', 'blocked-image.png')
 			->willReturn($blockedUrl);
 		$request = Server::get(IRequest::class);
+		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
 
 		$styleSheet = implode(' ', [
 			'big { background-image: url(https://tracker.com/script.png); }',
@@ -96,7 +101,7 @@ class HtmlTest extends TestCase {
 			'</style>',
 		]);
 
-		$html = new Html($urlGenerator, $request);
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
 		$sanitizedStyleSheet = $html->sanitizeStyleSheet($styleSheet);
 		self::assertSame($expected, $sanitizedStyleSheet);
 	}


### PR DESCRIPTION
This scopes the proxy to a specific email and URL.

Most changes are about injecting service and data. The main changes are trivial.

AI-Assisted: OpenCode (Claude Haiku 4.5)