### PR TITLE
fix: account settings section font size

### DIFF
--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -65,7 +65,7 @@
 					{{ t('mail', 'Please enter an email of the format name@example.com') }}
 				</p>
 
-				<h3>{{ t('mail', 'IMAP Settings') }}</h3>
+				<h4>{{ t('mail', 'IMAP Settings') }}</h4>
 				<NcInputField
 					id="man-imap-host"
 					v-model="manualConfig.imapHost"
@@ -144,7 +144,7 @@
 					required
 					@change="clearFeedback" />
 
-				<h3>{{ t('mail', 'SMTP Settings') }}</h3>
+				<h4>{{ t('mail', 'SMTP Settings') }}</h4>
 				<NcInputField
 					id="man-smtp-host"
 					ref="smtpHost"
@@ -776,6 +776,7 @@ export default {
 
 <style scoped>
 h4 {
+	font-size: 17px;
 	text-align: start;
 }
 


### PR DESCRIPTION
fixes #12748

The css change is necessary because changing only h4 doesnt visually change the size, because the NcAppSettingsSection  font size is still applied.

after
<img width="632" height="794" alt="Screenshot from 2026-06-17 11-31-31" src="https://github.com/user-attachments/assets/06e16ba1-e1ac-4700-a677-909711c2c1b4" />





## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
