### PR TITLE
[stable5.7] fix(deps): bump bytestream/horde-imap-client from 2.33.6 to ^2.34.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -824,16 +824,16 @@
         },
         {
             "name": "bytestream/horde-imap-client",
-            "version": "v2.33.6",
+            "version": "v2.34.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bytestream/Imap_Client.git",
-                "reference": "33dc825bb4fb0a3fc6c892625404807aee7cd861"
+                "reference": "0171a72c144fa050250e4b40dc0160507c265300"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bytestream/Imap_Client/zipball/33dc825bb4fb0a3fc6c892625404807aee7cd861",
-                "reference": "33dc825bb4fb0a3fc6c892625404807aee7cd861",
+                "url": "https://api.github.com/repos/bytestream/Imap_Client/zipball/0171a72c144fa050250e4b40dc0160507c265300",
+                "reference": "0171a72c144fa050250e4b40dc0160507c265300",
                 "shasum": ""
             },
             "require": {
@@ -875,9 +875,9 @@
             "description": "Horde IMAP client library",
             "homepage": "https://www.horde.org/libraries/Horde_Imap_Client",
             "support": {
-                "source": "https://github.com/bytestream/Imap_Client/tree/v2.33.6"
+                "source": "https://github.com/bytestream/Imap_Client/tree/v2.34.1"
             },
-            "time": "2025-04-30T16:20:39+00:00"
+            "time": "2026-04-23T09:47:18+00:00"
         },
         {
             "name": "bytestream/horde-listheaders",

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
-use Horde_Imap_Client_Ids;
 use function OCA\Mail\array_flat_map;
 use function OCA\Mail\chunk_uid_sequence;
 
@@ -60,9 +59,8 @@ class FunctionsTest extends TestCase {
 
 		$chunks = chunk_uid_sequence($uids, 10);
 
-		self::assertEquals([
-			new Horde_Imap_Client_Ids('100:101'),
-		], $chunks);
+		self::assertCount(1, $chunks);
+		self::assertEquals('100:101', $chunks[0]->tostring);
 	}
 
 	public function testChunkLongByteRange(): void {
@@ -70,11 +68,10 @@ class FunctionsTest extends TestCase {
 
 		$chunks = chunk_uid_sequence($uids, 10);
 
-		self::assertEquals([
-			new Horde_Imap_Client_Ids('100:101'),
-			new Horde_Imap_Client_Ids('103, 105'),
-			new Horde_Imap_Client_Ids('106, 201'),
-			new Horde_Imap_Client_Ids('203:204'),
-		], $chunks);
+		self::assertCount(4, $chunks);
+		self::assertEquals('100:101', $chunks[0]->tostring);
+		self::assertEquals('103,105', $chunks[1]->tostring);
+		self::assertEquals('106,201', $chunks[2]->tostring);
+		self::assertEquals('203:204', $chunks[3]->tostring);
 	}
 }


### PR DESCRIPTION
Assisted backport of https://github.com/nextcloud/mail/pull/12798