### PR TITLE
fix(renovate): use currentValue instead of currentVersion in commit m…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
 	],
 	"commitMessageAction": "Bump",
 	"commitMessageTopic": "{{depName}}",
-	"commitMessageExtra": "from {{currentVersion}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+	"commitMessageExtra": "from {{currentValue}} to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
 	"rangeStrategy": "bump",
 	"minimumReleaseAge": "7 days",
 	"rebaseWhen": "conflicted",


### PR DESCRIPTION
…essage

Using currentVersion resolves to the locked version from the lockfile, which can make bump PRs appear as downgrades when the range is being bumped forward. currentValue correctly reflects the range constraint in package.json.

Example: https://github.com/nextcloud/mail/pull/12851

AI-assisted: OpenCode (claude-sonnet-4.6)