### PR TITLE
fix(delegation): show delegates' display names instead of usernames

### DIFF
--- a/lib/Db/Delegation.php
+++ b/lib/Db/Delegation.php
@@ -23,9 +23,19 @@ class Delegation extends Entity implements JsonSerializable {
 	protected $accountId;
 	protected $userId;
 
+	private ?string $displayName = null;
+
 	public function __construct() {
 		$this->addType('userId', 'string');
 		$this->addType('accountId', 'integer');
+	}
+
+	public function getDisplayName(): ?string {
+		return $this->displayName;
+	}
+
+	public function setDisplayName(?string $displayName): void {
+		$this->displayName = $displayName;
 	}
 
 	#[ReturnTypeWillChange]
@@ -34,6 +44,7 @@ class Delegation extends Entity implements JsonSerializable {
 			'id' => $this->getId(),
 			'accountId' => $this->getAccountId(),
 			'userId' => $this->getUserId(),
+			'displayName' => $this->displayName ?? $this->getUserId(),
 		];
 	}
 }

--- a/lib/Service/DelegationService.php
+++ b/lib/Service/DelegationService.php
@@ -62,7 +62,11 @@ class DelegationService {
 	}
 
 	public function findDelegatedToUsersForAccount(int $accountId): array {
-		return $this->delegationMapper->findDelegatedToUsers($accountId);
+		return array_map(function (Delegation $delegation) {
+			$displayName = $this->userManager->get($delegation->getUserId())?->getDisplayName();
+			$delegation->setDisplayName($displayName);
+			return $delegation;
+		}, $this->delegationMapper->findDelegatedToUsers($accountId));
 	}
 
 	public function unDelegate(Account $account, string $userId, string $currentUserId): void {

--- a/src/components/DelegationModal.vue
+++ b/src/components/DelegationModal.vue
@@ -25,7 +25,7 @@
 					<NcListItem
 						v-for="user in delegates"
 						:key="user.userId"
-						:name="user.userId">
+						:name="user.displayName || user.userId">
 						<template #icon>
 							<NcAvatar
 								disable-menu
@@ -177,7 +177,7 @@ export default {
 			if (!this.revokeUser) {
 				return ''
 			}
-			return t('mail', '{userId} will no longer be able to act on your behalf', { userId: this.revokeUser.userId })
+			return t('mail', '{userId} will no longer be able to act on your behalf', { userId: this.revokeUser.displayName || this.revokeUser.userId })
 		},
 	},
 
@@ -260,8 +260,8 @@ export default {
 			this.delegating = true
 			try {
 				const delegation = await delegate(this.account.accountId, this.selectedUser.id)
-				this.delegates.push(delegation)
-				showSuccess(t('mail', 'Delegated access to {userId}', { userId: this.selectedUser.id }))
+				this.delegates.push({ ...delegation, displayName: this.selectedUser.displayName })
+				showSuccess(t('mail', 'Delegated access to {displayName}', { displayName: this.selectedUser.displayName || this.selectedUser.id }))
 			} catch (error) {
 				logger.error('Could not delegate access', { error })
 				showError(t('mail', 'Could not delegate access'))
@@ -279,7 +279,7 @@ export default {
 			try {
 				await unDelegate(this.account.accountId, this.revokeUser.userId)
 				this.delegates = this.delegates.filter((d) => d.userId !== this.revokeUser.userId)
-				showSuccess(t('mail', 'Revoked access for {userId}', { userId: this.revokeUser.userId }))
+				showSuccess(t('mail', 'Revoked access for {displayName}', { displayName: this.revokeUser.displayName }))
 			} catch (error) {
 				logger.error('Could not revoke delegation', { error })
 				showError(t('mail', 'Could not revoke delegation'))

--- a/src/service/DelegationService.js
+++ b/src/service/DelegationService.js
@@ -10,6 +10,7 @@ import { generateUrl } from '@nextcloud/router'
  * @property {number} id the delegation id
  * @property {number} accountId the account id
  * @property {string} userId the delegated user id
+ * @property {string} displayName the delegated user's display name
  */
 
 /**

--- a/tests/Unit/Service/DelegationServiceTest.php
+++ b/tests/Unit/Service/DelegationServiceTest.php
@@ -149,6 +149,7 @@ class DelegationServiceTest extends TestCase {
 
 	public function testFindDelegatedToUsersForAccount(): void {
 		$delegation = new Delegation();
+		$delegation->setId(10);
 		$delegation->setAccountId(1);
 		$delegation->setUserId('delegatee');
 
@@ -157,10 +158,15 @@ class DelegationServiceTest extends TestCase {
 			->with(1)
 			->willReturn([$delegation]);
 
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn('Delegatee Name');
+		$this->userManager->method('get')->with('delegatee')->willReturn($user);
+
 		$result = $this->service->findDelegatedToUsersForAccount(1);
 
 		$this->assertCount(1, $result);
 		$this->assertEquals('delegatee', $result[0]->getUserId());
+		$this->assertEquals('Delegatee Name', $result[0]->getDisplayName());
 	}
 
 	public function testUnDelegateSuccess(): void {


### PR DESCRIPTION
In the account delegation modal list users by their display names instead of usernames 

- [ ] The content of this PR was partly or fully generated using AI
