### PR TITLE
feat(UserMigration): Overwork migration to include all settings (tags)

### DIFF
--- a/lib/UserMigration/MailAccountMigrator.php
+++ b/lib/UserMigration/MailAccountMigrator.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\UserMigration;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\UserMigration\Service\AccountMigrationService;
 use OCA\Mail\UserMigration\Service\AppConfigMigrationService;
+use OCA\Mail\UserMigration\Service\TagsMigrationService;
 use OCA\Mail\UserMigration\Service\TextBlocksMigrationService;
 use OCA\Mail\UserMigration\Service\TrustedSendersMigrationService;
 use OCP\IL10N;
@@ -34,6 +35,7 @@ class MailAccountMigrator implements IMigrator {
 		private readonly AppConfigMigrationService $appConfigMigrationService,
 		private readonly TrustedSendersMigrationService $trustedSendersMigrationService,
 		private readonly TextBlocksMigrationService $textBlocksMigrationService,
+		private readonly TagsMigrationService $tagsMigrationService,
 	) {
 	}
 
@@ -50,8 +52,12 @@ class MailAccountMigrator implements IMigrator {
 		$this->appConfigMigrationService->exportAppConfiguration($user, $exportDestination, $output);
 		$this->trustedSendersMigrationService->exportTrustedSenders($user, $exportDestination, $output);
 		$this->textBlocksMigrationService->exportTextBlocks($user, $exportDestination, $output);
+		$this->tagsMigrationService->exportTags($user, $exportDestination, $output);
 	}
 
+	/**
+	 * @throws \OCP\DB\Exception
+	 */
 	#[\Override]
 	public function import(IUser $user, IImportSource $importSource, OutputInterface $output): void {
 		$output->writeln(
@@ -62,6 +68,7 @@ class MailAccountMigrator implements IMigrator {
 		$this->appConfigMigrationService->importAppConfiguration($user, $importSource, $output);
 		$this->trustedSendersMigrationService->importTrustedSenders($user, $importSource, $output);
 		$this->textBlocksMigrationService->importTextBlocks($user, $importSource, $output);
+		$migratedTags = $this->tagsMigrationService->importTags($user, $importSource, $output);
 
 		$this->accountMigrationService->scheduleBackgroundJobs($user, $output);
 	}

--- a/lib/UserMigration/Service/TagsMigrationService.php
+++ b/lib/UserMigration/Service/TagsMigrationService.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\UserMigration\Service;
+
+use JsonException;
+use OCA\Mail\Db\Tag;
+use OCA\Mail\Db\TagMapper;
+use OCA\Mail\UserMigration\MailAccountMigrator;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TagsMigrationService {
+	public const TAGS_FILE = MailAccountMigrator::EXPORT_ROOT . '/tags.json';
+
+	public function __construct(
+		private readonly TagMapper $tagMapper,
+		private readonly IL10N $l10n,
+	) {
+	}
+
+	/**
+	 * Export all tags the user currently uses.
+	 *
+	 * @throws UserMigrationException
+	 */
+	public function exportTags(IUser $user, IExportDestination $exportDestination, OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Exporting tags for user %s', [$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		$tags = $this->tagMapper->getAllTagsForUser($user->getUID());
+
+		try {
+			$exportDestination->addFileContents(self::TAGS_FILE, json_encode($tags, JSON_THROW_ON_ERROR));
+		} catch (JsonException|UserMigrationException $exception) {
+			throw new UserMigrationException(
+				"Failed to export tags for user {$user->getUID()}",
+				previous: $exception
+			);
+		}
+	}
+
+	/**
+	 * Import all tags the user used on export.
+	 *
+	 * @throws \OCP\DB\Exception
+	 */
+	public function importTags(IUser $user, IImportSource $importSource, OutputInterface $output): array {
+		$output->writeln(
+			$this->l10n->t('Importing tags for user %s', [$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		try {
+			$tagsFileContent = $importSource->getFileContents(self::TAGS_FILE);
+		} catch (UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Tags for user %s not found. Continue...', [$user->getUID()]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return [];
+		}
+
+		try {
+			$tags = json_decode($tagsFileContent, true, flags: JSON_THROW_ON_ERROR);
+			$this->validateTags($tags);
+		} catch (JsonException|UserMigrationException) {
+			$output->writeln(
+				$this->l10n->t('Tag configuration for user %s is invalid and will be skipped. Continue...', [ $user->getUID() ]),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+
+			return [];
+		}
+
+
+		$newTags = [];
+
+		foreach ($tags as $tag) {
+			$newTag = new Tag();
+
+			$newTag->setUserId($user->getUID());
+			$newTag->setDisplayName($tag['displayName']);
+			$newTag->setImapLabel($tag['imapLabel']);
+			$newTag->setColor($tag['color']);
+			$newTag->setIsDefaultTag($tag['isDefaultTag']);
+
+			$newTags[$tag['id']] = $this->tagMapper->insert($newTag)->getId();
+		}
+
+		return $newTags;
+	}
+
+	/**
+	 * Validate the parsed tags to ensure they
+	 * have the expected structure and types.
+	 *
+	 * @throws UserMigrationException
+	 */
+	private function validateTags(mixed $tags): void {
+		$tagsArrayIsValid = is_array($tags) && array_is_list($tags);
+		if (!$tagsArrayIsValid) {
+			throw new UserMigrationException('Invalid tags export structure');
+		}
+
+		foreach ($tags as $tag) {
+			$tagArrayIsValid = is_array($tag);
+
+			$idIsValid = $tagArrayIsValid
+				&& array_key_exists('id', $tag)
+				&& is_int($tag['id']);
+
+			$displayNameIsValid = $tagArrayIsValid
+				&& array_key_exists('displayName', $tag)
+				&& is_string($tag['displayName']);
+
+			$imapLabelIsValid = $tagArrayIsValid
+				&& array_key_exists('imapLabel', $tag)
+				&& is_string($tag['imapLabel']);
+
+			$colorIsValid = $tagArrayIsValid
+				&& array_key_exists('color', $tag)
+				&& is_string($tag['color']);
+
+			$isDefaultTagIsValid = $tagArrayIsValid
+				&& array_key_exists('isDefaultTag', $tag)
+				&& is_bool($tag['isDefaultTag']);
+
+			if (
+				!$idIsValid
+				|| !$displayNameIsValid
+				|| !$imapLabelIsValid
+				|| !$colorIsValid
+				|| !$isDefaultTagIsValid
+			) {
+				throw new UserMigrationException('Invalid tag entry');
+			}
+		}
+	}
+}

--- a/tests/Unit/UserMigration/Service/TagsMigrationServiceTest.php
+++ b/tests/Unit/UserMigration/Service/TagsMigrationServiceTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\UserMigration\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\Tag;
+use OCA\Mail\UserMigration\Service\TagsMigrationService;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TagsMigrationServiceTest extends TestCase {
+	private const USER_ID = '123';
+	private OutputInterface $output;
+	private IUser $user;
+	private IExportDestination $exportDestination;
+	private IImportSource $importSource;
+	private ServiceMockObject $serviceMock;
+	private TagsMigrationService $migrationService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->output = $this->createMock(OutputInterface::class);
+		$this->exportDestination = $this->createMock(IExportDestination::class);
+		$this->importSource = $this->createMock(IImportSource::class);
+
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')->willReturn(self::USER_ID);
+
+		$this->serviceMock = $this->createServiceMock(TagsMigrationService::class);
+		$this->migrationService = $this->serviceMock->getService();
+	}
+
+	public function testExportsMultipleTags(): void {
+		$tagsList = [$this->getTestingTag(), $this->getSuccessfulTag()];
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TagsMigrationService::TAGS_FILE, json_encode($tagsList));
+
+		$this->serviceMock->getParameter('tagMapper')
+			->method('getAllTagsForUser')
+			->with(self::USER_ID)
+			->willReturn($tagsList);
+		$this->migrationService->exportTags($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testExportsNoTags(): void {
+		$tagsList = [];
+
+		$this->serviceMock->getParameter('tagMapper')
+			->method('getAllTagsForUser')
+			->with(self::USER_ID)
+			->willReturn($tagsList);
+		$this->exportDestination->expects(self::once())
+			->method('addFileContents')
+			->with(TagsMigrationService::TAGS_FILE, json_encode($tagsList));
+
+		$this->migrationService->exportTags($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testImportMultipleTags(): void {
+		$testingTag = $this->getTestingTag();
+		$successfulTag = $this->getSuccessfulTag();
+		$tagsList = [$testingTag, $successfulTag];
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TagsMigrationService::TAGS_FILE)
+			->willReturn(json_encode($tagsList));
+
+		$callCount = 0;
+		$expectedTags = [$testingTag, $successfulTag];
+		$this->serviceMock->getParameter('tagMapper')
+			->expects(self::exactly(2))
+			->method('insert')
+			->willReturnCallback(function (Tag $tag) use (
+				&$callCount,
+				$expectedTags
+			): Tag {
+				$expectedTag = $expectedTags[$callCount];
+				self::assertSame(self::USER_ID, $tag->getUserId());
+				self::assertSame($expectedTag->getDisplayName(), $tag->getDisplayName());
+				self::assertSame($expectedTag->getImapLabel(), $tag->getImapLabel());
+				self::assertSame($expectedTag->getColor(), $tag->getColor());
+				self::assertSame($expectedTag->getIsDefaultTag(), $tag->getIsDefaultTag());
+				$tag->setId(random_int(10, 999));
+				$callCount++;
+				return $tag;
+			});
+
+		$mappedTags = $this->migrationService->importTags($this->user, $this->importSource, $this->output);
+
+		$this->assertCount(2, $mappedTags);
+		$this->assertArrayHasKey($testingTag->getId(), $mappedTags);
+		$this->assertIsInt($mappedTags[$testingTag->getId()]);
+		$this->assertArrayHasKey($successfulTag->getId(), $mappedTags);
+		$this->assertIsInt($mappedTags[$successfulTag->getId()]);
+	}
+
+	public function testImportNoTags(): void {
+		$tagsList = [];
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TagsMigrationService::TAGS_FILE)
+			->willReturn(json_encode($tagsList));
+		$this->serviceMock->getParameter('tagMapper')
+			->expects(self::never())
+			->method('insert');
+
+		$mappedTags = $this->migrationService->importTags($this->user, $this->importSource, $this->output);
+
+		$this->assertCount(0, $mappedTags);
+	}
+
+	public function testImportNoFileIsBeingIgnored(): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TagsMigrationService::TAGS_FILE)
+			->willThrowException(new UserMigrationException());
+		$this->serviceMock->getParameter('tagMapper')
+			->expects(self::never())
+			->method('insert');
+
+		$mappedTags = $this->migrationService->importTags($this->user, $this->importSource, $this->output);
+
+		$this->assertCount(0, $mappedTags);
+	}
+
+	public static function provideFileContentsWithNoTagsImported(): array {
+		return [
+			'empty list' => [json_encode([])],
+			'invalid JSON' => ['this is not valid json {{{'],
+			'JSON object instead of list' => [json_encode(['unexpected' => 'object'])],
+		];
+	}
+
+	/**
+	 * @dataProvider provideFileContentsWithNoTagsImported
+	 */
+	public function testImportEmptyOrInvalidTags(string $fileContents): void {
+		$this->importSource->expects(self::once())
+			->method('getFileContents')
+			->with(TagsMigrationService::TAGS_FILE)
+			->willReturn($fileContents);
+		$this->serviceMock->getParameter('tagMapper')
+			->expects(self::never())
+			->method('insert');
+
+		$mappedTags = $this->migrationService->importTags($this->user, $this->importSource, $this->output);
+
+		$this->assertCount(0, $mappedTags);
+	}
+
+	private function getTestingTag(): Tag {
+		$testingTag = new Tag();
+
+		$testingTag->setId(1);
+		$testingTag->setUserId(self::USER_ID);
+		$testingTag->setImapLabel('testing');
+		$testingTag->setDisplayName('Testing');
+		$testingTag->setColor('#fff');
+		$testingTag->setIsDefaultTag(false);
+
+		return $testingTag;
+	}
+
+	private function getSuccessfulTag(): Tag {
+		$successfulTag = new Tag();
+
+		$successfulTag->setId(2);
+		$successfulTag->setUserId(self::USER_ID);
+		$successfulTag->setImapLabel('successful');
+		$successfulTag->setDisplayName('Successful');
+		$successfulTag->setColor('#fff');
+		$successfulTag->setIsDefaultTag(false);
+
+		return $successfulTag;
+	}
+
+}


### PR DESCRIPTION
This PR belongs to a series of PRs that will enhance the user migration to include all settings.

Included changes in this PR:
- Allow export of tags
- Allow import of tags
- Unit tests for import and export

Please ignore the failed CI run regarding the unconventional commit message. That happens as I tag another feature branch for better overview here.

Refs https://github.com/nextcloud/mail/issues/12001