### PR TITLE
fix(imap): log number of connections during CLI sync

### DIFF
--- a/lib/Command/SyncAccount.php
+++ b/lib/Command/SyncAccount.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Command;
 use OCA\Mail\Account;
 use OCA\Mail\Exception\IncompleteSyncException;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\Sync\ImapToDbSynchronizer;
@@ -34,17 +35,20 @@ final class SyncAccount extends Command {
 	private MailboxSync $mailboxSync;
 	private ImapToDbSynchronizer $syncService;
 	private LoggerInterface $logger;
+	private IMAPClientFactory $clientFactory;
 
 	public function __construct(AccountService $service,
 		MailboxSync $mailboxSync,
 		ImapToDbSynchronizer $messageSync,
-		LoggerInterface $logger) {
+		LoggerInterface $logger,
+		IMAPClientFactory $clientFactory) {
 		parent::__construct();
 
 		$this->accountService = $service;
 		$this->mailboxSync = $mailboxSync;
 		$this->syncService = $messageSync;
 		$this->logger = $logger;
+		$this->clientFactory = $clientFactory;
 	}
 
 	/**
@@ -94,6 +98,10 @@ final class SyncAccount extends Command {
 			$mbs = (int)(memory_get_usage() / 1024 / 1024);
 			$output->writeln("<info>Batch of new messages sync'ed. " . $mbs . 'MB of memory in use</info>');
 			$this->sync($account, $force, $output);
+		}
+
+		foreach ($this->clientFactory->getLoginStats() as $host => $count) {
+			$consoleLogger->debug(sprintf('%d IMAP connection(s) to %s', $count, $host));
 		}
 	}
 }

--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -28,6 +28,12 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 	private ?IMemcache $rateLimiterCache = null;
 	private ?ITimeFactory $timeFactory = null;
 	private ?string $hash = null;
+	private IMAPClientFactory $factory;
+
+	public function __construct(array $params, IMAPClientFactory $factory) {
+		parent::__construct($params);
+		$this->factory = $factory;
+	}
 
 	public function enableRateLimiter(
 		IMemcache $cache,
@@ -57,7 +63,9 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 	private const RATE_LIMIT_WINDOW = 3 * 60 * 60;
 
 	protected function imapLogin() {
-		return parent::_login();
+		$result = parent::_login();
+		$this->factory->recordLogin($this->_params['hostspec']);
+		return $result;
 	}
 
 	#[\Override]

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -27,6 +27,9 @@ use function implode;
 use function json_encode;
 
 class IMAPClientFactory {
+	/** @var array<string, int> */
+	private array $loginCounts = [];
+
 	/** @var ICrypto */
 	private $crypto;
 
@@ -134,7 +137,7 @@ class IMAPClientFactory {
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}
 
-		$client = new HordeImapClient($params);
+		$client = new HordeImapClient($params, $this);
 
 		$rateLimitingCache = $this->cacheFactory->createDistributed('mail_imap_ratelimit');
 		if ($rateLimitingCache instanceof IMemcache) {
@@ -142,5 +145,14 @@ class IMAPClientFactory {
 		}
 
 		return $client;
+	}
+
+	public function recordLogin(string $host): void {
+		$this->loginCounts[$host] = ($this->loginCounts[$host] ?? 0) + 1;
+	}
+
+	/** @return array<string, int> */
+	public function getLoginStats(): array {
+		return $this->loginCounts;
 	}
 }


### PR DESCRIPTION
For performance troubleshooting:

```
...
[debug] Skipping mailbox sync for 9342
[debug] Skipping mailbox sync for 9354
[debug] Skipping mailbox sync for 9359
[debug] Skipping mailbox sync for 9350
[debug] Skipping mailbox sync for 9347
[debug] Skipping mailbox sync for 9341
[debug] Skipping mailbox sync for 9343
[debug] Skipping threading as there were no significant changes
[debug] 1 IMAP connection(s) to mx.acme.com
```

AI-assisted: Claude Code (Claude Sonnet 4.6)