### PR TITLE
feat(editor): preserve arbitrary font sizes and families in content

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -248,6 +248,22 @@ export default {
 					],
 				},
 
+				// Preserve arbitrary font sizes/families on inserted or pasted
+				// HTML (e.g. app-generated signatures). Without supportAllValues
+				// the Font plugins drop any value not in their preset list, so
+				// raw-HTML signatures lose font-size/font-family on send.
+				// NOTE: supportAllValues is incompatible with the default *named*
+				// presets ('tiny'/'big'/…) — it requires numeric options, or
+				// CKEditor throws at init and the editor fails to mount.
+				fontSize: {
+					options: [9, 10, 11, 12, 13, 14, 16, 18, 24, 'default'],
+					supportAllValues: true,
+				},
+
+				fontFamily: {
+					supportAllValues: true,
+				},
+
 			},
 		}
 	},


### PR DESCRIPTION
### Problem — custom HTML signatures don't work

Setting a **custom HTML signature** (a branded block with specific fonts and
sizes — e.g. a 13pt name, 11pt role/phone, 9pt address, a logo and links) is a
common, reasonable requirement. Today it's effectively **impossible to do
faithfully through Mail**: the signature is stored correctly, looks correct in
account settings, but **loses its typography the moment it passes through the
composer**, and reaches recipients with the wrong size and font.

Concretely, given a signature span like:

`<span style="color:#3c3c3b;font-family:Arial,Helvetica,sans-serif;font-size:13pt">…</span>`

the recipient receives:

`<span style="color:#3c3c3b">…</span>`  ← font-size and font-family gone.

`color` survives; `font-size` and `font-family` are dropped. There is no way to
work around it from the signature HTML — the loss happens inside the editor.

### Root cause

The composer's CKEditor `FontSize` / `FontFamily` plugins run with their
default presets and `supportAllValues` disabled. When signature/pasted HTML is
inserted into the editor, any `font-size` or `font-family` that isn't one of
the built-in presets is stripped during the model round-trip. (`color` is kept
because `FontColor` accepts all values by default — which is exactly the
behaviour size/family should have too.)

### Fix

Enable `supportAllValues: true` on both Font plugins so inline `font-size` and
`font-family` survive:

```js
fontSize: {
    options: [9, 10, 11, 12, 13, 14, 16, 18, 24, 'default'],
    supportAllValues: true,
},
fontFamily: {
    supportAllValues: true,
},