### PR TITLE
feat: add filter-based mass selection via search modal

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -168,7 +168,7 @@
 import { showError } from '@nextcloud/dialogs'
 import { NcActionButton as ActionButton, NcActions as Actions, NcButton, NcDialog } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
-import { differenceWith } from 'ramda'
+
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import IconSelect from 'vue-material-design-icons/CloseThick.vue'
 import EmailRead from 'vue-material-design-icons/EmailOpenOutline.vue'
@@ -266,11 +266,20 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		selection: {
+			type: Array,
+			default: () => [],
+		},
+
+		flatIndex: {
+			type: Number,
+			default: 0,
+		},
 	},
 
 	data() {
 		return {
-			selection: [],
 			showMoveModal: false,
 			showTagModal: false,
 			lastToggledIndex: undefined,
@@ -362,14 +371,32 @@ export default {
 	},
 
 	watch: {
-		sortedEnvelops(newVal, oldVal) {
-			// Unselect vanished envelopes
-			const newIds = newVal.map((env) => env.databaseId)
-			this.selection = this.selection.filter((id) => newIds.includes(id))
-			differenceWith((a, b) => a.databaseId === b.databaseId, oldVal, newVal)
-				.forEach((env) => {
-					env.flags.selected = false
+		selection: {
+			handler(newSelection) {
+				if (this._localToggleInProgress) {
+					return
+				}
+				// Sync flags.selected when the selection changes from outside this
+				// instance (e.g. shift-click across groups, Select All / Unselect All).
+				const selectionSet = new Set(newSelection)
+				this.sortedEnvelops.forEach((env) => {
+					env.flags.selected = selectionSet.has(env.databaseId)
 				})
+			},
+			immediate: true,
+		},
+
+		sortedEnvelops(newVal, oldVal) {
+			// Skip if a local toggle is in progress to avoid race conditions
+			if (this._localToggleInProgress) {
+				return
+			}
+			// Unselect vanished envelopes by emitting cleaned selection
+			const newIds = new Set(newVal.map((env) => env.databaseId))
+			const cleanedSelection = this.selection.filter((id) => newIds.has(id))
+			if (cleanedSelection.length !== this.selection.length) {
+				this.$emit('update:selection', cleanedSelection, this.envelopes)
+			}
 		},
 	},
 
@@ -534,20 +561,24 @@ export default {
 			this.unselectAll()
 		},
 
-		setEnvelopeSelected(envelope, selected) {
-			const alreadySelected = this.selection.includes(envelope.databaseId)
-			if (selected && !alreadySelected) {
-				envelope.flags.selected = true
-				this.selection.push(envelope.databaseId)
-			} else if (!selected && alreadySelected) {
-				envelope.flags.selected = false
-				this.selection.splice(this.selection.indexOf(envelope.databaseId), 1)
-			}
-		},
-
 		onEnvelopeSelectToggle(envelope, index, selected) {
 			this.lastToggledIndex = index
-			this.setEnvelopeSelected(envelope, selected)
+			this._localToggleInProgress = true
+			// Compute new local selection from the authoritative prop, applying this
+			// single toggle. flags.selected is unreliable here: the selection watcher
+			// may have been skipped (while _localToggleInProgress was true) leaving
+			// flags stale, and Pinia store updates can replace the flags object
+			// entirely, wiping selected=true during a background sync.
+			const myIds = new Set(this.sortedEnvelops.map((e) => e.databaseId))
+			const currentLocal = this.selection.filter((id) => myIds.has(id))
+			const newLocal = selected
+				? [...new Set([...currentLocal, envelope.databaseId])]
+				: currentLocal.filter((id) => id !== envelope.databaseId)
+			this.$emit('update:selection', newLocal, this.envelopes)
+			// Reset after next tick — Vue batches watchers at end of tick
+			this.$nextTick(() => {
+				this._localToggleInProgress = false
+			})
 		},
 
 		onEnvelopeSelectMultiple(envelope, index) {
@@ -558,12 +589,12 @@ export default {
 				return
 			}
 
-			const start = Math.min(lastToggledIndex, index)
-			const end = Math.max(lastToggledIndex, index)
-			const selected = this.selection.includes(envelope.databaseId)
-			for (let i = start; i <= end; i++) {
-				this.setEnvelopeSelected(this.sortedEnvelops[i], !selected)
-			}
+			// Convert to global flat indices and delegate to the parent
+			const globalFrom = this.flatIndex + lastToggledIndex
+			const globalTo = this.flatIndex + index
+			// If the clicked envelope is already selected, deselect the range
+			const deselect = this.selection.includes(envelope.databaseId)
+			this.$emit('select-range', globalFrom, globalTo, deselect)
 			this.lastToggledIndex = index
 		},
 
@@ -571,7 +602,7 @@ export default {
 			this.sortedEnvelops.forEach((env) => {
 				env.flags.selected = false
 			})
-			this.selection = []
+			this.$emit('update:selection', [], this.envelopes)
 		},
 
 		onOpenMoveModal() {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -15,9 +15,48 @@
 			v-else-if="loadingCacheInitialization"
 			:hint="t('mail', 'Loading messages …')"
 			:slow-hint="t('mail', 'Indexing your messages. This can take a bit longer for larger folders.')" />
-		<EmptyMailboxSection v-else-if="isPriorityInbox && !hasMessages" key="empty" />
-		<EmptyMailbox v-else-if="!hasMessages" key="empty" />
-		<template v-else-if="hasGroupedEnvelopes && !isPriorityInbox">
+		<EmptyMailboxSection v-else-if="isPriorityInbox && !hasMessages && !loadingAllMatching" key="empty-section" />
+		<EmptyMailbox v-else-if="!hasMessages && !loadingAllMatching" key="empty-mailbox" />
+		<div v-else>
+			<NcCheckboxRadioSwitch
+				:model-value="selectMode"
+				:disabled="loadingAllMatching"
+				type="checkbox"
+				class="select-all-bar"
+				@update:model-value="selectMode ? unselectAll() : selectAll()">
+				{{ selectAllLabel }}
+			</NcCheckboxRadioSwitch>
+			<div v-if="loadingAllMatching" class="select-all-loading">
+				<NcLoadingIcon :size="16" />
+				<span>{{ t('mail', 'Loading all matching messages…') }}</span>
+			</div>
+			<div v-if="selectAllHint && !loadingAllMatching && !allSelected && !selectionLimitReached" class="select-all-hint">
+				{{ selectAllHint }}
+			</div>
+			<div v-if="selectionLimitReached" class="select-all-hint select-all-limit-warning">
+				{{ n('mail',
+					'Selection limited to {count} message — use a filter to narrow results, or process in several batches.',
+					'Selection limited to {count} messages — use a filter to narrow results, or process in several batches.',
+					flatEnvelopeList.length, { count: flatEnvelopeList.length }) }}
+			</div>
+			<div
+				v-if="allSelected && !selectAllMatching && !endReached && !isPriorityInbox"
+				class="select-all-banner">
+				<span v-if="hasFilter">{{ n('mail',
+					'All {visible} message on this page selected. Select all messages matching this filter?',
+					'All {visible} messages on this page selected. Select all messages matching this filter?',
+					flatEnvelopeList.length,
+					{ visible: flatEnvelopeList.length }) }}</span>
+				<span v-else>{{ n('mail',
+					'All {visible} message on this page selected. Select all messages in this folder?',
+					'All {visible} messages on this page selected. Select all messages in this folder?',
+					flatEnvelopeList.length,
+					{ visible: flatEnvelopeList.length }) }}</span>
+				<NcButton type="primary" @click="selectAllMatchingAction">
+					{{ hasFilter ? t('mail', 'Select all matching messages') : t('mail', 'Select all messages in this folder') }}
+				</NcButton>
+			</div>
+			<template v-if="hasGroupedEnvelopes && !isPriorityInbox">
 			<div v-for="[label, group] in groupEnvelopes" :key="label">
 				<SectionTitle class="section-title" :name="getLabelForGroup(label)" />
 				<EnvelopeList
@@ -28,7 +67,11 @@
 					:loading-more="false"
 					:load-more-button="false"
 					:skip-transition="skipListTransition"
-					@delete="onDelete" />
+					:selection="selection"
+					:flat-index="getGroupFlatIndex(label)"
+					@delete="onDelete"
+					@update:selection="onUpdateSelection"
+					@select-range="onSelectRange" />
 			</div>
 		</template>
 		<EnvelopeList
@@ -41,13 +84,18 @@
 			:loading-more="loadingMore"
 			:load-more-button="showLoadMore"
 			:skip-transition="skipListTransition"
+			:selection="selection"
+			:flat-index="0"
 			@delete="onDelete"
-			@load-more="loadMore" />
+			@load-more="loadMore"
+			@update:selection="onUpdateSelection"
+			@select-range="onSelectRange" />
+		</div>
 	</div>
 </template>
 
 <script>
-import { showError, showWarning } from '@nextcloud/dialogs'
+import { showError, showInfo, showWarning } from '@nextcloud/dialogs'
 import { mapStores } from 'pinia'
 import { findIndex, propEq } from 'ramda'
 import EmptyMailbox from './EmptyMailbox.vue'
@@ -56,6 +104,7 @@ import EnvelopeList from './EnvelopeList.vue'
 import Error from './Error.vue'
 import Loading from './Loading.vue'
 import LoadingSkeleton from './LoadingSkeleton.vue'
+import { NcButton, NcCheckboxRadioSwitch, NcLoadingIcon } from '@nextcloud/vue'
 import SectionTitle from './SectionTitle.vue'
 import MailboxLockedError from '../errors/MailboxLockedError.js'
 import MailboxNotCachedError from '../errors/MailboxNotCachedError.js'
@@ -65,7 +114,12 @@ import NoTrashMailboxConfiguredError
 import logger from '../logger.js'
 import useMainStore from '../store/mainStore.js'
 import { mailboxHasRights } from '../util/acl.js'
+import { favoritesQuery, priorityImportantQuery, priorityOtherQuery } from '../util/priorityInbox.js'
 import { wait } from '../util/wait.js'
+
+// Hard cap: unified mailboxes fan out to N_accounts sub-fetches per page, so
+// 500 messages can mean hundreds of API calls. Beyond this, renderer runs OOM.
+const MAX_SELECT_MESSAGES = 500
 
 export default {
 	name: 'Mailbox',
@@ -76,6 +130,9 @@ export default {
 		Error,
 		Loading,
 		LoadingSkeleton,
+		NcButton,
+		NcCheckboxRadioSwitch,
+		NcLoadingIcon,
 		SectionTitle,
 	},
 
@@ -141,6 +198,10 @@ export default {
 			endReached: false,
 			syncedMailboxes: new Set(),
 			skipListTransition: false,
+			selection: [],
+			selectAllMatching: false,
+			loadingAllMatching: false,
+			selectionLimitReached: false,
 		}
 	},
 
@@ -175,22 +236,140 @@ export default {
 		showLoadMore() {
 			return !this.endReached && this.paginate === 'manual'
 		},
+
+		/**
+		 * Flat list of all visible envelopes, regardless of grouping.
+		 * Used for shift-click range selection and Select All.
+		 */
+		flatEnvelopeList() {
+			const sortVisible = (items) => this.sortOrder === 'oldest'
+				? [...items].sort((a, b) => (a.dateInt < b.dateInt ? -1 : 1))
+				: items
+
+			if (this.hasGroupedEnvelopes) {
+				return this.groupEnvelopes.flatMap(([, group]) => sortVisible(group))
+			}
+			return sortVisible(this.envelopesToShow)
+		},
+
+		selectMode() {
+			return this.selection.length > 0
+		},
+
+		allSelected() {
+			return this.flatEnvelopeList.length > 0
+				&& this.selection.length === this.flatEnvelopeList.length
+		},
+
+		hasFilter() {
+			if (!this.searchQuery) {
+				return false
+			}
+			const trimmed = this.searchQuery.trim()
+			// System section queries that should not count as user filters
+			if (trimmed === priorityImportantQuery || trimmed === priorityOtherQuery || trimmed === favoritesQuery) {
+				return false
+			}
+			return !/^match:allof\s*$/.test(trimmed)
+		},
+
+		/**
+		 * Context-aware label for the select-all checkbox.
+		 * - With active filter: "Select {N} matching messages"
+		 * - Without filter, more pages exist (non-Priority inbox): "Select {N} loaded messages"
+		 * - All loaded, or Priority inbox (no filter): "Select all {N} messages"
+		 */
+		selectAllLabel() {
+			if (this.loadingAllMatching) {
+				return this.t('mail', 'Selecting messages…')
+			}
+
+			const count = this.flatEnvelopeList.length
+			// When messages are selected, show the actual selection count
+			if (this.selectMode) {
+				return this.n('mail',
+					'{count} selected',
+					'{count} selected',
+					this.selection.length, { count: this.selection.length })
+			}
+
+			if (this.hasFilter) {
+				return this.n('mail',
+					'Select {count} matching message',
+					'Select {count} matching messages',
+					count, { count })
+			}
+			if (!this.endReached && count > 0 && !this.isPriorityInbox) {
+				return this.n('mail',
+					'Select {count} loaded message',
+					'Select {count} loaded messages',
+					count, { count })
+			}
+			return this.n('mail',
+				'Select {count} message',
+				'Select all {count} messages',
+				count, { count })
+		},
+
+		/**
+		 * Hint shown below the select-all checkbox to give context
+		 * about how many messages are available and how to select more.
+		 */
+		selectAllHint() {
+			if (this.paginate === 'manual' || this.endReached || this.flatEnvelopeList.length === 0) {
+				return ''
+			}
+			if (this.hasFilter) {
+				return this.t('mail', 'Scroll down to load more messages, or click an avatar circle to select one at a time')
+			}
+			return this.t('mail', 'Scroll down to load more messages, use a filter to refine, or click an avatar circle to select one at a time')
+		},
 	},
 
 	watch: {
+		selection(newVal, oldVal) {
+			// Notify sibling sections (Priority inbox) when selection becomes non-empty.
+			// Only fire for user-initiated transitions — not after a programmatic mass-select
+			// (selectAllMatching = true) so concurrent sections don't clear each other.
+			if (newVal.length > 0 && oldVal.length === 0 && !this.loadingAllMatching && !this.selectAllMatching) {
+				this.bus.emit('section-selected', this.searchQuery)
+			}
+		},
+
 		mailbox() {
+			this.selection = []
+			this.selectAllMatching = false
+			this.loadingAllMatching = false
+			this.selectionLimitReached = false
+			this.endReached = false
+			this.expanded = false
 			this.loadEnvelopes()
 				.then(() => {
-					logger.debug(`syncing mailbox ${this.mailbox.databaseId} (${this.query}) after folder change`)
+					logger.debug(`syncing mailbox ${this.mailbox.databaseId} (${this.searchQuery}) after folder change`)
 					this.sync(false)
 				})
 		},
 
 		searchQuery() {
+			if (this.loadingAllMatching) {
+				return
+			}
+			this.selection = []
+			this.selectAllMatching = false
+			this.loadingAllMatching = false
+			this.selectionLimitReached = false
+			this.endReached = false
+			this.expanded = false
 			this.loadEnvelopes()
 		},
 
 		sortOrder() {
+			this.selection = []
+			this.selectAllMatching = false
+			this.loadingAllMatching = false
+			this.selectionLimitReached = false
+			this.endReached = false
+			this.expanded = false
 			this.loadEnvelopes()
 		},
 	},
@@ -198,8 +377,9 @@ export default {
 	created() {
 		this.bus.on('load-more', this.onScroll)
 		this.bus.on('delete', this.onDelete)
-		this.bus.on('archive', this.onArchive)
 		this.bus.on('shortcut', this.handleShortcut)
+		this.bus.on('select-all-matching', this.onBusSelectAllMatching)
+		this.bus.on('section-selected', this.onBusSectionSelected)
 		this.loadMailboxInterval = setInterval(this.loadMailbox, 60000)
 	},
 
@@ -220,8 +400,9 @@ export default {
 	unmounted() {
 		this.bus.off('load-more', this.onScroll)
 		this.bus.off('delete', this.onDelete)
-		this.bus.off('archive', this.onArchive)
 		this.bus.off('shortcut', this.handleShortcut)
+		this.bus.off('select-all-matching', this.onBusSelectAllMatching)
+		this.bus.off('section-selected', this.onBusSectionSelected)
 		this.stopInterval()
 	},
 
@@ -230,7 +411,7 @@ export default {
 			this.loadingCacheInitialization = true
 			this.error = false
 
-			logger.debug(`syncing folder ${this.mailbox.databaseId} (${this.query}) during cache initalization`)
+			logger.debug(`syncing folder ${this.mailbox.databaseId} (${this.searchQuery}) during cache initialization`)
 			this.sync(true)
 				.then(() => {
 					this.loadingCacheInitialization = false
@@ -239,9 +420,10 @@ export default {
 				})
 		},
 
-		async loadEnvelopes() {
-			logger.debug(`Fetching envelopes for folder ${this.mailbox.databaseId} (${this.searchQuery})`, this.mailbox)
-			if (!this.syncedMailboxes.has(this.mailbox.databaseId + (this.searchQuery ?? ''))) {
+		async loadEnvelopes(queryOverride) {
+			const query = queryOverride ?? this.searchQuery
+			logger.debug(`Fetching envelopes for folder ${this.mailbox.databaseId} (${query})`, this.mailbox)
+			if (!this.loadingAllMatching && !this.syncedMailboxes.has(this.mailbox.databaseId + (query ?? ''))) {
 				// Only trigger skeleton if we didn't sync envelopes yet
 				this.loadingEnvelopes = true
 			} else {
@@ -257,21 +439,21 @@ export default {
 			try {
 				const envelopes = await this.mainStore.fetchEnvelopes({
 					mailboxId: this.mailbox.databaseId,
-					query: this.searchQuery,
+					query,
 					limit: this.initialPageSize,
 				})
 
 				logger.debug(envelopes.length + ' envelopes fetched', { envelopes })
 
-				this.syncedMailboxes.add(this.mailbox.databaseId + (this.searchQuery ?? ''))
+				this.syncedMailboxes.add(this.mailbox.databaseId + (query ?? ''))
 				this.loadingEnvelopes = false
 			} catch (error) {
 				await matchError(error, {
 					[MailboxLockedError.getName()]: async (error) => {
 						logger.info(`Mailbox ${this.mailbox.databaseId} (${this.searchQuery}) is locked`, { error })
 						await wait(15 * 1000)
-						// Keep trying
-						await this.loadEnvelopes()
+						// Keep trying with the same query override so the cache key stays consistent
+						await this.loadEnvelopes(queryOverride)
 					},
 					[MailboxNotCachedError.getName()]: async (error) => {
 						logger.info(`Mailbox ${this.mailbox.databaseId} (${this.searchQuery}) not cached. Triggering initialization`, { error })
@@ -293,11 +475,12 @@ export default {
 			}
 		},
 
-		async loadMore() {
+		async loadMore(queryOverride) {
+			const query = queryOverride ?? this.searchQuery
 			if (!this.expanded && this.envelopesToShow.length < this.envelopes.length) {
 				logger.debug('expanding envelope list')
 				this.expanded = true
-				return
+				return true
 			}
 
 			logger.debug('fetching next envelope page')
@@ -306,14 +489,18 @@ export default {
 			try {
 				const envelopes = await this.mainStore.fetchNextEnvelopePage({
 					mailboxId: this.mailbox.databaseId,
-					query: this.searchQuery,
+					query,
 				})
 				if (envelopes.length === 0) {
 					logger.info('envelope list end reached')
 					this.endReached = true
+				} else {
+					this.expanded = true
 				}
+				return true
 			} catch (error) {
 				logger.error('could not fetch next envelope page', { error })
+				return false
 			} finally {
 				this.loadingMore = false
 			}
@@ -543,6 +730,9 @@ export default {
 		// onDelete(id): Load more message and navigate to other message if needed
 		// id: The id of the message being delete
 		onDelete(id) {
+			// Remove from selection if selected
+			this.selection = this.selection.filter((selectedId) => selectedId !== id)
+
 			// Get a new message
 			this.mainStore.fetchNextEnvelopes({
 				mailboxId: this.mailbox.databaseId,
@@ -604,6 +794,174 @@ export default {
 			this.loadMailboxInterval = undefined
 		},
 
+		/**
+		 * Compute the flat index offset for a group label.
+		 * Used by grouped EnvelopeList children to emit
+		 * correct global indices for shift-click range selection.
+		 *
+		 * @param {string} label The group label key
+		 * @return {number} Flat index of the first envelope in this group
+		 */
+		getGroupFlatIndex(label) {
+			let offset = 0
+			for (const [groupLabel, group] of this.groupEnvelopes) {
+				if (groupLabel === label) {
+					return offset
+				}
+				offset += group.length
+			}
+			return offset
+		},
+
+		/**
+		 * Handle a child EnvelopeList updating its selection.
+		 * The child emits its full new selection array (local IDs),
+		 * and we merge it with the global selection, replacing
+		 * any IDs from this child's visible envelope set.
+		 *
+		 * @param {number[]} childSelection Array of selected envelope databaseIds
+		 * @param {object[]} childEnvelopes Array of envelopes visible in this child
+		 */
+		onUpdateSelection(childSelection, childEnvelopes) {
+			const childIds = new Set(childEnvelopes.map((e) => e.databaseId))
+			const visibleIds = new Set(this.flatEnvelopeList.map((e) => e.databaseId))
+			// User manually changed selection — re-enable mutual exclusion signalling.
+			this.selectAllMatching = false
+			this.selection = [
+				...this.selection.filter((id) => !childIds.has(id)),
+				...childSelection,
+			].filter((id) => visibleIds.has(id))
+		},
+
+		/**
+		 * Handle shift-click range selection across the flat envelope list.
+		 * Called by a child EnvelopeList with global flat indices.
+		 *
+		 * @param {number} fromIndex Start of the range (global flat index)
+		 * @param {number} toIndex End of the range (global flat index)
+		 * @param {boolean} deselect If true, remove the range from selection
+		 */
+		onSelectRange(fromIndex, toIndex, deselect = false) {
+			const start = Math.min(fromIndex, toIndex)
+			const end = Math.max(fromIndex, toIndex)
+			const idsInRange = new Set(
+				this.flatEnvelopeList
+					.slice(start, end + 1)
+					.map((e) => e.databaseId),
+			)
+			// User manually shift-clicked — re-enable mutual exclusion signalling.
+			this.selectAllMatching = false
+			if (deselect) {
+				this.selection = this.selection.filter((id) => !idsInRange.has(id))
+			} else {
+				const newSelection = new Set(this.selection)
+				for (const id of idsInRange) {
+					newSelection.add(id)
+				}
+				this.selection = [...newSelection]
+			}
+		},
+
+		selectAll() {
+			this.selection = this.flatEnvelopeList.map((e) => e.databaseId)
+		},
+
+		/**
+		 * Triggered by the in-page banner button to select all messages in the
+		 * current folder/filter without going through the search modal.
+		 * Unlike the concurrent bus-triggered path, this is a single-section
+		 * intentional action so mutual exclusion should fire on completion.
+		 */
+		selectAllMatchingAction() {
+			this.onBusSelectAllMatching({ emitSectionSelected: true })
+		},
+
+		/**
+		 * Handler for the 'select-all-matching' bus event.
+		 * Forces a fresh load, then fetches all pages and selects everything.
+		 *
+		 * @param {object} [options] Options
+		 * @param {boolean} [options.emitSectionSelected] Emit 'section-selected' on completion
+		 *   to enforce mutual exclusion. Should be true only for single-section banner clicks,
+		 *   not for concurrent bus-triggered mass-selects (search modal path).
+		 */
+		async onBusSelectAllMatching({ emitSectionSelected = false } = {}) {
+			// Set flag before yield to block the searchQuery watcher
+			this.loadingAllMatching = true
+			// appendToSearch() props lag one render tick — wait for section-filtered searchQuery
+			await this.$nextTick()
+			const effectiveQuery = this.searchQuery
+
+			this.selection = []
+			this.selectAllMatching = true
+			this.selectionLimitReached = false
+			this.endReached = false
+			this.expanded = false
+			this.syncedMailboxes.delete(this.mailbox.databaseId + (effectiveQuery ?? ''))
+
+			try {
+				await this.loadEnvelopes(effectiveQuery)
+				let loadFailed = false
+				while (!this.endReached && this.flatEnvelopeList.length < MAX_SELECT_MESSAGES) {
+					if (!await this.loadMore(effectiveQuery)) {
+						loadFailed = true
+						break
+					}
+				}
+				if (loadFailed) {
+					this.selectAllMatching = false
+					logger.error('Mass select aborted: a page failed to load')
+					showError(t('mail', 'Could not load all messages. Please try again.'))
+					return
+				}
+				if (!this.endReached && this.flatEnvelopeList.length >= MAX_SELECT_MESSAGES) {
+					this.selectionLimitReached = true
+					logger.warn(`Mass select capped at ${MAX_SELECT_MESSAGES} messages (${this.flatEnvelopeList.length} loaded) to prevent OOM`)
+				}
+				// Wait for groupEnvelopes prop to propagate from parent (one render cycle)
+				await this.$nextTick()
+				this.selection = this.flatEnvelopeList.slice(0, MAX_SELECT_MESSAGES).map((e) => e.databaseId)
+				if (emitSectionSelected && this.selection.length > 0) {
+					this.bus.emit('section-selected', effectiveQuery)
+				}
+			} catch (error) {
+				logger.error('Failed to load all matching envelopes', { error })
+				this.selectAllMatching = false
+				showError(t('mail', 'Could not load all messages. Please try again.'))
+			} finally {
+				this.loadingAllMatching = false
+			}
+		},
+
+		onBusSectionSelected(activeQuery) {
+			// Another section on the same bus became active — clear our selection.
+			// Each section has its own independent toolbar so cross-section selection
+			// cannot be acted upon in a single operation.
+			if (activeQuery !== this.searchQuery && this.selection.length > 0) {
+				// Only notify the user when their own manual selection is cleared.
+				// A programmatic mass-select (selectAllMatching = true) is silently
+				// superseded — showing a toast for it would be confusing and noisy.
+				const wasUserInitiated = !this.selectAllMatching
+				this.selection = []
+				this.selectAllMatching = false
+				this.selectionLimitReached = false
+				if (wasUserInitiated) {
+					showInfo(t('mail', 'Selection cleared — only one Priority inbox section can be selected at a time'))
+				}
+			}
+		},
+
+		unselectAll() {
+			this.selection = []
+			this.selectAllMatching = false
+			this.loadingAllMatching = false
+			this.selectionLimitReached = false
+			// Intentional: collapse back to the initial page so the user starts
+			// fresh after clearing selection (avoids a full loaded list with
+			// nothing selected, which looks broken on re-entry).
+			this.expanded = false
+		},
+
 		getLabelForGroup(group) {
 			switch (group) {
 				case 'lastHour':
@@ -636,5 +994,57 @@ export default {
 	height: 100%;
 	display: flex;
 	justify-content: center;
+}
+
+.select-all-bar {
+	display: flex;
+	align-items: center;
+	margin-top: 8px;
+	padding: 4px 8px;
+	cursor: pointer;
+	border-bottom: 1px solid var(--color-border);
+	&:hover {
+		background-color: var(--color-background-hover);
+	}
+}
+
+.select-all-loading {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 4px 8px 4px 36px;
+	color: var(--color-text-maxcontrast);
+	font-size: var(--default-font-size);
+	border-bottom: 1px solid var(--color-border);
+}
+
+.select-all-hint {
+	padding: 2px 8px 2px 36px;
+	color: var(--color-text-maxcontrast);
+	font-size: calc(var(--default-font-size) * 0.85);
+	border-bottom: 1px solid var(--color-border);
+}
+
+.select-all-limit-warning {
+	color: var(--color-main-text);
+	background-color: var(--color-warning);
+	border-radius: var(--border-radius);
+	padding: 2px 6px;
+}
+
+.select-all-banner {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding: 8px 12px;
+	background-color: var(--color-primary-light);
+	border-bottom: 1px solid var(--color-border);
+	font-size: var(--default-font-size);
+
+	span {
+		flex: 1;
+		min-width: 120px;
+	}
 }
 </style>

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -16,7 +16,8 @@
 					<SearchMessages
 						:mailbox="mailbox"
 						:account-id="account.accountId"
-						@search-changed="onUpdateSearchQuery" />
+						@search-changed="onUpdateSearchQuery"
+						@select-all-matching="onSelectAllMatching" />
 				</div>
 				<AppContentList
 					v-infinite-scroll="onScroll"
@@ -217,6 +218,7 @@ import {
 import useMainStore from '../store/mainStore.js'
 import { groupEnvelopesByDate } from '../util/groupedEnvelopes.js'
 import {
+	favoritesQuery,
 	priorityImportantQuery,
 	priorityOtherQuery,
 } from '../util/priorityInbox.js'
@@ -276,7 +278,7 @@ export default {
 
 			priorityImportantQuery,
 			priorityOtherQuery,
-			favoriteQuery: 'is:starred',
+			favoriteQuery: favoritesQuery,
 			favoriteInitialPageSize: 5,
 			startMailboxTimer: undefined,
 			hasContent: false,
@@ -601,6 +603,11 @@ export default {
 
 		onUpdateSearchQuery(query) {
 			this.searchQuery = query
+		},
+
+		onSelectAllMatching(query) {
+			this.searchQuery = query
+			this.bus.emit('select-all-matching')
 		},
 	},
 }

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -378,9 +378,14 @@ export default {
 					icon: IconClose,
 				},
 				{
+					label: t('mail', 'Select all matching'),
+					callback: () => this.selectAllMatching(),
+					type: 'primary',
+				},
+				{
 					label: t('mail', 'Search'),
 					callback: () => this.closeSearchModal(),
-					type: 'primary',
+					type: 'tertiary',
 					icon: IconMagnify,
 				},
 			],
@@ -447,7 +452,7 @@ export default {
 				body: this.searchInMessageBody !== null && this.searchInMessageBody.length > 1 ? this.searchInMessageBody : '',
 				tags: this.selectedTags.length > 0 ? this.selectedTags.map((item) => item.id) : '',
 				flags: this.searchFlags.length > 0 ? this.searchFlags.map((item) => item) : '',
-				mentions: this.mentionsMe,
+				mentions: this.mentionsMe ? this.mentionsMe : '',
 				start: this.prepareStart(),
 				end: this.prepareEnd(),
 			}
@@ -563,11 +568,19 @@ export default {
 		},
 
 		closeSearchModal() {
+			if (!this.moreSearchActions) {
+				return
+			}
 			this.moreSearchActions = false
 			this.match = 'allof'
-			this.$nextTick(() => {
-				this.sendQueryEvent()
-			})
+			this.sendQueryEvent()
+		},
+
+		selectAllMatching() {
+			this.match = 'allof'
+			this.moreSearchActions = false
+			// No sendQueryEvent() — bus handler manages loading to avoid watcher race
+			this.$emit('select-all-matching', this.searchQuery)
 		},
 
 		sendQueryEvent() {


### PR DESCRIPTION
Depends on: #12900

Closes #4285
Closes #7880
Closes #11527
Refs #6070
Refs #7276
Refs #11526
Refs #11973
Refs #11420

## Summary

Built on #12900 which centralised selection state in `Mailbox`, this PR completes #4285 and #7880 by adding three complementary ways to select messages for bulk actions:

1. **Checkbox row** — click the checkbox at the top of the list to select all currently loaded messages at once.

2. **Select-all banner** — after clicking the checkbox to select all loaded messages, if more pages remain a banner appears. Clicking it loads all remaining pages and selects every message in the current view.

3. **Search modal "Select all matching"** (new primary button) — open the search dialog, set any filter combination, and click "Select all matching". The modal closes, all matching messages are loaded across all pages, and the entire result set is selected ready for bulk action.

In all three flows, selection is capped at 500 messages to prevent OOM in unified mailboxes (which fan out to N IMAP accounts per page fetch). When the cap is reached a warning explains it and suggests narrowing the filter or working in batches.

Also fixes **shift-click range selection across date groups** (#11527): shift-clicking a message in a different date group from the last-selected one now correctly selects all messages in between.

Also adds full **Priority inbox support**: each of the four sections (Favorites, Follow-up, Important, Other) gets its own independent select-all flow. Selecting messages in one section automatically clears the selection in any other, since each section has its own action toolbar and cross-section bulk operations are not possible.

## Screenshots

### Search modal — new "Select all matching" primary button
<img width="606" height="730" alt="Screenshot_20260507_114235_select_feat_Search parameters_ovelay" src="https://github.com/user-attachments/assets/2baf6612-09b5-437d-97dd-db08ea046cbe" />

### Mass-select result — N selected with action toolbar
<img width="648" height="862" alt="Screenshot_20260510_102704_selft_filter_with_result_background" src="https://github.com/user-attachments/assets/5db70c78-86e6-40a0-b3b6-c2d3f0496c74" />

### Priority inbox mutual exclusion — section cleared toast
<img width="1580" height="874" alt="Screenshot_20260510_103559_toast_priority_mailbox" src="https://github.com/user-attachments/assets/5a1a2c4f-e909-46a4-9bab-888c629d27ff" />

## Architecture

### Component interaction

```
User clicks "Select all matching" in search modal
        │
        ▼
SearchMessages.vue
  emits 'select-all-matching' (query string)
        │
        ▼
MailboxThread.vue
  sets this.searchQuery = query          ← must happen before bus emit
  emits bus('select-all-matching')       ← broadcast to all Mailbox instances
        │
        ├─────────────────────────────────────────────┐
        ▼                                             ▼
Mailbox.vue × 2 (regular / Unified inbox) Mailbox.vue × 4 (Priority inbox only)
  Favorites  (isPriorityInbox=true)     Favorites, Follow-up, Important, Other
  Main       (isPriorityInbox=false)    all have isPriorityInbox=true
  share one mitt bus                    share one mitt bus
  Main owns the select-all banner       each fetches its own filtered pages
  each fetches its own filtered pages   mutual exclusion via 'section-selected'
        │                                             │
        ▼                                             ▼
EnvelopeList.vue (per section)          EnvelopeList.vue (per section)
  receives selection[] as prop            receives selection[] as prop
  emits update:selection (delta)          emits update:selection / select-range
  emits select-range (flat indices)
```

State flows **down** via props, changes flow **up** via Vue events, and cross-instance coordination uses the shared **mitt bus**.

---

### Key design decisions

Every `MailboxThread` view mounts at least two `Mailbox` instances on the same bus — a Favorites section and a Main section. The Priority inbox (`PRIORITY_INBOX_ID`) extends this to four sections (Favorites, Follow-up, Important, Other), all with `isPriorityInbox=true`. The unified inbox (`UNIFIED_INBOX_ID`) uses the same two-section layout as a regular folder and requires no special handling. The decisions below address the non-obvious coordination problems the multi-instance shared-bus pattern creates.

**1. Capturing the settled query before loading**
Priority inbox sections inject a query suffix one Vue render tick _after_ the parent's `searchQuery` prop changes. Starting mass-select immediately would use a stale query and corrupt the cache key. The fix is to raise a lock flag (`loadingAllMatching`) before yielding — which simultaneously blocks the `searchQuery` watcher from triggering a competing reload — then read the settled, section-filtered query after the tick.

**2. Mutual exclusion between sections**
Each section has its own independent action toolbar, so a selection spanning two sections can't be acted upon in a single bulk operation. When a section's selection goes from empty to non-empty (user-initiated), it broadcasts a `section-selected` event on the shared bus. Any sibling holding a selection clears itself with an info toast.

**3. Concurrent mass-selects must not interfere**
The search modal triggers mass-select on all sections simultaneously — each independently loads its own filtered pages. Mutual exclusion must _not_ fire on completion: each finishing section would otherwise clear the others' just-loaded selections. So `section-selected` is emitted only on user-initiated transitions, never at the end of a programmatic mass-load.

**4. OOM protection: 500-message cap**
The unified inbox fans out to N IMAP accounts per page fetch. Without a ceiling, large multi-account selections exhaust client memory. The loop halts at 500 and shows a visible warning rather than silently truncating.

**5. Keeping the spinner visible during mass-select**
Mass-select forces a cache invalidation to guarantee a fresh fetch. Without a guard, this triggers `LoadingSkeleton`, hiding the spinner mid-operation. A `!loadingAllMatching` condition in `loadEnvelopes()` suppresses the skeleton so the spinner stays visible throughout.

## Changes

### `SearchMessages.vue`
- Added **"Select all matching"** as a primary `NcDialog` button; **"Search"** demoted to tertiary
- `selectAllMatching()` sets `match = 'allof'`, closes the modal, then emits `select-all-matching` with the full computed query string — intentionally **no `sendQueryEvent()`** to avoid a concurrent reload
- `closeSearchModal()` has an idempotency guard — safe to call multiple times
- Fixed `filterData.mentions`: coerces `false` to `''` so `mentions:false` is never appended to the IMAP query string

### `MailboxThread.vue`
- Wires `@select-all-matching="onSelectAllMatching"` on `SearchMessages`
- `onSelectAllMatching(query)` sets `this.searchQuery = query` **before** `this.bus.emit('select-all-matching')` so each Priority inbox section reads the correct parent query when it captures `effectiveQuery` after its own `$nextTick`

### `Mailbox.vue`
- `isPriorityInbox` prop — hides the select-all banner, disables envelope grouping, and shows an empty-section placeholder (mutual exclusion via `section-selected` fires on all instances regardless of this flag)
- `loadingAllMatching` / `selectAllMatching` / `selectionLimitReached` data flags
- `onBusSelectAllMatching()` — full mass-select lifecycle: raises flag, yields tick, clears cache, fetches all pages, caps at 500, selects all; both failure paths (page-load error mid-loop and outer catch) now show an error toast and reset `selectAllMatching` (previously silent — console-only logging)
- `loadEnvelopes()` — `!loadingAllMatching` guard suppresses `LoadingSkeleton` during mass-select
- `selection` watcher — emits `section-selected` on 0 → non-zero transition, guarded by `!loadingAllMatching`
- `onBusSectionSelected(activeQuery)` — clears sibling section selection with info toast ("Selection cleared — only one Priority inbox section can be selected at a time"); self-guard via `activeQuery !== this.searchQuery`
- `selectAllMatchingAction()` — in-page banner entry point (calls `onBusSelectAllMatching()` directly, no bus round-trip)
- `selectAllLabel` computed — context-aware label:

| Condition | Label |
|-----------|-------|
| `loadingAllMatching` | Selecting messages… |
| `selectMode` | N selected |
| `hasFilter` | Select N matching messages |
| `!endReached && count > 0` | Select N loaded messages |
| _(default)_ | Select all N messages |

- `select-all-banner` — prompts to load all matching when all visible are selected and more exist; **hidden for Priority inbox**; button label adapts: "Select all matching messages" when a filter is active, "Select all messages in this folder" otherwise
- `select-all-limit-warning` — shown in warning colour when 500-cap is hit: "Selection limited to N messages — use a filter to narrow results, or process in several batches."
- `onUpdateSelection()` — merged into single array assignment (removes intermediate empty reactive state)
- `unselectAll()` — also clears `loadingAllMatching` and `expanded`
- `bus.on/off('section-selected', ...)` symmetric in `created`/`unmounted`
- Imports `priorityImportantQuery`, `priorityOtherQuery`, and `favoritesQuery` constants instead of hardcoding strings in `hasFilter`

### `EnvelopeList.vue`
- `_localToggleInProgress` guard on both `selection` and `sortedEnvelops` watchers — prevents watchers from overwriting `flags.selected` during a local click; reset via `$nextTick` to survive Vue's watcher flush

## How to test

- [ ] Open any folder → click the checkbox row → all visible messages selected, action toolbar appears
- [ ] Open a large folder (more than one page of messages) → scroll down to load a second page → without selecting anything, verify the checkbox-row label updates to "Select N loaded messages" where N reflects only the messages loaded so far, not the full folder total
- [ ] Select all visible in a large folder (no filter) → **banner appears** → click it → all pages load and select
- [ ] Open the search modal → set a filter → click **"Search"** (tertiary button, not "Select all matching") → filter results load → select all loaded via checkbox → banner appears with filter wording → click it → all matching messages across all pages selected
- [ ] Open the search modal → set any filter → click **"Select all matching"** (primary button) → modal closes, spinner appears, all matching messages across all pages are selected directly (no banner step)
- [ ] While messages are selected, click individual avatar circles to deselect/reselect one at a time → count updates correctly, no spurious multi-deselect
- [ ] Shift-click across messages in different date groups → range selected correctly
- [ ] **Priority inbox** → open Priority inbox → click avatar circles in the **Important** section to select one or more messages → then click an avatar circle in the **Other** section → verify the Important selection clears automatically and a toast appears: "Selection cleared — only one Priority inbox section can be selected at a time"
- [ ] **Priority inbox** → select in Important → click individual avatars to add/remove messages within the same section → sibling sections are not affected
- [ ] Open a folder with > 500 messages → trigger mass-select via the banner or search modal → selection stops at 500 and shows the cap warning in orange with actionable advice
- [ ] Open DevTools → Network tab → start a mass-select on a large folder → set network to Offline mid-load → spinner disappears, error toast appears, no messages remain selected
- [ ] Bulk actions (delete, mark read, move, tag) apply correctly to all selected messages

## Known limitations

- **No cross-section bulk actions in Priority inbox.** Selecting in Important and then clicking in Other clears the first section. There is no toolbar that spans sections, so a cross-section selection cannot be acted upon.
- **500-message cap.** Raising it requires backend pagination performance improvements first.
- **No server-side "select all" flag.** Bulk operations iterate over the `selection` array and fire individual API calls. A future improvement would be a server-side endpoint accepting a filter query and performing the operation without enumerating IDs client-side