### PR TITLE
feat: add select-all checkbox and lift selection state to parent

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -266,11 +266,20 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		selection: {
+			type: Array,
+			default: () => [],
+		},
+
+		flatIndex: {
+			type: Number,
+			default: 0,
+		},
 	},
 
 	data() {
 		return {
-			selection: [],
 			showMoveModal: false,
 			showTagModal: false,
 			lastToggledIndex: undefined,
@@ -362,10 +371,27 @@ export default {
 	},
 
 	watch: {
+		selection: {
+			handler(newSelection) {
+				// Sync flags.selected with the global selection prop.
+				// This ensures checkboxes stay correct when another
+				// EnvelopeList instance changes the selection (e.g. shift-click
+				// across groups, or Select All / Unselect All).
+				const selectionSet = new Set(newSelection)
+				this.sortedEnvelops.forEach((env) => {
+					env.flags.selected = selectionSet.has(env.databaseId)
+				})
+			},
+			immediate: true,
+		},
+
 		sortedEnvelops(newVal, oldVal) {
-			// Unselect vanished envelopes
-			const newIds = newVal.map((env) => env.databaseId)
-			this.selection = this.selection.filter((id) => newIds.includes(id))
+			// Unselect vanished envelopes by emitting cleaned selection
+			const newIds = new Set(newVal.map((env) => env.databaseId))
+			const cleanedSelection = this.selection.filter((id) => newIds.has(id))
+			if (cleanedSelection.length !== this.selection.length) {
+				this.$emit('update:selection', cleanedSelection, this.envelopes)
+			}
 			differenceWith((a, b) => a.databaseId === b.databaseId, oldVal, newVal)
 				.forEach((env) => {
 					env.flags.selected = false
@@ -538,16 +564,22 @@ export default {
 			const alreadySelected = this.selection.includes(envelope.databaseId)
 			if (selected && !alreadySelected) {
 				envelope.flags.selected = true
-				this.selection.push(envelope.databaseId)
 			} else if (!selected && alreadySelected) {
 				envelope.flags.selected = false
-				this.selection.splice(this.selection.indexOf(envelope.databaseId), 1)
 			}
+		},
+
+		emitLocalSelection() {
+			const localIds = this.sortedEnvelops
+				.filter((env) => env.flags.selected)
+				.map((env) => env.databaseId)
+			this.$emit('update:selection', localIds, this.envelopes)
 		},
 
 		onEnvelopeSelectToggle(envelope, index, selected) {
 			this.lastToggledIndex = index
 			this.setEnvelopeSelected(envelope, selected)
+			this.emitLocalSelection()
 		},
 
 		onEnvelopeSelectMultiple(envelope, index) {
@@ -558,12 +590,12 @@ export default {
 				return
 			}
 
-			const start = Math.min(lastToggledIndex, index)
-			const end = Math.max(lastToggledIndex, index)
-			const selected = this.selection.includes(envelope.databaseId)
-			for (let i = start; i <= end; i++) {
-				this.setEnvelopeSelected(this.sortedEnvelops[i], !selected)
-			}
+			// Convert to global flat indices and delegate to the parent
+			const globalFrom = this.flatIndex + lastToggledIndex
+			const globalTo = this.flatIndex + index
+			// If the clicked envelope is already selected, deselect the range
+			const deselect = this.selection.includes(envelope.databaseId)
+			this.$emit('select-range', globalFrom, globalTo, deselect)
 			this.lastToggledIndex = index
 		},
 
@@ -571,7 +603,7 @@ export default {
 			this.sortedEnvelops.forEach((env) => {
 				env.flags.selected = false
 			})
-			this.selection = []
+			this.$emit('update:selection', [], this.envelopes)
 		},
 
 		onOpenMoveModal() {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -382,6 +382,7 @@ export default {
 					env.flags.selected = selectionSet.has(env.databaseId)
 				})
 			},
+
 			immediate: true,
 		},
 

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -27,45 +27,46 @@
 				</NcCheckboxRadioSwitch>
 			</div>
 			<template v-if="hasGroupedEnvelopes && !isPriorityInbox">
-			<div v-for="[label, group] in groupEnvelopes" :key="label">
-				<SectionTitle class="section-title" :name="getLabelForGroup(label)" />
-				<EnvelopeList
-					:account="account"
-					:mailbox="mailbox"
-					:search-query="searchQuery"
-					:envelopes="group"
-					:loading-more="false"
-					:load-more-button="false"
-					:skip-transition="skipListTransition"
-					:selection="selection"
-					:flat-index="getGroupFlatIndex(label)"
-					@delete="onDelete"
-					@update:selection="onUpdateSelection"
-					@select-range="onSelectRange" />
-			</div>
-		</template>
-		<EnvelopeList
-			v-else
-			:account="account"
-			:load-more-label="loadMoreLabel"
-			:mailbox="mailbox"
-			:search-query="searchQuery"
-			:envelopes="envelopesToShow"
-			:loading-more="loadingMore"
-			:load-more-button="showLoadMore"
-			:skip-transition="skipListTransition"
-			:selection="selection"
-			:flat-index="0"
-			@delete="onDelete"
-			@load-more="loadMore"
-			@update:selection="onUpdateSelection"
-			@select-range="onSelectRange" />
+				<div v-for="[label, group] in groupEnvelopes" :key="label">
+					<SectionTitle class="section-title" :name="getLabelForGroup(label)" />
+					<EnvelopeList
+						:account="account"
+						:mailbox="mailbox"
+						:search-query="searchQuery"
+						:envelopes="group"
+						:loading-more="false"
+						:load-more-button="false"
+						:skip-transition="skipListTransition"
+						:selection="selection"
+						:flat-index="getGroupFlatIndex(label)"
+						@delete="onDelete"
+						@update:selection="onUpdateSelection"
+						@select-range="onSelectRange" />
+				</div>
+			</template>
+			<EnvelopeList
+				v-else
+				:account="account"
+				:load-more-label="loadMoreLabel"
+				:mailbox="mailbox"
+				:search-query="searchQuery"
+				:envelopes="envelopesToShow"
+				:loading-more="loadingMore"
+				:load-more-button="showLoadMore"
+				:skip-transition="skipListTransition"
+				:selection="selection"
+				:flat-index="0"
+				@delete="onDelete"
+				@load-more="loadMore"
+				@update:selection="onUpdateSelection"
+				@select-range="onSelectRange" />
 		</div>
 	</div>
 </template>
 
 <script>
 import { showError, showWarning } from '@nextcloud/dialogs'
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
 import { findIndex, propEq } from 'ramda'
 import EmptyMailbox from './EmptyMailbox.vue'
@@ -74,7 +75,6 @@ import EnvelopeList from './EnvelopeList.vue'
 import Error from './Error.vue'
 import Loading from './Loading.vue'
 import LoadingSkeleton from './LoadingSkeleton.vue'
-import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import SectionTitle from './SectionTitle.vue'
 import MailboxLockedError from '../errors/MailboxLockedError.js'
 import MailboxNotCachedError from '../errors/MailboxNotCachedError.js'
@@ -703,11 +703,9 @@ export default {
 		onSelectRange(fromIndex, toIndex, deselect = false) {
 			const start = Math.min(fromIndex, toIndex)
 			const end = Math.max(fromIndex, toIndex)
-			const idsInRange = new Set(
-				this.flatEnvelopeList
-					.slice(start, end + 1)
-					.map((e) => e.databaseId),
-			)
+			const idsInRange = new Set(this.flatEnvelopeList
+				.slice(start, end + 1)
+				.map((e) => e.databaseId))
 			if (deselect) {
 				this.selection = this.selection.filter((id) => !idsInRange.has(id))
 			} else {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -18,7 +18,7 @@
 		<EmptyMailboxSection v-else-if="isPriorityInbox && !hasMessages" key="empty" />
 		<EmptyMailbox v-else-if="!hasMessages" key="empty" />
 		<div v-else>
-			<div v-if="!selectMode" class="select-all-bar">
+			<div v-if="!selectMode" class="select-all-bar" @click="selectAll">
 				<NcCheckboxRadioSwitch
 					:model-value="false"
 					type="checkbox"

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -17,7 +17,16 @@
 			:slow-hint="t('mail', 'Indexing your messages. This can take a bit longer for larger folders.')" />
 		<EmptyMailboxSection v-else-if="isPriorityInbox && !hasMessages" key="empty" />
 		<EmptyMailbox v-else-if="!hasMessages" key="empty" />
-		<template v-else-if="hasGroupedEnvelopes && !isPriorityInbox">
+		<div v-else>
+			<div v-if="!selectMode" class="select-all-bar">
+				<NcCheckboxRadioSwitch
+					:model-value="false"
+					type="checkbox"
+					@update:checked="selectAll">
+					{{ n('mail', 'Select {count} message', 'Select all {count} messages', flatEnvelopeList.length, { count: flatEnvelopeList.length }) }}
+				</NcCheckboxRadioSwitch>
+			</div>
+			<template v-if="hasGroupedEnvelopes && !isPriorityInbox">
 			<div v-for="[label, group] in groupEnvelopes" :key="label">
 				<SectionTitle class="section-title" :name="getLabelForGroup(label)" />
 				<EnvelopeList
@@ -28,7 +37,11 @@
 					:loading-more="false"
 					:load-more-button="false"
 					:skip-transition="skipListTransition"
-					@delete="onDelete" />
+					:selection="selection"
+					:flat-index="getGroupFlatIndex(label)"
+					@delete="onDelete"
+					@update:selection="onUpdateSelection"
+					@select-range="onSelectRange" />
 			</div>
 		</template>
 		<EnvelopeList
@@ -41,8 +54,13 @@
 			:loading-more="loadingMore"
 			:load-more-button="showLoadMore"
 			:skip-transition="skipListTransition"
+			:selection="selection"
+			:flat-index="0"
 			@delete="onDelete"
-			@load-more="loadMore" />
+			@load-more="loadMore"
+			@update:selection="onUpdateSelection"
+			@select-range="onSelectRange" />
+		</div>
 	</div>
 </template>
 
@@ -56,6 +74,7 @@ import EnvelopeList from './EnvelopeList.vue'
 import Error from './Error.vue'
 import Loading from './Loading.vue'
 import LoadingSkeleton from './LoadingSkeleton.vue'
+import { NcCheckboxRadioSwitch } from '@nextcloud/vue'
 import SectionTitle from './SectionTitle.vue'
 import MailboxLockedError from '../errors/MailboxLockedError.js'
 import MailboxNotCachedError from '../errors/MailboxNotCachedError.js'
@@ -76,6 +95,7 @@ export default {
 		Error,
 		Loading,
 		LoadingSkeleton,
+		NcCheckboxRadioSwitch,
 		SectionTitle,
 	},
 
@@ -141,6 +161,7 @@ export default {
 			endReached: false,
 			syncedMailboxes: new Set(),
 			skipListTransition: false,
+			selection: [],
 		}
 	},
 
@@ -175,10 +196,37 @@ export default {
 		showLoadMore() {
 			return !this.endReached && this.paginate === 'manual'
 		},
+
+		/**
+		 * Flat list of all visible envelopes, regardless of grouping.
+		 * Used for shift-click range selection and Select All.
+		 */
+		flatEnvelopeList() {
+			if (this.hasGroupedEnvelopes) {
+				return this.groupEnvelopes.flatMap(([, group]) => group)
+			}
+			return this.envelopesToShow
+		},
+
+		/**
+		 * Whether selection mode is active (at least one envelope selected).
+		 */
+		selectMode() {
+			return this.selection.length > 0
+		},
+
+		/**
+		 * Whether all visible envelopes are currently selected.
+		 */
+		allSelected() {
+			return this.flatEnvelopeList.length > 0
+				&& this.selection.length === this.flatEnvelopeList.length
+		},
 	},
 
 	watch: {
 		mailbox() {
+			this.selection = []
 			this.loadEnvelopes()
 				.then(() => {
 					logger.debug(`syncing mailbox ${this.mailbox.databaseId} (${this.query}) after folder change`)
@@ -187,10 +235,12 @@ export default {
 		},
 
 		searchQuery() {
+			this.selection = []
 			this.loadEnvelopes()
 		},
 
 		sortOrder() {
+			this.selection = []
 			this.loadEnvelopes()
 		},
 	},
@@ -543,6 +593,9 @@ export default {
 		// onDelete(id): Load more message and navigate to other message if needed
 		// id: The id of the message being delete
 		onDelete(id) {
+			// Remove from selection if selected
+			this.selection = this.selection.filter((selectedId) => selectedId !== id)
+
 			// Get a new message
 			this.mainStore.fetchNextEnvelopes({
 				mailboxId: this.mailbox.databaseId,
@@ -604,6 +657,82 @@ export default {
 			this.loadMailboxInterval = undefined
 		},
 
+		/**
+		 * Compute the flat index offset for a group label.
+		 * Used by grouped EnvelopeList children to emit
+		 * correct global indices for shift-click range selection.
+		 *
+		 * @param {string} label The group label key
+		 * @return {number} Flat index of the first envelope in this group
+		 */
+		getGroupFlatIndex(label) {
+			let offset = 0
+			for (const [groupLabel, group] of this.groupEnvelopes) {
+				if (groupLabel === label) {
+					return offset
+				}
+				offset += group.length
+			}
+			return offset
+		},
+
+		/**
+		 * Handle a child EnvelopeList updating its selection.
+		 * The child emits its full new selection array (local IDs),
+		 * and we merge it with the global selection, replacing
+		 * any IDs from this child's visible envelope set.
+		 *
+		 * @param {number[]} childSelection Array of selected envelope databaseIds
+		 * @param {object[]} childEnvelopes Array of envelopes visible in this child
+		 */
+		onUpdateSelection(childSelection, childEnvelopes) {
+			const childIds = new Set(childEnvelopes.map((e) => e.databaseId))
+			// Remove all IDs from this child's scope, then add the new selection
+			this.selection = this.selection.filter((id) => !childIds.has(id))
+			this.selection.push(...childSelection)
+		},
+
+		/**
+		 * Handle shift-click range selection across the flat envelope list.
+		 * Called by a child EnvelopeList with global flat indices.
+		 *
+		 * @param {number} fromIndex Start of the range (global flat index)
+		 * @param {number} toIndex End of the range (global flat index)
+		 * @param {boolean} deselect If true, remove the range from selection
+		 */
+		onSelectRange(fromIndex, toIndex, deselect = false) {
+			const start = Math.min(fromIndex, toIndex)
+			const end = Math.max(fromIndex, toIndex)
+			const idsInRange = new Set(
+				this.flatEnvelopeList
+					.slice(start, end + 1)
+					.map((e) => e.databaseId),
+			)
+			if (deselect) {
+				this.selection = this.selection.filter((id) => !idsInRange.has(id))
+			} else {
+				const newSelection = new Set(this.selection)
+				for (const id of idsInRange) {
+					newSelection.add(id)
+				}
+				this.selection = [...newSelection]
+			}
+		},
+
+		/**
+		 * Select all visible envelopes.
+		 */
+		selectAll() {
+			this.selection = this.flatEnvelopeList.map((e) => e.databaseId)
+		},
+
+		/**
+		 * Clear the current selection.
+		 */
+		unselectAll() {
+			this.selection = []
+		},
+
 		getLabelForGroup(group) {
 			switch (group) {
 				case 'lastHour':
@@ -636,5 +765,17 @@ export default {
 	height: 100%;
 	display: flex;
 	justify-content: center;
+}
+
+.select-all-bar {
+	display: flex;
+	align-items: center;
+	margin-top: 8px;
+	padding: 4px 8px;
+	cursor: pointer;
+	border-bottom: 1px solid var(--color-border);
+	&:hover {
+		background-color: var(--color-background-hover);
+	}
 }
 </style>


### PR DESCRIPTION
Depends on: #12899

Refs #4285
Refs #7880
Refs #6070
Refs #7276
Refs #11526

Follow-up: #12901 adds filter-based mass selection

### Summary

Adds a "Select all X messages" checkbox above the envelope list and lifts
envelope selection state from individual `EnvelopeList` instances to the
`Mailbox` parent, enabling cross-group shift-click range selection and
global select-all/unselect-all.

Together with #12901 this fully closes #4285 and #7880.

### Changes by file

**`Mailbox.vue`**
- Select-all checkbox using `NcCheckboxRadioSwitch` at the top of the list
- Shows "Select all N messages" with the current visible page count
- Hidden once selection mode is active (multiselect header takes over)
- `margin-top: 8px` so it doesn't sit flush against the sticky search bar
- `selection` array in data — single source of truth for selection state
- `selectAll()`, `unselectAll()` methods for global control
- `flatEnvelopeList`, `selectMode`, `allSelected` computed properties
- `onUpdateSelection()`, `onSelectRange()`, `getGroupFlatIndex()` methods
- Passes `selection` prop down to `EnvelopeList` children
- Listens for `update:selection` and `select-range` events from children
- Resets selection on mailbox or filter change
- `.select-all-bar` CSS

**`EnvelopeList.vue`**
- `selection` prop (type `Array`, replaces local `data().selection`)
- `flatIndex` prop (type `Number`, for cross-group shift-click indexing)
- Watch on `selection` prop with `immediate: true` to sync `flags.selected`
- `emitLocalSelection()` method — emits `update:selection` to parent
- Shift-click now emits `select-range` with global flat indices
- Deleted local `selection` from `data()` and `setEnvelopeSelected` mutations

### How to test

1. Open a mailbox → "Select all N messages" checkbox visible at top
2. Click it → all visible messages selected → multiselect header appears
3. Shift-click across messages in different date groups → range selected
4. Change mailbox or filter → checkbox resets to unchecked
5. Unselect all → checkbox reappears

### Screenshots

<img width="303" height="365" alt="Select All - Screenshot_20260507_061040" src="https://github.com/user-attachments/assets/926408c3-ddc4-4379-a5c2-0ac4a6618b21" />
