### PR TITLE
fix(ui): restore isSubscribed getter on mailbox update

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -1956,6 +1956,11 @@ export default function mainStoreActions() {
 		updateMailboxMutation({ mailbox }) {
 			const account = this.accountsUnmapped[mailbox.accountId]
 			transformMailboxName(account, mailbox)
+			Object.defineProperty(mailbox, 'isSubscribed', {
+				get() {
+					return this.attributes?.includes('\\subscribed') ?? false
+				},
+			})
 			Vue.set(this.mailboxes, mailbox.databaseId, mailbox)
 		},
 		removeMailboxMutation({ id }) {


### PR DESCRIPTION
updateMailboxMutation replaced the mailbox object with the server response, losing the Object.defineProperty getter for isSubscribed (originally added in addMailboxToState). Without the getter, isSubscribed became undefined after any patch, causing NcActionCheckbox to re-emit update:checked and trigger an unintended subscription change.

## How to test

* Open the app
* Open the actions menu of a mailbox
* Check *Sync in background*

main: *Subscribed* gets unselected after a few seconds
here: *Subscribed* state remains

Assisted-by: Claude:claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced mailbox subscription status tracking. The system now properly identifies and tracks which mailboxes have subscription markers, improving mailbox organization and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->