### PR TITLE
feat(aliases): add admin setting to disable alias creation

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -346,6 +346,11 @@ return [
 			'verb' => 'POST'
 		],
 		[
+			'name' => 'settings#setAllowNewMailAliases',
+			'url' => '/api/settings/allownewaliases',
+			'verb' => 'POST'
+		],
+		[
 			'name' => 'settings#setEnabledLlmProcessing',
 			'url' => '/api/settings/llm',
 			'verb' => 'PUT'

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -305,6 +305,11 @@ class PageController extends Controller {
 		);
 
 		$this->initialStateService->provideInitialState(
+			'allow-new-aliases',
+			$this->config->getAppValue('mail', 'allow_new_mail_aliases', 'yes') === 'yes'
+		);
+
+		$this->initialStateService->provideInitialState(
 			'llm_summaries_available',
 			$this->aiIntegrationsService->isLlmProcessingEnabled() && $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
 		);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -114,6 +114,11 @@ class SettingsController extends Controller {
 		$this->config->setAppValue('mail', 'allow_new_mail_accounts', $allowed ? 'yes' : 'no');
 	}
 
+	public function setAllowNewMailAliases(bool $allowed): JSONResponse {
+		$this->config->setAppValue('mail', 'allow_new_mail_aliases', $allowed ? 'yes' : 'no');
+		return new JSONResponse([]);
+	}
+
 	public function setEnabledLlmProcessing(bool $enabled): JSONResponse {
 		$this->config->setAppValue('mail', 'llm_processing', $enabled ? 'yes' : 'no');
 		return new JSONResponse([]);

--- a/lib/Service/AliasesService.php
+++ b/lib/Service/AliasesService.php
@@ -15,6 +15,7 @@ use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Exception\ClientException;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 
 class AliasesService {
 	/** @var AliasMapper */
@@ -22,10 +23,13 @@ class AliasesService {
 
 	/** @var MailAccountMapper */
 	private $mailAccountMapper;
+	/** @var IConfig */
+	private $config;
 
-	public function __construct(AliasMapper $aliasMapper, MailAccountMapper $mailAccountMapper) {
+	public function __construct(AliasMapper $aliasMapper, MailAccountMapper $mailAccountMapper, IConfig $config) {
 		$this->aliasMapper = $aliasMapper;
 		$this->mailAccountMapper = $mailAccountMapper;
+		$this->config = $config;
 	}
 
 	/**
@@ -67,6 +71,10 @@ class AliasesService {
 	 * @throws DoesNotExistException
 	 */
 	public function create(string $userId, int $accountId, string $alias, string $aliasName): Alias {
+		if ($this->config->getAppValue('mail', 'allow_new_mail_aliases', 'yes') === 'no') {
+			throw new ClientException('Creating aliases has been disabled by the administrator.');
+		}
+
 		$this->mailAccountMapper->find($userId, $accountId);
 
 		$aliasEntity = new Alias();

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -84,6 +84,12 @@ class AdminSettings implements ISettings {
 
 		$this->initialStateService->provideInitialState(
 			Application::APP_ID,
+			'allow_new_mail_aliases',
+			$this->config->getAppValue('mail', 'allow_new_mail_aliases', 'yes') === 'yes'
+		);
+
+		$this->initialStateService->provideInitialState(
+			Application::APP_ID,
 			'layout_message_view',
 			$this->config->getAppValue('mail', 'layout_message_view', 'threaded')
 		);

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -12,6 +12,7 @@
 		:name="t('mail', 'Account settings')"
 		@update:open="updateOpen">
 		<AppSettingsSection
+			v-if="allowNewAliases"
 			id="alias-settings"
 			:name="t('mail', 'Aliases')">
 			<AliasSettings :account="account" @rename-primary-alias="scrollToAccountSettings" />
@@ -208,6 +209,10 @@ export default {
 
 		email() {
 			return this.account.emailAddress
+		},
+
+		allowNewAliases() {
+			return this.mainStore.getPreference('allow-new-aliases', true)
 		},
 	},
 

--- a/src/components/AliasSettings.vue
+++ b/src/components/AliasSettings.vue
@@ -53,7 +53,7 @@
 
 		<div v-if="!account.provisioningId" class="aliases-controls">
 			<ButtonVue
-				v-if="!showForm"
+				v-if="!showForm && allowNewAliases"
 				type="primary"
 				:aria-label="t('mail', 'Add alias')"
 				@click="showForm = true">
@@ -124,6 +124,10 @@ export default {
 		...mapStores(useMainStore),
 		aliases() {
 			return this.account.aliases
+		},
+
+		allowNewAliases() {
+			return this.mainStore.getPreference('allow-new-aliases', true)
 		},
 
 		accountAlias() {

--- a/src/components/settings/AdminSettings.vue
+++ b/src/components/settings/AdminSettings.vue
@@ -136,6 +136,21 @@
 				</p>
 			</article>
 		</div>
+		<div class="app-description">
+			<h3>{{ t('mail', 'Allow aliases') }}</h3>
+			<article>
+				<p>
+					{{ t('mail', 'The Mail app does not verify aliases. If this is enabled without existing server-side support, your mail server will likely reject outgoing messages, causing emails to fail.') }}
+				</p>
+				<p>
+					<NcCheckboxRadioSwitch v-model="allowNewMailAliases"
+						type="switch"
+						@update:checked="updateAllowNewMailAliases">
+						{{ t('mail', 'Allow users to create mail aliases') }}
+					</NcCheckboxRadioSwitch>
+				</p>
+			</article>
+		</div>
 		<div
 			v-if="isLlmSummaryConfigured"
 			class="app-description">
@@ -300,6 +315,7 @@ import {
 	setImportanceClassificationEnabledByDefault,
 	setLayoutMessageView,
 	updateAllowNewMailAccounts,
+	updateAllowNewMailAliases,
 	updateEnabledSmartReply,
 	updateLlmEnabled,
 	updateProvisioningSettings,
@@ -368,6 +384,7 @@ export default {
 			},
 
 			allowNewMailAccounts: loadState('mail', 'allow_new_mail_accounts', true),
+			allowNewMailAliases: loadState('mail', 'allow_new_mail_aliases', true),
 			isLlmSummaryConfigured: loadState('mail', 'enabled_llm_summary_backend'),
 			isLlmEnabled: loadState('mail', 'llm_processing', true),
 			isLlmFreePromptConfigured: loadState('mail', 'enabled_llm_free_prompt_backend'),
@@ -430,6 +447,10 @@ export default {
 
 		async updateAllowNewMailAccounts(checked) {
 			await updateAllowNewMailAccounts(checked)
+		},
+
+		async updateAllowNewMailAliases(checked) {
+			await updateAllowNewMailAliases(checked)
 		},
 
 		async updateLlmEnabled(checked) {

--- a/src/init.js
+++ b/src/init.js
@@ -70,6 +70,10 @@ export default function initAfterAppCreation() {
 		value: loadState('mail', 'allow-new-accounts', true),
 	})
 	mainStore.savePreferenceMutation({
+		key: 'allow-new-aliases',
+		value: loadState('mail', 'allow-new-aliases', true),
+	})
+	mainStore.savePreferenceMutation({
 		key: 'password-is-unavailable',
 		value: loadState('mail', 'password-is-unavailable', false),
 	})

--- a/src/service/SettingsService.js
+++ b/src/service/SettingsService.js
@@ -61,6 +61,14 @@ export function updateAllowNewMailAccounts(allowed) {
 	return axios.post(url, data).then((resp) => resp.data)
 }
 
+export function updateAllowNewMailAliases(allowed) {
+	const url = generateUrl('/apps/mail/api/settings/allownewaliases')
+	const data = {
+		allowed,
+	}
+	return axios.post(url, data).then((resp) => resp.data)
+}
+
 export async function updateLlmEnabled(enabled) {
 	const url = generateUrl('/apps/mail/api/settings/llm')
 	const data = {

--- a/tests/Unit/Controller/AliasesControllerTest.php
+++ b/tests/Unit/Controller/AliasesControllerTest.php
@@ -18,6 +18,7 @@ use OCA\Mail\Service\AliasesService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
 
 class AliasesControllerTest extends TestCase {
 	private $controller;
@@ -46,8 +47,12 @@ class AliasesControllerTest extends TestCase {
 
 		$this->aliasMapper = $this->createMock(AliasMapper::class);
 		$this->mailAccountMapper = $this->createMock(MailAccountMapper::class);
+		$config = $this->createMock(IConfig::class);
+		$config->method('getAppValue')
+			->with('mail', 'allow_new_mail_aliases', 'yes')
+			->willReturn('yes');
 
-		$this->aliasService = new AliasesService($this->aliasMapper, $this->mailAccountMapper);
+		$this->aliasService = new AliasesService($this->aliasMapper, $this->mailAccountMapper, $config);
 		$this->controller = new AliasesController($this->appName, $this->request, $this->aliasService, $this->userId);
 	}
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -269,7 +269,7 @@ class PageControllerTest extends TestCase {
 				['version', '0.0.0', '26.0.0'],
 				['app.mail.attachment-size-limit', 0, 123],
 			]);
-		$this->config->expects($this->exactly(7))
+		$this->config->expects($this->exactly(8))
 			->method('getAppValue')
 			->withConsecutive(
 				[ 'mail', 'installed_version' ],
@@ -279,6 +279,7 @@ class PageControllerTest extends TestCase {
 				['mail', 'microsoft_oauth_tenant_id' ],
 				['core', 'backgroundjobs_mode', 'ajax' ],
 				['mail', 'allow_new_mail_accounts', 'yes'],
+				['mail', 'allow_new_mail_aliases', 'yes'],
 			)->willReturnOnConsecutiveCalls(
 				$this->returnValue('1.2.3'),
 				$this->returnValue('threaded'),
@@ -287,7 +288,7 @@ class PageControllerTest extends TestCase {
 				$this->returnValue(''),
 				$this->returnValue('cron'),
 				$this->returnValue('yes'),
-				$this->returnValue('no')
+				$this->returnValue('yes'),
 			);
 		$this->aiIntegrationsService->expects(self::exactly(4))
 			->method('isLlmProcessingEnabled')

--- a/tests/Unit/Service/AliasesServiceTest.php
+++ b/tests/Unit/Service/AliasesServiceTest.php
@@ -14,6 +14,7 @@ use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\AliasesService;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 
 class AliasesServiceTest extends TestCase {
 	/** @var AliasesService */
@@ -28,15 +29,24 @@ class AliasesServiceTest extends TestCase {
 	/** @var MailAccountMapper */
 	private $mailAccountMapper;
 
+	/** @var IConfig */
+	private $config;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->aliasMapper = $this->createMock(AliasMapper::class);
 		$this->mailAccountMapper = $this->createMock(MailAccountMapper::class);
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->config->method('getAppValue')
+			->with('mail', 'allow_new_mail_aliases', 'yes')
+			->willReturn('yes');
 
 		$this->service = new AliasesService(
 			$this->aliasMapper,
-			$this->mailAccountMapper
+			$this->mailAccountMapper,
+			$this->config,
 		);
 	}
 
@@ -121,6 +131,23 @@ class AliasesServiceTest extends TestCase {
 			$entity->getAlias(),
 			$entity->getName()
 		);
+	}
+
+	public function testCreateDisabledByAdmin(): void {
+		$this->expectException(ClientException::class);
+		$this->expectExceptionMessage('Creating aliases has been disabled by the administrator.');
+
+		$this->config->expects(self::once())
+			->method('getAppValue')
+			->with('mail', 'allow_new_mail_aliases', 'yes')
+			->willReturn('no');
+
+		$this->mailAccountMapper->expects(self::never())
+			->method('find');
+		$this->aliasMapper->expects(self::never())
+			->method('insert');
+
+		$this->service->create(300, 200, 'jane@doe.com', 'Jane Doe');
 	}
 
 	public function testDelete(): void {

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -37,7 +37,7 @@ class AdminSettingsTest extends TestCase {
 	}
 
 	public function testGetForm() {
-		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(14))
+		$this->serviceMock->getParameter('initialStateService')->expects($this->exactly(15))
 			->method('provideInitialState')
 			->withConsecutive(
 				[
@@ -53,6 +53,11 @@ class AdminSettingsTest extends TestCase {
 				[
 					Application::APP_ID,
 					'allow_new_mail_accounts',
+					$this->anything()
+				],
+				[
+					Application::APP_ID,
+					'allow_new_mail_aliases',
 					$this->anything()
 				],
 				[


### PR DESCRIPTION
Introduces an `allow_new_mail_aliases` app config flag (default: yes) that lets administrators prevent users from creating new mail aliases. This is useful for providers who want to prevent alias creation or manage it elsewhere.

- Backend: guard in AliasesService::create() throws ClientException when disabled
- Admin UI: toggle switch in AdminSettings, mirroring the existing "allow new mail accounts" setting
- Frontend: hides the "Add alias" button when disabled + (warning) description for setting
- Exposed via PageController initial state and storable via occ config:app:set

Extends existing unit tests for AliasesService, AdminSettings, and PageController to cover the new setting.