### PR TITLE
ci: stop updating stable5.6 (EOL)

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -28,7 +28,6 @@ jobs:
           - ${{ github.event.repository.default_branch }}
           - 'stable5.8'
           - 'stable5.7'
-          - 'stable5.6'
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-public-suffix-list.yml
+++ b/.github/workflows/update-public-suffix-list.yml
@@ -18,7 +18,6 @@ jobs:
           - 'main'
           - 'stable5.8'
           - 'stable5.7'
-          - 'stable5.6'
 
     name: update-public-suffix-list-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,3 +1,2 @@
 stable5.8
 stable5.7
-stable5.6

--- a/renovate.json
+++ b/renovate.json
@@ -25,8 +25,7 @@
 	"baseBranchPatterns": [
 		"main",
 		"stable5.8",
-		"stable5.7",
-		"stable5.6"
+		"stable5.7"
 	],
 	"enabledManagers": [
 		"composer",


### PR DESCRIPTION
5.6 was needed for Nextcloud 31, which reached EOL 2026-02. We can also stop any automations for that branch.