### PR TITLE
fix(a11y): add missing ARIA labels to form inputs and buttons

### DIFF
--- a/src/components/AliasForm.vue
+++ b/src/components/AliasForm.vue
@@ -14,12 +14,14 @@
 				v-model="changeName"
 				type="text"
 				class="alias-form__form__input"
+				:aria-label="t('mail', 'Alias name')"
 				required>
 			<input
 				v-model="changeAlias"
 				:disabled="alias.provisioned"
 				type="email"
 				class="alias-form__form__input"
+				:aria-label="t('mail', 'Email address')"
 				required>
 		</form>
 		<div v-else>

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -24,7 +24,9 @@
 				{{ attachment.sizeString }}
 			</span>
 		</div>
-		<button @click="onDelete(attachment)">
+		<button
+			:aria-label="t('mail', 'Remove attachment {fileName}', { fileName: attachment.displayName ?? attachment.fileName })"
+			@click="onDelete(attachment)">
 			<Close :size="20" />
 		</button>
 	</li>

--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -10,7 +10,12 @@
 		<div class="modal-content">
 			<h2>{{ t('mail', 'Create event') }}</h2>
 			<div class="eventTitle">
-				<input v-model="eventTitle" :disabled="generatingData" type="text">
+				<label for="eventTitle">{{ t('mail', 'Title') }}</label>
+				<input
+					id="eventTitle"
+					v-model="eventTitle"
+					:disabled="generatingData"
+					type="text">
 			</div>
 			<div class="dateTimePicker">
 				<DatetimePicker

--- a/src/components/SearchMessages.vue
+++ b/src/components/SearchMessages.vue
@@ -71,7 +71,7 @@
 						</div>
 					</div>
 					<div class="modal-inner--field">
-						<label class="modal-inner--label" for="fromId">
+						<label class="modal-inner--label">
 							{{ t('mail', 'Date') }}
 						</label>
 						<div class="modal-inner--container range">

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -7,7 +7,8 @@
 		<div class="modal-content">
 			<h2>{{ t('mail', 'Create task') }}</h2>
 			<div class="taskTitle">
-				<input v-model="taskTitle" type="text">
+				<label for="taskTitle">{{ t('mail', 'Title') }}</label>
+				<input id="taskTitle" v-model="taskTitle" type="text">
 			</div>
 			<div class="all-day">
 				<DatetimePicker


### PR DESCRIPTION
Fixed unlabelled inputs in the event/task creation modals, the alias edit form, and the composer attachment list.

Assisted-by: ClaudeCode:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
