### PR TITLE
fix(EnvelopeList): remove multiple select bars and fix drag and drop

### DIFF
--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -116,7 +116,29 @@
 			</div>
 		</transition>
 
-		<transition-group :name="listTransitionName">
+		<template v-if="sections">
+			<div v-for="[label, group] in sections" :key="label">
+				<SectionTitle class="section-title" :name="label" />
+				<transition-group :name="listTransitionName">
+					<Envelope
+						v-for="env in group"
+						:key="env.databaseId"
+						:data="env"
+						:mailbox="mailbox"
+						:selected="selection.includes(env.databaseId)"
+						:select-mode="selectMode"
+						:has-multiple-accounts="hasMultipleAccounts"
+						:selected-envelopes="selectedEnvelopes"
+						:compact-mode="compactMode"
+						@delete="$emit('delete', env.databaseId)"
+						@update:selected="onEnvelopeSelectToggle(env, envelopeSortedIndexMap.get(env.databaseId), $event)"
+						@select-multiple="onEnvelopeSelectMultiple(env, envelopeSortedIndexMap.get(env.databaseId))"
+						@open:quick-actions-settings="showQuickActionsSettings = true" />
+				</transition-group>
+			</div>
+		</template>
+
+		<transition-group v-else :name="listTransitionName">
 			<Envelope
 				v-for="(env, index) in sortedEnvelops"
 				:key="env.databaseId"
@@ -185,6 +207,7 @@ import IconDelete from 'vue-material-design-icons/TrashCanOutline.vue'
 import Settings from '../components/quickActions/Settings.vue'
 import Envelope from './Envelope.vue'
 import MoveModal from './MoveModal.vue'
+import SectionTitle from './SectionTitle.vue'
 import TagModal from './TagModal.vue'
 import dragEventBus from '../directives/drag-and-drop/util/dragEventBus.js'
 import { matchError } from '../errors/match.js'
@@ -212,6 +235,7 @@ export default {
 		IconSelect,
 		MoveModal,
 		OpenInNewIcon,
+		SectionTitle,
 		ShareIcon,
 		AlertOctagonIcon,
 		TagIcon,
@@ -237,7 +261,14 @@ export default {
 
 		envelopes: {
 			type: Array,
-			required: true,
+			required: false,
+			default: () => [],
+		},
+
+		sections: {
+			type: Array,
+			required: false,
+			default: null,
 		},
 
 		searchQuery: {
@@ -286,12 +317,23 @@ export default {
 		},
 
 		sortedEnvelops() {
+			if (this.sections) {
+				return this.sections.flatMap(([, group]) => group)
+			}
 			if (this.sortOrder === 'oldest') {
 				return [...this.envelopes].sort((a, b) => {
 					return a.dateInt < b.dateInt ? -1 : 1
 				})
 			}
 			return [...this.envelopes]
+		},
+
+		envelopeSortedIndexMap() {
+			const map = new Map()
+			this.sortedEnvelops.forEach((env, index) => {
+				map.set(env.databaseId, index)
+			})
+			return map
 		},
 
 		selectMode() {

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -18,18 +18,15 @@
 		<EmptyMailboxSection v-else-if="isPriorityInbox && !hasMessages" key="empty" />
 		<EmptyMailbox v-else-if="!hasMessages" key="empty" />
 		<template v-else-if="hasGroupedEnvelopes && !isPriorityInbox">
-			<div v-for="[label, group] in groupEnvelopes" :key="label">
-				<SectionTitle class="section-title" :name="getLabelForGroup(label)" />
-				<EnvelopeList
-					:account="account"
-					:mailbox="mailbox"
-					:search-query="searchQuery"
-					:envelopes="group"
-					:loading-more="false"
-					:load-more-button="false"
-					:skip-transition="skipListTransition"
-					@delete="onDelete" />
-			</div>
+			<EnvelopeList
+				:account="account"
+				:mailbox="mailbox"
+				:search-query="searchQuery"
+				:sections="translatedSections"
+				:loading-more="false"
+				:load-more-button="false"
+				:skip-transition="skipListTransition"
+				@delete="onDelete" />
 		</template>
 		<EnvelopeList
 			v-else
@@ -56,7 +53,6 @@ import EnvelopeList from './EnvelopeList.vue'
 import Error from './Error.vue'
 import Loading from './Loading.vue'
 import LoadingSkeleton from './LoadingSkeleton.vue'
-import SectionTitle from './SectionTitle.vue'
 import MailboxLockedError from '../errors/MailboxLockedError.js'
 import MailboxNotCachedError from '../errors/MailboxNotCachedError.js'
 import { matchError } from '../errors/match.js'
@@ -76,7 +72,6 @@ export default {
 		Error,
 		Loading,
 		LoadingSkeleton,
-		SectionTitle,
 	},
 
 	props: {
@@ -174,6 +169,10 @@ export default {
 
 		showLoadMore() {
 			return !this.endReached && this.paginate === 'manual'
+		},
+
+		translatedSections() {
+			return this.groupEnvelopes.map(([label, group]) => [this.getLabelForGroup(label), group])
 		},
 	},
 


### PR DESCRIPTION
Fixes:
- Different sections in the envelope list (like today, yesterday, last week) having separate multiselect action bars
- Dragging and dropping multiselected envelopes would only move one of the emails and not all of them