### PR TITLE
chore(agents): Document git commit -s for proper DCO sign-off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,11 @@ After completing code changes:
 
 All commits must include two lines at the end:
 1. Agent/model attribution: `AI-assisted: <agent> (model)`
-2. DCO sign-off: `Signed-off-by: Name <email>`
+2. DCO sign-off: Use `git commit -s` to add automatically
+
+When committing, use: `git commit -m "message" -s`
+
+This ensures the sign-off includes your configured Git user email.
 
 Example:
 ```


### PR DESCRIPTION
- Clarify that DCO sign-off should use 'git commit -s' flag
- Ensures sign-off includes configured Git user email
- Add usage example: git commit -m "message" -s

Necessary because my agent still did it wrong after https://github.com/nextcloud/mail/pull/12749.

AI-assisted: OpenCode (Claude Haiku 4.5)