### PR TITLE
fix(ui): Handle focus trap through provide / inject

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -25,7 +25,7 @@
 			<p class="settings-hint">
 				{{ t('mail', 'A signature is added to the text of new messages and replies.') }}
 			</p>
-			<SignatureSettings :account="account" @show-toolbar="handleShowToolbar" />
+			<SignatureSettings :account="account" />
 		</AppSettingsSection>
 		<AppSettingsSection id="writing-mode" :name="t('mail', 'Writing mode')">
 			<p class="settings-hint">
@@ -179,6 +179,12 @@ export default {
 		NcCheckboxRadioSwitch,
 	},
 
+	provide() {
+		return {
+			addToFocusTrap: (trapElement) => this.trapElements.push(trapElement),
+		}
+	},
+
 	props: {
 		account: {
 			required: true,
@@ -232,10 +238,6 @@ export default {
 
 		updateOpen() {
 			this.$emit('update:open')
-		},
-
-		handleShowToolbar(element) {
-			this.trapElements.push(element)
 		},
 
 		async onToggleClassification(classificationEnabled) {

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -114,8 +114,7 @@
 						:label="t('mail', 'Text blocks')"
 						:description="t('mail', 'Reusable pieces of text that can be inserted in messages')">
 						<List
-							:text-blocks="getMyTextBlocks()"
-							@show-toolbar="handleShowToolbar" />
+							:text-blocks="getMyTextBlocks()" />
 						<NcButton variant="secondary" wide @click="() => textBlockDialogOpen = true">
 							<template #icon>
 								<IconAdd :size="20" />
@@ -126,8 +125,7 @@
 							<h6>{{ t('mail', 'Shared with me') }}</h6>
 							<List
 								:text-blocks="getSharedTextBlocks()"
-								:shared="true"
-								@show-toolbar="handleShowToolbar" />
+								:shared="true" />
 						</template>
 					</NcFormGroup>
 				</NcAppSettingsSection>
@@ -243,8 +241,7 @@
 						:is-bordered="true"
 						:html="true"
 						:placeholder="t('mail', 'Content of the text block')"
-						:bus="bus"
-						:show-toolbar="handleShowToolbar" />
+						:bus="bus" />
 					<div class="text-block-buttons">
 						<NcButton
 							variant="tertiary"
@@ -343,6 +340,12 @@ export default {
 		NcHotkeyList,
 		NcHotkey,
 		IconArrow,
+	},
+
+	provide() {
+		return {
+			addToFocusTrap: (trapElement) => this.trapElements.push(trapElement),
+		}
 	},
 
 	props: {
@@ -742,10 +745,6 @@ export default {
 			iframe.style = 'display: none'
 			iframe.src = 'https://api.mailvelope.com/authorize-domain/?api=true'
 			document.body.append(iframe)
-		},
-
-		handleShowToolbar(element) {
-			this.trapElements.push(element)
 		},
 
 		newTextBlock() {

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -260,8 +260,7 @@
 				@input="onEditorInput"
 				@ready="onEditorReady"
 				@mention="handleMention"
-				@submit="onEditorSubmit"
-				@show-toolbar="handleShow" />
+				@submit="onEditorSubmit" />
 			<MailvelopeEditor
 				v-else
 				ref="mailvelopeEditor"
@@ -711,6 +710,7 @@ export default {
 			type: Array,
 			required: true,
 		},
+
 	},
 
 	data() {
@@ -1139,10 +1139,6 @@ export default {
 				return this.seemsValidEmailAddress(this.recipientSearchTerms[event])
 			}
 			return false
-		},
-
-		handleShow(event) {
-			this.$emit('show-toolbar', event)
 		},
 
 		openPicker() {

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -107,8 +107,7 @@
 						@draft="onDraft"
 						@discard-draft="discardDraft"
 						@upload-attachment="onAttachmentUploading"
-						@send="onSend"
-						@show-toolbar="handleShow" />
+						@send="onSend" />
 				</KeepAlive>
 			</div>
 
@@ -157,6 +156,12 @@ export default {
 		MaximizeIcon,
 		DefaultComposerIcon,
 		RecipientInfo,
+	},
+
+	provide() {
+		return {
+			addToFocusTrap: (trapElement) => this.additionalTrapElements.push(trapElement),
+		}
 	},
 
 	props: {
@@ -305,10 +310,6 @@ export default {
 			if (!this.mainStore.composerMessageIsSaved && this.changed) {
 				await this.onDraft(this.cookedComposerData, { showToast: true })
 			}
-		},
-
-		handleShow(element) {
-			this.additionalTrapElements.push(element)
 		},
 
 		/**

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -32,8 +32,7 @@
 				:html="true"
 				:placeholder="t('mail', 'Signature …')"
 				:bus="bus"
-				class="signature-editor-wrapper__editor"
-				@show-toolbar="handleShowToolbar" />
+				class="signature-editor-wrapper__editor" />
 		</div>
 		<p v-if="isLargeSignature" class="warning-large-signature">
 			{{ t('mail', 'Your signature is larger than 2 MB. This may affect the performance of your editor.') }}
@@ -189,9 +188,6 @@ export default {
 				})
 		},
 
-		handleShowToolbar(event) {
-			this.$emit('show-toolbar', event)
-		},
 	},
 }
 </script>

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -193,16 +193,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.ck.ck-editor__editable_inline {
-  width: 100%;
-  max-width: 78vw;
-  height: 100%;
-  min-height: 100px;
-  border-radius: var(--border-radius) !important;
-  border: 1px solid var(--color-border) !important;
-  box-shadow: none !important;
-}
-
 /* Wrapper to visually delimit the signature editor area from surrounding settings */
 .signature-editor-wrapper {
 	margin-top: 8px;

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -69,6 +69,10 @@ export default {
 		Ckeditor: CKEditor.component,
 	},
 
+	inject: {
+		addToFocusTrap: { default: () => {} },
+	},
+
 	props: {
 		value: {
 			type: String,
@@ -494,7 +498,7 @@ export default {
 			}
 
 			if (this.html) {
-				this.$emit('show-toolbar', editor.ui._focusableToolbarDefinitions[0].toolbarView.element)
+				this.addToFocusTrap('.ck-body-wrapper')
 			}
 
 			this.bus.on('append-to-body-at-cursor', this.appendToBodyAtCursor)


### PR DESCRIPTION
Alternative for https://github.com/nextcloud/mail/pull/12182

Here's an alternative approach to solving the focus trap issue, using provide and inject. I find the current event-driven approach a bit noisy for this case. For application data I'd still prefer the event-driven approach as it offers a clearer flow, especially when reading the code manually, but for the focus trap I think this is a nice alternative.