### PR TITLE
fix(ui): unset error state after account setting update

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -265,7 +265,8 @@ export default function mainStoreActions() {
 			return handleHttpAuthErrors(async () => {
 				const account = await updateAccount(config)
 				logger.debug('account updated', { account })
-				this.editAccountMutation(account)
+				this.editAccountMutation({ ...account, error: false })
+				await this.syncMailboxesForAccount(this.accountsUnmapped[account.id])
 				return account
 			})
 		},

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -5,6 +5,7 @@
 
 import { createPinia, setActivePinia } from 'pinia'
 import { curry, range, reverse } from 'ramda'
+import * as AccountService from '../../../service/AccountService.js'
 import * as MailboxService from '../../../service/MailboxService.js'
 import * as MessageService from '../../../service/MessageService.js'
 import * as NotificationService from '../../../service/NotificationService.js'
@@ -12,6 +13,7 @@ import { PAGE_SIZE, UNIFIED_INBOX_ID } from '../../../store/constants.js'
 import useMainStore from '../../../store/mainStore.js'
 import { normalizedEnvelopeListId } from '../../../util/normalization.js'
 
+vi.mock('../../../service/AccountService.js')
 vi.mock('../../../service/MailboxService.js')
 vi.mock('../../../service/MessageService.js')
 vi.mock('../../../service/NotificationService.js')
@@ -714,6 +716,27 @@ describe('Vuex store actions', () => {
 
 		it('returns empty array when message has no attachments', () => {
 			expect(store.prepareAttachments({})).toEqual([])
+		})
+	})
+
+	describe('updateAccount', () => {
+		it('clears the error flag and syncs mailboxes after a successful settings update', async () => {
+			const account = {
+				id: 7,
+				personalNamespace: '',
+				mailboxes: [],
+				error: true,
+			}
+			store.addAccountMutation(account)
+
+			const updatedAccount = { id: 7, personalNamespace: '', mailboxes: [] }
+			AccountService.update.mockResolvedValue(updatedAccount)
+			MailboxService.fetchAll.mockResolvedValue([])
+
+			await store.updateAccount({ accountId: 7 })
+
+			expect(store.accountsUnmapped[7].error).toBe(false)
+			expect(MailboxService.fetchAll).toHaveBeenCalledWith(7, true)
 		})
 	})
 })


### PR DESCRIPTION
Bonus for https://github.com/nextcloud/mail/pull/13067: an account that can connect again would stay in the error state until page reload. With this change the mailboxes are synchronized and the error state is cleared. The account is usable conveniently.


Assisted-by: Claude:claude-fable-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
