### PR TITLE
fix(send): skip IMAP APPEND when server already saved sent message

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -429,6 +429,25 @@ class MessageMapper {
 	}
 
 	/**
+	 * Returns true if a message with the given Message-ID header already exists in $mailbox.
+	 * Used to detect server-side automatic sent-message saving (e.g. Exchange).
+	 *
+	 * @throws Horde_Imap_Client_Exception
+	 */
+	public function existsInMailboxByMessageId(
+		Horde_Imap_Client_Socket $client,
+		Mailbox $mailbox,
+		string $messageId,
+	): bool {
+		$query = new Horde_Imap_Client_Search_Query();
+		$query->headerText('Message-ID', $messageId);
+		$result = $client->search($mailbox->getName(), $query, [
+			'results' => [Horde_Imap_Client::SEARCH_RESULTS_COUNT],
+		]);
+		return ($result['count'] ?? 0) > 0;
+	}
+
+	/**
 	 * @throws Horde_Imap_Client_Exception
 	 */
 	public function addFlag(Horde_Imap_Client_Socket $client,

--- a/lib/Send/CopySentMessageHandler.php
+++ b/lib/Send/CopySentMessageHandler.php
@@ -30,7 +30,8 @@ class CopySentMessageHandler extends AHandler {
 		Mailbox $mailbox,
 		string $rawMessage,
 	): bool {
-		if (!preg_match('/^Message-ID:\s*(<[^>]+>)/im', $rawMessage, $m)) {
+		[$headers] = preg_split("/\r?\n\r?\n/", $rawMessage, 2);
+		if (!preg_match('/^Message-ID:\s*(<[^>\r\n]+>)/im', $headers, $m)) {
 			return false;
 		}
 		try {

--- a/lib/Send/CopySentMessageHandler.php
+++ b/lib/Send/CopySentMessageHandler.php
@@ -10,11 +10,13 @@ namespace OCA\Mail\Send;
 use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
+use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Db\LocalMessage;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class CopySentMessageHandler extends AHandler {
@@ -22,6 +24,7 @@ class CopySentMessageHandler extends AHandler {
 		private MailboxMapper $mailboxMapper,
 		private LoggerInterface $logger,
 		private MessageMapper $messageMapper,
+		private IConfig $config,
 	) {
 	}
 
@@ -85,7 +88,9 @@ class CopySentMessageHandler extends AHandler {
 
 		// Some servers (e.g. Exchange) auto-save sent messages, so skip the APPEND when the
 		// message is already present to avoid duplicates in the Sent folder.
-		if ($this->isAlreadySavedByServer($client, $sentMailbox, $rawMessage)) {
+		// Opt-in via: occ config:app:set mail smtp_saves_sent --value=true
+		if ($this->config->getAppValue(Application::APP_ID, 'smtp_saves_sent', 'false') === 'true'
+			&& $this->isAlreadySavedByServer($client, $sentMailbox, $rawMessage)) {
 			$this->logger->debug('Sent message already present in sent mailbox (server auto-saved), skipping APPEND');
 			$localMessage->setStatus(LocalMessage::STATUS_PROCESSED);
 			return $this->processNext($account, $localMessage, $client);

--- a/lib/Send/CopySentMessageHandler.php
+++ b/lib/Send/CopySentMessageHandler.php
@@ -11,6 +11,7 @@ use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Db\LocalMessage;
+use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\IMAP\MessageMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -22,6 +23,22 @@ class CopySentMessageHandler extends AHandler {
 		private LoggerInterface $logger,
 		private MessageMapper $messageMapper,
 	) {
+	}
+
+	private function isAlreadySavedByServer(
+		Horde_Imap_Client_Socket $client,
+		Mailbox $mailbox,
+		string $rawMessage,
+	): bool {
+		if (!preg_match('/^Message-ID:\s*(<[^>]+>)/im', $rawMessage, $m)) {
+			return false;
+		}
+		try {
+			return $this->messageMapper->existsInMailboxByMessageId($client, $mailbox, $m[1]);
+		} catch (Horde_Imap_Client_Exception $e) {
+			$this->logger->warning('Could not search for existing sent message, proceeding with APPEND', ['exception' => $e]);
+			return false;
+		}
 	}
 
 	#[\Override]
@@ -63,6 +80,14 @@ class CopySentMessageHandler extends AHandler {
 			]);
 
 			return $localMessage;
+		}
+
+		// Some servers (e.g. Exchange) auto-save sent messages, so skip the APPEND when the
+		// message is already present to avoid duplicates in the Sent folder.
+		if ($this->isAlreadySavedByServer($client, $sentMailbox, $rawMessage)) {
+			$this->logger->debug('Sent message already present in sent mailbox (server auto-saved), skipping APPEND');
+			$localMessage->setStatus(LocalMessage::STATUS_PROCESSED);
+			return $this->processNext($account, $localMessage, $client);
 		}
 
 		try {

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -243,6 +243,33 @@ class MailTransmissionIntegrationTest extends TestCase {
 		$this->assertMessageCount(1, 'Sent');
 	}
 
+	public function testSkipsAppendWhenServerAlreadySavedSentMessage(): void {
+		$messageId = '<server-saved-' . microtime(true) . '@domain.tld>';
+		$rawMessage = implode("\r\n", [
+			'From: user@domain.tld',
+			'To: recipient@domain.com',
+			'Message-ID: ' . $messageId,
+			'Subject: server auto-save test',
+			'',
+			'Body text',
+		]);
+
+		// Simulate what an Exchange-style server does: save to Sent before the client does
+		$this->saveMimeMessage('Sent', $rawMessage);
+		$this->assertMessageCount(1, 'Sent');
+
+		$this->message->setRaw($rawMessage);
+
+		/** @var IMAPClientFactory $clientFactory */
+		$clientFactory = Server::get(IMAPClientFactory::class);
+		$client = $clientFactory->getClient($this->account);
+		/** @var CopySentMessageHandler $handler */
+		$handler = Server::get(CopySentMessageHandler::class);
+		$handler->process($this->account, $this->message, $client);
+
+		$this->assertMessageCount(1, 'Sent');
+	}
+
 	public function testSaveNewDraft() {
 		$message = NewMessageData::fromRequest($this->account, 'greetings', 'hello there', 'recipient@domain.com', null, null, [], false);
 		[,,$uid] = $this->transmission->saveDraft($message);

--- a/tests/Integration/Service/MailTransmissionIntegrationTest.php
+++ b/tests/Integration/Service/MailTransmissionIntegrationTest.php
@@ -42,6 +42,7 @@ use OCA\Mail\Support\PerformanceLogger;
 use OCA\Mail\Tests\Integration\Framework\ImapTest;
 use OCA\Mail\Tests\Integration\TestCase;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
 use OCP\IUser;
 use OCP\Security\ICrypto;
 use OCP\Server;
@@ -254,6 +255,9 @@ class MailTransmissionIntegrationTest extends TestCase {
 			'Body text',
 		]);
 
+		// Enable the opt-in feature flag
+		Server::get(IConfig::class)->setAppValue('mail', 'smtp_saves_sent', 'true');
+
 		// Simulate what an Exchange-style server does: save to Sent before the client does
 		$this->saveMimeMessage('Sent', $rawMessage);
 		$this->assertMessageCount(1, 'Sent');
@@ -266,6 +270,8 @@ class MailTransmissionIntegrationTest extends TestCase {
 		/** @var CopySentMessageHandler $handler */
 		$handler = Server::get(CopySentMessageHandler::class);
 		$handler->process($this->account, $this->message, $client);
+
+		Server::get(IConfig::class)->deleteAppValue('mail', 'smtp_saves_sent');
 
 		$this->assertMessageCount(1, 'Sent');
 	}

--- a/tests/Unit/Send/CopySendMessageHandlerTest.php
+++ b/tests/Unit/Send/CopySendMessageHandlerTest.php
@@ -208,6 +208,79 @@ class CopySendMessageHandlerTest extends TestCase {
 		$this->handler->process($account, $mock, $client);
 	}
 
+	public function testProcessSkipsAppendWhenServerAlreadySaved(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setSentMailboxId(1);
+		$mailAccount->setUserId('bob');
+		$account = new Account($mailAccount);
+		$localMessage = $this->getMockBuilder(LocalMessage::class);
+		$localMessage->addMethods(['getStatus', 'setStatus', 'getRaw']);
+		$mock = $localMessage->getMock();
+		$mailbox = new Mailbox();
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$rawWithMessageId = "Message-ID: <abc@example.com>\r\nSubject: Test\r\n\r\nBody";
+
+		$mock->expects(self::once())
+			->method('getStatus')
+			->willReturn(LocalMessage::STATUS_RAW);
+		$mock->expects(self::once())
+			->method('getRaw')
+			->willReturn($rawWithMessageId);
+		$this->mailboxMapper->expects(self::once())
+			->method('findById')
+			->willReturn($mailbox);
+		$this->messageMapper->expects(self::once())
+			->method('existsInMailboxByMessageId')
+			->with($client, $mailbox, '<abc@example.com>')
+			->willReturn(true);
+		$this->messageMapper->expects(self::never())
+			->method('save');
+		$mock->expects(self::once())
+			->method('setStatus')
+			->with(LocalMessage::STATUS_PROCESSED);
+		$this->flagRepliedMessageHandler->expects(self::once())
+			->method('process');
+
+		$this->handler->process($account, $mock, $client);
+	}
+
+	public function testProcessFallsBackToAppendWhenSearchFails(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setSentMailboxId(1);
+		$mailAccount->setUserId('bob');
+		$account = new Account($mailAccount);
+		$localMessage = $this->getMockBuilder(LocalMessage::class);
+		$localMessage->addMethods(['getStatus', 'setStatus', 'getRaw']);
+		$mock = $localMessage->getMock();
+		$mailbox = new Mailbox();
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$rawWithMessageId = "Message-ID: <xyz@example.com>\r\nSubject: Test\r\n\r\nBody";
+
+		$mock->expects(self::once())
+			->method('getStatus')
+			->willReturn(LocalMessage::STATUS_RAW);
+		$mock->expects(self::once())
+			->method('getRaw')
+			->willReturn($rawWithMessageId);
+		$this->mailboxMapper->expects(self::once())
+			->method('findById')
+			->willReturn($mailbox);
+		$this->messageMapper->expects(self::once())
+			->method('existsInMailboxByMessageId')
+			->willThrowException(new Horde_Imap_Client_Exception());
+		$this->loggerInterface->expects(self::once())
+			->method('warning');
+		$this->messageMapper->expects(self::once())
+			->method('save');
+		$mock->expects(self::once())
+			->method('setStatus')
+			->with(LocalMessage::STATUS_PROCESSED);
+		$this->flagRepliedMessageHandler->expects(self::once())
+			->method('process');
+
+		$this->handler->process($account, $mock, $client);
+	}
+
 	public function testProcessNoRawMessage(): void {
 		$mailAccount = new MailAccount();
 		$mailAccount->setSentMailboxId(1);

--- a/tests/Unit/Send/CopySendMessageHandlerTest.php
+++ b/tests/Unit/Send/CopySendMessageHandlerTest.php
@@ -19,6 +19,7 @@ use OCA\Mail\IMAP\MessageMapper;
 use OCA\Mail\Send\CopySentMessageHandler;
 use OCA\Mail\Send\FlagRepliedMessageHandler;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -27,6 +28,7 @@ class CopySendMessageHandlerTest extends TestCase {
 	private LoggerInterface|MockObject $loggerInterface;
 	private MockObject|MessageMapper $messageMapper;
 	private MockObject|FlagRepliedMessageHandler $flagRepliedMessageHandler;
+	private IConfig|MockObject $config;
 	private CopySentMessageHandler $handler;
 
 	protected function setUp(): void {
@@ -35,10 +37,13 @@ class CopySendMessageHandlerTest extends TestCase {
 		$this->loggerInterface = $this->createMock(LoggerInterface::class);
 		$this->messageMapper = $this->createMock(MessageMapper::class);
 		$this->flagRepliedMessageHandler = $this->createMock(FlagRepliedMessageHandler::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->config->method('getAppValue')->willReturn('false');
 		$this->handler = new CopySentMessageHandler(
 			$this->mailboxMapper,
 			$this->loggerInterface,
 			$this->messageMapper,
+			$this->config,
 		);
 		$this->handler->setNext($this->flagRepliedMessageHandler);
 	}
@@ -220,6 +225,8 @@ class CopySendMessageHandlerTest extends TestCase {
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);
 		$rawWithMessageId = "Message-ID: <abc@example.com>\r\nSubject: Test\r\n\r\nBody";
 
+		$this->config->method('getAppValue')->willReturn('true');
+
 		$mock->expects(self::once())
 			->method('getStatus')
 			->willReturn(LocalMessage::STATUS_RAW);
@@ -255,6 +262,8 @@ class CopySendMessageHandlerTest extends TestCase {
 		$mailbox = new Mailbox();
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);
 		$rawWithMessageId = "Message-ID: <xyz@example.com>\r\nSubject: Test\r\n\r\nBody";
+
+		$this->config->method('getAppValue')->willReturn('true');
 
 		$mock->expects(self::once())
 			->method('getStatus')


### PR DESCRIPTION
Some mail servers (e.g. Microsoft Exchange/Office 365) automatically save a copy of sent messages to the Sent folder upon SMTP submission. When Nextcloud Mail also does an IMAP APPEND, the user ends up with duplicates.

After SMTP delivery succeeds, search the Sent mailbox for the outgoing message's Message-ID header. If the server already saved it, skip the APPEND. If the IMAP search fails for any reason, fall through and APPEND as normal (safe degradation).

The check is an overhead for the vast majority of setups so this is an opt-in feature. Admin docs at https://github.com/nextcloud/documentation/pull/15015.

AI-assisted: Claude Code (claude-sonnet-4-6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate saves to the Sent folder when the mail server has already stored the sent message (handler now skips redundant appends).

* **Tests**
  * Added unit and integration tests to verify skipping behavior and proper fallback when mailbox existence checks fail.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nextcloud/mail/pull/12932)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->