### PR TITLE
fix(auth): detect and warn about MS accounts without oauth setup

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -234,7 +234,10 @@
 			</Tab>
 		</Tabs>
 		<div v-if="isGoogleAccount && !googleOauthUrl" class="account-form__google-sso">
-			{{ t('mail', 'For the Google account to work with this app you need to enable two-factor authentication for Google and generate an app password.') }}
+			{{ t('mail', 'Google requires OAuth authentication. If your Nextcloud admin has not configured Google OAuth, you can use a Google App Password instead.') }}
+		</div>
+		<div v-if="isMicrosoftAccount && !microsoftOauthUrl" class="account-form__microsoft-sso">
+			{{ t('mail', 'Microsoft requires OAuth authentication. Ask your Nextcloud admin to configure Microsoft OAuth in the admin settings.') }}
 		</div>
 		<div class="account-form__submit-buttons">
 			<ButtonVue


### PR DESCRIPTION
We get more and more reports of users who are confused that their ms/outlook/live.com accounts don't work. This is a Microsoft restriction and something only the admin can fix.

<img width="617" height="693" alt="image" src="https://github.com/user-attachments/assets/ec8e7e82-6909-4af6-bde2-9942eed9392c" />

We already had the hint for Google. Now there is also one for Microsoft.

Fixes https://github.com/nextcloud/mail/issues/12779