### PR TITLE
feat(classifier): only train on user set important messages

### DIFF
--- a/lib/BackgroundJob/FollowUpClassifierJob.php
+++ b/lib/BackgroundJob/FollowUpClassifierJob.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\BackgroundJob;
 
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\ThreadMapper;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\AccountService;
@@ -102,6 +103,7 @@ class FollowUpClassifierJob extends QueuedJob {
 			$message,
 			$tag,
 			true,
+			MessageTags::TYPE_CLASSIFIER,
 		);
 	}
 }

--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -14,6 +14,7 @@ use OCA\Mail\Account;
 use OCA\Mail\Attachment;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
@@ -183,11 +184,14 @@ interface IMailManager {
 	 * @param Message $message
 	 * @param Tag $tag
 	 * @param bool $value
+	 * @param string $type Source of the tag, one of MessageTags::TYPE_USER (default)
+	 *                    or MessageTags::TYPE_CLASSIFIER. Used so the importance
+	 *                    classifier does not train on its own predictions.
 	 *
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function tagMessage(Account $account, string $mailbox, Message $message, Tag $tag, bool $value): void;
+	public function tagMessage(Account $account, string $mailbox, Message $message, Tag $tag, bool $value, string $type = MessageTags::TYPE_USER): void;
 
 	/**
 	 * @param Account $account

--- a/lib/Db/MessageTags.php
+++ b/lib/Db/MessageTags.php
@@ -18,13 +18,27 @@ use ReturnTypeWillChange;
  * @method void setImapMessageId(string $imapMessageId)
  * @method int getTagId()
  * @method void setTagId(int $tagId)
+ * @method string getType()
+ * @method void setType(string $type)
  */
 class MessageTags extends Entity implements JsonSerializable {
+	/**
+	 * Tag was applied by the user (manual interaction).
+	 */
+	public const TYPE_USER = 'user';
+
+	/**
+	 * Tag was applied by the automatic importance classifier.
+	 */
+	public const TYPE_CLASSIFIER = 'classifier';
+
 	protected $imapMessageId;
 	protected $tagId;
+	protected $type = self::TYPE_USER;
 
 	public function __construct() {
 		$this->addType('tagId', 'integer');
+		$this->addType('type', 'string');
 	}
 
 	#[\Override]
@@ -34,6 +48,7 @@ class MessageTags extends Entity implements JsonSerializable {
 			'id' => $this->getId(),
 			'imapMessageId' => $this->getImapMessageId(),
 			'tagId' => $this->getTagId(),
+			'type' => $this->getType(),
 		];
 	}
 }

--- a/lib/Db/TagMapper.php
+++ b/lib/Db/TagMapper.php
@@ -76,7 +76,7 @@ class TagMapper extends QBMapper {
 	 *
 	 * To tag (flag) a message on IMAP, @see \OCA\Mail\Service\MailManager::tagMessage
 	 */
-	public function tagMessage(Tag $tag, string $messageId, string $userId): void {
+	public function tagMessage(Tag $tag, string $messageId, string $userId, string $type = MessageTags::TYPE_USER): void {
 		try {
 			$tag = $this->getTagByImapLabel($tag->getImapLabel(), $userId);
 		} catch (DoesNotExistException $e) {
@@ -86,7 +86,8 @@ class TagMapper extends QBMapper {
 		$qb = $this->db->getQueryBuilder();
 		$qb->insert('mail_message_tags')
 			->setValue('imap_message_id', $qb->createNamedParameter($messageId))
-			->setValue('tag_id', $qb->createNamedParameter($tag->getId(), IQueryBuilder::PARAM_INT));
+			->setValue('tag_id', $qb->createNamedParameter($tag->getId(), IQueryBuilder::PARAM_INT))
+			->setValue('type', $qb->createNamedParameter($type));
 		$qb->executeStatement();
 	}
 
@@ -141,6 +142,44 @@ class TagMapper extends QBMapper {
 			$queryResult->closeCursor();
 		}
 		return $tags;
+	}
+
+	/**
+	 * Return the IMAP message IDs of messages whose given tag was applied by
+	 * the automatic classifier (rather than the user). Useful for excluding
+	 * classifier-applied labels from the importance classifier's training
+	 * set so it does not reinforce its own predictions.
+	 *
+	 * @param Message[] $messages
+	 * @return string[]
+	 */
+	public function getClassifierTaggedMessageIds(array $messages, string $userId, string $imapLabel): array {
+		if ($messages === []) {
+			return [];
+		}
+		$ids = array_map(static fn (Message $message) => $message->getMessageId(), $messages);
+
+		$qb = $this->db->getQueryBuilder();
+		$query = $qb->selectDistinct('mt.imap_message_id')
+			->from($this->getTableName(), 't')
+			->join('t', 'mail_message_tags', 'mt', $qb->expr()->eq('t.id', 'mt.tag_id', IQueryBuilder::PARAM_INT))
+			->where(
+				$qb->expr()->in('mt.imap_message_id', $qb->createParameter('ids'), IQueryBuilder::PARAM_STR_ARRAY),
+				$qb->expr()->eq('t.user_id', $qb->createNamedParameter($userId, IQueryBuilder::PARAM_STR)),
+				$qb->expr()->eq('t.imap_label', $qb->createNamedParameter($imapLabel, IQueryBuilder::PARAM_STR)),
+				$qb->expr()->eq('mt.type', $qb->createNamedParameter(MessageTags::TYPE_CLASSIFIER, IQueryBuilder::PARAM_STR)),
+			);
+
+		$messageIds = [];
+		foreach (array_chunk($ids, 1000) as $chunk) {
+			$query->setParameter('ids', $chunk, IQueryBuilder::PARAM_STR_ARRAY);
+			$result = $query->executeQuery();
+			while (($row = $result->fetch()) !== false) {
+				$messageIds[] = $row['imap_message_id'];
+			}
+			$result->closeCursor();
+		}
+		return $messageIds;
 	}
 
 	/**

--- a/lib/Migration/Version5900Date20260507120000.php
+++ b/lib/Migration/Version5900Date20260507120000.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCA\Mail\Db\MessageTags;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\Attributes\ColumnType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Tracks whether a message tag was applied by the user or by the
+ * automatic importance classifier. Existing rows are preserved as
+ * user-applied so they remain valid ground truth for training.
+ *
+ * @psalm-api
+ */
+#[AddColumn(
+	table: 'mail_message_tags',
+	name: 'type',
+	type: ColumnType::STRING,
+	description: 'Source of the tag: user vs classifier',
+)]
+class Version5900Date20260507120000 extends SimpleMigrationStep {
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('mail_message_tags')) {
+			return null;
+		}
+
+		$table = $schema->getTable('mail_message_tags');
+		if (!$table->hasColumn('type')) {
+			$table->addColumn('type', Types::STRING, [
+				'notnull' => true,
+				'length' => 16,
+				'default' => MessageTags::TYPE_USER,
+			]);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -16,6 +16,8 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
+use OCA\Mail\Db\Tag;
+use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Exception\ClassifierTrainingException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Model\Classifier;
@@ -109,18 +111,22 @@ class ImportanceClassifier {
 
 	private ContainerInterface $container;
 
+	private TagMapper $tagMapper;
+
 	public function __construct(MailboxMapper $mailboxMapper,
 		MessageMapper $messageMapper,
 		PersistenceService $persistenceService,
 		PerformanceLogger $performanceLogger,
 		ImportanceRulesClassifier $rulesClassifier,
-		ContainerInterface $container) {
+		ContainerInterface $container,
+		TagMapper $tagMapper) {
 		$this->mailboxMapper = $mailboxMapper;
 		$this->messageMapper = $messageMapper;
 		$this->persistenceService = $persistenceService;
 		$this->performanceLogger = $performanceLogger;
 		$this->rulesClassifier = $rulesClassifier;
 		$this->container = $container;
+		$this->tagMapper = $tagMapper;
 	}
 
 	private static function createDefaultEstimator(): KNearestNeighbors {
@@ -180,10 +186,28 @@ class ImportanceClassifier {
 			$this->messageMapper->findLatestMessages($account->getUserId(), $mailboxIds, self::MAX_TRAINING_SET_SIZE),
 			[$this, 'filterMessageHasSenderEmail']
 		);
+
+		// Drop messages whose importance flag was set by the classifier itself.
+		// We have no ground truth for these, so including them would let the
+		// classifier reinforce its own predictions over time.
+		$classifierTaggedIds = array_flip($this->tagMapper->getClassifierTaggedMessageIds(
+			$messages,
+			$account->getUserId(),
+			Tag::LABEL_IMPORTANT,
+		));
+		$autoTaggedDropped = 0;
+		$messages = array_filter($messages, static function (Message $message) use ($classifierTaggedIds, &$autoTaggedDropped) {
+			if (isset($classifierTaggedIds[$message->getMessageId()])) {
+				$autoTaggedDropped++;
+				return false;
+			}
+			return true;
+		});
+
 		$importantMessages = array_filter($messages, static fn (Message $message) => $message->getFlagImportant() === true);
 		$nMessages = count($messages);
 		$nImportant = count($importantMessages);
-		$logger->debug("found $nMessages messages of which $nImportant are important");
+		$logger->debug("found $nMessages messages of which $nImportant are important (dropped $autoTaggedDropped classifier-tagged messages)");
 		if (count($importantMessages) < self::COLD_START_THRESHOLD) {
 			$logger->info('not enough messages to train a classifier');
 			return null;

--- a/lib/Service/Classification/NewMessagesClassifier.php
+++ b/lib/Service/Classification/NewMessagesClassifier.php
@@ -14,6 +14,7 @@ use OCA\Mail\Account;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Exception\ClientException;
@@ -89,7 +90,7 @@ class NewMessagesClassifier {
 				if ($prediction) {
 					$message->setFlagImportant(true);
 					$this->mailManager->flagMessage($account, $mailbox->getName(), $message->getUid(), Tag::LABEL_IMPORTANT, true);
-					$this->mailManager->tagMessage($account, $mailbox->getName(), $message, $importantTag, true);
+					$this->mailManager->tagMessage($account, $mailbox->getName(), $message, $importantTag, true, MessageTags::TYPE_CLASSIFIER);
 				}
 			}
 		} catch (ServiceException $e) {

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -21,6 +21,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMessageMapper;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\MessageTagsMapper;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
@@ -493,7 +494,7 @@ class MailManager implements IMailManager {
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function tagMessagesWithClient(Horde_Imap_Client_Socket $client, Account $account, Mailbox $mailbox, array $messages, Tag $tag, bool $value):void {
+	public function tagMessagesWithClient(Horde_Imap_Client_Socket $client, Account $account, Mailbox $mailbox, array $messages, Tag $tag, bool $value, string $type = MessageTags::TYPE_USER):void {
 		if ($this->isPermflagsEnabled($client, $account, $mailbox->getName()) === true) {
 			$messageIds = array_map(static fn (Message $message) => $message->getUid(), $messages);
 			try {
@@ -514,7 +515,7 @@ class MailManager implements IMailManager {
 
 		if ($value) {
 			foreach ($messages as $message) {
-				$this->tagMapper->tagMessage($tag, $message->getMessageId(), $account->getUserId());
+				$this->tagMapper->tagMessage($tag, $message->getMessageId(), $account->getUserId(), $type);
 			}
 		} else {
 			foreach ($messages as $message) {
@@ -540,7 +541,7 @@ class MailManager implements IMailManager {
 	 * @link https://github.com/nextcloud/mail/issues/25
 	 */
 	#[\Override]
-	public function tagMessage(Account $account, string $mailbox, Message $message, Tag $tag, bool $value): void {
+	public function tagMessage(Account $account, string $mailbox, Message $message, Tag $tag, bool $value, string $type = MessageTags::TYPE_USER): void {
 		try {
 			$mb = $this->mailboxMapper->find($account, $mailbox);
 		} catch (DoesNotExistException $e) {
@@ -548,7 +549,7 @@ class MailManager implements IMailManager {
 		}
 		$client = $this->imapClientFactory->getClient($account);
 		try {
-			$this->tagMessagesWithClient($client, $account, $mb, [$message], $tag, $value);
+			$this->tagMessagesWithClient($client, $account, $mb, [$message], $tag, $value, $type);
 		} finally {
 			$client->logout();
 		}

--- a/tests/Unit/Job/FollowUpClassifierJobTest.php
+++ b/tests/Unit/Job/FollowUpClassifierJobTest.php
@@ -16,6 +16,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\ThreadMapper;
 use OCA\Mail\Service\AccountService;
@@ -115,7 +116,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->willReturn($tag);
 		$this->mailManager->expects(self::once())
 			->method('tagMessage')
-			->with($account, 'sent', $message, $tag, true);
+			->with($account, 'sent', $message, $tag, true, MessageTags::TYPE_CLASSIFIER);
 
 		$this->job->run($argument);
 	}
@@ -248,7 +249,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->willReturn($tag);
 		$this->mailManager->expects(self::once())
 			->method('tagMessage')
-			->with($account, 'sent', $message, $tag, true);
+			->with($account, 'sent', $message, $tag, true, MessageTags::TYPE_CLASSIFIER);
 
 		$this->job->run($argument);
 	}
@@ -302,7 +303,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->willReturn($tag);
 		$this->mailManager->expects(self::once())
 			->method('tagMessage')
-			->with($account, 'sent', $message, $tag, true);
+			->with($account, 'sent', $message, $tag, true, MessageTags::TYPE_CLASSIFIER);
 
 		$this->job->run($argument);
 	}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -18,6 +18,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMessageMapper;
+use OCA\Mail\Db\MessageTags;
 use OCA\Mail\Db\MessageTagsMapper;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
@@ -450,6 +451,9 @@ class MailManagerTest extends TestCase {
 		$account->expects($this->once())
 			->method('getUserId')
 			->willReturn('test');
+		$this->tagMapper->expects($this->once())
+			->method('tagMessage')
+			->with($tag, $message->getMessageId(), 'test', MessageTags::TYPE_USER);
 		$this->manager->tagMessage($account, 'INBOX', $message, $tag, true);
 	}
 


### PR DESCRIPTION
Fix #10537

I wonder if we should make user set have more weight instead of just dismissing them. 
The model will have no data to train on if user never set important messages. 

AI-assisted: opus4.7 - claude  