### PR TITLE
fix(smtp): handle non ascii sender names

### DIFF
--- a/.patches/horde-mail-rfc822-isAtext-empty-zero.patch
+++ b/.patches/horde-mail-rfc822-isAtext-empty-zero.patch
@@ -1,0 +1,11 @@
+--- a/lib/Horde/Mail/Rfc822.php
++++ b/lib/Horde/Mail/Rfc822.php
+@@ -802,7 +802,7 @@
+             return strcspn($chr, $validate);
+         }
+
+-        $ord = empty($chr) ? 0 : ord($chr);
++        $ord = ($chr === '' || $chr === false) ? 0 : ord($chr);
+
+         /* UTF-8 characters check. */
+         if ($ord > 127) {

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -180,6 +180,12 @@ SPDX-FileCopyrightText = "angrychimp, Teon d.o.o. - Bostjan Skufca, Marcus Boint
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
+path = [".patches/horde-mail-rfc822-isAtext-empty-zero.patch"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nextcloud GmbH and Nextcloud contributors"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
 path = [".patches/url-normalizer-fix-deprecation-warning-on-PHP-8.5.patch"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2013 Glen Scott"

--- a/patches.json
+++ b/patches.json
@@ -19,6 +19,13 @@
 					"upstream-fix-url": "https://github.com/PHPMailer/DKIMValidator/pull/21"
 				}
 			}
+		],
+		"bytestream/horde-mail": [
+			{
+				"description": "Fix _rfc822IsAtext treating digit 0 as empty due to PHP empty() quirk",
+				"url": ".patches/horde-mail-rfc822-isAtext-empty-zero.patch",
+				"sha256": "b864ec2b2ba71b37a44c05e69934ec9f95269b8f1cc1ef8352a294e02ae3eb71"
+			}
 		]
 	}
 }

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,5 +1,5 @@
 {
-    "_hash": "e3297c923adcdbd735cc8da9765e21e3f6bcb9f669ed228d8954814d910fc127",
+    "_hash": "6053b3121d6c1645269ff3498cce80b35864f85ff75b039cc6c5889e28706293",
     "patches": {
         "glenscott/url-normalizer": [
             {
@@ -23,6 +23,18 @@
                 "depth": 1,
                 "extra": {
                     "upstream-fix-url": "https://github.com/PHPMailer/DKIMValidator/pull/21",
+                    "provenance": "patches-file:patches.json"
+                }
+            }
+        ],
+        "bytestream/horde-mail": [
+            {
+                "package": "bytestream/horde-mail",
+                "description": "Fix _rfc822IsAtext treating digit 0 as empty due to PHP empty() quirk",
+                "url": ".patches/horde-mail-rfc822-isAtext-empty-zero.patch",
+                "sha256": "b864ec2b2ba71b37a44c05e69934ec9f95269b8f1cc1ef8352a294e02ae3eb71",
+                "depth": 1,
+                "extra": {
                     "provenance": "patches-file:patches.json"
                 }
             }


### PR DESCRIPTION
This is a hotfix. I will submit this upstream too.

Fixes https://github.com/nextcloud/mail/issues/12965
Fixes https://github.com/nextcloud/mail/issues/12985

## How to test

* Set your account name to `Christophé`
* Send an email

main: sending fails
here: sending works

Regression of https://github.com/bytestream/Mail/commit/5054666fe1a43f86a85e911111c115a133d80334.

Demo: https://3v4l.org/k9sJM