### PR TITLE
fix(ui): use v-model for assistance setting switches

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -203,7 +203,7 @@
 				<NcAppSettingsSection v-if="followUpFeatureAvailable" id="autotagging-settings" :name="t('mail', 'Assistance features')">
 					<NcFormBox>
 						<NcFormBoxSwitch
-							:checked="useFollowUpReminders"
+							v-model="useFollowUpReminders"
 							:disabled="loadingFollowUpReminders">
 							{{ followUpReminderText }}
 						</NcFormBoxSwitch>
@@ -212,9 +212,8 @@
 				<NcAppSettingsSection v-if="contextChatFeatureAvailable" id="context-chat-settings" :name="t('mail', 'Context Chat integration')">
 					<NcFormBox>
 						<NcFormBoxSwitch
-							:checked="useContextChat"
-							:disabled="loadingContextChat"
-							@update:modelValue="onToggleContextChat">
+							v-model="useContextChat"
+							:disabled="loadingContextChat">
 							{{ contextChatText }}
 						</NcFormBoxSwitch>
 					</NcFormBox>


### PR DESCRIPTION
:checked is not a prop on NcFormBoxSwitch (it expects modelValue), so both the follow-up reminders and context chat switches always appeared off and unresponsive. Switch to v-model which wires the existing computed setters correctly.

Issue started at 544820926 with defunct :checked attribute and fully broke with d43846f3f.

Assisted-by: Claude:claude-sonnet-4-6