### PR TITLE
[stable5.7] chore(deps): Update horde-mime to 2.14.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58118b5d211447f560722687603b9e91",
+    "content-hash": "0fae8ee5d2eee8509c71801936edfbe1",
     "packages": [
         {
             "name": "amphp/amp",
@@ -988,16 +988,16 @@
         },
         {
             "name": "bytestream/horde-mime",
-            "version": "v2.13.2",
+            "version": "v2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bytestream/Mime.git",
-                "reference": "63eb21725983e437536d457135719df5a42e3cf4"
+                "reference": "6cd0216b850ea811ebc543c4b5731ef3a256ba89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bytestream/Mime/zipball/63eb21725983e437536d457135719df5a42e3cf4",
-                "reference": "63eb21725983e437536d457135719df5a42e3cf4",
+                "url": "https://api.github.com/repos/bytestream/Mime/zipball/6cd0216b850ea811ebc543c4b5731ef3a256ba89",
+                "reference": "6cd0216b850ea811ebc543c4b5731ef3a256ba89",
                 "shasum": ""
             },
             "require": {
@@ -1010,7 +1010,7 @@
                 "bytestream/horde-text-flowed": "^2",
                 "bytestream/horde-translation": "^2.2",
                 "bytestream/horde-util": "^2",
-                "php": "^7.4 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "bytestream/horde-text-filter": "^2.4",
@@ -1046,9 +1046,9 @@
             "description": "MIME library",
             "homepage": "https://www.horde.org/libraries/Horde_Mime",
             "support": {
-                "source": "https://github.com/bytestream/Mime/tree/v2.13.2"
+                "source": "https://github.com/bytestream/Mime/tree/v2.14.1"
             },
-            "time": "2024-08-12T14:10:09+00:00"
+            "time": "2026-03-30T09:58:39+00:00"
         },
         {
             "name": "bytestream/horde-secret",

--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -60,7 +60,7 @@ class Converter {
 		}
 
 		$converted = @mb_convert_encoding($data, 'UTF-8', $charset);
-		if ($converted === false) {
+		if ($converted === false && $charset !== null) {
 			// Might be a charset that PHP mb doesn't know how to handle, fall back to iconv
 			$converted = iconv($charset, 'UTF-8', $data);
 		}

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -155,7 +155,10 @@ class ImapMessageFetcher {
 				&& $structure->getContentTypeParameter('protocol') === 'application/pgp-encrypted');
 			if ($this->isPgpMimeEncrypted) {
 				$this->plainMessage = $this->loadBodyData($structure, '2', false);
-				$this->attachmentsToIgnore[] = $structure->getPartByIndex(1)->getName();
+				$attachmentName = $structure->getPartByIndex(1)?->getName();
+				if ($attachmentName !== null) {
+					$this->attachmentsToIgnore[] = $attachmentName;
+				}
 			}
 
 			$this->hasAnyAttachment = $this->hasAttachments($structure);


### PR DESCRIPTION
To unblock https://github.com/nextcloud/mail/pull/12765

Psalm is flagging, that getRaw might return `string|resource`. 

This is resolved by updating horde-mim (https://github.com/bytestream/Mime/releases/tag/v2.14.0 and https://github.com/bytestream/Mime/releases/tag/v2.14.1).

If you prfer to not update, then we can add a safe-guard as I had in an older iteration of it: https://github.com/nextcloud/mail/commit/6a2e51c1e55f0ff49c3698fb42f11dc60426c97a#diff-36c8130b1bc43570dee0d419c85f7000c236fb81c05782f8c9251600128a98e0R451.