### PR TITLE
fix: Load translations via filesystem path

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -415,7 +415,7 @@ export default {
 					/* eslint-disable @stylistic/comma-dangle, @stylistic/function-paren-newline */
 					const { default: coreTranslations } = await import(
 						/* webpackMode: "lazy" */
-						`ckeditor5/translations/${candidate}.js`
+						`../../node_modules/ckeditor5/build/translations/${candidate}.js`
 					)
 					/* eslint-enable @stylistic/comma-dangle, @stylistic/function-paren-newline */
 


### PR DESCRIPTION
- Work around newer webpack/enhanced-resolve rejecting dynamic ckeditor5/translations/* package imports
- Load CKEditor locale bundles via the installed package filesystem path to keep translation loading working

AI-assisted: OpenCode (gpt-5.4)