### PR TITLE
fix(sieve): fix handling of empty existing sieve scripts

### DIFF
--- a/lib/Service/MailFilter/FilterBuilder.php
+++ b/lib/Service/MailFilter/FilterBuilder.php
@@ -121,15 +121,17 @@ class FilterBuilder {
 			$lines[] = self::SEPARATOR;
 		}
 
-		/*
-		 * Using implode("\r\n", $lines) may introduce an extra newline if the original script already ends with one.
-		 * There may be a cleaner solution, but I couldn't find one that works seamlessly with Filter and Autoresponder.
-		 * Feel free to give it a try!
-		 */
-		if (str_ends_with($untouchedScript, self::SIEVE_NEWLINE . self::SIEVE_NEWLINE)) {
-			$untouchedScript = substr($untouchedScript, 0, -2);
+		if (strlen($untouchedScript) !== 0) {
+			/*
+			 * Using implode("\r\n", $lines) may introduce an extra newline if the original script already ends with one.
+			 * There may be a cleaner solution, but I couldn't find one that works seamlessly with Filter and Autoresponder.
+			 * Feel free to give it a try!
+			 */
+			if (str_ends_with($untouchedScript, self::SIEVE_NEWLINE . self::SIEVE_NEWLINE)) {
+				$untouchedScript = substr($untouchedScript, 0, -2);
+			}
+			$lines[] = $untouchedScript;
 		}
-		$lines[] = $untouchedScript;
 
 		if (count($filters) > 0) {
 			$lines[] = self::SEPARATOR;


### PR DESCRIPTION
This patch implements a check to more cleanly handle the case where the user's existing Sieve script is empty.
This occurs in the following two cases (from what I've tested):

- User cleared the contents in the Sieve script editor manually
- The Sieve script files on the server were deleted otherwise

This issue was first encountered when I implemented the redirect action in #13095 (See blank line at start of built script).

<img width="669" height="433" alt="blank line uptop" src="https://github.com/user-attachments/assets/e9e5c59f-4bc5-4b75-9e26-756c9aee31f3" />

I must presume this wasn't an issue before now because every other implemented action in the Filter UI also needed to import something, somehow causing that empty string in `$lines` to disappear. Debugging via Exceptions shows that an empty script file leads to a blank string at the start of `$lines`:

> Before

<img width="906" height="50" alt="empty string" src="https://github.com/user-attachments/assets/7284ebd9-6afb-44a9-8dd9-df9764f04906" />

> After

<img width="884" height="39" alt="after" src="https://github.com/user-attachments/assets/d33c5ed0-cc68-40c0-b784-1fdc7820f79d" />
