### PR TITLE
fix(api): validate targetPath is an existing folder on saveAttachment

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -821,6 +821,12 @@ class MessagesController extends Controller {
 		if ($this->userFolder === null) {
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
+		if (!$this->userFolder->nodeExists($targetPath)) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
+		if (!($this->userFolder->get($targetPath) instanceof Folder)) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		}
 		try {
 			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -375,10 +375,15 @@ class MessagesControllerTest extends TestCase {
 			->method('getName')
 			->with()
 			->will($this->returnValue('cat.jpg'));
+		$folderNode = $this->createMock(Folder::class);
 		$this->userFolder->expects($this->once())
+			->method('get')
+			->with('Downloads')
+			->willReturn($folderNode);
+		$this->userFolder->expects($this->exactly(2))
 			->method('nodeExists')
-			->with('Downloads/cat.jpg')
-			->will($this->returnValue(false));
+			->withConsecutive(['Downloads'], ['Downloads/cat.jpg'])
+			->willReturnOnConsecutiveCalls(true, false);
 		$file = $this->getMockBuilder('\OCP\Files\File')
 			->disableOriginalConstructor()
 			->getMock();
@@ -438,10 +443,15 @@ class MessagesControllerTest extends TestCase {
 			->method('getName')
 			->with()
 			->will($this->returnValue('cat.jpg'));
+		$folderNode = $this->createMock(Folder::class);
 		$this->userFolder->expects($this->once())
+			->method('get')
+			->with('Downloads')
+			->willReturn($folderNode);
+		$this->userFolder->expects($this->exactly(2))
 			->method('nodeExists')
-			->with('Downloads/cat.jpg')
-			->will($this->returnValue(false));
+			->withConsecutive(['Downloads'], ['Downloads/cat.jpg'])
+			->willReturnOnConsecutiveCalls(true, false);
 		$file = $this->getMockBuilder('\OCP\Files\File')
 			->disableOriginalConstructor()
 			->getMock();
@@ -464,6 +474,35 @@ class MessagesControllerTest extends TestCase {
 		);
 
 		$this->assertEquals($expected, $response);
+	}
+
+	public function testSaveAttachmentTargetPathNotFound(): void {
+		$this->userFolder->expects($this->once())
+			->method('nodeExists')
+			->with('NoSuchFolder')
+			->willReturn(false);
+
+		$response = $this->controller->saveAttachment(123, '1', 'NoSuchFolder');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testSaveAttachmentTargetPathIsFile(): void {
+		$fileNode = $this->getMockBuilder('\OCP\Files\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userFolder->expects($this->once())
+			->method('nodeExists')
+			->with('some/file.txt')
+			->willReturn(true);
+		$this->userFolder->expects($this->once())
+			->method('get')
+			->with('some/file.txt')
+			->willReturn($fileNode);
+
+		$response = $this->controller->saveAttachment(123, '1', 'some/file.txt');
+
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 
 	public function testDownloadAttachments() {


### PR DESCRIPTION
This mirrors the frontend mime filter on the backend.