### PR TITLE
[codex] fix SMTP sender validation for digit-leading domains

### DIFF
--- a/lib/SMTP/LenientSmtphordeTransport.php
+++ b/lib/SMTP/LenientSmtphordeTransport.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\SMTP;
+
+use Horde_Mail_Exception;
+use Horde_Mail_Rfc822;
+use Horde_Mail_Transport_Smtphorde;
+
+class LenientSmtphordeTransport extends Horde_Mail_Transport_Smtphorde {
+	/**
+	 * Work around Horde's overly strict domain validation for envelope senders.
+	 *
+	 * @throws Horde_Mail_Exception
+	 */
+	public function prepareHeaders(array $headers) {
+		$from = null;
+		$lines = [];
+		$raw = $headers['_raw'] ?? null;
+
+		foreach ($headers as $key => $value) {
+			if (strcasecmp($key, 'From') === 0) {
+				$parser = new Horde_Mail_Rfc822();
+				$addresses = $parser->parseAddressList($value, [
+					'validate' => false,
+				]);
+				$from = $addresses[0]->bare_address;
+
+				if (strstr($from, ' ')) {
+					return false;
+				}
+
+				$lines[] = $key . ': ' . $this->_normalizeEOL($value);
+			} elseif (!$raw && (strcasecmp($key, 'Received') === 0)) {
+				$received = [];
+				if (!is_array($value)) {
+					$value = [$value];
+				}
+
+				foreach ($value as $line) {
+					$received[] = $key . ': ' . $this->_normalizeEOL($line);
+				}
+
+				$lines = array_merge($received, $lines);
+			} elseif (!$raw) {
+				if (is_array($value)) {
+					$value = implode(', ', $value);
+				}
+				$lines[] = $key . ': ' . $this->_normalizeEOL($value);
+			}
+		}
+
+		return [$from, $raw ?: implode($this->sep, $lines)];
+	}
+}

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -11,7 +11,6 @@ namespace OCA\Mail\SMTP;
 
 use Exception;
 use Horde_Mail_Transport;
-use Horde_Mail_Transport_Smtphorde;
 use Horde_Smtp_Password_Xoauth2;
 use OCA\Mail\Account;
 use OCA\Mail\Exception\ServiceException;
@@ -86,6 +85,6 @@ class SmtpClientFactory {
 			$fn = "mail-{$account->getUserId()}-{$account->getId()}-smtp.log";
 			$params['debug'] = $this->config->getSystemValue('datadirectory') . '/' . $fn;
 		}
-		return new Horde_Mail_Transport_Smtphorde($params);
+		return new LenientSmtphordeTransport($params);
 	}
 }

--- a/tests/Unit/SMTP/LenientSmtphordeTransportTest.php
+++ b/tests/Unit/SMTP/LenientSmtphordeTransportTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Smtp;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\SMTP\LenientSmtphordeTransport;
+
+class LenientSmtphordeTransportTest extends TestCase {
+	public function testPrepareHeadersAllowsDomainsStartingWithDigit(): void {
+		$transport = new LenientSmtphordeTransport();
+
+		[$from, $headers] = $transport->prepareHeaders([
+			'From' => 'Test User <user@180grad-kiel.de>',
+			'Subject' => 'Regression test',
+		]);
+
+		$this->assertSame('user@180grad-kiel.de', $from);
+		$this->assertStringContainsString('From: Test User <user@180grad-kiel.de>', $headers);
+	}
+}

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -13,6 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Mail_Transport_Smtphorde;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
+use OCA\Mail\SMTP\LenientSmtphordeTransport;
 use OCA\Mail\SMTP\SmtpClientFactory;
 use OCA\Mail\Support\HostNameFactory;
 use OCP\IConfig;
@@ -70,7 +71,7 @@ class SmtpClientFactoryTest extends TestCase {
 		$this->hostNameFactory->expects($this->once())
 			->method('getHostName')
 			->willReturn('cloud.example.com');
-		$expected = new Horde_Mail_Transport_Smtphorde([
+		$expected = new LenientSmtphordeTransport([
 			'host' => 'smtp.domain.tld',
 			'password' => 'pass123',
 			'port' => 25,


### PR DESCRIPTION
## Summary

- route SMTP sends through a small `LenientSmtphordeTransport` wrapper
- disable Horde's strict `From` header validation for sender addresses so domains like `180grad-kiel.de` are accepted
- add a regression test for digit-leading domains and update the SMTP factory test to cover the new transport

## Why

`Horde_Mail_Transport::prepareHeaders()` uses `Horde_Mail_Rfc822` with `validate => true` for the `From` header. That rejects valid domains whose labels start with digits, which breaks message sending for addresses like `user@180grad-kiel.de` even though RFC 1123 permits them.

This keeps the workaround local to the SMTP transport used by Mail instead of patching vendor code in place.

## Validation

- Added a unit regression test for `From: Test User <user@180grad-kiel.de>`
- Ran `git diff --check`
- Could not run PHPUnit locally in this environment because `php` is not installed

Closes #12992
