### PR TITLE
fix: shortcuts

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -387,7 +387,7 @@ export default {
 						next = envelopes[idx - 1]
 					}
 
-					if (!next) {
+					if (!next || next.databaseId === currentId) {
 						logger.debug('ignoring shortcut: head or tail of envelope list reached', {
 							envelopes,
 							idx,
@@ -407,6 +407,7 @@ export default {
 						},
 					})
 					break
+				case 'backspace':
 				case 'del':
 					if (!this.hasDeleteAcl()) {
 						return
@@ -482,6 +483,10 @@ export default {
 					break
 				case 'unseen':
 					logger.debug('marking as seen/unseen via shortcut')
+
+					if (!env.flags) {
+						break
+					}
 
 					if (!this.hasSeenAcl()) {
 						showWarning(t('mail', 'Your IMAP server does not support storing the seen/unseen state.'))

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -371,7 +371,7 @@ export default {
 			const idx = envelopes.indexOf(env)
 			let next
 
-			if (e.srcKey !== 'refresh' && !env) {
+			if (!env) {
 				logger.debug('envelope is not in the list, ignoring shortcut', {
 					srcKey: e.srcKey,
 				})
@@ -475,11 +475,6 @@ export default {
 						env,
 						error,
 					}))
-					break
-				case 'refresh':
-					logger.debug(`syncing folder ${this.mailbox.databaseId} (${this.searchQuery}) per shortcut`)
-					this.sync(false)
-
 					break
 				case 'unseen':
 					logger.debug('marking as seen/unseen via shortcut')

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -373,7 +373,7 @@ export default {
 			const idx = envelopes.indexOf(env)
 			let next
 
-			if (e.srcKey !== 'refresh' && !env) {
+			if (!env) {
 				logger.debug('envelope is not in the list, ignoring shortcut', {
 					srcKey: e.srcKey,
 				})
@@ -482,11 +482,6 @@ export default {
 						env,
 						error,
 					}))
-					break
-				case 'refresh':
-					logger.debug(`syncing folder ${this.mailbox.databaseId} (${this.searchQuery}) per shortcut`)
-					this.sync(false)
-
 					break
 				case 'unseen':
 					logger.debug('marking as seen/unseen via shortcut')

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -389,7 +389,7 @@ export default {
 						next = envelopes[idx - 1]
 					}
 
-					if (!next) {
+					if (!next || next.databaseId === currentId) {
 						logger.debug('ignoring shortcut: head or tail of envelope list reached', {
 							envelopes,
 							idx,
@@ -409,6 +409,7 @@ export default {
 						},
 					})
 					break
+				case 'backspace':
 				case 'del':
 					if (!this.hasDeleteAcl()) {
 						return
@@ -489,6 +490,10 @@ export default {
 					break
 				case 'unseen':
 					logger.debug('marking as seen/unseen via shortcut')
+
+					if (!env.flags) {
+						break
+					}
 
 					if (!this.hasSeenAcl()) {
 						showWarning(t('mail', 'Your IMAP server does not support storing the seen/unseen state.'))

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -220,6 +220,7 @@ import {
 	UNIFIED_INBOX_ID,
 } from '../store/constants.js'
 import useMainStore from '../store/mainStore.js'
+import eventBus from '../util/eventBus.js'
 import { groupEnvelopesByDate } from '../util/groupedEnvelopes.js'
 import {
 	priorityImportantQuery,
@@ -519,6 +520,11 @@ export default {
 				this.mainStore.startComposerSession({
 					isBlankMessage: true,
 				})
+				return
+			}
+			// Refresh through NewMessageButtonHeader so its spinner animates
+			if (e.srcKey === 'refresh') {
+				eventBus.emit('mail:refresh')
 				return
 			}
 			this.bus.emit('shortcut', e)

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -278,6 +278,7 @@ export default {
 				prev: ['arrowleft'],
 				refresh: ['r'],
 				unseen: ['u'],
+				compose: ['c'],
 			},
 
 			priorityImportantQuery,
@@ -513,6 +514,13 @@ export default {
 		},
 
 		onShortcut(e) {
+			// Handled here because the bus fans out to multiple Mailbox instances
+			if (e.srcKey === 'compose') {
+				this.mainStore.startComposerSession({
+					isBlankMessage: true,
+				})
+				return
+			}
 			this.bus.emit('shortcut', e)
 		},
 

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -14,6 +14,7 @@
 			<div :class="{ list__wrapper: !showThread || !isMobile }">
 				<div v-if="!showThread || !isMobile" class="sticky-header">
 					<SearchMessages
+						ref="searchMessages"
 						:mailbox="mailbox"
 						:account-id="account.accountId"
 						@search-changed="onUpdateSearchQuery" />
@@ -270,6 +271,7 @@ export default {
 			searchQuery: undefined,
 			shortkeys: {
 				del: ['del'],
+				backspace: ['backspace'],
 				arch: ['a'],
 				flag: ['s'],
 				next: ['arrowright'],
@@ -461,6 +463,7 @@ export default {
 
 	created() {
 		this.handleMailto()
+		document.addEventListener('keydown', this.handleSearchShortcut, true)
 	},
 
 	async mounted() {
@@ -475,6 +478,7 @@ export default {
 
 	beforeUnmount() {
 		clearTimeout(this.startMailboxTimer)
+		document.removeEventListener('keydown', this.handleSearchShortcut, true)
 	},
 
 	methods: {
@@ -510,6 +514,16 @@ export default {
 
 		onShortcut(e) {
 			this.bus.emit('shortcut', e)
+		},
+
+		handleSearchShortcut(event) {
+			if (event.target instanceof Element && event.target.matches('input, textarea, [contenteditable]')) {
+				return
+			}
+			if (event.key === 'f' && (event.metaKey || event.ctrlKey) && this.$refs.searchMessages) {
+				event.preventDefault()
+				this.$refs.searchMessages.focusInput()
+			}
 		},
 
 		appendToSearch(str) {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -14,6 +14,7 @@
 			<div :class="{ list__wrapper: !showThread || !isMobile }">
 				<div v-if="!showThread || !isMobile" class="sticky-header">
 					<SearchMessages
+						ref="searchMessages"
 						:mailbox="mailbox"
 						:account-id="account.accountId"
 						@search-changed="onUpdateSearchQuery" />
@@ -270,6 +271,7 @@ export default {
 			searchQuery: undefined,
 			shortkeys: {
 				del: ['del'],
+				backspace: ['backspace'],
 				arch: ['a'],
 				flag: ['s'],
 				next: ['arrowright'],
@@ -461,6 +463,7 @@ export default {
 
 	created() {
 		this.handleMailto()
+		document.addEventListener('keydown', this.handleSearchShortcut, true)
 	},
 
 	async mounted() {
@@ -475,6 +478,7 @@ export default {
 
 	beforeDestroy() {
 		clearTimeout(this.startMailboxTimer)
+		document.removeEventListener('keydown', this.handleSearchShortcut, true)
 	},
 
 	methods: {
@@ -510,6 +514,16 @@ export default {
 
 		onShortcut(e) {
 			this.bus.emit('shortcut', e)
+		},
+
+		handleSearchShortcut(event) {
+			if (event.target instanceof Element && event.target.matches('input, textarea, [contenteditable]')) {
+				return
+			}
+			if (event.key === 'f' && (event.metaKey || event.ctrlKey) && this.$refs.searchMessages) {
+				event.preventDefault()
+				this.$refs.searchMessages.focusInput()
+			}
 		},
 
 		appendToSearch(str) {

--- a/src/components/NewMessageButtonHeader.vue
+++ b/src/components/NewMessageButtonHeader.vue
@@ -42,6 +42,7 @@ import IconAdd from 'vue-material-design-icons/Plus.vue'
 import IconRefresh from 'vue-material-design-icons/Refresh.vue'
 import logger from '../logger.js'
 import useMainStore from '../store/mainStore.js'
+import eventBus from '../util/eventBus.js'
 
 export default {
 	name: 'NewMessageButtonHeader',
@@ -78,8 +79,21 @@ export default {
 		},
 	},
 
+	mounted() {
+		if (this.showRefresh) {
+			eventBus.on('mail:refresh', this.refreshMailbox)
+		}
+	},
+
+	beforeUnmount() {
+		eventBus.off('mail:refresh', this.refreshMailbox)
+	},
+
 	methods: {
 		async refreshMailbox() {
+			if (!this.currentMailbox) {
+				return
+			}
 			if (this.refreshing === true) {
 				logger.debug('already sync\'ing mailbox.. aborting')
 				return

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -6,6 +6,7 @@
 	<div class="search-messages">
 		<div class="search-messages__input">
 			<input
+				ref="searchInput"
 				v-model="query"
 				type="text"
 				class="search-messages--input"
@@ -492,6 +493,10 @@ export default {
 	},
 
 	methods: {
+		focusInput() {
+			this.$refs.searchInput.focus()
+		},
+
 		hideButtonsWithDelay(delay = false) {
 			if (delay) {
 				setTimeout(() => {

--- a/src/util/eventBus.js
+++ b/src/util/eventBus.js
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import mitt from 'mitt'
+const eventBus = mitt()
+export default eventBus


### PR DESCRIPTION
fix #12976
*  ⌫ is backspace on macos 
* Fixed broken unseen/seen toggle
* handle multiple mailboxes on next/prev 
* re-enabled search focus 

Needs testing on linux and/or windows to avoid regressions 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backspace key now triggers deletion alongside the Delete key.
  * Cmd+F/Meta+F keyboard shortcut now focuses the search input for improved search workflow.

* **Improvements**
  * Refined keyboard navigation to prevent unnecessary routing when selection cannot advance to a different message.
  * Enhanced robustness of seen/unseen toggle with added validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->