### PR TITLE
feat(sieve): implement redirecting action in filter UI

### DIFF
--- a/lib/Service/MailFilter/FilterBuilder.php
+++ b/lib/Service/MailFilter/FilterBuilder.php
@@ -90,6 +90,10 @@ class FilterBuilder {
 				if ($action['type'] === 'stop') {
 					$actions[] = 'stop;';
 				}
+				if ($action['type'] === 'forward') {
+					$recipient = SieveUtils::escapeString($action['recipient']);
+					$actions[] = sprintf('redirect "%s";', $recipient);
+				}
 			}
 
 			if (count($tests) > 1) {

--- a/src/components/mailFilter/Action.vue
+++ b/src/components/mailFilter/Action.vue
@@ -39,6 +39,7 @@ import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import ActionAddflag from './ActionAddflag.vue'
 import ActionAddSystemFlag from './ActionAddSystemFlag.vue'
 import ActionFileinto from './ActionFileinto.vue'
+import ActionForward from './ActionForward.vue'
 import ActionStop from './ActionStop.vue'
 import { MailFilterActions } from '../../models/mailFilter.ts'
 
@@ -51,6 +52,7 @@ export default {
 		ActionFileinto,
 		ActionAddflag,
 		ActionStop,
+		ActionForward,
 		DeleteIcon,
 	},
 
@@ -85,6 +87,10 @@ export default {
 					id: MailFilterActions.Stop,
 					label: this.t('mail', 'Stop'),
 				},
+				{
+					id: MailFilterActions.Forward,
+					label: this.t('mail', 'Forward to'),
+				},
 			],
 		}
 	},
@@ -103,6 +109,8 @@ export default {
 				return ActionStop
 			} else if (this.action.type === MailFilterActions.AddSystemFlag) {
 				return ActionAddSystemFlag
+			} else if (this.action.type === MailFilterActions.Forward) {
+				return ActionForward
 			}
 			return null
 		},

--- a/src/components/mailFilter/ActionForward.vue
+++ b/src/components/mailFilter/ActionForward.vue
@@ -1,0 +1,53 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<NcTextField
+		:required="true"
+		:model-value="recipient"
+		:label-outside="true"
+		:placeholder="t('mail', 'Enter recipient')"
+		@update:value="onInput" />
+</template>
+
+<script>
+import { NcTextField } from '@nextcloud/vue'
+
+export default {
+	name: 'ActionForward',
+	components: {
+		NcTextField,
+	},
+
+	props: {
+		action: {
+			type: Object,
+			required: true,
+		},
+
+		account: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	computed: {
+		recipient() {
+			return this.action.recipient ?? ''
+		},
+	},
+
+	methods: {
+		onInput(value) {
+			this.$emit('update-action', { recipient: value })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.input-field {
+	display: inline-block; /* for flex expand */
+}
+</style>

--- a/src/models/mailFilter.ts
+++ b/src/models/mailFilter.ts
@@ -23,6 +23,7 @@ export enum MailFilterConditionOperator {
 
 export enum MailFilterActions {
 	AddSystemFlag = 'addsystemflag',
+	Forward = 'forward',
 	Stop = 'stop',
 }
 
@@ -82,6 +83,15 @@ export class MailFilterActionStop implements MailFilterAction {
 	constructor() {
 		this.id = randomId()
 		this.type = 'stop'
+	}
+}
+
+export class MailFilterActionForward implements MailFilterAction {
+	public id: number
+	public type: string
+	constructor() {
+		this.id = randomId()
+		this.type = 'forward'
 	}
 }
 

--- a/tests/data/mail-filter/builder9.json
+++ b/tests/data/mail-filter/builder9.json
@@ -1,0 +1,23 @@
+[
+	{
+		"name": "Test 9",
+		"enable": true,
+		"operator": "allof",
+		"tests": [
+			{
+				"operator": "is",
+				"values": [
+					"bob@example.org"
+				],
+				"field": "to"
+			}
+		],
+		"actions": [
+			{
+				"type": "forward",
+				"flag": "alice@example.org"
+			}
+		],
+		"priority": 10
+	}
+]

--- a/tests/data/mail-filter/builder9.sieve
+++ b/tests/data/mail-filter/builder9.sieve
@@ -1,0 +1,8 @@
+# Hello, this is a test
+### Nextcloud Mail: Filters ### DON'T EDIT ###
+# FILTER: [{"name":"Test 9","enable":true,"operator":"allof","tests":[{"operator":"is","values":["bob@example.org"],"field":"to"}],"actions":[{"type":"forward","recipient":"alice@example.org"}],"priority":10}]
+# Test 9
+if address :is :all "To" ["bob@example.org"] {
+	redirect "alice@example.org";
+}
+### Nextcloud Mail: Filters ### DON'T EDIT ###


### PR DESCRIPTION
This patch implements an action for redirecting via the Sieve 'redirect' directive.

<img width="616" height="660" alt="form to create forward" src="https://github.com/user-attachments/assets/eec3b172-102e-405a-b979-82d06abf9eb3" />


I've attempted to include a corresponding test case, but was unfortunately unable to figure out how the tests are run - thus being unable to test my test. Sorry about that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Forward to" mail filter action, enabling users to automatically forward emails matching filter rules to a specified recipient address.

* **Tests**
  * Added test fixtures to validate forward mail filter action functionality and Sieve script generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->