### PR TITLE
fix(imap): use UID FETCH instead of UID SEARCH in getPageSize

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -1033,17 +1033,8 @@ class MessageMapper {
 	private function getPageSize(Horde_Imap_Client_Socket $client,
 		string $mailbox,
 		Horde_Imap_Client_Ids $idsToFetch): int {
-		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
-		$rangeSearchQuery->ids($idsToFetch);
-		$rangeSearchResult = $client->search(
-			$mailbox,
-			$rangeSearchQuery,
-			[
-				'results' => [
-					Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-				],
-			]
-		);
-		return (int)$rangeSearchResult['count'];
+		$query = new Horde_Imap_Client_Fetch_Query();
+		$query->uid();
+		return count($client->fetch($mailbox, $query, ['ids' => $idsToFetch]));
 	}
 }

--- a/tests/Unit/IMAP/MessageMapperTest.php
+++ b/tests/Unit/IMAP/MessageMapperTest.php
@@ -17,7 +17,6 @@ use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Fetch_Results;
 use Horde_Imap_Client_Ids;
-use Horde_Imap_Client_Search_Query;
 use Horde_Imap_Client_Socket;
 use Horde_Mime_Part;
 use OCA\Mail\Db\Mailbox;
@@ -294,44 +293,30 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
-		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('123:321'));
-		$client->expects(self::exactly(2))
+		$client->expects(self::once())
 			->method('search')
-			->withConsecutive(
+			->with(
+				$mailbox,
+				null,
 				[
-					$mailbox,
-					null,
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_MIN,
-							Horde_Imap_Client::SEARCH_RESULTS_MAX,
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						]
+					'results' => [
+						Horde_Imap_Client::SEARCH_RESULTS_MIN,
+						Horde_Imap_Client::SEARCH_RESULTS_MAX,
+						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
 					]
-				],
-				[
-					$mailbox,
-					($rangeSearchQuery),
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						]
-					],
-				],
+				]
 			)
-			->willReturnOnConsecutiveCalls(
-				[
-					'min' => 123,
-					'max' => 321,
-					'count' => 50,
-				],
-				[
-					'count' => 50,
-				],
-			);
+			->willReturn([
+				'min' => 123,
+				'max' => 321,
+				'count' => 50,
+			]);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
+		$pageSizeResults = new Horde_Imap_Client_Fetch_Results();
+		for ($i = 0; $i < 50; $i++) {
+			$pageSizeResults[$i] = new Horde_Imap_Client_Data_Fetch();
+		}
 		$uidResults = new Horde_Imap_Client_Fetch_Results();
 		foreach (range(123, 321) as $i) {
 			$uid = new Horde_Imap_Client_Data_Fetch();
@@ -339,9 +324,16 @@ class MessageMapperTest extends TestCase {
 			$uidResults[$i] = $uid;
 		}
 		$bodyResults = new Horde_Imap_Client_Fetch_Results();
-		$client->expects(self::exactly(2))
+		$client->expects(self::exactly(3))
 			->method('fetch')
 			->withConsecutive(
+				[
+					$mailbox,
+					$query,
+					[
+						'ids' => new Horde_Imap_Client_Ids('123:321'),
+					]
+				],
 				[
 					$mailbox,
 					$query,
@@ -356,6 +348,7 @@ class MessageMapperTest extends TestCase {
 				]
 			)
 			->willReturnOnConsecutiveCalls(
+				$pageSizeResults,
 				$uidResults,
 				$bodyResults
 			);
@@ -377,44 +370,30 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
-		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('301:321'));
-		$client->expects(self::exactly(2))
+		$client->expects(self::once())
 			->method('search')
-			->withConsecutive(
+			->with(
+				$mailbox,
+				null,
 				[
-					$mailbox,
-					null,
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_MIN,
-							Horde_Imap_Client::SEARCH_RESULTS_MAX,
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						],
+					'results' => [
+						Horde_Imap_Client::SEARCH_RESULTS_MIN,
+						Horde_Imap_Client::SEARCH_RESULTS_MAX,
+						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
 					],
-				],
-				[
-					$mailbox,
-					$rangeSearchQuery,
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						],
-					],
-				],
+				]
 			)
-			->willReturnOnConsecutiveCalls(
-				[
-					'min' => 123,
-					'max' => 321,
-					'count' => 50,
-				],
-				[
-					'count' => 50,
-				],
-			);
+			->willReturn([
+				'min' => 123,
+				'max' => 321,
+				'count' => 50,
+			]);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
+		$pageSizeResults = new Horde_Imap_Client_Fetch_Results();
+		for ($i = 0; $i < 50; $i++) {
+			$pageSizeResults[$i] = new Horde_Imap_Client_Data_Fetch();
+		}
 		$uidResults = new Horde_Imap_Client_Fetch_Results();
 		foreach (range(123, 321) as $i) {
 			$uid = new Horde_Imap_Client_Data_Fetch();
@@ -422,9 +401,16 @@ class MessageMapperTest extends TestCase {
 			$uidResults[$i] = $uid;
 		}
 		$bodyResults = new Horde_Imap_Client_Fetch_Results();
-		$client->expects(self::exactly(2))
+		$client->expects(self::exactly(3))
 			->method('fetch')
 			->withConsecutive(
+				[
+					$mailbox,
+					$query,
+					[
+						'ids' => new Horde_Imap_Client_Ids('301:321'),
+					]
+				],
 				[
 					$mailbox,
 					$query,
@@ -439,6 +425,7 @@ class MessageMapperTest extends TestCase {
 				]
 			)
 			->willReturnOnConsecutiveCalls(
+				$pageSizeResults,
 				$uidResults,
 				$bodyResults
 			);
@@ -467,44 +454,30 @@ class MessageMapperTest extends TestCase {
 		/** @var Horde_Imap_Client_Socket|MockObject $client */
 		$client = $this->createMock(Horde_Imap_Client_Socket::class);
 		$mailbox = 'inbox';
-		$rangeSearchQuery = new Horde_Imap_Client_Search_Query();
-		$rangeSearchQuery->ids(new Horde_Imap_Client_Ids('92001:99999'));
-		$client->expects(self::exactly(2))
+		$client->expects(self::once())
 			->method('search')
-			->withConsecutive(
+			->with(
+				$mailbox,
+				null,
 				[
-					$mailbox,
-					null,
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_MIN,
-							Horde_Imap_Client::SEARCH_RESULTS_MAX,
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						],
+					'results' => [
+						Horde_Imap_Client::SEARCH_RESULTS_MIN,
+						Horde_Imap_Client::SEARCH_RESULTS_MAX,
+						Horde_Imap_Client::SEARCH_RESULTS_COUNT,
 					],
-				],
-				[
-					$mailbox,
-					$rangeSearchQuery,
-					[
-						'results' => [
-							Horde_Imap_Client::SEARCH_RESULTS_COUNT,
-						],
-					],
-				],
+				]
 			)
-			->willReturnOnConsecutiveCalls(
-				[
-					'min' => 10000,
-					'max' => 99999,
-					'count' => 50000,
-				],
-				[
-					'count' => 50,
-				],
-			);
+			->willReturn([
+				'min' => 10000,
+				'max' => 99999,
+				'count' => 50000,
+			]);
 		$query = new Horde_Imap_Client_Fetch_Query();
 		$query->uid();
+		$pageSizeResults = new Horde_Imap_Client_Fetch_Results();
+		for ($i = 0; $i < 50; $i++) {
+			$pageSizeResults[$i] = new Horde_Imap_Client_Data_Fetch();
+		}
 		$uidResults = new Horde_Imap_Client_Fetch_Results();
 		foreach (range(92000, 98000) as $i) {
 			$uid = new Horde_Imap_Client_Data_Fetch();
@@ -512,9 +485,16 @@ class MessageMapperTest extends TestCase {
 			$uidResults[$i] = $uid;
 		}
 		$bodyResults = new Horde_Imap_Client_Fetch_Results();
-		$client->expects(self::exactly(2))
+		$client->expects(self::exactly(3))
 			->method('fetch')
 			->withConsecutive(
+				[
+					$mailbox,
+					$query,
+					[
+						'ids' => new Horde_Imap_Client_Ids('92001:99999'),
+					]
+				],
 				[
 					$mailbox,
 					$query,
@@ -529,6 +509,7 @@ class MessageMapperTest extends TestCase {
 				]
 			)
 			->willReturnOnConsecutiveCalls(
+				$pageSizeResults,
 				$uidResults,
 				$bodyResults
 			);


### PR DESCRIPTION
grommunio-imap rejects the UID SEARCH UID <range> command used to count messages in a candidate page. Replace with a UID FETCH (UID) which is mandated by RFC 3501 and universally supported.

Assisted-by: Claude:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
