### PR TITLE
feat(UserMigration): Overwork migration to include all settings (S/MIME certificates)

### DIFF
--- a/lib/UserMigration/MailAccountMigrator.php
+++ b/lib/UserMigration/MailAccountMigrator.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\UserMigration;
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\UserMigration\Service\AccountMigrationService;
 use OCA\Mail\UserMigration\Service\AppConfigMigrationService;
+use OCA\Mail\UserMigration\Service\SmimeMigrationService;
 use OCA\Mail\UserMigration\Service\TagsMigrationService;
 use OCA\Mail\UserMigration\Service\TextBlocksMigrationService;
 use OCA\Mail\UserMigration\Service\TrustedSendersMigrationService;
@@ -36,6 +37,7 @@ class MailAccountMigrator implements IMigrator {
 		private readonly TrustedSendersMigrationService $trustedSendersMigrationService,
 		private readonly TextBlocksMigrationService $textBlocksMigrationService,
 		private readonly TagsMigrationService $tagsMigrationService,
+		private readonly SmimeMigrationService $smimeMigrationService,
 	) {
 	}
 
@@ -53,6 +55,7 @@ class MailAccountMigrator implements IMigrator {
 		$this->trustedSendersMigrationService->exportTrustedSenders($user, $exportDestination, $output);
 		$this->textBlocksMigrationService->exportTextBlocks($user, $exportDestination, $output);
 		$this->tagsMigrationService->exportTags($user, $exportDestination, $output);
+		$this->smimeMigrationService->exportCertificates($user, $exportDestination, $output);
 	}
 
 	/**

--- a/lib/UserMigration/Service/SmimeMigrationService.php
+++ b/lib/UserMigration/Service/SmimeMigrationService.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\UserMigration\Service;
+
+use Exception;
+use JsonException;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Service\SmimeService;
+use OCA\Mail\UserMigration\MailAccountMigrator;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\Security\ICrypto;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use OCP\UserMigration\UserMigrationException;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SmimeMigrationService {
+	public const SMIME_CERTIFICATE_FOLDER = MailAccountMigrator::EXPORT_ROOT . '/certificates/';
+	public const SMIME_CERTIFICATE_FILES = self::SMIME_CERTIFICATE_FOLDER . MailAccountMigrator::FILENAME_PLACEHOLDER . '.json';
+
+	public function __construct(
+		private readonly SmimeService $smimeService,
+		private readonly ICrypto $crypto,
+		private readonly IL10N $l10n,
+	) {
+	}
+
+	/**
+	 * Export all S/MIME certificates added by the user
+	 * on export.
+	 *
+	 * @throws UserMigrationException
+	 * @throws ServiceException
+	 * @throws Exception
+	 */
+	public function exportCertificates(IUser $user,
+		IExportDestination $exportDestination,
+		OutputInterface $output): void {
+		$output->writeln(
+			$this->l10n->t('Exporting S/MIME certificates for user %s',
+				[$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		$certificates = $this->smimeService->findAllCertificates($user->getUID());
+
+		foreach ($certificates as $certificate) {
+			$exportContent = [
+				'id' => $certificate->getId(),
+				'certificate' => $this->crypto->decrypt($certificate->getCertificate()),
+				'privateKey' => $certificate->getPrivateKey() !== null
+					? $this->crypto->decrypt((string)$certificate->getPrivateKey())
+					: null,
+			];
+
+			try {
+				$exportDestination->addFileContents(
+					str_replace(
+						MailAccountMigrator::FILENAME_PLACEHOLDER,
+						(string)$certificate->getId(),
+						self::SMIME_CERTIFICATE_FILES
+					), json_encode($exportContent, JSON_THROW_ON_ERROR)
+				);
+			} catch (JsonException|UserMigrationException $exception) {
+				throw new UserMigrationException(
+					"Failed to export S/MIME certificates for user {$user->getUID()}",
+					previous: $exception
+				);
+			}
+
+
+		}
+	}
+
+	/**
+	 * Import all S/MIME certificates added by the user.
+	 *
+	 * @return array Contains the old certificate ID as array key and the new
+	 *               certificate ID as value.
+	 *
+	 * @throws UserMigrationException
+	 * @throws ServiceException
+	 */
+	public function importCertificates(IUser $user,
+		IImportSource $importSource,
+		OutputInterface $output): array {
+		$output->writeln(
+			$this->l10n->t('Importing S/MIME certificates for user %s',
+				[$user->getUID()]),
+			OutputInterface::VERBOSITY_VERBOSE
+		);
+
+		$certificatesMapping = [];
+
+		if ($importSource->pathExists(self::SMIME_CERTIFICATE_FOLDER)) {
+			$certificates = $importSource->getFolderListing(self::SMIME_CERTIFICATE_FOLDER);
+
+			foreach ($certificates as $certificateFilePath) {
+				try {
+					$certificate = json_decode($importSource->getFileContents($certificateFilePath),
+						true, flags: JSON_THROW_ON_ERROR);
+					$this->validateCertificate($certificate);
+				} catch (JsonException|UserMigrationException) {
+					$output->writeln(
+						$this->l10n->t('S/MIME configuration %s for user %s is invalid and will be skipped. Continue...',
+							[$certificateFilePath, $user->getUID()]),
+						OutputInterface::VERBOSITY_VERBOSE
+					);
+
+					continue;
+				}
+
+				$newCertificate = $this->smimeService->createCertificate($user->getUID(),
+					$certificate['certificate'], $certificate['privateKey']);
+
+				$oldCertificateId = $certificate['id'];
+				$certificatesMapping[$oldCertificateId] = $newCertificate->getId();
+			}
+
+		}
+
+		if (count($certificatesMapping) === 0) {
+			$output->writeln(
+				$this->l10n->t('No S/MIME certificates for user %s found. Continue...',
+					[$user->getUID()]
+				),
+				OutputInterface::VERBOSITY_VERBOSE
+			);
+		}
+
+		return $certificatesMapping;
+	}
+
+	/**
+	 * Validate the parsed certificates to ensure they
+	 * have the expected structure and types.
+	 *
+	 * @throws UserMigrationException
+	 */
+	private function validateCertificate(mixed $certificate): void {
+		$certificateArrayIsValid = is_array($certificate);
+
+		$idIsValid = $certificateArrayIsValid
+			&& array_key_exists('id', $certificate)
+			&& is_int($certificate['id']);
+
+		$certificateNameIsValid = $certificateArrayIsValid
+			&& array_key_exists('certificate', $certificate)
+			&& is_string($certificate['certificate']);
+
+		$privateKeyIsValid = $certificateArrayIsValid
+			&& array_key_exists('privateKey', $certificate)
+			&& (is_string($certificate['privateKey']) || is_null($certificate['privateKey']));
+
+		if (
+			!$idIsValid
+			|| !$certificateNameIsValid
+			|| !$privateKeyIsValid
+		) {
+			throw new UserMigrationException('Invalid certificate entry');
+		}
+	}
+}

--- a/tests/Unit/UserMigration/Service/SmimeMigrationServiceTest.php
+++ b/tests/Unit/UserMigration/Service/SmimeMigrationServiceTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Unit\UserMigration\Service;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Exception;
+use OCA\Mail\Db\SmimeCertificate;
+use OCA\Mail\UserMigration\MailAccountMigrator;
+use OCA\Mail\UserMigration\Service\SmimeMigrationService;
+use OCP\IUser;
+use OCP\UserMigration\IExportDestination;
+use OCP\UserMigration\IImportSource;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SmimeMigrationServiceTest extends TestCase {
+	private const USER_ID = '123';
+	private OutputInterface $output;
+	private IUser $user;
+	private IExportDestination $exportDestination;
+	private IImportSource $importSource;
+	private ServiceMockObject $serviceMock;
+	private SmimeMigrationService $migrationService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->output = $this->createMock(OutputInterface::class);
+		$this->exportDestination = $this->createMock(IExportDestination::class);
+		$this->importSource = $this->createMock(IImportSource::class);
+
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')->willReturn(self::USER_ID);
+
+		$this->serviceMock = $this->createServiceMock(SmimeMigrationService::class);
+
+		$this->serviceMock->getParameter('crypto')
+			->method('encrypt')
+			->willReturnCallback(function (string $value) {
+				return $value . '_encrypted';
+			});
+
+		$this->serviceMock->getParameter('crypto')
+			->method('decrypt')
+			->willReturnCallback(function (string $encryptedValue) {
+				if (!str_ends_with($encryptedValue, '_encrypted')) {
+					throw new Exception('Invalid encrypted value');
+				}
+				return substr($encryptedValue, 0, strlen($encryptedValue) - strlen('_encrypted'));
+			});
+
+		$this->migrationService = $this->serviceMock->getService();
+	}
+
+	public function testExportsMultipleCertificates(): void {
+		$userCertificate = $this->getUserCertificate();
+		$chainCertificate = $this->getChainCertificate();
+		$callCount = 0;
+		$expectedCertificates = [$userCertificate, $chainCertificate];
+		$this->exportDestination->expects(self::exactly(2))->method('addFileContents')
+			->willReturnCallback(function (string $filename, string $fileContent) use (&$callCount, $expectedCertificates): void {
+				$expected = $expectedCertificates[$callCount];
+				self::assertSame(
+					str_replace(MailAccountMigrator::FILENAME_PLACEHOLDER, (string)$expected->getId(), SmimeMigrationService::SMIME_CERTIFICATE_FILES),
+					$filename
+				);
+				self::assertSame(
+					json_encode(['id' => $expected->getId(), 'certificate' => $expected->getCertificate(), 'privateKey' => $expected->getPrivateKey()]),
+					$fileContent
+				);
+				$callCount++;
+			});
+		$this->serviceMock->getParameter('crypto')->expects(self::exactly(3))->method('decrypt');
+
+		$allEncryptedCertificates = [$this->getEncryptedSmimeCertificate($userCertificate), $this->getEncryptedSmimeCertificate($chainCertificate)];
+		$this->serviceMock->getParameter('smimeService')->method('findAllCertificates')->with(self::USER_ID)->willReturn($allEncryptedCertificates);
+		$this->migrationService->exportCertificates($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testExportsNoCertificates(): void {
+		$certificateFiles = [];
+
+		$this->serviceMock->getParameter('smimeService')->method('findAllCertificates')->with(self::USER_ID)->willReturn($certificateFiles);
+		$this->exportDestination->expects(self::never())->method('addFileContents');
+
+		$this->migrationService->exportCertificates($this->user, $this->exportDestination, $this->output);
+	}
+
+	public function testImportMultipleCertificates(): void {
+		$userCertificate = $this->getUserCertificate();
+		$chainCertificate = $this->getChainCertificate();
+
+		$certificateFiles = [str_replace(MailAccountMigrator::FILENAME_PLACEHOLDER, (string)$userCertificate->getId(), SmimeMigrationService::SMIME_CERTIFICATE_FILES),
+			str_replace(MailAccountMigrator::FILENAME_PLACEHOLDER, (string)$chainCertificate->getId(), SmimeMigrationService::SMIME_CERTIFICATE_FILES)];
+
+		$this->importSource->expects(self::once())->method('pathExists')->willReturn(true);
+		$this->importSource->expects(self::once())->method('getFolderListing')->willReturn($certificateFiles);
+
+		$expectedCertificates = [$userCertificate, $chainCertificate];
+
+		$getFileContentsCallCount = 0;
+		$this->importSource->expects(self::exactly(2))->method('getFileContents')
+			->willReturnCallback(function (string $filename) use (&$getFileContentsCallCount, $certificateFiles, $expectedCertificates): string {
+				$expected = $expectedCertificates[$getFileContentsCallCount];
+				self::assertSame($certificateFiles[$getFileContentsCallCount], $filename);
+				$result = json_encode(['id' => $expected->getId(), 'certificate' => $expected->getCertificate(), 'privateKey' => $expected->getPrivateKey()]);
+				$getFileContentsCallCount++;
+				return $result;
+			});
+
+		$createCertificateCallCount = 0;
+		$this->serviceMock->getParameter('smimeService')->expects(self::exactly(2))->method('createCertificate')
+			->willReturnCallback(function (string $userId, string $certificate, ?string $privateKey) use (&$createCertificateCallCount, $expectedCertificates): SmimeCertificate {
+				$expected = $expectedCertificates[$createCertificateCallCount];
+				self::assertSame(self::USER_ID, $userId);
+				self::assertSame($expected->getCertificate(), $certificate);
+				self::assertSame($expected->getPrivateKey(), $privateKey);
+				$newCertificate = new SmimeCertificate();
+				$newCertificate->setId(random_int(10, 999));
+				$createCertificateCallCount++;
+				return $newCertificate;
+			});
+
+		$mappedCertificates = $this->migrationService->importCertificates($this->user, $this->importSource, $this->output);
+
+		$this->assertCount(2, $mappedCertificates);
+		$this->assertArrayHasKey($userCertificate->getId(), $mappedCertificates);
+		$this->assertIsInt($mappedCertificates[$userCertificate->getId()]);
+		$this->assertArrayHasKey($chainCertificate->getId(), $mappedCertificates);
+		$this->assertIsInt($mappedCertificates[$chainCertificate->getId()]);
+	}
+
+	public function testImportNoCertificatesFolder(): void {
+		$this->importSource->expects(self::once())->method('pathExists')->willReturn(false);
+		$this->importSource->expects(self::never())->method('getFolderListing');
+		$this->importSource->expects(self::never())->method('getFileContents');
+		$this->serviceMock->getParameter('smimeService')->expects(self::never())->method('createCertificate');
+		$mappedTags = $this->migrationService->importCertificates($this->user, $this->importSource, $this->output);
+		$this->assertCount(0, $mappedTags);
+	}
+
+	public static function provideFileContentsWithNoCertificatesImported(): array {
+		return [
+			'empty list' => [json_encode([])],
+			'invalid JSON' => ['this is not valid json {{{'],
+			'missing required fields' => [json_encode(['unexpected' => 'field'])],
+		];
+	}
+
+	/**
+	 * @dataProvider provideFileContentsWithNoCertificatesImported
+	 */
+	public function testImportEmptyOrInvalidCertificates(string $fileContents): void {
+		$certificateFile = str_replace(MailAccountMigrator::FILENAME_PLACEHOLDER, '1', SmimeMigrationService::SMIME_CERTIFICATE_FILES);
+		$this->importSource->expects(self::once())->method('pathExists')->willReturn(true);
+		$this->importSource->expects(self::once())->method('getFolderListing')->willReturn([$certificateFile]);
+		$this->importSource->expects(self::once())->method('getFileContents')->with($certificateFile)->willReturn($fileContents);
+		$this->serviceMock->getParameter('smimeService')->expects(self::never())->method('createCertificate');
+		$mappedCertificates = $this->migrationService->importCertificates($this->user, $this->importSource, $this->output);
+		$this->assertCount(0, $mappedCertificates);
+	}
+
+	private function getUserCertificate(): SmimeCertificate {
+		$certificate = new SmimeCertificate();
+
+		$certificate->setId(1);
+		$certificate->setUserId(self::USER_ID);
+		$certificate->setEmailAddress('user@domain.tld');
+		$publicKey = file_get_contents(__DIR__ . '/../../../data/smime-certs/user@domain.tld.crt');
+		$privateKey = file_get_contents(__DIR__ . '/../../../data/smime-certs/user@domain.tld.key');
+		$certificate->setCertificate($publicKey);
+		$certificate->setPrivateKey($privateKey);
+
+		return $certificate;
+	}
+
+	private function getChainCertificate(): SmimeCertificate {
+		$certificate = new SmimeCertificate();
+
+		$certificate->setId(2);
+		$certificate->setUserId(self::USER_ID);
+		$certificate->setEmailAddress('chain@imap.localhost');
+		$publicKey = file_get_contents(__DIR__ . '/../../../data/smime-certs/chain@imap.localhost.crt');
+		$certificate->setCertificate($publicKey);
+		$certificate->setPrivateKey(null);
+
+		return $certificate;
+	}
+
+	private function getEncryptedSmimeCertificate(SmimeCertificate $certificateToEncrypt): SmimeCertificate {
+		$encryptedCertificate = new SmimeCertificate();
+
+		$encryptedCertificate->setId($certificateToEncrypt->getId());
+		$encryptedCertificate->setUserId($certificateToEncrypt->getUserId());
+		$encryptedCertificate->setEmailAddress($certificateToEncrypt->getEmailAddress());
+		$encryptedCertificate->setCertificate("{$certificateToEncrypt->getCertificate()}_encrypted");
+		$encryptedCertificate->setPrivateKey($certificateToEncrypt->getPrivateKey() !== null ? "{$certificateToEncrypt->getPrivateKey()}_encrypted" : null);
+
+		return $encryptedCertificate;
+	}
+}


### PR DESCRIPTION
This PR belongs to a series of PRs that will enhance the user migration to include all settings.

Included changes in this PR:
- Allow export of certificates
- Allow import of certificates
- Unit tests for import and export

Please ignore the failed CI run regarding the unconventional commit message. That happens as I tag another feature branch for better overview here.

Refs https://github.com/nextcloud/mail/issues/12001