### PR TITLE
fix(frontend): log swallowed errors in catch blocks

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -810,6 +810,7 @@ export default {
 				// Handle rate limit: 429 Too Many Requests
 				// Ref https://axios-http.com/docs/handling_errors
 				if (error.response?.status === 429) {
+					logger.error('mailbox repair rate-limited', { error })
 					showError(t('mail', 'Please wait 10 minutes before repairing again'))
 				} else {
 					throw error

--- a/src/components/RecipientBubble.vue
+++ b/src/components/RecipientBubble.vue
@@ -229,6 +229,7 @@ export default {
 				await navigator.clipboard.writeText(this.email)
 				showSuccess(t('mail', 'Copied email address to clipboard'))
 			} catch (e) {
+				logger.error('could not copy email address to clipboard', { error: e })
 				showError(t('mail', 'Could not copy email address to clipboard'))
 			}
 		},

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -1141,6 +1141,7 @@ export default {
 				}
 				this.showTranslationModal = true
 			} catch (error) {
+				logger.error('could not open translation modal, message not loaded', { error })
 				showError(t('mail', 'Please wait for the message to load'))
 			}
 		},

--- a/src/components/TranslationModal.vue
+++ b/src/components/TranslationModal.vue
@@ -188,6 +188,7 @@ export default {
 				await navigator.clipboard.writeText(this.translatedMessage)
 				showSuccess(t('mail', 'Translation copied to clipboard'))
 			} catch (error) {
+				logger.error('could not copy translation to clipboard', { error })
 				showError(t('mail', 'Translation could not be copied'))
 			}
 		},

--- a/src/components/textBlocks/ListItem.vue
+++ b/src/components/textBlocks/ListItem.vue
@@ -209,7 +209,8 @@ export default {
 		async deleteTextBlock() {
 			await this.mainStore.deleteTextBlock({ id: this.textBlock.id }).then(() => {
 				showSuccess(t('mail', 'Text block deleted'))
-			}).catch(() => {
+			}).catch((error) => {
+				logger.error('failed to delete text block', { error })
 				showError(t('mail', 'Failed to delete text block'))
 			})
 		},
@@ -222,6 +223,7 @@ export default {
 				showSuccess(t('mail', 'Text block shared with {sharee}', { sharee: sharee.shareWith }))
 				this.share = null
 			} catch (error) {
+				logger.error('failed to share text block', { error })
 				showError(t('mail', 'Failed to share text block with {sharee}', { sharee: sharee.shareWith }))
 			}
 		},
@@ -232,6 +234,7 @@ export default {
 				this.shares = this.shares.filter((share) => share.shareWith !== sharee.shareWith)
 				showSuccess(t('mail', 'Share deleted for {name}', { name: sharee.shareWith }))
 			} catch (error) {
+				logger.error('failed to delete text block share', { error })
 				showError(t('mail', 'Failed to delete share with {name}', { name: sharee.shareWith }))
 			}
 		},


### PR DESCRIPTION
Add logger.error() calls to catch blocks that previously only showed a user-facing notification without logging the caught error, making these failures invisible to prod debugging.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
