### PR TITLE
perf(imap): fetch only required header fields during sync

### DIFF
--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -530,10 +530,18 @@ class ImapMessageFetcher {
 	}
 
 	private function parseHeaders(Horde_Imap_Client_Data_Fetch $fetch): void {
-		/** @var resource $headersStream */
-		$headersStream = $fetch->getHeaderText('0', Horde_Imap_Client_Data_Fetch::HEADER_STREAM);
-		$parsedHeaders = Horde_Mime_Headers::parseHeaders($headersStream);
-		fclose($headersStream);
+		// Prefer the targeted HEADER.FIELDS fetch used by the sync path (BODY.PEEK[HEADER.FIELDS (...)]).
+		// Fall back to the full header text when loadBody=true re-fetches with headerText().
+		$parsedHeaders = $fetch->getHeaders('syncFields', Horde_Imap_Client_Data_Fetch::HEADER_PARSE);
+		if ($parsedHeaders === null) {
+			/** @var resource $headersStream */
+			$headersStream = $fetch->getHeaderText('0', Horde_Imap_Client_Data_Fetch::HEADER_STREAM);
+			if ($headersStream === null) {
+				return;
+			}
+			$parsedHeaders = Horde_Mime_Headers::parseHeaders($headersStream);
+			fclose($headersStream);
+		}
 
 		$references = $parsedHeaders->getHeader('references');
 		if ($references !== null) {

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -282,11 +282,16 @@ class MessageMapper {
 		$query->flags();
 		$query->uid();
 		$query->imapDate();
-		$query->headerText(
+		$query->headers(
+			'syncFields',
 			[
-				'cache' => true,
-				'peek' => true,
-			]
+				'references',
+				'disposition-notification-to',
+				'dkim-signature',
+				'list-unsubscribe',
+				'list-unsubscribe-post',
+			],
+			['peek' => true],
 		);
 
 		if (is_array($ids)) {

--- a/tests/Integration/IMAP/ImapMessageFetcherIntegrationTest.php
+++ b/tests/Integration/IMAP/ImapMessageFetcherIntegrationTest.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Tests\Integration\IMAP;
 
+use Horde_Imap_Client_Ids;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\SmimeCertificate;
 use OCA\Mail\Db\SmimeCertificateMapper;
 use OCA\Mail\IMAP\ImapMessageFetcherFactory;
+use OCA\Mail\IMAP\MessageMapper as ImapMessageMapper;
 use OCA\Mail\Tests\Integration\Framework\ImapTest;
 use OCA\Mail\Tests\Integration\Framework\ImapTestAccount;
 use OCA\Mail\Tests\Integration\TestCase;
@@ -186,5 +188,66 @@ class ImapMessageFetcherIntegrationTest extends TestCase {
 		$this->assertFalse($message->isEncrypted());
 		$this->assertTrue($message->isSigned());
 		$this->assertTrue($message->isSignatureValid());
+	}
+
+	/**
+	 * Verifies that all five header fields parsed during the loadBody=false sync path
+	 * are correctly extracted. This is the regression guard for switching from
+	 * BODY.PEEK[HEADER] (full headers) to BODY.PEEK[HEADER.FIELDS (...)] (selective).
+	 */
+	public function testSyncPathParsesAllRequiredHeaderFields(): void {
+		// Append raw bytes directly to avoid Horde_Mime_Mail rewriting the headers
+		$rawMime = implode("\r\n", [
+			'From: sender@test.invalid',
+			'To: recipient@test.invalid',
+			'Subject: Header fields test',
+			'Message-ID: <header-fields-test@test.invalid>',
+			'References: <parent@test.invalid>',
+			'Disposition-Notification-To: sender@test.invalid',
+			'DKIM-Signature: v=1; a=rsa-sha256; d=test.invalid; s=default;',
+			' h=from:to:subject;',
+			' bh=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=;',
+			' b=ZXhhbXBsZXNpZ25hdHVyZQ==',
+			'List-Unsubscribe: <https://test.invalid/unsubscribe>',
+			'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+			'Content-Type: text/plain; charset=utf-8',
+			'',
+			'Test body',
+		]);
+
+		$appendClient = $this->getClient(null);
+		$uid = $appendClient->append('INBOX', [['data' => $rawMime]])->ids[0];
+		$appendClient->logout();
+
+		/** @var ImapMessageMapper $mapper */
+		$mapper = Server::get(ImapMessageMapper::class);
+		$fetchClient = $this->getClient($this->account);
+		try {
+			$messages = $mapper->findByIds(
+				$fetchClient,
+				'INBOX',
+				new Horde_Imap_Client_Ids([$uid]),
+				$this->account->getUserId(),
+			);
+		} finally {
+			$fetchClient->logout();
+		}
+
+		$this->assertCount(1, $messages);
+		$message = $messages[0];
+
+		// disposition-notification-to
+		$this->assertSame('sender@test.invalid', $message->getDispositionNotificationTo());
+
+		// dkim-signature (no public getter — check via serialization)
+		$this->assertTrue($message->jsonSerialize()['hasDkimSignature']);
+
+		// list-unsubscribe + list-unsubscribe-post
+		$this->assertSame('https://test.invalid/unsubscribe', $message->getUnsubscribeUrl());
+		$this->assertTrue($message->isOneClickUnsubscribe());
+
+		// references — flows through toDbMessage() which parses IDs from the raw value
+		$dbMessage = $message->toDbMessage(1, $this->account);
+		$this->assertStringContainsString('parent@test.invalid', $dbMessage->getReferences() ?? '');
 	}
 }


### PR DESCRIPTION
Replace full BODY.PEEK[HEADER] with BODY.PEEK[HEADER.FIELDS (...)] in findByIds(), downloading only the 5 headers actually needed by parseHeaders(). Reduces header data per message 10-30x, cutting initial sync time from minutes to seconds on slow IMAP connections and preventing web request timeouts.

## How to test

1. Add an account
2. Close the web UI
3. Wait a bit for any processes to finish
4. Delete all mailboxes of the account in the DB
5. Reset the account's last_mailbox_sync
6. Run `occ mail:account:sync -vvv`

main: slower
here: faster

When I patch IMAPClientFactory to have `$params['debug_literal'] = true;` and enable debug for the account, I see the log sizes:

main: 20M
here: 8.2M

```
  ┌──────────────────────────┬────────┬───────┬─────────┐                                                                                                                                                                                      
  │         Mailbox          │ Before │ After │ Speedup │
  ├──────────────────────────┼────────┼───────┼─────────┤                                                                                                                                                                                      
  │ INBOX pass 1 (2292 msgs) │ 107s   │ 10s   │ 10.7×   │               
  ├──────────────────────────┼────────┼───────┼─────────┤
  │ INBOX pass 2 (3680 msgs) │ 242s   │ 33s   │ 7.3×    │                                                                                                                                                                                      
  ├──────────────────────────┼────────┼───────┼─────────┤
  │ Sent (2945 msgs)         │ 131s   │ 12s   │ 10.9×   │                                                                                                                                                                                      
  ├──────────────────────────┼────────┼───────┼─────────┤                                                                                                                                                                                      
  │ Total                    │ 480s   │ 55s   │ 8.7×    │
  └──────────────────────────┴────────┴───────┴─────────┘
```

AI-assisted: Claude Code (claude-sonnet-4-6)