### PR TITLE
feat(UserMigration): Overwork migration to include all settings (trusted senders)

### DIFF
--- a/lib/UserMigration/MailAccountMigrator.php
+++ b/lib/UserMigration/MailAccountMigrator.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\UserMigration;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\UserMigration\Service\AccountMigrationService;
 use OCA\Mail\UserMigration\Service\AppConfigMigrationService;
+use OCA\Mail\UserMigration\Service\TrustedSendersMigrationService;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\Security\ICrypto;
@@ -30,6 +31,7 @@ class MailAccountMigrator implements IMigrator {
 		private readonly ICrypto $crypto,
 		private readonly AccountMigrationService $accountMigrationService,
 		private readonly AppConfigMigrationService $appConfigMigrationService,
+		private readonly TrustedSendersMigrationService $trustedSendersMigrationService,
 	) {
 	}
 
@@ -44,6 +46,7 @@ class MailAccountMigrator implements IMigrator {
 		);
 
 		$this->appConfigMigrationService->exportAppConfiguration($user, $exportDestination, $output);
+		$this->trustedSendersMigrationService->exportTrustedSenders($user, $exportDestination, $output);
 	}
 
 	#[\Override]
@@ -54,6 +57,7 @@ class MailAccountMigrator implements IMigrator {
 		);
 
 		$this->appConfigMigrationService->importAppConfiguration($user, $importSource, $output);
+		$this->trustedSendersMigrationService->importTrustedSenders($user, $importSource, $output);
 
 		$this->accountMigrationService->scheduleBackgroundJobs($user, $output);
 	}

--- a/lib/UserMigration/Service/TrustedSendersMigrationService.php
+++ b/lib/UserMigration/Service/TrustedSendersMigrationService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\UserMigration\Service;
+
+use JsonException;
+use OCA\Mail\Contracts\ITrustedSenderService;
+use OCA\Mail\UserMigration\MailAccountMigrator;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TrustedSendersMigrationService {
+	public const TRUSTED_SENDERS_FILE = MailAccountMigrator::EXPORT_ROOT . '/trusted_senders.json';
+
+	public function __construct(
+		private readonly ITrustedSenderService $trustedSenderService,
+		private readonly IL10N $l10n,
+	) {
+	}
+
+	/**
+	 * Export all addresses the user defined as trustworthy.
+	 *
+	 * @throws UserMigrationException
+	 */
+	public function exportTrustedSenders(IUser $user, IExportDestination $exportDestination, OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Exporting trusted senders for user %s', [ $user->getUID() ]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		$trustedSenders = $this->trustedSenderService->getTrusted($user->getUID());
+
+		try {
+			$exportDestination->addFileContents(self::TRUSTED_SENDERS_FILE, json_encode($trustedSenders, JSON_THROW_ON_ERROR));
+		} catch (JsonException|UserMigrationException $exception) {
+			throw new UserMigrationException(
+				"Failed to export trusted senders configuration for user {$user->getUID()}",
+				previous: $exception
+			);
+		}
+	}
+
+	/**
+	 * Import all addresses the user defined as trustworthy
+	 * on export.
+	 */
+	public function importTrustedSenders(IUser $user, IImportSource $importSource, OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Importing trusted senders for user %s', [ $user->getUID() ]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		try {
+			$trustedSendersFileContent = $importSource->getFileContents(self::TRUSTED_SENDERS_FILE);
+		} catch (UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Trusted senders configuration for user %s not found. Continue...', [ $user->getUID() ]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return;
+		}
+
+		try {
+			$trustedSenders = json_decode($trustedSendersFileContent, true, flags: JSON_THROW_ON_ERROR);
+			$this->validateTrustedSenders($trustedSenders);
+		} catch (JsonException|UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Trusted senders configuration for user %s is invalid and will be skipped. Continue...', [ $user->getUID() ]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return;
+		}
+
+
+		foreach ($trustedSenders as $trustedSender) {
+			$output->writeln(
+				$this->l10n->t('Importing trusted sender %s for user %s', [$trustedSender['email'], $user->getUID()]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			$this->trustedSenderService->trust($user->getUID(), $trustedSender['email'], $trustedSender['type']);
+		}
+	}
+
+	/**
+	 * Validate the parsed trusted senders to ensure they
+	 * have the expected structure and types.
+	 *
+	 * @throws UserMigrationException
+	 */
+	private function validateTrustedSenders(mixed $trustedSenders): void {
+		$trustedSendersArrayIsValid = is_array($trustedSenders) && array_is_list($trustedSenders);
+		if (!$trustedSendersArrayIsValid) {
+			throw new UserMigrationException('Invalid trusted senders export structure');
+		}
+
+		foreach ($trustedSenders as $trustedSender) {
+			$trustedSenderArrayIsValid = is_array($trustedSender);
+
+			$emailIsValid = $trustedSenderArrayIsValid
+				&& array_key_exists('email', $trustedSender)
+				&& is_string($trustedSender['email']);
+
+			$typeIsValid = $trustedSenderArrayIsValid
+				&& array_key_exists('type', $trustedSender)
+				&& is_string($trustedSender['type']);
+
+			if (!$emailIsValid || !$typeIsValid) {
+				throw new UserMigrationException('Invalid trusted sender entry');
+			}
+		}
+	}
+}

--- a/tests/Unit/UserMigration/Service/TrustedSendersMigrationServiceTest.php
+++ b/tests/Unit/UserMigration/Service/TrustedSendersMigrationServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\UserMigration\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\TrustedSender;
+use OCA\Mail\UserMigration\Service\TrustedSendersMigrationService;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TrustedSendersMigrationServiceTest extends TestCase {
+	private const USER_ID = '123';
+	private OutputInterface $output;
+	private IUser $user;
+	private IExportDestination $exportDestination;
+	private IImportSource $importSource;
+	private ServiceMockObject $serviceMock;
+	private TrustedSendersMigrationService $migrationService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->output = $this->createMock(OutputInterface::class);
+		$this->exportDestination = $this->createMock(IExportDestination::class);
+		$this->importSource = $this->createMock(IImportSource::class);
+
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')->willReturn(self::USER_ID);
+
+		$this->serviceMock = $this->createServiceMock(TrustedSendersMigrationService::class);
+		$this->migrationService = $this->serviceMock->getService();
+	}
+
+	public function testExportsMultipleTrustedSenders(): void {
+		$trustedSendersList = [$this->getTrustedIndividual(), $this->getTrustedDomain()];
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TrustedSendersMigrationService::TRUSTED_SENDERS_FILE, json_encode($trustedSendersList));
+
+		$this->serviceMock->getParameter('trustedSenderService')
+			->method('getTrusted')
+			->with(self::USER_ID)
+			->willReturn($trustedSendersList);
+		$this->migrationService->exportTrustedSenders($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testExportsNoneTrustedSenders(): void {
+		$trustedSendersList = [];
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TrustedSendersMigrationService::TRUSTED_SENDERS_FILE, json_encode($trustedSendersList));
+
+		$this->serviceMock->getParameter('trustedSenderService')
+			->method('getTrusted')
+			->with(self::USER_ID)
+			->willReturn($trustedSendersList);
+		$this->migrationService->exportTrustedSenders($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testImportMultipleTrustedSenders(): void {
+		$trustedIndividual = $this->getTrustedIndividual();
+		$trustedDomain = $this->getTrustedDomain();
+		$trustedSendersList = [$trustedIndividual, $trustedDomain];
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TrustedSendersMigrationService::TRUSTED_SENDERS_FILE)
+			->willReturn(json_encode($trustedSendersList));
+
+		$callCount = 0;
+		$expectedSenders = [$trustedIndividual, $trustedDomain];
+		$this->serviceMock->getParameter('trustedSenderService')
+			->expects(self::exactly(2))
+			->method('trust')
+			->willReturnCallback(function (string $uid, string $email, string $type) use (&$callCount, $expectedSenders): void {
+				$expectedSender = $expectedSenders[$callCount];
+				self::assertSame(self::USER_ID, $uid);
+				self::assertEquals([$expectedSender->getEmail(), $expectedSender->getType()], [$email, $type]);
+				$callCount++;
+			});
+
+		$this->migrationService->importTrustedSenders($this->user, $this->importSource, $this->output);
+	}
+
+	public function testImportNoFileIsBeingIgnored(): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TrustedSendersMigrationService::TRUSTED_SENDERS_FILE)
+			->willThrowException(new UserMigrationException());
+
+		$this->serviceMock->getParameter('trustedSenderService')
+			->expects(self::never())
+			->method('trust');
+
+		$this->migrationService->importTrustedSenders($this->user, $this->importSource, $this->output);
+	}
+
+	public static function provideFileContentsWithNoTrustedSendersImported(): array {
+		return [
+			'empty list' => [json_encode([])],
+			'invalid JSON' => ['this is not valid json {{{'],
+			'JSON object instead of list' => [json_encode(['unexpected' => 'object'])],
+		];
+	}
+
+	/**
+	 * @dataProvider provideFileContentsWithNoTrustedSendersImported
+	 */
+	public function testImportEmptyOrInvalidTrustedSenders(string $fileContents): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TrustedSendersMigrationService::TRUSTED_SENDERS_FILE)
+			->willReturn($fileContents);
+
+		$this->serviceMock->getParameter('trustedSenderService')
+			->expects(self::never())
+			->method('trust');
+
+		$this->migrationService->importTrustedSenders($this->user, $this->importSource, $this->output);
+	}
+
+	private function getTrustedIndividual(): TrustedSender {
+		$individualSender = new TrustedSender;
+
+		$individualSender->setId(1);
+		$individualSender->setUserId(self::USER_ID);
+		$individualSender->setEmail('max@mustermann.com');
+		$individualSender->setType('individual');
+
+		return $individualSender;
+	}
+
+	private function getTrustedDomain(): TrustedSender {
+		$domainSender = new TrustedSender();
+
+		$domainSender->setId(2);
+		$domainSender->setUserId(self::USER_ID);
+		$domainSender->setEmail('nextcloud.com');
+		$domainSender->setType('domain');
+
+		return $domainSender;
+	}
+}


### PR DESCRIPTION
This PR belongs to a series of PRs that will enhance the user migration to include all settings.

Included changes in this PR:
- Allow export of trusted senders
- Allow import of trusted senders
- Unit tests for import and export

Please ignore the failed CI run regarding the unconventional commit message. That happens as I tag another feature branch for better overview here.

Refs #12001 