### PR TITLE
chore: Move TestLogger to phpunit vendor-bin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
 		"psr/log": "^1.0.4|^2|^3"
 	},
 	"require-dev": {
-		"fig/log-test": "^1.2.1",
 		"psalm/phar": "^5.26.1",
 		"roave/security-advisories": "dev-master"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "957fa4d92b4c75b257b689fd921d0a93",
+    "content-hash": "6b6a3e5ea86fb4218afe65e7470bc3ac",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3291,55 +3291,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "fig/log-test",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log-test.git",
-                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log-test/zipball/83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
-                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0",
-                "psr/log": "^2.0 | ^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0 || ^11.0",
-                "squizlabs/php_codesniffer": "^3.6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/",
-                    "role": "Organisation"
-                }
-            ],
-            "description": "Test utilities for the psr/log package that backs the PSR-3 specification.",
-            "keywords": [
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/log-test/issues",
-                "source": "https://github.com/php-fig/log-test/tree/1.2.1"
-            },
-            "time": "2025-11-11T10:33:05+00:00"
-        },
         {
             "name": "psalm/phar",
             "version": "5.26.1",

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -6,6 +6,7 @@
 		"sort-packages": true
 	},
 	"require-dev": {
-		"christophwurst/nextcloud_testing": "^1.1.3"
+		"christophwurst/nextcloud_testing": "^1.1.3",
+		"fig/log-test": "^1.2"
 	}
 }

--- a/vendor-bin/phpunit/composer.lock
+++ b/vendor-bin/phpunit/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8df47d40b09bad037b778cdb33a0b4ec",
+    "content-hash": "4b765e2a0f5f16b352d732eedfd53ddc",
     "packages": [],
     "packages-dev": [
         {
@@ -118,6 +118,55 @@
                 }
             ],
             "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "fig/log-test",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log-test.git",
+                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log-test/zipball/83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
+                "reference": "83acb6c12875ea4f349dc4fe8b7d8e239c2b3715",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/log": "^2.0 | ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0 || ^11.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/",
+                    "role": "Organisation"
+                }
+            ],
+            "description": "Test utilities for the psr/log package that backs the PSR-3 specification.",
+            "keywords": [
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/log-test/issues",
+                "source": "https://github.com/php-fig/log-test/tree/1.2.1"
+            },
+            "time": "2025-11-11T10:33:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -850,6 +899,56 @@
                 }
             ],
             "time": "2026-01-27T05:25:09+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
The motivation for this change is an obvious "me problem" :)

I run a script to update my dev instance that also executes git pull and composer i --no-dev (to avoid pollution from dev dependencies, probably less likely due to vendor-bin nowadays, but still a good default I think).

Every time I run the unit tests for the mail app, they fail because TestLogger is missing and I forgot to run composer i for the mail app. This can be resolved by moving the logger to phpunit vendor-bin, or we ditch it completely and stub it.