### PR TITLE
Fix border colors in composer

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -700,7 +700,7 @@ export default {
 	flex: 0 0 370px;
 	overflow-y: auto;
 	padding-inline-start: 5px;
-	border-inline-start: 1px solid var(--color-text-maxcontrast);
+	border-inline-start: 1px solid var(--color-border);
 	@media (max-width: #{variables.$breakpoint-mobile}) {
 		display: none;
 	}

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -666,7 +666,11 @@ https://github.com/ckeditor/ckeditor5/issues/1142
 	border-radius: var(--border-radius-large) !important;
 	background: var(--color-main-background) !important;
     color: var(--color-main-text) !important;
-	border: 1px solid var(--color-text-maxcontrast) !important;
+	border: 1px solid var(--color-border) !important;
+
+	.ck.ck-toolbar__separator {
+		background: var(--color-border) !important;
+	}
 }
 
 .ck-rounded-corners .ck.ck-dropdown__panel, .ck.ck-dropdown__panel.ck-rounded-corners {


### PR DESCRIPTION
Fix border colors of both the vertical divider as well as the CKEditor formatting element. They were too contrasting before, now using normal color-border.

Before | After
-|-
<img width="1460" height="907" alt="Screenshot From 2026-05-04 12-14-38" src="https://github.com/user-attachments/assets/701643b0-f5c6-4bc3-846c-cc2c0cf5eddc" />|<img width="1460" height="907" alt="Screenshot From 2026-05-04 12-11-11" src="https://github.com/user-attachments/assets/2874cd2d-4e1e-4567-84d5-a76191ebcb72" />
<img width="1460" height="907" alt="Screenshot From 2026-05-04 12-20-03" src="https://github.com/user-attachments/assets/b0ee22dd-7b72-4cf7-b646-4e17c04c508d" />|<img width="1460" height="907" alt="Screenshot From 2026-05-04 12-21-36" src="https://github.com/user-attachments/assets/f84145b7-99c0-47e2-bc70-62d8a7d0a00c" />

