### PR TITLE
fix(ui): restore virtual start mailbox too

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -57,10 +57,13 @@ export default function initAfterAppCreation() {
 		key: 'sort-favorites',
 		value: preferences['sort-favorites'],
 	})
-	const startMailboxId = preferences['start-mailbox-id']
+	let startMailboxId = preferences['start-mailbox-id']
+	if (startMailboxId && !['unified', 'priority'].includes(startMailboxId)) {
+		startMailboxId = parseInt(startMailboxId, 10)
+	}
 	mainStore.savePreferenceMutation({
 		key: 'start-mailbox-id',
-		value: startMailboxId ? parseInt(startMailboxId, 10) : null,
+		value: startMailboxId,
 	})
 	mainStore.savePreferenceMutation({
 		key: 'index-context-chat',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/13084

The *start mailbox id* is always saved, also for *priority* and *unified*. But since it was always parsed to an int the two virtual mailboxes did not work. Priority only happened to "work" because it was also the fallback.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
