### PR TITLE
ci: semver-pin stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:
         repo-token: ${{ secrets.COMMAND_BOT_PAT }}
         stale-issue-message: >


### PR DESCRIPTION
To prevent hash updates like https://github.com/nextcloud/mail/pull/12996.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
