### PR TITLE
[stable5.8] fix(recipient-list): scroll on overflow

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -34,12 +34,14 @@
 									{{ moreParticipantsString }}
 								</span>
 							</template>
-							<RecipientBubble
-								v-for="participant in threadParticipants.slice(participantsToDisplay)"
-								:key="participant.email"
-								:title="participant.email"
-								:email="participant.email"
-								:label="participant.label" />
+							<div class="thread-participants-overflow">
+								<RecipientBubble
+									v-for="participant in threadParticipants.slice(participantsToDisplay)"
+									:key="participant.email"
+									:title="participant.email"
+									:email="participant.email"
+									:label="participant.label" />
+							</div>
 						</NcPopover>
 						<!-- Remaining participants, if any (Needed to have avatarHeader reactive) -->
 						<RecipientBubble
@@ -741,12 +743,16 @@ export default {
 	overflow: hidden;
 	display: flex;
 	align-items: stretch;
+}
 
-	:deep(.v-popper--theme-dropdown.v-popper__popper .v-popper__inner) {
-		height: 300px;
-		width: 250px;
-		overflow: auto;
-	}
+.thread-participants-overflow {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: var(--default-grid-baseline);
+	max-height: min(50vh, 400px);
+	max-width: min(80vw, 320px);
+	overflow-y: auto;
 }
 
 .avatar-more {


### PR DESCRIPTION
PS: this is only for 5.8 and prior, as main has a new logic 
| b | a |
|--------|--------|
| <img width="1138" height="595" alt="image" src="https://github.com/user-attachments/assets/76911a70-8beb-44be-91a7-9c0663c09ccc" /> | <img width="1138" height="580" alt="image" src="https://github.com/user-attachments/assets/12dd7012-c59f-436f-8cf5-2b943f556b67" /> | 