### PR TITLE
fix: correct favorite/unfavorite bulk action logic

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -43,7 +43,7 @@
 						v-if="isAtLeastOneSelectedFavorite"
 						variant="tertiary"
 						:title="n('mail', 'Unfavorite {number}', 'Unfavorite {number}', selection.length, { number: selection.length })"
-						@click.prevent="favoriteAll">
+						@click.prevent="unfavoriteAll">
 						<IconUnFavorite :size="20" />
 					</NcButton>
 
@@ -51,7 +51,7 @@
 						v-if="isAtLeastOneSelectedUnFavorite"
 						variant="tertiary"
 						:title="n('mail', 'Favorite {number}', 'Favorite {number}', selection.length, { number: selection.length })"
-						@click.prevent="unFavoriteAll">
+						@click.prevent="favoriteAll">
 						<IconFavorite :size="20" />
 					</NcButton>
 
@@ -454,23 +454,21 @@ export default {
 			this.unselectAll()
 		},
 
-		favoriteAll() {
-			const favFlag = !this.isAtLeastOneSelectedUnFavorite
+		unfavoriteAll() {
 			this.selectedEnvelopes.forEach((envelope) => {
 				this.mainStore.markEnvelopeFavoriteOrUnfavorite({
 					envelope,
-					favFlag,
+					favFlag: false,
 				})
 			})
 			this.unselectAll()
 		},
 
-		unFavoriteAll() {
-			const favFlag = !this.isAtLeastOneSelectedFavorite
+		favoriteAll() {
 			this.selectedEnvelopes.forEach((envelope) => {
 				this.mainStore.markEnvelopeFavoriteOrUnfavorite({
 					envelope,
-					favFlag,
+					favFlag: true,
 				})
 			})
 			this.unselectAll()


### PR DESCRIPTION
Refs #12149

### Changes

**Favorite/unfavorite logic**
- Rename methods: `favoriteAll()` → `unfavoriteAll()`, `unFavoriteAll()` → `favoriteAll()`
- Use explicit `favFlag: true` / `favFlag: false` instead of inverted computed checks (`!this.isAtLeastOneSelectedX`)
- Previously, when all selected messages shared the same state (e.g. all favorited), clicking "Unfavorite" computed `favFlag = true` (no-op). Now it always passes the correct flag.

### How to test

1. Select all favorited messages → click "Unfavorite" → all become unfavorited
2. Select all unfavorited messages → click "Favorite" → all become favorited
3. Repeat with mixed selection (some favorite, some not)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced multiselect favorite and unfavorite controls. The "Favorite" button now reliably marks all selected items as favorites, while the "Unfavorite" button marks them as unfavorites. Selection is automatically cleared after each action. The updated controls provide more predictable and consistent behavior when managing multiple items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->