### PR TITLE
fix(imap): prevent null HIGHESTMODSEQ after initial sync

### DIFF
--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -374,7 +374,18 @@ class ImapToDbSynchronizer {
 			throw new IncompleteSyncException("Initial sync is not complete for $loggingMailboxId ($cached of $total messages cached).");
 		}
 
-		$syncToken = $client->getSyncToken($mailbox->getName());
+		// Get the sync token from a cache-enabled client. The non-cache client
+		// used above does not activate CONDSTORE/QRESYNC, so its sync token
+		// lacks HIGHESTMODSEQ. Without it, the first partial sync falls into
+		// Horde's "no MODSEQ" fallback that resolves ALL UIDs, causing OOM on
+		// large mailboxes.
+		$client->logout();
+		$cacheClient = $this->clientFactory->getClient($account);
+		try {
+			$syncToken = $cacheClient->getSyncToken($mailbox->getName());
+		} finally {
+			$cacheClient->logout();
+		}
 		$mailbox->setSyncNewToken($syncToken);
 		$mailbox->setSyncChangedToken($syncToken);
 		$mailbox->setSyncVanishedToken($syncToken);

--- a/tests/Unit/Service/Sync/ImapToDbSynchronizerTest.php
+++ b/tests/Unit/Service/Sync/ImapToDbSynchronizerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\Sync;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Data_Capability_Imap;
+use Horde_Imap_Client_Socket;
+use OCA\Mail\Account;
+use OCA\Mail\Contracts\IMailManager;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Db\MessageMapper as DatabaseMessageMapper;
+use OCA\Mail\Db\TagMapper;
+use OCA\Mail\Events\SynchronizationEvent;
+use OCA\Mail\IMAP\IMAPClientFactory;
+use OCA\Mail\IMAP\MessageMapper as ImapMessageMapper;
+use OCA\Mail\IMAP\Sync\Synchronizer;
+use OCA\Mail\Service\Classification\NewMessagesClassifier;
+use OCA\Mail\Service\Sync\ImapToDbSynchronizer;
+use OCA\Mail\Support\PerformanceLogger;
+use OCA\Mail\Support\PerformanceLoggerTask;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class ImapToDbSynchronizerTest extends TestCase {
+	private DatabaseMessageMapper&MockObject $dbMapper;
+	private IMAPClientFactory&MockObject $clientFactory;
+	private ImapMessageMapper&MockObject $imapMapper;
+	private MailboxMapper&MockObject $mailboxMapper;
+	private IEventDispatcher&MockObject $dispatcher;
+	private PerformanceLogger&MockObject $performanceLogger;
+	private ImapToDbSynchronizer $synchronizer;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->dbMapper = $this->createMock(DatabaseMessageMapper::class);
+		$this->clientFactory = $this->createMock(IMAPClientFactory::class);
+		$this->imapMapper = $this->createMock(ImapMessageMapper::class);
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
+		$this->performanceLogger = $this->createMock(PerformanceLogger::class);
+		$this->performanceLogger->method('startWithLogger')
+			->willReturn($this->createStub(PerformanceLoggerTask::class));
+		$this->synchronizer = new ImapToDbSynchronizer(
+			$this->dbMapper,
+			$this->clientFactory,
+			$this->imapMapper,
+			$this->mailboxMapper,
+			$this->createStub(DatabaseMessageMapper::class),
+			$this->createStub(Synchronizer::class),
+			$this->dispatcher,
+			$this->performanceLogger,
+			$this->createStub(LoggerInterface::class),
+			$this->createStub(IMailManager::class),
+			$this->createStub(TagMapper::class),
+			$this->createStub(NewMessagesClassifier::class),
+		);
+	}
+
+	public function testInitialSyncGetsSyncTokenFromCacheClient(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setUserId('user');
+		$account = new Account($mailAccount);
+		$mailbox = new Mailbox();
+		$mailbox->setId(100);
+		$mailbox->setName('INBOX');
+		$mailbox->setAccountId(1);
+		$mailbox->setSelectable(true);
+		$capability = $this->createMock(Horde_Imap_Client_Data_Capability_Imap::class);
+		$capability->method('isEnabled')->with('QRESYNC')->willReturn(false);
+		$initialClient = $this->createMock(Horde_Imap_Client_Socket::class);
+		$initialClient->method('__get')->with('capability')->willReturn($capability);
+		$noCacheClient = $this->createMock(Horde_Imap_Client_Socket::class);
+		$cacheClient = $this->createMock(Horde_Imap_Client_Socket::class);
+		$cacheClient->expects($this->once())
+			->method('getSyncToken')
+			->with('INBOX')
+			->willReturn('dG9rZW5XaXRoSA==');
+		$cacheClient->expects($this->once())->method('logout');
+		$this->clientFactory->expects($this->exactly(2))
+			->method('getClient')
+			->willReturnMap([
+				[$account, false, $noCacheClient],
+				[$account, true, $cacheClient],
+			]);
+		$this->dbMapper->method('findHighestUid')->willReturn(null);
+		$this->imapMapper->method('findAll')->willReturn([
+			'messages' => [],
+			'all' => true,
+			'total' => 0,
+		]);
+		$this->mailboxMapper->expects($this->once())
+			->method('update')
+			->with($this->callback(function (Mailbox $mb) {
+				return $mb->getSyncNewToken() === 'dG9rZW5XaXRoSA=='
+					&& $mb->getSyncChangedToken() === 'dG9rZW5XaXRoSA=='
+					&& $mb->getSyncVanishedToken() === 'dG9rZW5XaXRoSA==';
+			}));
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->isInstanceOf(SynchronizationEvent::class));
+		$this->synchronizer->sync(
+			$account,
+			$initialClient,
+			$mailbox,
+			$this->createStub(LoggerInterface::class),
+		);
+	}
+}


### PR DESCRIPTION
This brings back https://github.com/nextcloud/mail/pull/6880 which was lost in https://github.com/nextcloud/mail/pull/8968.

Having no HIGHESTMODSEQ after initial sync means that the server will report all emails as changed.

Note: accounts that were synced initially but ran into OOM at the first partial sync will stay in a OOM loop because the sync token with null was persisted before. This needs a separate fix.