### PR TITLE
fix(tests): externalize CJS deps in vitest config

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,5 +15,10 @@ export default defineConfig({
 		environment: 'jsdom',
 		// Required for transforming CSS files
 		pool: 'vmForks',
+		server: {
+			deps: {
+				external: ['https-proxy-agent', 'agent-base'],
+			},
+		},
 	},
 })


### PR DESCRIPTION
https-proxy-agent and agent-base (CJS-only, pulled in by axios 1.17.0) interfere with module mocking in vitest v4's vmForks pool, causing vi.mock() to silently fail on MailboxService/MessageService.

Assisted-by: Claude:claude-opus-4-7



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
