### PR TITLE
fix(AccountService): Invalidate cache after account creation/change/deletion

### DIFF
--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -149,6 +149,10 @@ class AccountService {
 		}
 		$this->aliasesService->deleteAll($accountId);
 		$this->mapper->delete($mailAccount);
+
+		// Invalidate cache to ensure deleted account is not included
+		// in subsequent `findByUserId` and `findByUserIdAndAddress` calls
+		unset($this->accounts[$currentUserId]);
 	}
 
 	/**
@@ -164,6 +168,10 @@ class AccountService {
 		}
 		$this->aliasesService->deleteAll($accountId);
 		$this->mapper->delete($mailAccount);
+
+		// Invalidate cache to ensure deleted account is not included
+		// in subsequent `findByUserId` and `findByUserIdAndAddress` calls
+		unset($this->accounts[$mailAccount->getUserId()]);
 	}
 
 	/**
@@ -176,11 +184,21 @@ class AccountService {
 		// Insert background jobs for this account
 		$this->scheduleBackgroundJobs($newAccount->getId());
 
+		// Invalidate cache to ensure created account is being included
+		// in subsequent `findByUserId` and `findByUserIdAndAddress` calls
+		unset($this->accounts[$newAccount->getUserId()]);
+
 		return $newAccount;
 	}
 
 	public function update(MailAccount $account): MailAccount {
-		return $this->mapper->update($account);
+		$updatedAccount = $this->mapper->update($account);
+
+		// Invalidate cache to ensure changes to account are being included
+		// in subsequent `findByUserId` and `findByUserIdAndAddress` calls
+		unset($this->accounts[$updatedAccount->getUserId()]);
+
+		return $updatedAccount;
 	}
 
 	/**
@@ -196,6 +214,10 @@ class AccountService {
 		$mailAccount = $account->getMailAccount();
 		$mailAccount->setSignature($signature);
 		$this->mapper->save($mailAccount);
+
+		// Invalidate cache to ensure changed signature is being included
+		// in subsequent `findByUserId` and `findByUserIdAndAddress` calls
+		unset($this->accounts[$uid]);
 	}
 
 	/**

--- a/tests/Unit/Service/AccountServiceTest.php
+++ b/tests/Unit/Service/AccountServiceTest.php
@@ -234,6 +234,100 @@ class AccountServiceTest extends TestCase {
 		$this->assertTrue($connected);
 	}
 
+	public function testDeleteInvalidatesCache(): void {
+		$accountId = 33;
+		$this->account1->setUserId($this->user);
+
+		$this->mapper->expects(self::exactly(2))
+			->method('findByUserId')
+			->with($this->user)
+			->willReturn([$this->account1]);
+		$this->mapper->method('find')
+			->with($this->user, $accountId)
+			->willReturn($this->account1);
+
+		$this->accountService->findByUserId($this->user);
+		$this->accountService->delete($this->user, $accountId);
+		$this->accountService->findByUserId($this->user);
+	}
+
+	public function testDeleteByAccountIdInvalidatesCache(): void {
+		$accountId = 33;
+		$this->account1->setUserId($this->user);
+		$this->account1->setId($accountId);
+
+		$this->mapper->expects(self::exactly(2))
+			->method('findByUserId')
+			->with($this->user)
+			->willReturn([$this->account1]);
+		$this->mapper->method('findById')
+			->with($accountId)
+			->willReturn($this->account1);
+
+		$this->accountService->findByUserId($this->user);
+		$this->accountService->deleteByAccountId($accountId);
+		$this->accountService->findByUserId($this->user);
+	}
+
+	public function testSaveInvalidatesCache(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1000);
+		$mailAccount->setUserId($this->user);
+
+		$this->mapper->expects(self::exactly(2))
+			->method('findByUserId')
+			->with($this->user)
+			->willReturn([$mailAccount]);
+		$this->mapper->method('save')
+			->willReturnArgument(0);
+		$this->time->method('getTime')
+			->willReturn(1755850409);
+		$this->jobList->method('has')
+			->willReturn(true);
+
+		$this->accountService->findByUserId($this->user);
+		$this->accountService->save($mailAccount);
+		$this->accountService->findByUserId($this->user);
+	}
+
+	public function testUpdateInvalidatesCache(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1000);
+		$mailAccount->setUserId($this->user);
+
+		$this->mapper->expects(self::exactly(2))
+			->method('findByUserId')
+			->with($this->user)
+			->willReturn([$mailAccount]);
+		$this->mapper->method('update')
+			->willReturnArgument(0);
+
+		$this->accountService->findByUserId($this->user);
+		$this->accountService->update($mailAccount);
+		$this->accountService->findByUserId($this->user);
+	}
+
+	public function testUpdateSignatureInvalidatesCache(): void {
+		$id = 3;
+		$uid = $this->user;
+		$mailAccount = new MailAccount();
+		$mailAccount->setId($id);
+		$mailAccount->setUserId($uid);
+
+		$this->mapper->expects(self::exactly(2))
+			->method('findByUserId')
+			->with($uid)
+			->willReturn([$mailAccount]);
+		$this->mapper->method('find')
+			->with($uid, $id)
+			->willReturn($mailAccount);
+		$this->mapper->method('save');
+
+		$this->accountService->findByUserId($uid);
+		$this->accountService->updateSignature($id, $uid, 'sig');
+		$this->accountService->findByUserId($uid);
+	}
+
 	public function testScheduleBackgroundJobs(): void {
 		$mailAccountId = 1000;
 		$this->time->expects(self::once())


### PR DESCRIPTION
While working on #12777, I found out that the cache isn't being invalidated after any change. This **may** cause some issues, although those will be very rare as the lifecycle of the `AccountService` class is limited to each request. For performance reasons, it may be worth to move the cache to `memcache`, which then will survive the lifecycle of the `AccountService` class.

AI-assisted: Claude Sonnet 4.6