### PR TITLE
chore(lint): Reduce linting time with PHP 8.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,12 @@
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
-		"lint": "find . -name \\*.php -not -path './vendor*/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n1 php -l",
+		"lint": [
+			"@lint-8.2-or-earlier",
+			"@lint-8.3-or-later"
+		],
+		"lint-8.2-or-earlier": "[ $(php -r \"echo PHP_VERSION_ID;\") -ge 80300 ] || find . -type f -name '*.php' -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n1 -P$(nproc) php -l",
+		"lint-8.3-or-later": "[ $(php -r \"echo PHP_VERSION_ID;\") -lt 80300 ] || find . -type f -name '*.php' -not -path './vendor/*' -not -path './vendor-bin/*' -not -path './tests/stubs/*' -print0 | xargs -0 -n200 -P$(nproc) php -l",
 		"psalm": "psalm.phar",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType",
 		"post-install-cmd": [


### PR DESCRIPTION
Reduces the actual linting time from ~30s to ~0s

Before | After
---|---
https://github.com/nextcloud/mail/actions/runs/27022844986/job/79755116865 | https://github.com/nextcloud/mail/actions/runs/27062713787/job/79878194191?pr=13032
<img width="465" height="458" alt="grafik" src="https://github.com/user-attachments/assets/648691c1-cd7f-41d6-89bf-7c134c7346e5" /> | <img width="477" height="441" alt="grafik" src="https://github.com/user-attachments/assets/22cf8a2f-da65-48c1-912a-0915cd6e109d" />
