### PR TITLE
Change order of sans-serif and Noto Color Emoji

### DIFF
--- a/css/html-response.css
+++ b/css/html-response.css
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 * {
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, 'Noto Color Emoji', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', Arial, sans-serif, 'Noto Color Emoji', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 html {


### PR DESCRIPTION
If Noto Color Emoji is installed, but none of the preceding fonts are, the UI for plaintext emails gets pretty messed up with super-wide spaces as the emoji font takes precedence. The rest of NC has sans-serif placed ahead of the Noto emoji font for this reason.
