### PR TITLE
chore(.gitignore): ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tests/.phpunit.result.cache
 /playwright
 /playwright-report
 /test-results
+
+# Agents 
+.claude/


### PR DESCRIPTION
The goal is to be able to run 
* `git add . `
* `npm run lint:fix` 
* ... 

on checkout branch, while simultaneously using worktrees 

context: claude by default creates worktrees in .claude/worktrees https://code.claude.com/docs/en/worktrees 


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
