### PR TITLE
[stable5.7] fix(deps): Bump dompurify to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "nextcloud-mail",
-      "version": "5.7.6",
+      "version": "5.7.9",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
@@ -36,7 +36,7 @@
         "color-convert": "^2.0.1",
         "core-js": "^3.48.0",
         "debounce-promise": "^3.1.2",
-        "dompurify": "^3.3.1",
+        "dompurify": "^3.4.0",
         "escape-html": "^1.0.3",
         "html-to-text": "^9.0.5",
         "ical.js": "^2.2.1",
@@ -8427,13 +8427,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "color-convert": "^2.0.1",
     "core-js": "^3.48.0",
     "debounce-promise": "^3.1.2",
-    "dompurify": "^3.3.1",
+    "dompurify": "^3.4.0",
     "escape-html": "^1.0.3",
     "html-to-text": "^9.0.5",
     "ical.js": "^2.2.1",


### PR DESCRIPTION
- Updated dompurify from ^3.3.1 to ^3.4.0
- Verified no breaking changes to functionality

AI-assisted: OpenCode (Claude Haiku 4.5)