### PR TITLE
fix(ui): close attachment actions menu after clicking Download or Sav…

### DIFF
--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -42,6 +42,7 @@
 				</ActionButton>
 				<ActionButton
 					class="attachment-download"
+					:close-after-click="true"
 					@click="download">
 					<template #icon>
 						<IconDownload :size="20" />
@@ -51,7 +52,8 @@
 				<ActionButton
 					class="attachment-save-to-cloud"
 					:disabled="savingToCloud"
-					@click.stop="() => isFilePickerOpen = true">
+					:close-after-click="true"
+					@click="() => isFilePickerOpen = true">
 					<template #icon>
 						<IconSave v-if="!savingToCloud" :size="20" />
 						<IconLoading v-else-if="savingToCloud" :size="20" />


### PR DESCRIPTION
…e to Files

NcActionButton in @nextcloud/vue v8 does not auto-close the NcActions menu — the close-after-click prop must be set explicitly. The .stop modifier on the Save to Files button was also a historical leftover from when it was a plain button outside of NcActions and is no longer needed.

## How to test

1. Open the app
2. Open an email with attachments
3. Open the actions menu of one attachment
4. Click *Safe to Files*

main: actions menu stays open.
here: actions menu closes.

AI-assisted: OpenCode (claude-sonnet-4.6)