### PR TITLE
ci: bump mariadb from 11.4 to 11.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
                   - 993:993
                   - 4190:4190
           mariadb-service:
-              image: ghcr.io/nextcloud/continuous-integration-mariadb-11.4:latest
+              image: ghcr.io/nextcloud/continuous-integration-mariadb-11.8:latest
               env:
                   MARIADB_ROOT_PASSWORD: my-secret-pw
                   MARIADB_DATABASE: nextcloud


### PR DESCRIPTION
11.8 is recommended: https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html#server

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
