### PR TITLE
fix(ui): sub-mailbox drops blocked by parent cascade

### DIFF
--- a/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
+++ b/src/directives/drag-and-drop/droppable-mailbox/droppable-mailbox.js
@@ -83,7 +83,7 @@ export class DroppableMailbox {
 	}
 
 	onDragOver(event) {
-		if (!this.isCurrentlyDragging) {
+		if (!this.isCurrentlyDragging || !this.canBeDropped()) {
 			return
 		}
 
@@ -102,7 +102,7 @@ export class DroppableMailbox {
 	}
 
 	onDragLeave(event) {
-		if (!this.isCurrentlyDragging) {
+		if (!this.isCurrentlyDragging || !this.canBeDropped()) {
 			return
 		}
 
@@ -111,7 +111,7 @@ export class DroppableMailbox {
 	}
 
 	async onDrop(event) {
-		if (!this.isCurrentlyDragging) {
+		if (!this.isCurrentlyDragging || !this.canBeDropped()) {
 			return
 		}
 

--- a/src/directives/drag-and-drop/styles/droppable-mailbox.scss
+++ b/src/directives/drag-and-drop/styles/droppable-mailbox.scss
@@ -41,8 +41,10 @@
 }
 
 [droppable-mailbox="disabled"] {
-	pointer-events: none;
-	opacity: .3;
+	> div > a {
+		pointer-events: none;
+		opacity: .3;
+	}
 }
 
 [droppable-mailbox="dragover"] {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/12951

Two bugs in the droppable-mailbox directive:

1. [droppable-mailbox="disabled"] applied pointer-events:none and opacity:.3 to the whole element, cascading into sub-mailboxes rendered in the slot and making them unreachable as drop targets.

2. With pointer-events:none unscoped, drag events reached the wrapper div of disabled mailboxes; onDragLeave unconditionally called setStatus('enabled'), visually re-enabling them mid-drag.

Scope the disabled styling to > div > a (matching the dragover state) and add canBeDropped() guards to onDragOver/onDragLeave/onDrop.

Partly introduced by https://github.com/nextcloud/mail/pull/12650. cc @cdvv7788

## How to test

1. Create a mailbox structure mb1 > mb1.1 > mb1.1.1 (parent - child - grand child)
2. Move an email into mb1
3. Open mb1
4. Try to drag and drop that email into mb1.1 or mb1.1.1

main: they are disabled
here: they are enabled

Assisted-by: Claude:claude-sonnet-4-6