### PR TITLE
fix: reply to own message addresses original recipient

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -522,8 +522,13 @@ export default function mainStoreActions() {
 
 					if (reply.mode === 'reply') {
 						logger.debug('Show simple reply composer', { reply })
+						const account = this.getAccount(reply.data.accountId)
 						let to = original.replyTo !== undefined ? original.replyTo : reply.data.from
-						if (reply.followUp) {
+						// Replying to a message we sent ourselves: follow up with the
+						// original recipient(s) instead of addressing ourselves.
+						const isOwnMessage = to.length > 0
+							&& to.every((addr) => addr.email === account.emailAddress)
+						if (reply.followUp || isOwnMessage) {
 							to = reply.data.to
 						}
 						this.startComposerSessionMutation({


### PR DESCRIPTION
related to #12707

Detect self-sent messages and follow up with the original recipient(s), mirroring the existing follow-up behaviour.

PS: not sure if this is the expected behaviour, fixed it as I would expect it to work. open for discussion 

Assisted-by: Claude:claude-opus-4-8