### PR TITLE
fix(ui): add NcModal name prop to SmimeCertificateModal for accessibi…

### DIFF
--- a/src/components/smime/SmimeCertificateModal.vue
+++ b/src/components/smime/SmimeCertificateModal.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcModal @close="$emit('close')">
+	<NcModal :name="showImportScreen ? t('mail', 'Import S/MIME certificate') : t('mail', 'S/MIME certificates')" @close="$emit('close')">
 		<div class="certificate-modal">
 			<div v-if="!showImportScreen" class="certificate-modal__list">
 				<h2>{{ t('mail', 'S/MIME certificates') }}</h2>


### PR DESCRIPTION
…lity

Fixes

```
[Vue warn]: [NcModal] You need either set the name or set a `labelId` for accessibility.

found in

---> <NcModal>
       <SmimeCertificateModal> at src/components/smime/SmimeCertificateModal.vue
         <NcFormGroup>
           <NcAppSettingsSection>... (1 recursive calls)
             <NcModal>
               <NcDialog>
                 <NcAppSettingsDialog>
                   <AppSettingsMenu> at src/components/AppSettingsMenu.vue
                     <NcAppNavigation>
                       <Navigation> at src/components/Navigation.vue
                         <NcContent>
                           <Home> at src/views/Home.vue
                             <App> at src/App.vue
                               <Root>
```

NcModal requires either `name` or `labelId` so screen readers can announce the dialog. Use a dynamic value matching the two h2 headings already rendered in the list and import views.

## How to test

1. Open the app
2. Open app settings
3. Open *Manage S/MIME certificates*

Assisted-by: Claude:claude-sonnet-4-6