### PR TITLE
feat(ui): add password change shortcut to server settings

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -108,6 +108,7 @@
 		<AppSettingsSection
 			v-if="account && !account.provisioningId && !account.isDelegated"
 			id="mail-server"
+			ref="mail-server"
 			:name="t('mail', 'Mail server')">
 			<div id="mail-settings">
 				<AccountForm
@@ -195,6 +196,11 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+
+		scrollToSection: {
+			type: String,
+			default: undefined,
+		},
 	},
 
 	data() {
@@ -226,6 +232,15 @@ export default {
 					accountId: this.account.id,
 				})
 			}
+		},
+
+		scrollToSection(newState) {
+			this.$nextTick(() => {
+				this.$refs[newState]?.$el?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'start',
+				})
+			})
 		},
 	},
 

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -33,8 +33,11 @@
 					<IconAlertTriangle
 						:size="18"
 						:title="t('mail', 'This account cannot connect')" />
-					<span>
+					<span @click="showAccountSettings(group.account.id, 'mail-server')">
 						{{ t('mail', 'Connection failed. Please verify your information and try again') }}
+						<NcButton
+							:aria-label="t('mail', 'Change password')"
+							variant="tertiary">{{ t('mail', 'Change password') }}</NcButton>
 					</span>
 				</div>
 				<template v-else-if="!isDisabled(group.account)">
@@ -83,7 +86,7 @@
 </template>
 
 <script>
-import { NcAppNavigation as AppNavigation, NcAppNavigationItem as AppNavigationItem } from '@nextcloud/vue'
+import { NcAppNavigation as AppNavigation, NcAppNavigationItem as AppNavigationItem, NcButton } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
 import IconAlertTriangle from 'vue-material-design-icons/AlertOutline.vue'
 import IconSetting from 'vue-material-design-icons/CogOutline.vue'
@@ -106,6 +109,7 @@ export default {
 		NavigationAccountExpandCollapse,
 		NavigationMailbox,
 		NavigationOutbox,
+		NcButton,
 		NewMessageButtonHeader,
 		IconSetting,
 		AppNavigationItem,
@@ -163,6 +167,10 @@ export default {
 	methods: {
 		showMailSettings() {
 			this.showSettings = true
+		},
+
+		showAccountSettings(accountId, section) {
+			this.mainStore.showSettingsForAccountMutation(accountId, section)
 		},
 
 		isCollapsed(account, mailbox) {

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -96,7 +96,11 @@
 				</template>
 			</template>
 		</NcAppNavigationCaption>
-		<AccountSettings :open="showSettings" :account="account" @update:open="showAccountSettings($event)" />
+		<AccountSettings
+			:open="showSettings"
+			:account="account"
+			:scroll-to-section="showSettingsSection"
+			@update:open="showAccountSettings($event)" />
 		<DelegationModal v-if="showDelegationModal" :account="account" @close="showDelegationModal = false" />
 	</Fragment>
 </template>
@@ -191,6 +195,10 @@ export default {
 		...mapStores(useMainStore),
 		showSettings() {
 			return this.mainStore.showSettingsForAccount(this.account.id)
+		},
+
+		showSettingsSection() {
+			return this.mainStore.showSettingsSectionForAccount(this.account.id)
 		},
 
 		visible() {

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -2357,8 +2357,11 @@ export default function mainStoreActions() {
 		hasCurrentUserPrincipalAndCollectionsMutation(hasCurrentUserPrincipalAndCollections) {
 			this.hasCurrentUserPrincipalAndCollections = hasCurrentUserPrincipalAndCollections
 		},
-		showSettingsForAccountMutation(accountId) {
-			this.showAccountSettings = accountId
+		showSettingsForAccountMutation(accountId, section) {
+			this.showAccountSettings = {
+				accountId,
+				section,
+			}
 		},
 		setMyTextBlocks(textBlocks) {
 			this.myTextBlocks = textBlocks
@@ -2500,7 +2503,13 @@ export default function mainStoreActions() {
 			return this.findMailboxBySpecialRole(accountId, 'inbox')
 		},
 		showSettingsForAccount(accountId) {
-			return this.showAccountSettings === accountId
+			return this.showAccountSettings?.accountId === accountId
+		},
+		showSettingsSectionForAccount(accountId) {
+			if (this.showAccountSettings?.accountId !== accountId) {
+				return undefined
+			}
+			return this.showAccountSettings.section
 		},
 		getMyTextBlocks() {
 			return this.myTextBlocks


### PR DESCRIPTION
Use case: server admins enforce password changes regularly. Users want a shortcut to enter the new password. This adds a simple button to the existing connectivity text that opens the account settings and scrolls to the server settings.

<img width="322" height="134" alt="image" src="https://github.com/user-attachments/assets/34961d39-fd04-4688-8166-40605ba79c8e" />

## How to test

1. Set up two accounts
2. Open the db and copy the inbound_password of one account to the other in oc_mail_accounts
3. Open the app

main: warning in the sidebar, nothing else.
here: warning in the sidebar and a shortcut to the server settings.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
