### PR TITLE
feat(UserMigration): Overwork migration to include all settings (text blocks)

### DIFF
--- a/lib/UserMigration/MailAccountMigrator.php
+++ b/lib/UserMigration/MailAccountMigrator.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\UserMigration;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\UserMigration\Service\AccountMigrationService;
 use OCA\Mail\UserMigration\Service\AppConfigMigrationService;
+use OCA\Mail\UserMigration\Service\TextBlocksMigrationService;
 use OCA\Mail\UserMigration\Service\TrustedSendersMigrationService;
 use OCP\IL10N;
 use OCP\IUser;
@@ -32,6 +33,7 @@ class MailAccountMigrator implements IMigrator {
 		private readonly AccountMigrationService $accountMigrationService,
 		private readonly AppConfigMigrationService $appConfigMigrationService,
 		private readonly TrustedSendersMigrationService $trustedSendersMigrationService,
+		private readonly TextBlocksMigrationService $textBlocksMigrationService,
 	) {
 	}
 
@@ -47,6 +49,7 @@ class MailAccountMigrator implements IMigrator {
 
 		$this->appConfigMigrationService->exportAppConfiguration($user, $exportDestination, $output);
 		$this->trustedSendersMigrationService->exportTrustedSenders($user, $exportDestination, $output);
+		$this->textBlocksMigrationService->exportTextBlocks($user, $exportDestination, $output);
 	}
 
 	#[\Override]
@@ -58,6 +61,7 @@ class MailAccountMigrator implements IMigrator {
 
 		$this->appConfigMigrationService->importAppConfiguration($user, $importSource, $output);
 		$this->trustedSendersMigrationService->importTrustedSenders($user, $importSource, $output);
+		$this->textBlocksMigrationService->importTextBlocks($user, $importSource, $output);
 
 		$this->accountMigrationService->scheduleBackgroundJobs($user, $output);
 	}

--- a/lib/UserMigration/Service/TextBlocksMigrationService.php
+++ b/lib/UserMigration/Service/TextBlocksMigrationService.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\UserMigration\Service;
+
+use JsonException;
+use OCA\Mail\Service\TextBlockService;
+use OCA\Mail\UserMigration\MailAccountMigrator;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TextBlocksMigrationService {
+	public const TEXT_BLOCKS_FILE = MailAccountMigrator::EXPORT_ROOT . '/text_blocks.json';
+
+	public function __construct(
+		private readonly TextBlockService $textBlockService,
+		private readonly IL10N $l10n,
+	) {
+	}
+
+	/**
+	 * Export all text blocks the user created itself.
+	 * This does not include those shared with others.
+	 *
+	 * @throws UserMigrationException
+	 */
+	public function exportTextBlocks(IUser $user, IExportDestination $exportDestination, OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Exporting text blocks for user %s', [$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		$textBlocks = $this->textBlockService->findAll($user->getUID());
+
+		try {
+			$exportDestination->addFileContents(self::TEXT_BLOCKS_FILE, json_encode($textBlocks, JSON_THROW_ON_ERROR));
+		} catch (JsonException|UserMigrationException $exception) {
+			throw new UserMigrationException(
+				"Failed to export text blocks for user {$user->getUID()}",
+				previous: $exception
+			);
+		}
+	}
+
+	/**
+	 * Import all text blocks the user created itself on export.
+	 * This does not include those shared with others.
+	 */
+	public function importTextBlocks(IUser $user, IImportSource $importSource, OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Importing text blocks for user %s', [$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		try {
+			$textBlocksFileContent = $importSource->getFileContents(self::TEXT_BLOCKS_FILE);
+		} catch (UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Text blocks for user %s not found. Continue...', [$user->getUID()]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return;
+		}
+
+		try {
+			$textBlocks = json_decode($textBlocksFileContent, true, flags: JSON_THROW_ON_ERROR);
+			$this->validateTextBlocks($textBlocks);
+		} catch (JsonException|UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Text blocks configuration for user %s is invalid and will be skipped. Continue...', [ $user->getUID() ]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return;
+		}
+
+
+		foreach ($textBlocks as $textBlock) {
+			$output->writeln(
+				$this->l10n->t('Importing text block %s for user %s', [$textBlock['title'], $user->getUID()]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			$this->textBlockService->create($user->getUID(), $textBlock['title'], $textBlock['content']);
+		}
+	}
+
+	/**
+	 * Validate the parsed text blocks to ensure they
+	 * have the expected structure and types.
+	 *
+	 * @throws UserMigrationException
+	 */
+	private function validateTextBlocks(mixed $textBlocks): void {
+		$textBlocksArrayIsValid = is_array($textBlocks) && array_is_list($textBlocks);
+		if (!$textBlocksArrayIsValid) {
+			throw new UserMigrationException('Invalid text blocks export structure');
+		}
+
+		foreach ($textBlocks as $textBlock) {
+			$textBlockArrayIsValid = is_array($textBlock);
+
+			$titleIsValid = $textBlockArrayIsValid
+				&& array_key_exists('title', $textBlock)
+				&& is_string($textBlock['title']);
+
+			$contentIsValid = $textBlockArrayIsValid
+				&& array_key_exists('content', $textBlock)
+				&& is_string($textBlock['content']);
+
+			if (!$titleIsValid || !$contentIsValid) {
+				throw new UserMigrationException('Invalid text block entry');
+			}
+		}
+	}
+}

--- a/tests/Unit/UserMigration/Service/TextBlocksMigrationServiceTest.php
+++ b/tests/Unit/UserMigration/Service/TextBlocksMigrationServiceTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\UserMigration\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\TextBlock;
+use OCA\Mail\UserMigration\Service\TextBlocksMigrationService;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TextBlocksMigrationServiceTest extends TestCase {
+	private const USER_ID = '123';
+	private OutputInterface $output;
+	private IUser $user;
+	private IExportDestination $exportDestination;
+	private IImportSource $importSource;
+	private ServiceMockObject $serviceMock;
+	private TextBlocksMigrationService $migrationService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->output = $this->createMock(OutputInterface::class);
+		$this->exportDestination = $this->createMock(IExportDestination::class);
+		$this->importSource = $this->createMock(IImportSource::class);
+
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')->willReturn(self::USER_ID);
+
+		$this->serviceMock = $this->createServiceMock(TextBlocksMigrationService::class);
+		$this->migrationService = $this->serviceMock->getService();
+	}
+
+	public function testExportsMultipleTextBlocks(): void {
+		$textBlocksList = [$this->getLoremIpsum1(), $this->getIpsumLorem2()];
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE, json_encode($textBlocksList));
+
+		$this->serviceMock->getParameter('textBlockService')
+			->method('findAll')
+			->with(self::USER_ID)
+			->willReturn($textBlocksList);
+		$this->migrationService->exportTextBlocks($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testExportsNoneTextBlocks(): void {
+		$textBlocksList = [];
+
+		$this->serviceMock->getParameter('textBlockService')
+			->method('findAll')
+			->with(self::USER_ID)
+			->willReturn($textBlocksList);
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE, json_encode($textBlocksList));
+
+		$this->migrationService->exportTextBlocks($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testImportMultipleTextBlocks(): void {
+		$textBlock1 = $this->getLoremIpsum1();
+		$textBlock2 = $this->getIpsumLorem2();
+		$textBlocksList = [$textBlock1, $textBlock2];
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE)
+			->willReturn(json_encode($textBlocksList));
+
+		$callCount = 0;
+		$expectedBlocks = [$textBlock1, $textBlock2];
+		$this->serviceMock->getParameter('textBlockService')
+			->expects(self::exactly(2))
+			->method('create')
+			->willReturnCallback(function (string $uid, string $title, string $content) use (&$callCount, $expectedBlocks): TextBlock {
+				$expectedBlock = $expectedBlocks[$callCount];
+				self::assertSame(self::USER_ID, $uid);
+				self::assertEquals([$expectedBlock->getTitle(), $expectedBlock->getContent()], [$title, $content]);
+				$callCount++;
+				return $expectedBlock;
+			});
+
+		$this->migrationService->importTextBlocks($this->user, $this->importSource, $this->output);
+	}
+
+	public function testImportNoneTextBlocks(): void {
+		$textBlocksList = [];
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE)
+			->willReturn(json_encode($textBlocksList));
+
+		$this->serviceMock->getParameter('textBlockService')
+			->expects(self::never())
+			->method('create');
+
+		$this->migrationService->importTextBlocks($this->user, $this->importSource, $this->output);
+	}
+
+	public function testImportNoFileIsBeingIgnored(): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE)
+			->willThrowException(new UserMigrationException());
+
+		$this->serviceMock->getParameter('textBlockService')
+			->expects(self::never())
+			->method('create');
+
+		$this->migrationService->importTextBlocks($this->user, $this->importSource, $this->output);
+	}
+
+	public static function provideFileContentsWithNoTextBlocksImported(): array {
+		return [
+			'empty list' => [json_encode([])],
+			'invalid JSON' => ['this is not valid json {{{'],
+			'JSON object instead of list' => [json_encode(['unexpected' => 'object'])],
+		];
+	}
+
+	/**
+	 * @dataProvider provideFileContentsWithNoTextBlocksImported
+	 */
+	public function testImportEmptyOrInvalidTextBlocks(string $fileContents): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TextBlocksMigrationService::TEXT_BLOCKS_FILE)
+			->willReturn($fileContents);
+
+		$this->serviceMock->getParameter('textBlockService')
+			->expects(self::never())
+			->method('create');
+
+		$this->migrationService->importTextBlocks($this->user, $this->importSource, $this->output);
+	}
+
+	private function getLoremIpsum1(): TextBlock {
+		$textBlock = new TextBlock();
+
+		$textBlock->setId(1);
+		$textBlock->setOwner(self::USER_ID);
+		$textBlock->setTitle('Lorem ipsum 1');
+		$textBlock->setPreview('Lorem ipsum dolor sit amet');
+		$textBlock->setContent('<p style="margin:0;">Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</p>');
+
+		return $textBlock;
+	}
+
+	private function getIpsumLorem2(): TextBlock {
+		$textBlock = new TextBlock();
+
+		$textBlock->setId(2);
+		$textBlock->setOwner(self::USER_ID);
+		$textBlock->setTitle('Ipsum lorem 2');
+		$textBlock->setPreview('Ipsum lorem amet sit dolor');
+		$textBlock->setContent('<p style="margin:0;">At vero eos et accusam et justo duo dolores et ea rebum.</p>');
+
+		return $textBlock;
+	}
+}


### PR DESCRIPTION
This PR belongs to a series of PRs that will enhance the user migration to include all settings.

Included changes in this PR:
- Allow export of text blocks
- Allow import of text blocks
- Unit tests for import and export

Please ignore the failed CI run regarding the unconventional commit message. That happens as I tag another feature branch for better overview here.

Refs https://github.com/nextcloud/mail/issues/12001