### PR TITLE
refactor: add null guards in db mappers and fix JsonResponse return type for Psalm 6

### DIFF
--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -70,11 +70,19 @@ class LocalMessageMapper extends QBMapper {
 
 		$recipientMap = [];
 		foreach ($recipients as $r) {
-			$recipientMap[$r->getLocalMessageId()][] = $r;
+			$localMessageId = $r->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$recipientMap[$localMessageId][] = $r;
 		}
 		$attachmentMap = [];
 		foreach ($attachments as $a) {
-			$attachmentMap[$a->getLocalMessageId()][] = $a;
+			$localMessageId = $a->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$attachmentMap[$localMessageId][] = $a;
 		}
 
 		return array_map(static function ($localMessage) use ($attachmentMap, $recipientMap) {
@@ -147,11 +155,19 @@ class LocalMessageMapper extends QBMapper {
 
 		$recipientMap = [];
 		foreach ($recipients as $r) {
-			$recipientMap[$r->getLocalMessageId()][] = $r;
+			$localMessageId = $r->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$recipientMap[$localMessageId][] = $r;
 		}
 		$attachmentMap = [];
 		foreach ($attachments as $a) {
-			$attachmentMap[$a->getLocalMessageId()][] = $a;
+			$localMessageId = $a->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$attachmentMap[$localMessageId][] = $a;
 		}
 
 		return array_map(static function ($localMessage) use ($attachmentMap, $recipientMap) {
@@ -196,11 +212,19 @@ class LocalMessageMapper extends QBMapper {
 
 		$recipientMap = [];
 		foreach ($recipients as $r) {
-			$recipientMap[$r->getLocalMessageId()][] = $r;
+			$localMessageId = $r->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$recipientMap[$localMessageId][] = $r;
 		}
 		$attachmentMap = [];
 		foreach ($attachments as $a) {
-			$attachmentMap[$a->getLocalMessageId()][] = $a;
+			$localMessageId = $a->getLocalMessageId();
+			if ($localMessageId === null) {
+				continue;
+			}
+			$attachmentMap[$localMessageId][] = $a;
 		}
 
 		return array_map(static function ($localMessage) use ($attachmentMap, $recipientMap) {
@@ -245,7 +269,7 @@ class LocalMessageMapper extends QBMapper {
 		try {
 			$message = $this->update($message);
 
-			$this->recipientMapper->updateRecipients($message->getId(), $message->getRecipients(), $to, $cc, $bcc);
+			$this->recipientMapper->updateRecipients($message->getId(), $message->getRecipients() ?? [], $to, $cc, $bcc);
 			$recipients = $this->recipientMapper->findByLocalMessageId($message->getId());
 			$message->setRecipients($recipients);
 			$this->db->commit();

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -545,7 +545,8 @@ class MessageMapper extends QBMapper {
 	 */
 	private function updateTags(Account $account, Message $message, array $tags, PerformanceLoggerTask $perf): void {
 		$imapTags = $message->getTags();
-		$dbTags = $tags[$message->getMessageId()] ?? [];
+		$messageId = $message->getMessageId();
+		$dbTags = $messageId !== null ? ($tags[$messageId] ?? []) : [];
 
 		if ($imapTags === [] && $dbTags === []) {
 			// neither old nor new tags
@@ -1354,7 +1355,8 @@ class MessageMapper extends QBMapper {
 		$tags = $this->tagMapper->getAllTagsForMessages($messages, $userId);
 		/** @var Message $message */
 		$messages = array_map(static function ($message) use ($tags) {
-			$message->setTags($tags[$message->getMessageId()] ?? []);
+			$messageId = $message->getMessageId();
+			$message->setTags($messageId !== null ? ($tags[$messageId] ?? []) : []);
 			return $message;
 		}, $messages);
 		return $messages;

--- a/lib/Http/JsonResponse.php
+++ b/lib/Http/JsonResponse.php
@@ -107,7 +107,7 @@ class JsonResponse extends Base {
 	 * @param Http::STATUS_* $status
 	 * @param array|JsonSerializable|bool|string $data
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function errorFromThrowable(Throwable $error,
 		int $status = Http::STATUS_INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary

- `LocalMessageMapper`: add null guard for `getLocalMessageId()` before using as array key in `getAllForUser`, `findDue`, `findDueDrafts`; use `?? []` for `getRecipients()` in `updateWithRecipients`
- `MessageMapper`: extract `getMessageId()` to a local variable with null guard before using as array key in `updateTags` and `findRelatedData`
- `JsonResponse`: align `@return static` → `@return self` on `errorFromThrowable` to match the actual PHP return type hint

These are Psalm 6 `PossiblyNullArrayOffset` and `MoreSpecificReturnType` errors that remain after the Psalm v6 upgrade in #11224.

## Test plan

- [x] PHP unit tests pass (`composer test:unit`)
- [x] Psalm static analysis passes (`composer psalm`)

Part of #11224