### PR TITLE
ci: pin front-end unit tests to ubuntu-24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,7 +208,7 @@ jobs:
               fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
               verbose: true
   frontend-unit-test:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-24.04
       name: Front-end unit tests
       steps:
           - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
vitest v4 with vmForks fails to apply vi.mock() reliably on the org's self-hosted runners (deterministic 11/261 failures in actions.spec.js and MessageService.spec.js). The same setup passes on GitHub-hosted runners. Pin ubuntu-24.04 to force the job onto the GitHub-hosted pool until the underlying runner issue is fixed.

Assisted-by: Claude:claude-opus-4-7



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
