### PR TITLE
fix(composer): Don't show 'No results' dropdown when To/Cc/Bcc focused, only with search term put in

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -52,11 +52,13 @@
 					id="to"
 					ref="toLabel"
 					:model-value="selectTo"
+					class="select"
 					:options="selectableRecipients.filter(recipient => !selectTo.some(to => to.email === recipient.email))"
 					:get-option-key="(option) => option.email"
 					:taggable="true"
 					:aria-label-combobox="t('mail', 'Select recipient')"
 					:filter-by="(option, label, search) => filterOption(option, label, search, 'to')"
+					:dropdown-should-open="shouldOpenRecipientDropdown"
 					:multiple="true"
 					:clear-search-on-select="true"
 					:loading="loadingIndicatorTo"
@@ -112,6 +114,7 @@
 					:get-option-key="(option) => option.email"
 					:no-wrap="false"
 					:filter-by="(option, label, search) => filterOption(option, label, search, 'cc')"
+					:dropdown-should-open="shouldOpenRecipientDropdown"
 					:taggable="true"
 					:clear-search-on-blur="() => clearOnBlur('cc')"
 					:append-to-body="false"
@@ -169,6 +172,7 @@
 					:filter-by="(option, label, search) => filterOption(option, label, search, 'bcc')"
 					:options="selectableRecipients.filter(recipient => !selectBcc.some(bcc => bcc.email === recipient.email))"
 					:get-option-key="(option) => option.email"
+					:dropdown-should-open="shouldOpenRecipientDropdown"
 					:taggable="true"
 					:clear-search-on-blur="() => clearOnBlur('bcc')"
 					:append-to-body="false"
@@ -1175,6 +1179,10 @@ export default {
 
 			return (label || '').toLocaleLowerCase().includes(searchInLowerCase)
 				|| (option?.email || '').toLocaleLowerCase().includes(searchInLowerCase)
+		},
+
+		shouldOpenRecipientDropdown({ noDrop, open, search }) {
+			return !noDrop && open && search.trim() !== ''
 		},
 
 		setAlias() {

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -378,4 +378,58 @@ describe('Composer', () => {
 
 		expect(view.vm.submitButtonTitle).toEqual('Encrypt with Mailvelope and send later Jan 1, 02:00 PM')
 	})
+
+	it('does not open the recipient dropdown on focus without a search term', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+
+		expect(view.vm.shouldOpenRecipientDropdown({
+			noDrop: false,
+			open: true,
+			search: '',
+		})).toEqual(false)
+	})
+
+	it('opens the recipient dropdown once a search term is entered', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+
+		expect(view.vm.shouldOpenRecipientDropdown({
+			noDrop: false,
+			open: true,
+			search: 'alice',
+		})).toEqual(true)
+	})
 })


### PR DESCRIPTION
When opening the composer, the "To" field is automatically focused. This is nice.

But before, this also automatically opened the search result dropdown, which of course shows "No results" for no search term. This change hides the dropdown until there is an actual search term given:

Before | After
-|-
<img width="873" height="177" alt="Screenshot From 2026-04-20 15-00-29" src="https://github.com/user-attachments/assets/fb8292cd-69a5-4d6f-8a39-fa41199251ec" />|<img width="873" height="177" alt="Screenshot From 2026-04-20 14-58-57" src="https://github.com/user-attachments/assets/43aa89f7-ca11-4b13-a3e6-dda49ee402a3" />



AI-assisted: GitHub Copilot (OpenAI GPT-5.4)

> **Prompt**
> When opening the composer via "New message", the "Contact or email address" field is focused by default. This is good. However, the dropdown immediately shows "No results", referring to the search-as-you-type suggestions which would show there from users and contacts. This should only show as soon as there is any content typed in the field.