### PR TITLE
feat: add notifications for account delegation

### DIFF
--- a/lib/Controller/DelegationController.php
+++ b/lib/Controller/DelegationController.php
@@ -86,7 +86,7 @@ class DelegationController extends Controller {
 		}
 
 		try {
-			$delegation = $this->delegationService->delegate($accountId, $userId);
+			$delegation = $this->delegationService->delegate($account, $userId, $this->currentUserId);
 		} catch (DelegationExistsException) {
 			return new JSONResponse(['message' => 'Delegation already exists'], Http::STATUS_CONFLICT);
 		}
@@ -111,7 +111,7 @@ class DelegationController extends Controller {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
-		$this->delegationService->unDelegate($accountId, $userId);
+		$this->delegationService->unDelegate($account, $userId, $this->currentUserId);
 		return new JSONResponse([], Http::STATUS_OK);
 	}
 }

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -72,8 +72,60 @@ class Notifier implements INotifier {
 						]
 					]);
 				break;
+			case 'account_delegation':
+				$notification->setIcon($this->url->getAbsoluteURL(
+					$this->url->linkTo('mail', 'img/delegation.svg')
+				));
+				$parameters = $notification->getSubjectParameters();
+				$messageParameters = $notification->getMessageParameters();
+				$delegated = $messageParameters['delegated'];
+				if ($delegated) {
+					$notification->setRichSubject($l->t('{account_email} has been delegated to you'), [
+						'account_email' => [
+							'type' => 'highlight',
+							'id' => (string)$parameters['id'],
+							'name' => $parameters['account_email']
+						]
+					]);
+					$notification->setRichMessage($l->t('{user} delegated {account} to you'),
+						[
+							'user' => [
+								'type' => 'user',
+								'id' => $messageParameters['current_user_id'],
+								'name' => $messageParameters['current_user_display_name'],
+							],
+							'account' => [
+								'type' => 'highlight',
+								'id' => (string)$messageParameters['id'],
+								'name' => $messageParameters['account_email']
+							]
+						]);
+				} else {
+					$notification->setRichSubject($l->t('{account_email} is no longer delegated to you'), [
+						'account_email' => [
+							'type' => 'highlight',
+							'id' => (string)$parameters['id'],
+							'name' => $parameters['account_email']
+						]
+					]);
+					$notification->setRichMessage($l->t('{user} revoked delagation for {account}'),
+						[
+							'user' => [
+								'type' => 'user',
+								'id' => $messageParameters['current_user_id'],
+								'name' => $messageParameters['current_user_display_name'],
+							],
+							'account' => [
+								'type' => 'highlight',
+								'id' => (string)$messageParameters['id'],
+								'name' => $messageParameters['account_email']
+							]
+						]);
+				}
+
+				break;
 			default:
-				throw  new UnknownNotificationException();
+				throw new UnknownNotificationException();
 		}
 
 		return $notification;

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -108,7 +108,7 @@ class Notifier implements INotifier {
 							'name' => $parameters['account_email']
 						]
 					]);
-					$notification->setRichMessage($l->t('{user} revoked delagation for {account}'),
+					$notification->setRichMessage($l->t('{user} revoked delegation for {account}'),
 						[
 							'user' => [
 								'type' => 'user',

--- a/lib/Service/DelegationService.php
+++ b/lib/Service/DelegationService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service;
 
+use OCA\Mail\Account;
 use OCA\Mail\Db\AliasMapper;
 use OCA\Mail\Db\Delegation;
 use OCA\Mail\Db\DelegationMapper;
@@ -18,6 +19,9 @@ use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\DelegationExistsException;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IUserManager;
+use OCP\Notification\IManager;
 
 class DelegationService {
 
@@ -28,10 +32,14 @@ class DelegationService {
 		private MessageMapper $messageMapper,
 		private AliasMapper $aliasMapper,
 		private LocalMessageMapper $localMessageMapper,
+		private IUserManager $userManager,
+		private IManager $notificationManager,
+		private ITimeFactory $time,
 	) {
 	}
 
-	public function delegate(int $accountId, string $userId): Delegation {
+	public function delegate(Account $account, string $userId, string $currentUserId): Delegation {
+		$accountId = $account->getId();
 		try {
 			$this->delegationMapper->find($accountId, $userId);
 			throw new DelegationExistsException("Delegation already exists for account $accountId and user $userId");
@@ -42,17 +50,21 @@ class DelegationService {
 		$delegation = new Delegation();
 		$delegation->setAccountId($accountId);
 		$delegation->setUserId($userId);
-		return $this->delegationMapper->insert($delegation);
+		$result = $this->delegationMapper->insert($delegation);
+		$this->notify($userId, $currentUserId, $account, true);
+		return $result;
 	}
 
 	public function findDelegatedToUsersForAccount(int $accountId): array {
 		return $this->delegationMapper->findDelegatedToUsers($accountId);
 	}
 
-	public function unDelegate(int $accountId, string $userId): void {
+	public function unDelegate(Account $account, string $userId, string $currentUserId): void {
 		try {
+			$accountId = $account->getId();
 			$delegation = $this->delegationMapper->find($accountId, $userId);
 			$this->delegationMapper->delete($delegation);
+			$this->notify($userId, $currentUserId, $account, false);
 		} catch (DoesNotExistException $e) {
 			// shouldn't end up here
 			// delegation not found nothing to undelegate
@@ -111,5 +123,38 @@ class DelegationService {
 	public function resolveLocalMessageUserId(int $localMessageId, string $currentUserId): string {
 		$accountId = $this->localMessageMapper->findAccountIdForLocalMessage($localMessageId);
 		return $this->resolveAccountUserId($accountId, $currentUserId);
+	}
+
+	/**
+	 * Send a notification on delegation
+	 * @param string $userId The user the account is being delegated to
+	 * @param string $currentUserId Current user
+	 * @param Account $account The delegated account
+	 * @param bool $delegated true for delegate|false for undelegate
+	 * @return void
+	 */
+	private function notify(string $userId, string $currentUserId, Account $account, bool $delegated) {
+		$notification = $this->notificationManager->createNotification();
+		$displayName = $this->userManager->getExistingUser($currentUserId)->getDisplayName();
+		$time = $this->time->getDateTime('now');
+		$notification
+			->setApp('mail')
+			->setUser($userId)
+			->setObject('delegation', (string)$account->getId())
+			->setSubject('account_delegation', [
+				'id' => $account->getId(),
+				'account_email' => $account->getEmail(),
+
+			])
+			->setDateTime($time)
+			->setMessage('account_delegation_changed', [
+				'id' => $account->getId(),
+				'delegated' => $delegated,
+				'current_user_id' => $currentUserId,
+				'current_user_display_name' => $displayName,
+				'account_email' => $account->getEmail(),
+			]
+			);
+		$this->notificationManager->notify($notification);
 	}
 }

--- a/lib/Service/DelegationService.php
+++ b/lib/Service/DelegationService.php
@@ -22,6 +22,8 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
+use OCP\Notification\IncompleteNotificationException;
+use Psr\Log\LoggerInterface;
 
 class DelegationService {
 
@@ -35,6 +37,7 @@ class DelegationService {
 		private IUserManager $userManager,
 		private IManager $notificationManager,
 		private ITimeFactory $time,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -135,7 +138,7 @@ class DelegationService {
 	 */
 	private function notify(string $userId, string $currentUserId, Account $account, bool $delegated) {
 		$notification = $this->notificationManager->createNotification();
-		$displayName = $this->userManager->getExistingUser($currentUserId)->getDisplayName();
+		$displayName = $this->userManager->get($currentUserId)?->getDisplayName() ?? $currentUserId;
 		$time = $this->time->getDateTime('now');
 		$notification
 			->setApp('mail')
@@ -155,6 +158,11 @@ class DelegationService {
 				'account_email' => $account->getEmail(),
 			]
 			);
-		$this->notificationManager->notify($notification);
+
+		try {
+			$this->notificationManager->notify($notification);
+		} catch (IncompleteNotificationException $e) {
+			$this->logger->warning('Failed to send delegation notification to {userId}', ['userId' => $userId,'exception' => $e]);
+		}
 	}
 }

--- a/tests/Unit/Controller/DelegationControllerTest.php
+++ b/tests/Unit/Controller/DelegationControllerTest.php
@@ -122,7 +122,7 @@ class DelegationControllerTest extends TestCase {
 
 		$this->delegationService->expects($this->once())
 			->method('delegate')
-			->with(1, 'delegatee')
+			->with($this->ownAccount, 'delegatee', $this->currentUserId)
 			->willReturn($delegation);
 
 		$response = $this->controller->delegate(1, 'delegatee');
@@ -217,7 +217,7 @@ class DelegationControllerTest extends TestCase {
 
 		$this->delegationService->expects($this->once())
 			->method('delegate')
-			->with(1, 'delegatee')
+			->with($this->ownAccount, 'delegatee', $this->currentUserId)
 			->willThrowException(new DelegationExistsException('Delegation already exists'));
 
 		$response = $this->controller->delegate(1, 'delegatee');
@@ -235,7 +235,7 @@ class DelegationControllerTest extends TestCase {
 
 		$this->delegationService->expects($this->once())
 			->method('unDelegate')
-			->with(1, 'delegatee');
+			->with($this->ownAccount, 'delegatee', $this->currentUserId);
 
 		$response = $this->controller->unDelegate(1, 'delegatee');
 

--- a/tests/Unit/Notification/NotifierTest.php
+++ b/tests/Unit/Notification/NotifierTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Notification;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Notification\Notifier;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
+use OCP\Notification\INotification;
+use OCP\Notification\UnknownNotificationException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class NotifierTest extends TestCase {
+	private IFactory&MockObject $factory;
+	private IURLGenerator&MockObject $url;
+	private IL10N&MockObject $l10n;
+	private Notifier $notifier;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->factory = $this->createMock(IFactory::class);
+		$this->url = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->method('t')->willReturnArgument(0);
+		$this->factory->method('get')->willReturn($this->l10n);
+
+		$this->notifier = new Notifier($this->factory, $this->url);
+	}
+
+	public function testGetID(): void {
+		$this->assertEquals('mail', $this->notifier->getID());
+	}
+
+	public function testGetName(): void {
+		$this->assertEquals('Mail', $this->notifier->getName());
+	}
+
+	public function testPrepareForeignAppThrows(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('other');
+
+		$this->expectException(UnknownNotificationException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testPrepareUnknownSubjectThrows(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('mail');
+		$notification->method('getSubject')->willReturn('something_unknown');
+
+		$this->expectException(UnknownNotificationException::class);
+
+		$this->notifier->prepare($notification, 'en');
+	}
+
+	public function testPrepareAccountDelegationDelegated(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('mail');
+		$notification->method('getSubject')->willReturn('account_delegation');
+		$notification->method('getSubjectParameters')->willReturn([
+			'id' => 1,
+			'account_email' => 'owner@example.com',
+		]);
+		$notification->method('getMessageParameters')->willReturn([
+			'id' => 1,
+			'delegated' => true,
+			'current_user_id' => 'owner',
+			'current_user_display_name' => 'Owner User',
+			'account_email' => 'owner@example.com',
+		]);
+
+		$this->url->method('linkTo')->with('mail', 'img/delegation.svg')->willReturn('/apps/mail/img/delegation.svg');
+		$this->url->method('getAbsoluteURL')->with('/apps/mail/img/delegation.svg')->willReturn('https://example.com/apps/mail/img/delegation.svg');
+
+		$notification->expects($this->once())
+			->method('setIcon')
+			->with('https://example.com/apps/mail/img/delegation.svg')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichSubject')
+			->with(
+				'{account_email} has been delegated to you',
+				[
+					'account_email' => [
+						'type' => 'highlight',
+						'id' => '1',
+						'name' => 'owner@example.com',
+					],
+				]
+			)
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichMessage')
+			->with(
+				'{user} delegated {account} to you',
+				[
+					'user' => [
+						'type' => 'user',
+						'id' => 'owner',
+						'name' => 'Owner User',
+					],
+					'account' => [
+						'type' => 'highlight',
+						'id' => '1',
+						'name' => 'owner@example.com',
+					],
+				]
+			)
+			->willReturnSelf();
+
+		$result = $this->notifier->prepare($notification, 'en');
+
+		$this->assertSame($notification, $result);
+	}
+
+	public function testPrepareAccountDelegationRevoked(): void {
+		$notification = $this->createMock(INotification::class);
+		$notification->method('getApp')->willReturn('mail');
+		$notification->method('getSubject')->willReturn('account_delegation');
+		$notification->method('getSubjectParameters')->willReturn([
+			'id' => 1,
+			'account_email' => 'owner@example.com',
+		]);
+		$notification->method('getMessageParameters')->willReturn([
+			'id' => 1,
+			'delegated' => false,
+			'current_user_id' => 'owner',
+			'current_user_display_name' => 'Owner User',
+			'account_email' => 'owner@example.com',
+		]);
+
+		$this->url->method('linkTo')->with('mail', 'img/delegation.svg')->willReturn('/apps/mail/img/delegation.svg');
+		$this->url->method('getAbsoluteURL')->with('/apps/mail/img/delegation.svg')->willReturn('https://example.com/apps/mail/img/delegation.svg');
+
+		$notification->expects($this->once())
+			->method('setIcon')
+			->with('https://example.com/apps/mail/img/delegation.svg')
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichSubject')
+			->with(
+				'{account_email} is no longer delegated to you',
+				[
+					'account_email' => [
+						'type' => 'highlight',
+						'id' => '1',
+						'name' => 'owner@example.com',
+					],
+				]
+			)
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setRichMessage')
+			->with(
+				'{user} revoked delegation for {account}',
+				[
+					'user' => [
+						'type' => 'user',
+						'id' => 'owner',
+						'name' => 'Owner User',
+					],
+					'account' => [
+						'type' => 'highlight',
+						'id' => '1',
+						'name' => 'owner@example.com',
+					],
+				]
+			)
+			->willReturnSelf();
+
+		$result = $this->notifier->prepare($notification, 'en');
+
+		$this->assertSame($notification, $result);
+	}
+}

--- a/tests/Unit/Service/DelegationServiceTest.php
+++ b/tests/Unit/Service/DelegationServiceTest.php
@@ -24,7 +24,6 @@ use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\DelegationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager;
@@ -41,7 +40,6 @@ class DelegationServiceTest extends TestCase {
 	private IUserManager&MockObject $userManager;
 	private IManager&MockObject $notificationManager;
 	private ITimeFactory&MockObject $timeFactory;
-	private IEventDispatcher&MockObject $eventDispatcher;
 	private DelegationService $service;
 
 	private Account $account;
@@ -58,7 +56,6 @@ class DelegationServiceTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->service = new DelegationService(
 			$this->delegationMapper,
@@ -67,6 +64,9 @@ class DelegationServiceTest extends TestCase {
 			$this->messageMapper,
 			$this->aliasMapper,
 			$this->localMessageMapper,
+			$this->userManager,
+			$this->notificationManager,
+			$this->timeFactory,
 		);
 
 		$mailAccount = new MailAccount();
@@ -76,7 +76,7 @@ class DelegationServiceTest extends TestCase {
 		$this->account = new Account($mailAccount);
 	}
 
-	private function mockNotification(): void {
+	private function mockNotification(): INotification&MockObject {
 		$notification = $this->createMock(INotification::class);
 		$notification->method('setApp')->willReturnSelf();
 		$notification->method('setUser')->willReturnSelf();
@@ -89,8 +89,10 @@ class DelegationServiceTest extends TestCase {
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getDisplayName')->willReturn('Owner User');
-		$this->userManager->method('get')->with('owner')->willReturn($user);
+		$this->userManager->method('getExistingUser')->with('owner')->willReturn($user);
 		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime());
+
+		return $notification;
 	}
 
 	public function testDelegateSuccess(): void {
@@ -112,7 +114,7 @@ class DelegationServiceTest extends TestCase {
 				return $d;
 			});
 
-		$result = $this->service->delegate($this->account->getId(), 'delegatee');
+		$result = $this->service->delegate($this->account, 'delegatee', 'owner');
 
 		$this->assertEquals(1, $result->getAccountId());
 		$this->assertEquals('delegatee', $result->getUserId());
@@ -133,7 +135,7 @@ class DelegationServiceTest extends TestCase {
 
 		$this->expectException(DelegationExistsException::class);
 
-		$this->service->delegate($this->account->getId(), 'delegatee');
+		$this->service->delegate($this->account, 'delegatee', 'owner');
 	}
 
 	public function testFindDelegatedToUsersForAccount(): void {
@@ -169,10 +171,12 @@ class DelegationServiceTest extends TestCase {
 			->method('delete')
 			->with($delegation);
 
-		$this->service->unDelegate($this->account->getId(), 'delegatee');
+		$this->service->unDelegate($this->account, 'delegatee', 'owner');
 	}
 
 	public function testUnDelegateWhenNotFound(): void {
+		$this->mockNotification();
+
 		$this->delegationMapper->expects($this->once())
 			->method('find')
 			->with(1, 'delegatee')
@@ -181,7 +185,7 @@ class DelegationServiceTest extends TestCase {
 		$this->delegationMapper->expects($this->never())
 			->method('delete');
 
-		$this->service->unDelegate($this->account->getId(), 'delegatee');
+		$this->service->unDelegate($this->account, 'delegatee', 'owner');
 	}
 
 	public function testResolveAccountUserIdOwner(): void {
@@ -309,5 +313,84 @@ class DelegationServiceTest extends TestCase {
 		$result = $this->service->resolveLocalMessageUserId(55, 'owner');
 
 		$this->assertEquals('owner', $result);
+	}
+
+	public function testDelegateSendsNotification(): void {
+		$notification = $this->mockNotification();
+		$now = new \DateTime();
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getDateTime')->willReturn($now);
+
+		$this->delegationMapper->method('find')
+			->willThrowException(new DoesNotExistException('Not found'));
+		$this->delegationMapper->method('insert')
+			->willReturnCallback(function (Delegation $d) {
+				$d->setId(10);
+				return $d;
+			});
+
+		$notification->expects($this->once())->method('setApp')->with('mail')->willReturnSelf();
+		$notification->expects($this->once())->method('setUser')->with('delegatee')->willReturnSelf();
+		$notification->expects($this->once())->method('setObject')->with('delegation', '1')->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setSubject')
+			->with('account_delegation', [
+				'id' => 1,
+				'account_email' => 'owner@example.com',
+			])
+			->willReturnSelf();
+		$notification->expects($this->once())->method('setDateTime')->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('account_delegation_changed', [
+				'id' => 1,
+				'delegated' => true,
+				'current_user_id' => 'owner',
+				'current_user_display_name' => 'Owner User',
+				'account_email' => 'owner@example.com',
+			])
+			->willReturnSelf();
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->service->delegate($this->account, 'delegatee', 'owner');
+	}
+
+	public function testUnDelegateSendsRevokedNotification(): void {
+		$notification = $this->mockNotification();
+
+		$delegation = new Delegation();
+		$delegation->setId(10);
+		$delegation->setAccountId(1);
+		$delegation->setUserId('delegatee');
+
+		$this->delegationMapper->method('find')->willReturn($delegation);
+
+		$notification->expects($this->once())->method('setApp')->with('mail')->willReturnSelf();
+		$notification->expects($this->once())->method('setUser')->with('delegatee')->willReturnSelf();
+		$notification->expects($this->once())->method('setObject')->with('delegation', '1')->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setSubject')
+			->with('account_delegation', [
+				'id' => 1,
+				'account_email' => 'owner@example.com',
+			])
+			->willReturnSelf();
+		$notification->expects($this->once())
+			->method('setMessage')
+			->with('account_delegation_changed', [
+				'id' => 1,
+				'delegated' => false,
+				'current_user_id' => 'owner',
+				'current_user_display_name' => 'Owner User',
+				'account_email' => 'owner@example.com',
+			])
+			->willReturnSelf();
+		$this->notificationManager->expects($this->once())
+			->method('notify')
+			->with($notification);
+
+		$this->service->unDelegate($this->account, 'delegatee', 'owner');
 	}
 }

--- a/tests/Unit/Service/DelegationServiceTest.php
+++ b/tests/Unit/Service/DelegationServiceTest.php
@@ -29,6 +29,7 @@ use OCP\IUserManager;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class DelegationServiceTest extends TestCase {
 	private DelegationMapper&MockObject $delegationMapper;
@@ -40,6 +41,7 @@ class DelegationServiceTest extends TestCase {
 	private IUserManager&MockObject $userManager;
 	private IManager&MockObject $notificationManager;
 	private ITimeFactory&MockObject $timeFactory;
+	private LoggerInterface&MockObject $logger;
 	private DelegationService $service;
 
 	private Account $account;
@@ -56,6 +58,7 @@ class DelegationServiceTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->service = new DelegationService(
 			$this->delegationMapper,
@@ -67,6 +70,7 @@ class DelegationServiceTest extends TestCase {
 			$this->userManager,
 			$this->notificationManager,
 			$this->timeFactory,
+			$this->logger,
 		);
 
 		$mailAccount = new MailAccount();
@@ -89,7 +93,7 @@ class DelegationServiceTest extends TestCase {
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getDisplayName')->willReturn('Owner User');
-		$this->userManager->method('getExistingUser')->with('owner')->willReturn($user);
+		$this->userManager->method('get')->with('owner')->willReturn($user);
 		$this->timeFactory->method('getDateTime')->willReturn(new \DateTime());
 
 		return $notification;


### PR DESCRIPTION
Part of https://github.com/nextcloud/mail/issues/12403
<img width="344" height="357" alt="image" src="https://github.com/user-attachments/assets/0a1e707f-950e-4ae4-b12c-a0472205b770" />
Unit tests Ai-assisted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account delegation now sends notifications to delegated users when they receive or lose delegation access to an account, including details about the delegating user and affected account.

* **Tests**
  * Added comprehensive test coverage for account delegation notifications, including notifier behavior and notification delivery for both delegation and revocation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nextcloud/mail/pull/12935)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->