### PR TITLE
fix: disable CSRF check for message-id deeplinks

### DIFF
--- a/lib/Controller/DeepLinkController.php
+++ b/lib/Controller/DeepLinkController.php
@@ -14,6 +14,7 @@ use OCA\Mail\Db\MailAccountMapper;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Service\AccountService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -40,6 +41,7 @@ class DeepLinkController extends Controller {
 	 * @param string $messageId
 	 * @return RedirectResponse
 	 */
+	#[NoCSRFRequired]
 	public function open(string $messageId): RedirectResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {


### PR DESCRIPTION
## Description
This PR fixes a CSRF error that occurs when accessing a message-id deeplink directly via the browser's address bar or via external apps. This feature was recently introduced in #12632 .

Since the route is accessed via a standard, stateless `GET` request from outside the Vue frontend, no CSRF token header is present. Adding the `#[NoCSRFRequired]` attribute to the `DeepLinkController::open` method allows the stateless redirect to work as intended.

## Related Issue
Follow-up fix for #12632.

## How to test
1. Log into Nextcloud.
2. Open a new tab and paste a valid deeplink directly into the URL bar, e.g.: `https://<your-nc>/apps/mail/open/<valid-message-id>`
3. Without this PR: Nextcloud throws a CSRF error.
4. With this PR: The request is processed, and you are correctly redirected to the expected email message.
