### PR TITLE
fix(psalm): adapt to updated OCP dev-master return types

### DIFF
--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -455,8 +455,7 @@ class MessageApiController extends OCSController {
 	 */
 	private function handleAttachments(): array {
 		$fileAttachments = $this->request->getUploadedFile('attachments');
-		$hasAttachments = isset($fileAttachments['name']);
-		if (!$hasAttachments) {
+		if (!isset($fileAttachments['name'])) {
 			return [];
 		}
 

--- a/lib/Db/Provisioning.php
+++ b/lib/Db/Provisioning.php
@@ -145,9 +145,7 @@ class Provisioning extends Entity implements JsonSerializable {
 	 * @return string
 	 */
 	private function buildUserEmail(string $original, IUser $user) {
-		if ($user->getUID() !== null) {
-			$original = str_replace('%USERID%', $user->getUID(), $original);
-		}
+		$original = str_replace('%USERID%', $user->getUID(), $original);
 		if ($user->getEMailAddress() !== null) {
 			$original = str_replace('%EMAIL%', $user->getEMailAddress(), $original);
 		}

--- a/tests/Unit/Controller/OutOfOfficeControllerTest.php
+++ b/tests/Unit/Controller/OutOfOfficeControllerTest.php
@@ -54,10 +54,12 @@ class OutOfOfficeControllerTest extends TestCase {
 			->willReturn(true);
 
 		$user = $this->createStub(IUser::class);
+		$user->method('getUID')->willReturn('user');
 		$state = $this->createStub(OutOfOfficeState::class);
 
 		$mailAccount = new MailAccount();
 		$mailAccount->setId(1);
+		$mailAccount->setUserId('user');
 		$mailAccount->setOutOfOfficeFollowsSystem($followSystem);
 		$account = new Account($mailAccount);
 


### PR DESCRIPTION
Tests are failing here: https://github.com/nextcloud/mail/pull/13018
Tried to fix it with claude

- IRequest::getUploadedFile now declared as array|null; use inline isset() so psalm can narrow the type correctly
- IUser::getUID now declared as non-nullable string; remove redundant null guard in Provisioning::buildUserEmail

Assisted-by: ClaudeCode:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal attachment handling logic.
  * Simplified user identification placeholder processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->