### PR TITLE
fix(ui): prevent type error during shortkey usage

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -374,6 +374,7 @@ export default {
 				logger.debug('envelope is not in the list, ignoring shortcut', {
 					srcKey: e.srcKey,
 				})
+				return
 			}
 
 			switch (e.srcKey) {


### PR DESCRIPTION
The shortkey event can fire multiple times. We have to ignore the ones that are not relevant (as the debug log says) and actually return.

## How to test

1. Open the app
2. Open an email
3. Press <kbd>u</kbd>

main:
```
[ERROR] mail: could not mark envelope as seen/unseen via shortkey 
Object { app: "mail", uid: "admin", level: 0, env: undefined, error: TypeError }
​
app: "mail"
​
env: undefined
​
error: TypeError: can't access property "flags", envelope is undefined
​
level: 0
​
uid: "admin"
​
<prototype>: Object { … }
```

and an error toast.

here: no error :sunglasses: 