### PR TITLE
fix(package): exclude dev config and patch files from release tarball

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -11,6 +11,7 @@ codecov.yml
 /coverage
 /.editorconfig
 /.eslintrc.js
+/eslint.config.mjs
 .git
 .git-blame-ignore-revs
 .gitattributes
@@ -45,3 +46,9 @@ codecov.yml
 /webpack.*
 /vitest.config.*
 /patches
+/.patches
+/patches.json
+/patches.lock.json
+/playwright.config.js
+/stylelint.config.js
+/tsconfig.json


### PR DESCRIPTION
eslint.config.mjs (flat config), stylelint.config.js, playwright.config.js, tsconfig.json, .patches/, patches.json, and patches.lock.json were all missing from .nextcloudignore and ended up in the v5.8.0 release tarball.

Assisted-by: Claude:claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated synchronization configuration to exclude additional development and configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nextcloud/mail/pull/12955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->