### PR TITLE
refactor(php): apply constructor property promotion (PHP 8.0+)

### DIFF
--- a/lib/Address.php
+++ b/lib/Address.php
@@ -22,11 +22,9 @@ class Address implements JsonSerializable {
 	public const TYPE_CC = 2;
 	public const TYPE_BCC = 3;
 
-	/** @var Horde_Mail_Rfc822_Address */
-	private $wrapped;
-
-	private function __construct(Horde_Mail_Rfc822_Address $wrapped) {
-		$this->wrapped = $wrapped;
+	private function __construct(
+		private Horde_Mail_Rfc822_Address $wrapped,
+	) {
 	}
 
 	public static function fromHorde(Horde_Mail_Rfc822_Address $horde): self {

--- a/lib/AddressList.php
+++ b/lib/AddressList.php
@@ -19,14 +19,12 @@ use ReturnTypeWillChange;
  * @psalm-immutable
  */
 class AddressList implements Countable, JsonSerializable {
-	/** @var list<Address> */
-	private array $addresses;
-
 	/**
 	 * @param list<Address> $addresses
 	 */
-	public function __construct(array $addresses = []) {
-		$this->addresses = $addresses;
+	public function __construct(
+		private array $addresses = [],
+	) {
 	}
 
 	/**

--- a/lib/Attachment.php
+++ b/lib/Attachment.php
@@ -11,26 +11,15 @@ namespace OCA\Mail;
 use Horde_Mime_Part;
 
 class Attachment {
-	private ?string $id;
-	private ?string $name;
-	private string $type;
-	private string $content;
-	private int $size;
-
 	public function __construct(
-		?string $id,
-		?string $name,
-		string $type,
-		string $content,
-		int $size,
+		private ?string $id,
+		private ?string $name,
+		private string $type,
+		private string $content,
+		private int $size,
 		public readonly ?string $contentId,
 		public readonly ?string $disposition,
 	) {
-		$this->id = $id;
-		$this->name = $name;
-		$this->type = $type;
-		$this->content = $content;
-		$this->size = $size;
 	}
 
 	public static function fromMimePart(Horde_Mime_Part $mimePart): self {

--- a/lib/BackgroundJob/CleanupJob.php
+++ b/lib/BackgroundJob/CleanupJob.php
@@ -15,15 +15,12 @@ use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 
 class CleanupJob extends TimedJob {
-	private CleanupService $cleanupService;
-	private LoggerInterface $logger;
-
-	public function __construct(ITimeFactory $time,
-		CleanupService $cleanupService,
-		LoggerInterface $logger) {
+	public function __construct(
+		ITimeFactory $time,
+		private CleanupService $cleanupService,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($time);
-		$this->cleanupService = $cleanupService;
-		$this->logger = $logger;
 
 		$this->setInterval(24 * 60 * 60);
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);

--- a/lib/BackgroundJob/DraftsJob.php
+++ b/lib/BackgroundJob/DraftsJob.php
@@ -14,16 +14,15 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 
 class DraftsJob extends TimedJob {
-	private DraftsService $draftsService;
-
-	public function __construct(ITimeFactory $time,
-		DraftsService $draftsService) {
+	public function __construct(
+		ITimeFactory $time,
+		private DraftsService $draftsService,
+	) {
 		parent::__construct($time);
 
 		// Run once per five minutes
 		$this->setInterval(5 * 60);
 		$this->setTimeSensitivity(self::TIME_SENSITIVE);
-		$this->draftsService = $draftsService;
 	}
 
 	#[\Override]

--- a/lib/BackgroundJob/IMipMessageJob.php
+++ b/lib/BackgroundJob/IMipMessageJob.php
@@ -14,14 +14,13 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 
 class IMipMessageJob extends TimedJob {
-	private IMipService $iMipService;
-
-	public function __construct(ITimeFactory $time,
-		IMipService $iMipService) {
+	public function __construct(
+		ITimeFactory $time,
+		private IMipService $iMipService,
+	) {
 		parent::__construct($time);
 
 		$this->setInterval(300);
-		$this->iMipService = $iMipService;
 	}
 
 	#[\Override]

--- a/lib/BackgroundJob/MigrateImportantJob.php
+++ b/lib/BackgroundJob/MigrateImportantJob.php
@@ -23,28 +23,16 @@ use OCP\BackgroundJob\QueuedJob;
 use Psr\Log\LoggerInterface;
 
 class MigrateImportantJob extends QueuedJob {
-	private MailboxMapper $mailboxMapper;
-	private MailAccountMapper $mailAccountMapper;
-	private MailManager $mailManager;
-	private MigrateImportantFromImapAndDb $migration;
-	private LoggerInterface $logger;
-	private IMAPClientFactory $imapClientFactory;
-
-	public function __construct(MailboxMapper $mailboxMapper,
-		MailAccountMapper $mailAccountMapper,
-		MailManager $mailManager,
-		MigrateImportantFromImapAndDb $migration,
-		LoggerInterface $logger,
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		private MailAccountMapper $mailAccountMapper,
+		private MailManager $mailManager,
+		private MigrateImportantFromImapAndDb $migration,
+		private LoggerInterface $logger,
 		ITimeFactory $timeFactory,
-		IMAPClientFactory $imapClientFactory,
+		private IMAPClientFactory $imapClientFactory,
 	) {
 		parent::__construct($timeFactory);
-		$this->mailboxMapper = $mailboxMapper;
-		$this->mailAccountMapper = $mailAccountMapper;
-		$this->mailManager = $mailManager;
-		$this->migration = $migration;
-		$this->logger = $logger;
-		$this->imapClientFactory = $imapClientFactory;
 	}
 
 	/**

--- a/lib/BackgroundJob/OutboxWorkerJob.php
+++ b/lib/BackgroundJob/OutboxWorkerJob.php
@@ -14,16 +14,15 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
 
 class OutboxWorkerJob extends TimedJob {
-	private OutboxService $outboxService;
-
-	public function __construct(ITimeFactory $time,
-		OutboxService $outboxService) {
+	public function __construct(
+		ITimeFactory $time,
+		private OutboxService $outboxService,
+	) {
 		parent::__construct($time);
 
 		// Run once per five minutes
 		$this->setInterval(5 * 60);
 		$this->setTimeSensitivity(self::TIME_SENSITIVE);
-		$this->outboxService = $outboxService;
 	}
 
 	#[\Override]

--- a/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
+++ b/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
@@ -20,24 +20,20 @@ use function sprintf;
 
 class PreviewEnhancementProcessingJob extends TimedJob {
 	private IUserManager $userManager;
-	private AccountService $accountService;
-	private LoggerInterface $logger;
 	private IJobList $jobList;
-	private PreprocessingService $preprocessingService;
 
-	public function __construct(ITimeFactory $time,
+	public function __construct(
+		ITimeFactory $time,
 		IUserManager $userManager,
-		AccountService $accountService,
-		PreprocessingService $preprocessingService,
-		LoggerInterface $logger,
-		IJobList $jobList) {
+		private AccountService $accountService,
+		private PreprocessingService $preprocessingService,
+		private LoggerInterface $logger,
+		IJobList $jobList,
+	) {
 		parent::__construct($time);
 
 		$this->userManager = $userManager;
-		$this->accountService = $accountService;
-		$this->logger = $logger;
 		$this->jobList = $jobList;
-		$this->preprocessingService = $preprocessingService;
 
 		$this->setInterval(3600);
 		$this->setTimeSensitivity(self::TIME_SENSITIVE);

--- a/lib/BackgroundJob/QuotaJob.php
+++ b/lib/BackgroundJob/QuotaJob.php
@@ -21,26 +21,22 @@ use function sprintf;
 
 class QuotaJob extends TimedJob {
 	private IUserManager $userManager;
-	private AccountService $accountService;
-	private IMailManager $mailManager;
-	private LoggerInterface $logger;
 	private IJobList $jobList;
 	private IManager $notificationManager;
 
-	public function __construct(ITimeFactory $time,
+	public function __construct(
+		ITimeFactory $time,
 		IUserManager $userManager,
-		AccountService $accountService,
-		IMailManager $mailManager,
+		private AccountService $accountService,
+		private IMailManager $mailManager,
 		IManager $notificationManager,
-		LoggerInterface $logger,
-		IJobList $jobList) {
+		private LoggerInterface $logger,
+		IJobList $jobList,
+	) {
 		parent::__construct($time);
 
 		$this->userManager = $userManager;
-		$this->accountService = $accountService;
-		$this->logger = $logger;
 		$this->jobList = $jobList;
-		$this->mailManager = $mailManager;
 
 		$this->setInterval(60 * 60 * 24 * 7);
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);

--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -30,30 +30,22 @@ class SyncJob extends TimedJob {
 	private const DEFAULT_SYNC_INTERVAL = 3600;
 
 	private IUserManager $userManager;
-	private AccountService $accountService;
-	private ImapToDbSynchronizer $syncService;
-	private MailboxSync $mailboxSync;
-	private LoggerInterface $logger;
 	private IJobList $jobList;
 	private readonly bool $forcedSyncInterval;
 
 	public function __construct(
 		ITimeFactory $time,
 		IUserManager $userManager,
-		AccountService $accountService,
-		MailboxSync $mailboxSync,
-		ImapToDbSynchronizer $syncService,
-		LoggerInterface $logger,
+		private AccountService $accountService,
+		private MailboxSync $mailboxSync,
+		private ImapToDbSynchronizer $syncService,
+		private LoggerInterface $logger,
 		IJobList $jobList,
 		private readonly IConfig $config,
 	) {
 		parent::__construct($time);
 
 		$this->userManager = $userManager;
-		$this->accountService = $accountService;
-		$this->syncService = $syncService;
-		$this->mailboxSync = $mailboxSync;
-		$this->logger = $logger;
 		$this->jobList = $jobList;
 
 		$configuredSyncInterval = $config->getSystemValueInt('app.mail.background-sync-interval');

--- a/lib/BackgroundJob/TrainImportanceClassifierJob.php
+++ b/lib/BackgroundJob/TrainImportanceClassifierJob.php
@@ -19,22 +19,17 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class TrainImportanceClassifierJob extends TimedJob {
-	private AccountService $accountService;
-	private ImportanceClassifier $classifier;
 	private IJobList $jobList;
-	private LoggerInterface $logger;
 
-	public function __construct(ITimeFactory $time,
-		AccountService $accountService,
-		ImportanceClassifier $classifier,
+	public function __construct(
+		ITimeFactory $time,
+		private AccountService $accountService,
+		private ImportanceClassifier $classifier,
 		IJobList $jobList,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($time);
-
-		$this->accountService = $accountService;
-		$this->classifier = $classifier;
 		$this->jobList = $jobList;
-		$this->logger = $logger;
 
 		$this->setInterval(24 * 60 * 60);
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);

--- a/lib/Command/AddMissingTags.php
+++ b/lib/Command/AddMissingTags.php
@@ -22,18 +22,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class AddMissingTags extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 
-	private LoggerInterface $logger;
-	private TagMapper $tagMapper;
-	private MailAccountMapper $mapper;
-
-	public function __construct(MailAccountMapper $mapper,
-		TagMapper $tagMapper,
-		LoggerInterface $logger) {
+	public function __construct(
+		private MailAccountMapper $mapper,
+		private TagMapper $tagMapper,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->mapper = $mapper;
-		$this->tagMapper = $tagMapper;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Command/CleanUp.php
+++ b/lib/Command/CleanUp.php
@@ -17,15 +17,11 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class CleanUp extends Command {
-	private CleanupService $cleanupService;
-	private LoggerInterface $logger;
-
-	public function __construct(CleanupService $cleanupService,
-		LoggerInterface $logger) {
+	public function __construct(
+		private CleanupService $cleanupService,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->cleanupService = $cleanupService;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Command/CreateAccount.php
+++ b/lib/Command/CreateAccount.php
@@ -35,20 +35,16 @@ final class CreateAccount extends Command {
 	public const ARGUMENT_SMTP_SSL_MODE = 'smtp-ssl-mode';
 	public const ARGUMENT_SMTP_USER = 'smtp-user';
 	public const ARGUMENT_SMTP_PASSWORD = 'smtp-password';
-
-	private AccountService $accountService;
 	private ICrypto $crypto;
 	private IUserManager $userManager;
 
 	public function __construct(
-		AccountService $service,
+		private AccountService $accountService,
 		ICrypto $crypto,
 		IUserManager $userManager,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
 		parent::__construct();
-
-		$this->accountService = $service;
 		$this->crypto = $crypto;
 		$this->userManager = $userManager;
 	}

--- a/lib/Command/CreateTagMigrationJobEntry.php
+++ b/lib/Command/CreateTagMigrationJobEntry.php
@@ -18,13 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class CreateTagMigrationJobEntry extends Command {
 	private JobList $jobList;
-	private MailboxMapper $mailboxMapper;
 
-	public function __construct(JobList $jobList,
-		MailboxMapper $mailboxMapper) {
+	public function __construct(
+		JobList $jobList,
+		private MailboxMapper $mailboxMapper,
+	) {
 		parent::__construct();
 		$this->jobList = $jobList;
-		$this->mailboxMapper = $mailboxMapper;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/DeleteAccount.php
+++ b/lib/Command/DeleteAccount.php
@@ -22,15 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class DeleteAccount extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 
-	private AccountService $accountService;
-	private LoggerInterface $logger;
-
-	public function __construct(AccountService $service,
-		LoggerInterface $logger) {
+	public function __construct(
+		private AccountService $accountService,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Command/DiagnoseAccount.php
+++ b/lib/Command/DiagnoseAccount.php
@@ -28,18 +28,12 @@ use function sort;
 final class DiagnoseAccount extends Command {
 	private const ARGUMENT_ACCOUNT_ID = 'account-id';
 
-	private AccountService $accountService;
-	private IMAPClientFactory $clientFactory;
-	private LoggerInterface $logger;
-
-	public function __construct(AccountService $service,
-		IMAPClientFactory $clientFactory,
-		LoggerInterface $logger) {
+	public function __construct(
+		private AccountService $accountService,
+		private IMAPClientFactory $clientFactory,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
-		$this->clientFactory = $clientFactory;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Command/ExportAccount.php
+++ b/lib/Command/ExportAccount.php
@@ -18,14 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ExportAccount extends Command {
 	public const ARGUMENT_USER_ID = 'user-id';
 	public const ARGUMENT_OUTPUT_FORMAT = 'output';
-
-	private AccountService $accountService;
 	private ICrypto $crypto;
 
-	public function __construct(AccountService $service, ICrypto $crypto) {
+	public function __construct(
+		private AccountService $accountService,
+		ICrypto $crypto,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
 		$this->crypto = $crypto;
 	}
 

--- a/lib/Command/ExportAccountThreads.php
+++ b/lib/Command/ExportAccountThreads.php
@@ -25,22 +25,18 @@ use function json_encode;
 final class ExportAccountThreads extends Command {
 	private const ARGUMENT_ACCOUNT_ID = 'account-id';
 	private const OPTION_REDACT = 'redact';
-
-	private AccountService $accountService;
 	private ISecureRandom $random;
 	private IHasher $hasher;
-	private MessageMapper $messageMapper;
 
-	public function __construct(AccountService $service,
+	public function __construct(
+		private AccountService $accountService,
 		ISecureRandom $random,
 		IHasher $hasher,
-		MessageMapper $messageMapper) {
+		private MessageMapper $messageMapper,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
 		$this->random = $random;
 		$this->hasher = $hasher;
-		$this->messageMapper = $messageMapper;
 	}
 
 	protected function configure(): void {

--- a/lib/Command/PredictImportance.php
+++ b/lib/Command/PredictImportance.php
@@ -27,21 +27,15 @@ final class PredictImportance extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 	public const ARGUMENT_SENDER = 'sender';
 	public const ARGUMENT_SUBJECT = 'subject';
-
-	private AccountService $accountService;
-	private ImportanceClassifier $classifier;
 	private IConfig $config;
-	private LoggerInterface $logger;
 
-	public function __construct(AccountService $service,
-		ImportanceClassifier $classifier,
+	public function __construct(
+		private AccountService $accountService,
+		private ImportanceClassifier $classifier,
 		IConfig $config,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
-		$this->classifier = $classifier;
-		$this->logger = $logger;
 		$this->config = $config;
 	}
 

--- a/lib/Command/RunMetaEstimator.php
+++ b/lib/Command/RunMetaEstimator.php
@@ -31,23 +31,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class RunMetaEstimator extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 	public const ARGUMENT_SHUFFLE = 'shuffle';
-
-	private AccountService $accountService;
-	private LoggerInterface $logger;
-	private ImportanceClassifier $classifier;
 	private IConfig $config;
 
 	public function __construct(
-		AccountService $accountService,
-		LoggerInterface $logger,
-		ImportanceClassifier $classifier,
+		private AccountService $accountService,
+		private LoggerInterface $logger,
+		private ImportanceClassifier $classifier,
 		IConfig $config,
 	) {
 		parent::__construct();
-
-		$this->accountService = $accountService;
-		$this->logger = $logger;
-		$this->classifier = $classifier;
 		$this->config = $config;
 	}
 

--- a/lib/Command/SyncAccount.php
+++ b/lib/Command/SyncAccount.php
@@ -31,24 +31,14 @@ final class SyncAccount extends Command {
 	public const ARGUMENT_ACCOUNT_ID = 'account-id';
 	public const OPTION_FORCE = 'force';
 
-	private AccountService $accountService;
-	private MailboxSync $mailboxSync;
-	private ImapToDbSynchronizer $syncService;
-	private LoggerInterface $logger;
-	private IMAPClientFactory $clientFactory;
-
-	public function __construct(AccountService $service,
-		MailboxSync $mailboxSync,
-		ImapToDbSynchronizer $messageSync,
-		LoggerInterface $logger,
-		IMAPClientFactory $clientFactory) {
+	public function __construct(
+		private AccountService $accountService,
+		private MailboxSync $mailboxSync,
+		private ImapToDbSynchronizer $syncService,
+		private LoggerInterface $logger,
+		private IMAPClientFactory $clientFactory,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
-		$this->mailboxSync = $mailboxSync;
-		$this->syncService = $messageSync;
-		$this->logger = $logger;
-		$this->clientFactory = $clientFactory;
 	}
 
 	/**

--- a/lib/Command/Thread.php
+++ b/lib/Command/Thread.php
@@ -26,14 +26,11 @@ use function memory_get_peak_usage;
 final class Thread extends Command {
 	public const ARGUMENT_INPUT_FILE = 'thread-file';
 
-	private ThreadBuilder $builder;
-	private LoggerInterface $logger;
-
-	public function __construct(ThreadBuilder $builder,
-		LoggerInterface $logger) {
+	public function __construct(
+		private ThreadBuilder $builder,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-		$this->builder = $builder;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Command/TrainAccount.php
+++ b/lib/Command/TrainAccount.php
@@ -26,18 +26,12 @@ final class TrainAccount extends Command {
 	public const ARGUMENT_DRY_RUN = 'dry-run';
 	public const ARGUMENT_FORCE = 'force';
 
-	private AccountService $accountService;
-	private ImportanceClassifier $classifier;
-	private LoggerInterface $logger;
-
-	public function __construct(AccountService $service,
-		ImportanceClassifier $classifier,
-		LoggerInterface $logger) {
+	public function __construct(
+		private AccountService $accountService,
+		private ImportanceClassifier $classifier,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct();
-
-		$this->accountService = $service;
-		$this->classifier = $classifier;
-		$this->logger = $logger;
 	}
 
 	protected function configure(): void {

--- a/lib/Controller/AccountApiController.php
+++ b/lib/Controller/AccountApiController.php
@@ -56,14 +56,10 @@ class AccountApiController extends OCSController {
 		}
 
 		$accounts = $this->accountService->findByUserId($userId);
-		$result = array_map(function (Account $account) {
-			return $this->transformAccountList($account, false);
-		}, $accounts);
+		$result = array_map(fn (Account $account) => $this->transformAccountList($account, false), $accounts);
 
 		$delegatedAccounts = $this->accountService->findDelegatedAccounts($userId);
-		$delegatedList = array_map(function (Account $account) {
-			return $this->transformAccountList($account, true);
-		}, $delegatedAccounts);
+		$delegatedList = array_map(fn (Account $account) => $this->transformAccountList($account, true), $delegatedAccounts);
 		array_push($result, ... $delegatedList);
 
 		return new DataResponse($result);

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -41,52 +41,32 @@ use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AccountsController extends Controller {
-	private AccountService $accountService;
-	private string $currentUserId;
-	private LoggerInterface $logger;
 	private IL10N $l10n;
-	private AliasesService $aliasesService;
-	private IMailTransmission $mailTransmission;
-	private SetupService $setup;
-	private IMailManager $mailManager;
-	private SyncService $syncService;
 	private IConfig $config;
 	private IRemoteHostValidator $hostValidator;
-	private MailboxSync $mailboxSync;
-	private DelegationService $delegationService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		AccountService $accountService,
-		$userId,
-		LoggerInterface $logger,
+		private AccountService $accountService,
+		private string $userId,
+		private LoggerInterface $logger,
 		IL10N $l10n,
-		AliasesService $aliasesService,
-		IMailTransmission $mailTransmission,
-		SetupService $setup,
-		IMailManager $mailManager,
-		SyncService $syncService,
+		private AliasesService $aliasesService,
+		private IMailTransmission $mailTransmission,
+		private SetupService $setup,
+		private IMailManager $mailManager,
+		private SyncService $syncService,
 		IConfig $config,
 		IRemoteHostValidator $hostValidator,
-		MailboxSync $mailboxSync,
+		private MailboxSync $mailboxSync,
 		private ITimeFactory $timeFactory,
-		DelegationService $delegationService,
+		private DelegationService $delegationService,
 	) {
 		parent::__construct($appName, $request);
-		$this->accountService = $accountService;
-		$this->currentUserId = $userId;
-		$this->logger = $logger;
 		$this->l10n = $l10n;
-		$this->aliasesService = $aliasesService;
-		$this->mailTransmission = $mailTransmission;
-		$this->setup = $setup;
-		$this->mailManager = $mailManager;
-		$this->syncService = $syncService;
 		$this->config = $config;
 		$this->hostValidator = $hostValidator;
-		$this->mailboxSync = $mailboxSync;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -96,17 +76,17 @@ class AccountsController extends Controller {
 	 */
 	#[TrapError]
 	public function index(): JSONResponse {
-		$mailAccounts = $this->accountService->findByUserId($this->currentUserId);
+		$mailAccounts = $this->accountService->findByUserId($this->userId);
 
 		$json = [];
 		foreach ($mailAccounts as $mailAccount) {
 			$conf = $mailAccount->jsonSerialize();
-			$conf['aliases'] = $this->aliasesService->findAll($conf['accountId'], $this->currentUserId);
+			$conf['aliases'] = $this->aliasesService->findAll($conf['accountId'], $this->userId);
 			$conf['isDelegated'] = false;
 			$json[] = $conf;
 		}
 
-		$delegatedAccounts = $this->accountService->findDelegatedAccounts($this->currentUserId);
+		$delegatedAccounts = $this->accountService->findDelegatedAccounts($this->userId);
 		foreach ($delegatedAccounts as $delegatedAccount) {
 			$conf = $delegatedAccount->jsonSerialize();
 			$conf['isDelegated'] = true;
@@ -126,7 +106,7 @@ class AccountsController extends Controller {
 	 */
 	#[TrapError]
 	public function show(int $id): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 
 		return new JSONResponse($this->accountService->find($effectiveUserId, $id));
 	}
@@ -152,9 +132,9 @@ class AccountsController extends Controller {
 		?string $smtpPassword = null,
 		string $authMethod = 'password'): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 			// Make sure the account actually exists
-			$this->accountService->find($this->currentUserId, $id);
+			$this->accountService->find($this->userId, $id);
 		} catch (ClientException $e) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
@@ -181,9 +161,9 @@ class AccountsController extends Controller {
 
 		try {
 			$result = MailJsonResponse::success(
-				$this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId, $authMethod, $id)
+				$this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->userId, $authMethod, $id)
 			);
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated account <$id> on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated account <$id> on behalf of $effectiveUserId");
 			return $result;
 		} catch (CouldNotConnectException $e) {
 			$data = [
@@ -239,7 +219,7 @@ class AccountsController extends Controller {
 		?bool $classificationEnabled = null,
 		?bool $imipCreate = null,
 	): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$account = $this->accountService->find($effectiveUserId, $id);
 
 		$dbAccount = $account->getMailAccount();
@@ -296,7 +276,7 @@ class AccountsController extends Controller {
 		$result = new JSONResponse(
 			new Account($this->accountService->save($dbAccount))
 		);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId patched account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId patched account <$id> on behalf of $effectiveUserId");
 		return $result;
 	}
 
@@ -313,9 +293,9 @@ class AccountsController extends Controller {
 	 */
 	#[TrapError]
 	public function updateSignature(int $id, ?string $signature = null): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$this->accountService->updateSignature($id, $effectiveUserId, $signature);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated signature for account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated signature for account <$id> on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}
 
@@ -330,9 +310,9 @@ class AccountsController extends Controller {
 	 */
 	#[TrapError]
 	public function destroy(int $id): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$this->accountService->delete($effectiveUserId, $id);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId deleted account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId deleted account <$id> on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}
 
@@ -385,7 +365,7 @@ class AccountsController extends Controller {
 			);
 		}
 		try {
-			$account = $this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->currentUserId, $authMethod, null, $classificationEnabled);
+			$account = $this->setup->createNewAccount($accountName, $emailAddress, $imapHost, $imapPort, $imapSslMode, $imapUser, $imapPassword, $smtpHost, $smtpPort, $smtpSslMode, $smtpUser, $smtpPassword, $this->userId, $authMethod, null, $classificationEnabled);
 			// Set initial heartbeat
 			$this->config->setUserValue(
 				$account->getUserId(),
@@ -445,7 +425,7 @@ class AccountsController extends Controller {
 			$this->logger->info("Updating draft <$draftId> in account <$id>");
 		}
 
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$account = $this->accountService->find($effectiveUserId, $id);
 		$previousDraft = null;
 		if ($draftId !== null) {
@@ -468,7 +448,7 @@ class AccountsController extends Controller {
 				null,
 				[]
 			);
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId saved draft in account <$id> on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId saved draft in account <$id> on behalf of $effectiveUserId");
 			return new JSONResponse([
 				'id' => $this->mailManager->getMessageIdForUid($draftsMailbox, $newUID)
 			]);
@@ -487,7 +467,7 @@ class AccountsController extends Controller {
 	 * @throws ClientException
 	 */
 	public function getQuota(int $id): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$account = $this->accountService->find($effectiveUserId, $id);
 
 		$quota = $this->mailManager->getQuota($account);
@@ -507,11 +487,11 @@ class AccountsController extends Controller {
 	 * @throws ClientException
 	 */
 	public function updateSmimeCertificate(int $id, ?int $smimeCertificateId = null) {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$account = $this->accountService->find($effectiveUserId, $id)->getMailAccount();
 		$account->setSmimeCertificateId($smimeCertificateId);
 		$this->accountService->update($account);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated S/MIME certificate for account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated S/MIME certificate for account <$id> on behalf of $effectiveUserId");
 		return MailJsonResponse::success();
 	}
 
@@ -524,7 +504,7 @@ class AccountsController extends Controller {
 	 * @throws ClientException
 	 */
 	public function testAccountConnection(int $id) {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		return new JSONResponse([
 			'data' => $this->accountService->testAccountConnection($effectiveUserId, $id),
 		]);

--- a/lib/Controller/ActionStepController.php
+++ b/lib/Controller/ActionStepController.php
@@ -21,16 +21,13 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\IRequest;
 
 class ActionStepController extends Controller {
-	private ?string $uid;
-
 	public function __construct(
 		IRequest $request,
-		?string $userId,
+		private ?string $userId,
 		private QuickActionsService $quickActionsService,
 		private AccountService $accountService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->uid = $userId;
 	}
 
 	/**
@@ -41,11 +38,11 @@ class ActionStepController extends Controller {
 	 */
 	#[TrapError]
 	public function create(string $name, int $order, int $actionId, ?int $tagId = null, ?int $mailboxId = null): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$action = $this->quickActionsService->find($actionId, $this->uid);
+			$action = $this->quickActionsService->find($actionId, $this->userId);
 			if ($action === null) {
 				return JsonResponse::fail('Action not found', Http::STATUS_BAD_REQUEST);
 			}
@@ -54,7 +51,7 @@ class ActionStepController extends Controller {
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::fail('Account not found', Http::STATUS_BAD_REQUEST);
 		}
-		if ($account->getUserId() !== $this->uid) {
+		if ($account->getUserId() !== $this->userId) {
 			return JsonResponse::fail('Account not found', Http::STATUS_BAD_REQUEST);
 		}
 		$actionStep = $this->quickActionsService->createActionStep($name, $order, $actionId, $tagId, $mailboxId);
@@ -72,11 +69,11 @@ class ActionStepController extends Controller {
 	#[TrapError]
 	public function update(int $id, string $name, int $order, ?int $tagId, ?int $mailboxId): JsonResponse {
 
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
-		$actionStep = $this->quickActionsService->findActionStep($id, $this->uid);
+		$actionStep = $this->quickActionsService->findActionStep($id, $this->userId);
 
 		$actionStep = $this->quickActionsService->updateActionStep($actionStep, $name, $order, $tagId, $mailboxId);
 
@@ -89,11 +86,11 @@ class ActionStepController extends Controller {
 	 * @return JsonResponse
 	 */
 	public function destroy(int $id): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$this->quickActionsService->deleteActionStep($id, $this->uid);
+			$this->quickActionsService->deleteActionStep($id, $this->userId);
 			return JsonResponse::success();
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::fail('Action step not found', Http::STATUS_NOT_FOUND);

--- a/lib/Controller/AliasesController.php
+++ b/lib/Controller/AliasesController.php
@@ -23,19 +23,14 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AliasesController extends Controller {
-	private AliasesService $aliasService;
-	private string $currentUserId;
-	private DelegationService $delegationService;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		AliasesService $aliasesService,
-		string $userId,
-		DelegationService $delegationService) {
+		private AliasesService $aliasService,
+		private string $userId,
+		private DelegationService $delegationService,
+	) {
 		parent::__construct($appName, $request);
-		$this->aliasService = $aliasesService;
-		$this->currentUserId = $userId;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -47,7 +42,7 @@ class AliasesController extends Controller {
 	 */
 	#[TrapError]
 	public function index(int $accountId): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		return new JSONResponse($this->aliasService->findAll($accountId, $effectiveUserId));
 	}
 
@@ -70,7 +65,7 @@ class AliasesController extends Controller {
 		string $alias,
 		string $aliasName,
 		?int $smimeCertificateId = null): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->userId);
 		$alias = $this->aliasService->update(
 			$effectiveUserId,
 			$id,
@@ -78,7 +73,7 @@ class AliasesController extends Controller {
 			$aliasName,
 			$smimeCertificateId,
 		);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated alias: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated alias: $id on behalf of $effectiveUserId");
 		return new JSONResponse($alias);
 	}
 
@@ -90,9 +85,9 @@ class AliasesController extends Controller {
 	 */
 	#[TrapError]
 	public function destroy(int $id): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->userId);
 		$alias = $this->aliasService->delete($effectiveUserId, $id);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId deleted alias: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId deleted alias: $id on behalf of $effectiveUserId");
 		return new JSONResponse($alias);
 	}
 
@@ -109,10 +104,10 @@ class AliasesController extends Controller {
 	 */
 	#[TrapError]
 	public function create(int $accountId, string $alias, string $aliasName): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		$alias = $this->aliasService->create($effectiveUserId, $accountId, $alias, $aliasName);
 		$id = $alias->getId();
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId created alias: $id  on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId created alias: $id  on behalf of $effectiveUserId");
 		return new JSONResponse(
 			$alias,
 			Http::STATUS_CREATED
@@ -131,9 +126,9 @@ class AliasesController extends Controller {
 	 */
 	#[TrapError]
 	public function updateSignature(int $id, ?string $signature = null): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAliasUserId($id, $this->userId);
 		$alias = $this->aliasService->updateSignature($effectiveUserId, $id, $signature);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated alias: $id 's signature on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated alias: $id 's signature on behalf of $effectiveUserId");
 		return new JSONResponse($alias);
 	}
 }

--- a/lib/Controller/AutoCompleteController.php
+++ b/lib/Controller/AutoCompleteController.php
@@ -19,17 +19,13 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AutoCompleteController extends Controller {
-	private AutoCompleteService $service;
-	private ?string $userId;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		AutoCompleteService $service,
-		?string $userId) {
+		private AutoCompleteService $service,
+		private ?string $userId,
+	) {
 		parent::__construct($appName, $request);
-
-		$this->service = $service;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/AutoConfigController.php
+++ b/lib/Controller/AutoConfigController.php
@@ -26,20 +26,16 @@ use function in_array;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AutoConfigController extends Controller {
-	private IspDb $ispDb;
-	private MxRecord $mxRecord;
-	private ConnectivityTester $connectivityTester;
 	private IRemoteHostValidator $hostValidator;
 
-	public function __construct(IRequest $request,
-		IspDb $ispDb,
-		MxRecord $mxRecord,
-		ConnectivityTester $connectivityTester,
-		IRemoteHostValidator $hostValidator) {
+	public function __construct(
+		IRequest $request,
+		private IspDb $ispDb,
+		private MxRecord $mxRecord,
+		private ConnectivityTester $connectivityTester,
+		IRemoteHostValidator $hostValidator,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->ispDb = $ispDb;
-		$this->mxRecord = $mxRecord;
-		$this->connectivityTester = $connectivityTester;
 		$this->hostValidator = $hostValidator;
 	}
 

--- a/lib/Controller/AvatarsController.php
+++ b/lib/Controller/AvatarsController.php
@@ -21,17 +21,13 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class AvatarsController extends Controller {
-	private IAvatarService $avatarService;
-	private string $uid;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		IAvatarService $avatarService,
-		string $userId) {
+		private IAvatarService $avatarService,
+		private string $userId,
+	) {
 		parent::__construct($appName, $request);
-
-		$this->avatarService = $avatarService;
-		$this->uid = $userId;
 	}
 
 	/**
@@ -51,7 +47,7 @@ class AvatarsController extends Controller {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		$avatar = $this->avatarService->getAvatar($email, $this->uid);
+		$avatar = $this->avatarService->getAvatar($email, $this->userId);
 		if (is_null($avatar)) {
 			// No avatar found
 			$response = new JSONResponse([], Http::STATUS_NO_CONTENT);
@@ -84,7 +80,7 @@ class AvatarsController extends Controller {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
-		$imageData = $this->avatarService->getAvatarImage($email, $this->uid);
+		$imageData = $this->avatarService->getAvatarImage($email, $this->userId);
 
 		if ($imageData === null) {
 			return $this->noAvatarFoundResponse();

--- a/lib/Controller/ContactIntegrationController.php
+++ b/lib/Controller/ContactIntegrationController.php
@@ -21,21 +21,18 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ContactIntegrationController extends Controller {
-	private ContactIntegrationService $service;
 	private ICache $cache;
-	private string $uid;
 
 
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		ContactIntegrationService $service,
+		private ContactIntegrationService $service,
 		ICacheFactory $cacheFactory,
-		string $userId) {
+		private string $userId,
+	) {
 		parent::__construct($appName, $request);
-
-		$this->service = $service;
 		$this->cache = $cacheFactory->createLocal('mail.contacts');
-		$this->uid = $userId;
 	}
 
 	/**
@@ -46,7 +43,7 @@ class ContactIntegrationController extends Controller {
 	 */
 	#[TrapError]
 	public function match(string $mail): JSONResponse {
-		return (new JSONResponse($this->service->findMatches($this->uid, $mail)))->cacheFor(60 * 60, false, true);
+		return (new JSONResponse($this->service->findMatches($this->userId, $mail)))->cacheFor(60 * 60, false, true);
 	}
 
 	/**
@@ -85,15 +82,15 @@ class ContactIntegrationController extends Controller {
 	 */
 	#[TrapError]
 	public function autoComplete(string $term): JSONResponse {
-		$cached = $this->cache->get("{$this->uid}:$term");
+		$cached = $this->cache->get("{$this->userId}:$term");
 		if ($cached !== null) {
 			$decoded = json_decode($cached, true);
 			if ($decoded !== null) {
 				return new JSONResponse($decoded);
 			}
 		}
-		$res = $this->service->autoComplete($this->uid, $term);
-		$this->cache->set("{$this->uid}:$term", json_encode($res), 24 * 3600);
+		$res = $this->service->autoComplete($this->userId, $term);
+		$this->cache->set("{$this->userId}:$term", json_encode($res), 24 * 3600);
 		return new JSONResponse($res);
 	}
 }

--- a/lib/Controller/DelegationController.php
+++ b/lib/Controller/DelegationController.php
@@ -24,18 +24,15 @@ use OCP\IUserManager;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class DelegationController extends Controller {
-	private ?string $currentUserId;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private DelegationService $delegationService,
 		private AccountService $accountService,
 		private IUserManager $userManager,
-		?string $userId,
+		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
-		$this->currentUserId = $userId;
 	}
 
 	#[NoAdminRequired]
@@ -47,7 +44,7 @@ class DelegationController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($account->getUserId() !== $this->currentUserId) {
+		if ($account->getUserId() !== $this->userId) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
@@ -59,11 +56,11 @@ class DelegationController extends Controller {
 	#[NoAdminRequired]
 	#[TrapError]
 	public function delegate(int $accountId, string $userId): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
-		if ($userId === $this->currentUserId) {
+		if ($userId === $this->userId) {
 			return new JSONResponse(['message' => 'Cannot delegate to yourself'], Http::STATUS_BAD_REQUEST);
 		}
 
@@ -73,7 +70,7 @@ class DelegationController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($account->getUserId() !== $this->currentUserId) {
+		if ($account->getUserId() !== $this->userId) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
@@ -86,7 +83,7 @@ class DelegationController extends Controller {
 		}
 
 		try {
-			$delegation = $this->delegationService->delegate($account, $userId, $this->currentUserId);
+			$delegation = $this->delegationService->delegate($account, $userId, $this->userId);
 		} catch (DelegationExistsException) {
 			return new JSONResponse(['message' => 'Delegation already exists'], Http::STATUS_CONFLICT);
 		}
@@ -97,7 +94,7 @@ class DelegationController extends Controller {
 	#[NoAdminRequired]
 	#[TrapError]
 	public function unDelegate(int $accountId, string $userId): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
@@ -107,11 +104,11 @@ class DelegationController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		if ($account->getUserId() !== $this->currentUserId) {
+		if ($account->getUserId() !== $this->userId) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
-		$this->delegationService->unDelegate($account, $userId, $this->currentUserId);
+		$this->delegationService->unDelegate($account, $userId, $this->userId);
 		return new JSONResponse([], Http::STATUS_OK);
 	}
 }

--- a/lib/Controller/DraftsController.php
+++ b/lib/Controller/DraftsController.php
@@ -26,29 +26,21 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class DraftsController extends Controller {
-	private DraftsService $service;
-	private string $userId;
-	private AccountService $accountService;
 	private ITimeFactory $timeFactory;
-	private SmimeService $smimeService;
-	private DelegationService $delegationService;
 
 
-	public function __construct(string $appName,
-		$userId,
+	public function __construct(
+		string $appName,
+		private string $userId,
 		IRequest $request,
-		DraftsService $service,
-		AccountService $accountService,
+		private DraftsService $service,
+		private AccountService $accountService,
 		ITimeFactory $timeFactory,
-		SmimeService $smimeService,
-		DelegationService $delegationService) {
+		private SmimeService $smimeService,
+		private DelegationService $delegationService,
+	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
-		$this->service = $service;
-		$this->accountService = $accountService;
 		$this->timeFactory = $timeFactory;
-		$this->smimeService = $smimeService;
-		$this->delegationService = $delegationService;
 	}
 
 	/**

--- a/lib/Controller/FilterController.php
+++ b/lib/Controller/FilterController.php
@@ -21,17 +21,14 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class FilterController extends Controller {
-	private string $currentUserId;
-
 	public function __construct(
 		IRequest $request,
-		string $userId,
+		private string $userId,
 		private FilterService $mailFilterService,
 		private AccountService $accountService,
 		private DelegationService $delegationService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->currentUserId = $userId;
 	}
 
 
@@ -41,7 +38,7 @@ class FilterController extends Controller {
 	#[Route(Route::TYPE_FRONTPAGE, verb: 'GET', url: '/api/filter/{accountId}', requirements: ['accountId' => '[\d]+'])]
 	#[NoAdminRequired]
 	public function getFilters(int $accountId): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		$account = $this->accountService->findById($accountId);
 
 		if ($account->getUserId() !== $effectiveUserId) {
@@ -58,7 +55,7 @@ class FilterController extends Controller {
 	#[Route(Route::TYPE_FRONTPAGE, verb: 'PUT', url: '/api/filter/{accountId}', requirements: ['accountId' => '[\d]+'])]
 	#[NoAdminRequired]
 	public function updateFilters(int $accountId, array $filters): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		$account = $this->accountService->findById($accountId);
 
 		if ($account->getUserId() !== $effectiveUserId) {
@@ -66,7 +63,7 @@ class FilterController extends Controller {
 		}
 
 		$this->mailFilterService->update($account->getMailAccount(), $filters);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated account: $accountId 's filters  on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated account: $accountId 's filters  on behalf of $effectiveUserId");
 
 		return new JSONResponse([]);
 	}

--- a/lib/Controller/GoogleIntegrationController.php
+++ b/lib/Controller/GoogleIntegrationController.php
@@ -30,25 +30,15 @@ use function filter_var;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class GoogleIntegrationController extends Controller {
-	private ?string $userId;
-	private GoogleIntegration $googleIntegration;
-	private AccountService $accountService;
-	private LoggerInterface $logger;
-	private MailboxSync $mailboxSync;
-
-
-	public function __construct(IRequest $request,
-		?string $userId,
-		GoogleIntegration $googleIntegration,
-		AccountService $accountService,
-		LoggerInterface $logger,
-		MailboxSync $mailboxSync) {
+	public function __construct(
+		IRequest $request,
+		private ?string $userId,
+		private GoogleIntegration $googleIntegration,
+		private AccountService $accountService,
+		private LoggerInterface $logger,
+		private MailboxSync $mailboxSync,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->userId = $userId;
-		$this->googleIntegration = $googleIntegration;
-		$this->accountService = $accountService;
-		$this->logger = $logger;
-		$this->mailboxSync = $mailboxSync;
 	}
 
 	/**

--- a/lib/Controller/InternalAddressController.php
+++ b/lib/Controller/InternalAddressController.php
@@ -19,17 +19,12 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\IRequest;
 
 class InternalAddressController extends Controller {
-	private ?string $uid;
-
 	public function __construct(
 		IRequest $request,
-		?string $userId,
+		private ?string $userId,
 		private InternalAddressService $internalAddressService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-
-		$this->internalAddressService = $internalAddressService;
-		$this->uid = $userId;
 	}
 
 	/**
@@ -41,12 +36,12 @@ class InternalAddressController extends Controller {
 	 */
 	#[TrapError]
 	public function setAddress(string $address, string $type): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
 		$internalAddress = $this->internalAddressService->add(
-			$this->uid,
+			$this->userId,
 			$address,
 			$type
 		);
@@ -66,12 +61,12 @@ class InternalAddressController extends Controller {
 	 */
 	#[TrapError]
 	public function removeAddress(string $address, string $type): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
 		$this->internalAddressService->add(
-			$this->uid,
+			$this->userId,
 			$address,
 			$type,
 			false
@@ -87,11 +82,11 @@ class InternalAddressController extends Controller {
 	 */
 	#[TrapError]
 	public function list(): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		$list = $this->internalAddressService->getInternalAddresses(
-			$this->uid
+			$this->userId
 		);
 
 		return JsonResponse::success($list);

--- a/lib/Controller/ListController.php
+++ b/lib/Controller/ListController.php
@@ -26,31 +26,21 @@ use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ListController extends Controller {
-	private IMailManager $mailManager;
-	private AccountService $accountService;
-	private IMAPClientFactory $clientFactory;
 	private IClientService $httpClientService;
-	private LoggerInterface $logger;
-	private ?string $currentUserId;
-	private DelegationService $delegationService;
 
-	public function __construct(IRequest $request,
-		IMailManager $mailManager,
-		AccountService $accountService,
-		IMAPClientFactory $clientFactory,
+	public function __construct(
+		IRequest $request,
+		private IMailManager $mailManager,
+		private AccountService $accountService,
+		private IMAPClientFactory $clientFactory,
 		IClientService $httpClientService,
-		LoggerInterface $logger,
-		?string $userId,
-		DelegationService $delegationService) {
+		private LoggerInterface $logger,
+		private ?string $userId,
+		private DelegationService $delegationService,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->mailManager = $mailManager;
-		$this->accountService = $accountService;
-		$this->clientFactory = $clientFactory;
 		$this->request = $request;
 		$this->httpClientService = $httpClientService;
-		$this->logger = $logger;
-		$this->currentUserId = $userId;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -58,12 +48,12 @@ class ListController extends Controller {
 	 * @UserRateThrottle(limit=10, period=3600)
 	 */
 	public function unsubscribe(int $id): JsonResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return JsonResponse::fail([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -99,7 +89,7 @@ class ListController extends Controller {
 		} finally {
 			$client->logout();
 		}
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId unsubscribed from mailing list: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId unsubscribed from mailing list: $id on behalf of $effectiveUserId");
 
 		return JsonResponse::success();
 	}

--- a/lib/Controller/LocalAttachmentsController.php
+++ b/lib/Controller/LocalAttachmentsController.php
@@ -21,20 +21,19 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class LocalAttachmentsController extends Controller {
-	private IAttachmentService $attachmentService;
-	private string $userId;
-
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IAttachmentService $attachmentService
 	 * @param string $UserId
 	 */
-	public function __construct(string $appName, IRequest $request,
-		IAttachmentService $attachmentService, $userId) {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IAttachmentService $attachmentService,
+		private string $userId,
+	) {
 		parent::__construct($appName, $request);
-		$this->attachmentService = $attachmentService;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/MailboxesController.php
+++ b/lib/Controller/MailboxesController.php
@@ -36,30 +36,18 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MailboxesController extends Controller {
-	private AccountService $accountService;
-	private IMailManager $mailManager;
-	private SyncService $syncService;
-	private ?string $currentUserId;
-	private DelegationService $delegationService;
-
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		AccountService $accountService,
-		?string $userId,
-		IMailManager $mailManager,
-		SyncService $syncService,
+		private AccountService $accountService,
+		private ?string $userId,
+		private IMailManager $mailManager,
+		private SyncService $syncService,
 		private readonly IConfig $config,
 		private readonly ITimeFactory $timeFactory,
-		DelegationService $delegationService,
+		private DelegationService $delegationService,
 	) {
 		parent::__construct($appName, $request);
-
-		$this->accountService = $accountService;
-		$this->currentUserId = $userId;
-		$this->mailManager = $mailManager;
-		$this->syncService = $syncService;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -75,12 +63,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function index(int $accountId, bool $forceSync = false): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -108,12 +96,12 @@ class MailboxesController extends Controller {
 		?string $name = null,
 		?bool $subscribed = null,
 		?bool $syncInBackground = null): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -126,7 +114,7 @@ class MailboxesController extends Controller {
 				$mailbox,
 				$name
 			);
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId changed mailbox: $id's name to $name on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId changed mailbox: $id's name to $name on behalf of $effectiveUserId");
 		}
 		if ($subscribed !== null) {
 			$mailbox = $this->mailManager->updateSubscription(
@@ -135,7 +123,7 @@ class MailboxesController extends Controller {
 				$subscribed
 			);
 			$subscribedVerb = $subscribed ? 'subscribed' : 'unsubscribed';
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId $subscribedVerb to mailbox: $id on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId $subscribedVerb to mailbox: $id on behalf of $effectiveUserId");
 
 		}
 		if ($syncInBackground !== null) {
@@ -144,7 +132,7 @@ class MailboxesController extends Controller {
 				$syncInBackground
 			);
 			$syncVerb = $syncInBackground ? 'enabled' : 'disabled';
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId $syncVerb background sync for mailbox: $id on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId $syncVerb background sync for mailbox: $id on behalf of $effectiveUserId");
 		}
 		return new JSONResponse($mailbox);
 	}
@@ -164,12 +152,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function sync(int $id, array $ids = [], ?int $lastMessageTimestamp = null, bool $init = false, string $sortOrder = 'newest', ?string $query = null): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -178,7 +166,7 @@ class MailboxesController extends Controller {
 		$order = $sortOrder === 'newest' ? IMailSearch::ORDER_NEWEST_FIRST: IMailSearch::ORDER_OLDEST_FIRST;
 
 		$this->config->setUserValue(
-			$this->currentUserId,
+			$this->userId,
 			Application::APP_ID,
 			'ui-heartbeat',
 			(string)$this->timeFactory->getTime(),
@@ -215,12 +203,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function clearCache(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -242,12 +230,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function markAllAsRead(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -256,7 +244,7 @@ class MailboxesController extends Controller {
 
 		$this->mailManager->markFolderAsRead($account, $mailbox);
 
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId marked all messages as read in mailbox: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId marked all messages as read in mailbox: $id on behalf of $effectiveUserId");
 
 		return new JSONResponse([]);
 	}
@@ -273,12 +261,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function stats(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -318,19 +306,19 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function create(int $accountId, string $name): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveAccountUserId($accountId, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 		$account = $this->accountService->find($effectiveUserId, $accountId);
 		$mailbox = $this->mailManager->createMailbox($account, $name);
 		$id = $mailbox->getId();
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId created mailbox: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId created mailbox: $id on behalf of $effectiveUserId");
 
 		return new JSONResponse($mailbox);
 	}
@@ -346,12 +334,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function destroy(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -359,7 +347,7 @@ class MailboxesController extends Controller {
 		$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
 
 		$this->mailManager->deleteMailbox($account, $mailbox);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId deleted mailbox: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId deleted mailbox: $id on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -376,12 +364,12 @@ class MailboxesController extends Controller {
 	 */
 	#[TrapError]
 	public function clearMailbox(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -389,7 +377,7 @@ class MailboxesController extends Controller {
 		$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
 
 		$this->mailManager->clearMailbox($account, $mailbox);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId cleared mailbox: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId cleared mailbox: $id on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}
 
@@ -400,12 +388,12 @@ class MailboxesController extends Controller {
 	#[NoAdminRequired]
 	#[UserRateLimit(limit: 10, period: 600)]
 	public function repair(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -413,7 +401,7 @@ class MailboxesController extends Controller {
 		$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
 
 		$this->syncService->repairSync($account, $mailbox);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId repaired mailbox: $id on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId repaired mailbox: $id on behalf of $effectiveUserId");
 
 		return new JsonResponse();
 	}

--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -49,11 +49,9 @@ use function array_merge;
  */
 class MessageApiController extends OCSController {
 
-	private ?string $userId;
-
 	public function __construct(
 		string $appName,
-		?string $userId,
+		private ?string $userId,
 		IRequest $request,
 		private AccountService $accountService,
 		private AliasesService $aliasesService,
@@ -70,7 +68,6 @@ class MessageApiController extends OCSController {
 		private DelegationService $delegationService,
 	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -57,73 +57,41 @@ use function array_map;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MessagesController extends Controller {
-	private AccountService $accountService;
-	private IMailManager $mailManager;
-	private IMailSearch $mailSearch;
-	private ItineraryService $itineraryService;
-	private ?string $currentUserId;
-	private LoggerInterface $logger;
-	private ?Folder $userFolder;
 	private IMimeTypeDetector $mimeTypeDetector;
 	private IL10N $l10n;
 	private IURLGenerator $urlGenerator;
 	private ContentSecurityPolicyNonceManager $nonceManager;
-	private ITrustedSenderService $trustedSenderService;
-	private IMailTransmission $mailTransmission;
-	private SmimeService $smimeService;
-	private IMAPClientFactory $clientFactory;
-	private IDkimService $dkimService;
-	private IUserPreferences $preferences;
-	private SnoozeService $snoozeService;
-	private AiIntegrationsService $aiIntegrationService;
-	private DelegationService $delegationService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		AccountService $accountService,
-		IMailManager $mailManager,
-		IMailSearch $mailSearch,
-		ItineraryService $itineraryService,
-		?string $userId,
-		$userFolder,
-		LoggerInterface $logger,
+		private AccountService $accountService,
+		private IMailManager $mailManager,
+		private IMailSearch $mailSearch,
+		private ItineraryService $itineraryService,
+		private ?string $userId,
+		private ?Folder $userFolder,
+		private LoggerInterface $logger,
 		IL10N $l10n,
 		IMimeTypeDetector $mimeTypeDetector,
 		IURLGenerator $urlGenerator,
 		ContentSecurityPolicyNonceManager $nonceManager,
-		ITrustedSenderService $trustedSenderService,
-		IMailTransmission $mailTransmission,
-		SmimeService $smimeService,
-		IMAPClientFactory $clientFactory,
-		IDkimService $dkimService,
-		IUserPreferences $preferences,
-		SnoozeService $snoozeService,
-		AiIntegrationsService $aiIntegrationService,
+		private ITrustedSenderService $trustedSenderService,
+		private IMailTransmission $mailTransmission,
+		private SmimeService $smimeService,
+		private IMAPClientFactory $clientFactory,
+		private IDkimService $dkimService,
+		private IUserPreferences $preferences,
+		private SnoozeService $snoozeService,
+		private AiIntegrationsService $aiIntegrationService,
 		private ICacheFactory $cacheFactory,
-		DelegationService $delegationService,
+		private DelegationService $delegationService,
 	) {
 		parent::__construct($appName, $request);
-		$this->accountService = $accountService;
-		$this->mailManager = $mailManager;
-		$this->mailSearch = $mailSearch;
-		$this->itineraryService = $itineraryService;
-		$this->currentUserId = $userId;
-		$this->userFolder = $userFolder;
-		$this->logger = $logger;
 		$this->l10n = $l10n;
 		$this->mimeTypeDetector = $mimeTypeDetector;
 		$this->urlGenerator = $urlGenerator;
 		$this->nonceManager = $nonceManager;
-		$this->trustedSenderService = $trustedSenderService;
-		$this->mailTransmission = $mailTransmission;
-		$this->smimeService = $smimeService;
-		$this->clientFactory = $clientFactory;
-		$this->dkimService = $dkimService;
-		$this->preferences = $preferences;
-		$this->snoozeService = $snoozeService;
-		$this->aiIntegrationService = $aiIntegrationService;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -148,13 +116,13 @@ class MessagesController extends Controller {
 		?int $limit = null,
 		?string $view = null,
 		?string $v = null): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		$limit = min(100, max(1, $limit));
 
 		try {
-			$effectiveUserId = $this->delegationService->resolveMailboxUserId($mailboxId, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMailboxUserId($mailboxId, $this->userId);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $mailboxId);
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
 		} catch (DoesNotExistException $e) {
@@ -162,7 +130,7 @@ class MessagesController extends Controller {
 		}
 
 		$this->logger->debug("loading messages of mailbox <$mailboxId>");
-		$sort = $this->preferences->getPreference($this->currentUserId, 'sort-order', 'newest') === 'newest' ? IMailSearch::ORDER_NEWEST_FIRST : IMailSearch::ORDER_OLDEST_FIRST;
+		$sort = $this->preferences->getPreference($this->userId, 'sort-order', 'newest') === 'newest' ? IMailSearch::ORDER_NEWEST_FIRST : IMailSearch::ORDER_OLDEST_FIRST;
 
 		$view = $view === 'singleton' ? IMailSearch::VIEW_SINGLETON : IMailSearch::VIEW_THREADED;
 
@@ -194,11 +162,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function show(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -229,11 +197,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function getBody(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -305,11 +273,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function getItineraries(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -328,11 +296,11 @@ class MessagesController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function getDkim(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -346,7 +314,7 @@ class MessagesController extends Controller {
 	}
 
 	private function isSenderTrusted(Message $message): bool {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return false;
 		}
 		$from = $message->getFrom();
@@ -359,7 +327,7 @@ class MessagesController extends Controller {
 			return false;
 		}
 		return $this->trustedSenderService->isTrusted(
-			$this->currentUserId,
+			$this->userId,
 			$email
 		);
 	}
@@ -375,11 +343,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function getThread(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -407,11 +375,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function move(int $id, int $destFolderId): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$srcMailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$dstMailbox = $this->mailManager->getMailbox($effectiveUserId, $destFolderId);
@@ -429,7 +397,7 @@ class MessagesController extends Controller {
 			$dstMailbox->getName()
 		);
 
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId moved message <$id> to mailbox <$destFolderId> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId moved message <$id> to mailbox <$destFolderId> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -447,11 +415,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function snooze(int $id, int $unixTimestamp, int $destMailboxId): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$srcMailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$dstMailbox = $this->mailManager->getMailbox($effectiveUserId, $destMailboxId);
@@ -462,7 +430,7 @@ class MessagesController extends Controller {
 		}
 
 		$this->snoozeService->snoozeMessage($message, $unixTimestamp, $srcAccount, $srcMailbox, $dstAccount, $dstMailbox);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId snoozed message <$id> to <$unixTimestamp> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId snoozed message <$id> to <$unixTimestamp> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -478,18 +446,18 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function unSnooze(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->snoozeService->unSnoozeMessage($message, $effectiveUserId);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId unsnoozed message <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId unsnoozed message <$id> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -506,11 +474,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function mdn(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -541,11 +509,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function getSource(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -586,11 +554,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function export(int $id): Response {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -630,7 +598,7 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function getHtmlBody(int $id, bool $plain = false): Response {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new TemplateResponse(
 				$this->appName,
 				'error',
@@ -641,7 +609,7 @@ class MessagesController extends Controller {
 		}
 		try {
 			try {
-				$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+				$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 				$message = $this->mailManager->getMessage($effectiveUserId, $id);
 				$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 				$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -722,11 +690,11 @@ class MessagesController extends Controller {
 	#[TrapError]
 	public function downloadAttachment(int $id,
 		string $attachmentId): Response {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -773,11 +741,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function downloadAttachments(int $id): Response {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -820,7 +788,7 @@ class MessagesController extends Controller {
 	public function saveAttachment(int $id,
 		string $attachmentId,
 		string $targetPath) {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		if ($this->userFolder === null) {
@@ -833,7 +801,7 @@ class MessagesController extends Controller {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -891,11 +859,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function setFlags(int $id, array $flags): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -910,7 +878,7 @@ class MessagesController extends Controller {
 			$flagChanges[] = "$flag=" . ($value ? 'true' : 'false');
 		}
 		$flagsSummary = implode(', ', $flagChanges);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated flags on message <$id> with [$flagsSummary] on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated flags on message <$id> with [$flagsSummary] on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}
 
@@ -927,11 +895,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function setTag(int $id, string $imapLabel): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -940,13 +908,13 @@ class MessagesController extends Controller {
 		}
 
 		try {
-			$tag = $this->mailManager->getTagByImapLabel($imapLabel, $this->currentUserId);
+			$tag = $this->mailManager->getTagByImapLabel($imapLabel, $this->userId);
 		} catch (ClientException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->mailManager->tagMessage($account, $mailbox->getName(), $message, $tag, true);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId added tag <$imapLabel> on message <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId added tag <$imapLabel> on message <$id> on behalf of $effectiveUserId");
 		return new JSONResponse($tag);
 	}
 
@@ -963,11 +931,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function removeTag(int $id, string $imapLabel): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -976,13 +944,13 @@ class MessagesController extends Controller {
 		}
 
 		try {
-			$tag = $this->mailManager->getTagByImapLabel($imapLabel, $this->currentUserId);
+			$tag = $this->mailManager->getTagByImapLabel($imapLabel, $this->userId);
 		} catch (ClientException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->mailManager->tagMessage($account, $mailbox->getName(), $message, $tag, false);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId removed tag <$imapLabel> on message <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId removed tag <$imapLabel> on message <$id> on behalf of $effectiveUserId");
 		return new JSONResponse($tag);
 	}
 
@@ -996,11 +964,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function destroy(int $id): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -1015,7 +983,7 @@ class MessagesController extends Controller {
 			$mailbox->getName(),
 			$message->getUid()
 		);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId deleted message <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId deleted message <$id> on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}
 
@@ -1028,11 +996,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function smartReply(int $messageId):JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($messageId, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($messageId, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $messageId);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -1060,11 +1028,11 @@ class MessagesController extends Controller {
 	 */
 	#[TrapError]
 	public function needsTranslation(int $messageId): JSONResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($messageId, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($messageId, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $messageId);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());

--- a/lib/Controller/MicrosoftIntegrationController.php
+++ b/lib/Controller/MicrosoftIntegrationController.php
@@ -25,21 +25,14 @@ use function filter_var;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MicrosoftIntegrationController extends Controller {
-	private ?string $userId;
-	private AccountService $accountService;
-	private MicrosoftIntegration $microsoftIntegration;
-	private LoggerInterface $logger;
-
-	public function __construct(IRequest $request,
-		?string $userId,
-		AccountService $accountService,
-		MicrosoftIntegration $microsoftIntegration,
-		LoggerInterface $logger) {
+	public function __construct(
+		IRequest $request,
+		private ?string $userId,
+		private AccountService $accountService,
+		private MicrosoftIntegration $microsoftIntegration,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->userId = $userId;
-		$this->accountService = $accountService;
-		$this->microsoftIntegration = $microsoftIntegration;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Controller/OutboxController.php
+++ b/lib/Controller/OutboxController.php
@@ -26,25 +26,16 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class OutboxController extends Controller {
-	private OutboxService $service;
-	private string $userId;
-	private AccountService $accountService;
-	private SmimeService $smimeService;
-	private DelegationService $delegationService;
-
-	public function __construct(string $appName,
-		$userId,
+	public function __construct(
+		string $appName,
+		private string $userId,
 		IRequest $request,
-		OutboxService $service,
-		AccountService $accountService,
-		SmimeService $smimeService,
-		DelegationService $delegationService) {
+		private OutboxService $service,
+		private AccountService $accountService,
+		private SmimeService $smimeService,
+		private DelegationService $delegationService,
+	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
-		$this->service = $service;
-		$this->accountService = $accountService;
-		$this->smimeService = $smimeService;
-		$this->delegationService = $delegationService;
 	}
 
 	/**

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -56,76 +56,50 @@ use function json_decode;
 class PageController extends Controller {
 	private IURLGenerator $urlGenerator;
 	private IConfig $config;
-	private AccountService $accountService;
-	private AliasesService $aliasesService;
-	private ?string $currentUserId;
 	private IUserSession $userSession;
-	private IUserPreferences $preferences;
-	private IMailManager $mailManager;
-	private TagMapper $tagMapper;
 	private IInitialState $initialStateService;
-	private LoggerInterface $logger;
-	private OutboxService $outboxService;
 	private IEventDispatcher $dispatcher;
 	private ICredentialstore $credentialStore;
-	private SmimeService $smimeService;
-	private AiIntegrationsService $aiIntegrationsService;
 	private IUserManager $userManager;
 	private IAvailabilityCoordinator $availabilityCoordinator;
-	private InternalAddressService $internalAddressService;
-	private QuickActionsService $quickActionsService;
-	private ContextChatSettingsService $contextChatSettingsService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		IURLGenerator $urlGenerator,
 		IConfig $config,
-		AccountService $accountService,
-		AliasesService $aliasesService,
-		?string $userId,
+		private AccountService $accountService,
+		private AliasesService $aliasesService,
+		private ?string $userId,
 		IUserSession $userSession,
-		IUserPreferences $preferences,
-		IMailManager $mailManager,
-		TagMapper $tagMapper,
+		private IUserPreferences $preferences,
+		private IMailManager $mailManager,
+		private TagMapper $tagMapper,
 		IInitialState $initialStateService,
-		LoggerInterface $logger,
-		OutboxService $outboxService,
+		private LoggerInterface $logger,
+		private OutboxService $outboxService,
 		IEventDispatcher $dispatcher,
 		ICredentialStore $credentialStore,
-		SmimeService $smimeService,
-		AiIntegrationsService $aiIntegrationsService,
+		private SmimeService $smimeService,
+		private AiIntegrationsService $aiIntegrationsService,
 		IUserManager $userManager,
-		InternalAddressService $internalAddressService,
+		private InternalAddressService $internalAddressService,
 		IAvailabilityCoordinator $availabilityCoordinator,
-		QuickActionsService $quickActionsService,
+		private QuickActionsService $quickActionsService,
 		private IAppManager $appManager,
-		ContextChatSettingsService $contextChatSettingsService,
+		private ContextChatSettingsService $contextChatSettingsService,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
 		parent::__construct($appName, $request);
 
 		$this->urlGenerator = $urlGenerator;
 		$this->config = $config;
-		$this->accountService = $accountService;
-		$this->aliasesService = $aliasesService;
-		$this->currentUserId = $userId;
 		$this->userSession = $userSession;
-		$this->preferences = $preferences;
-		$this->mailManager = $mailManager;
-		$this->tagMapper = $tagMapper;
 		$this->initialStateService = $initialStateService;
-		$this->logger = $logger;
-		$this->outboxService = $outboxService;
 		$this->dispatcher = $dispatcher;
 		$this->credentialStore = $credentialStore;
-		$this->smimeService = $smimeService;
-		$this->aiIntegrationsService = $aiIntegrationsService;
 		$this->userManager = $userManager;
-		$this->internalAddressService = $internalAddressService;
 		$this->availabilityCoordinator = $availabilityCoordinator;
-		$this->quickActionsService = $quickActionsService;
-		$this->contextChatSettingsService = $contextChatSettingsService;
 	}
 
 	/**
@@ -135,7 +109,7 @@ class PageController extends Controller {
 	 * @return TemplateResponse renders the index page
 	 */
 	public function index(): TemplateResponse {
-		if ($this->currentUserId === null) {
+		if ($this->userId === null) {
 			// This should not happen as the route requires authentication,
 			// but handle it defensively.
 			return new TemplateResponse($this->appName, 'index');
@@ -165,13 +139,13 @@ class PageController extends Controller {
 			$this->appManager->getAppVersion('mail'),
 		);
 
-		$mailAccounts = $this->accountService->findByUserId($this->currentUserId);
+		$mailAccounts = $this->accountService->findByUserId($this->userId);
 		$accountsJson = [];
 		foreach ($mailAccounts as $mailAccount) {
 			$json = $mailAccount->jsonSerialize();
 			$json['isDelegated'] = false;
 			$json['aliases'] = $this->aliasesService->findAll($mailAccount->getId(),
-				$this->currentUserId);
+				$this->userId);
 			try {
 				$mailboxes = $this->mailManager->getMailboxes($mailAccount);
 				$json['mailboxes'] = $mailboxes;
@@ -185,7 +159,7 @@ class PageController extends Controller {
 			$accountsJson[] = $json;
 		}
 
-		$delegatedAccounts = $this->accountService->findDelegatedAccounts($this->currentUserId);
+		$delegatedAccounts = $this->accountService->findDelegatedAccounts($this->userId);
 		foreach ($delegatedAccounts as $delegatedAccount) {
 			$json = $delegatedAccount->jsonSerialize();
 			$json['isDelegated'] = true;
@@ -210,31 +184,31 @@ class PageController extends Controller {
 		);
 		$this->initialStateService->provideInitialState(
 			'account-settings',
-			json_decode($this->preferences->getPreference($this->currentUserId, 'account-settings', '[]'), true, 512, JSON_THROW_ON_ERROR) ?? []
+			json_decode($this->preferences->getPreference($this->userId, 'account-settings', '[]'), true, 512, JSON_THROW_ON_ERROR) ?? []
 		);
 		$this->initialStateService->provideInitialState(
 			'tags',
-			$this->tagMapper->getAllTagsForUser($this->currentUserId)
+			$this->tagMapper->getAllTagsForUser($this->userId)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'internal-addresses-list',
-			$this->internalAddressService->getInternalAddresses($this->currentUserId)
+			$this->internalAddressService->getInternalAddresses($this->userId)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'internal-addresses',
-			$this->preferences->getPreference($this->currentUserId, 'internal-addresses', false)
+			$this->preferences->getPreference($this->userId, 'internal-addresses', false)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'smime-sign-aliases',
-			json_decode($this->preferences->getPreference($this->currentUserId, 'smime-sign-aliases', '[]'), true, 512, JSON_THROW_ON_ERROR) ?? []
+			json_decode($this->preferences->getPreference($this->userId, 'smime-sign-aliases', '[]'), true, 512, JSON_THROW_ON_ERROR) ?? []
 		);
 
 		$this->initialStateService->provideInitialState(
 			'sort-order',
-			$this->preferences->getPreference($this->currentUserId, 'sort-order', 'newest')
+			$this->preferences->getPreference($this->userId, 'sort-order', 'newest')
 		);
 
 		try {
@@ -252,21 +226,21 @@ class PageController extends Controller {
 		$this->initialStateService->provideInitialState('preferences', [
 			'attachment-size-limit' => $this->config->getSystemValue('app.mail.attachment-size-limit', 0),
 			'app-version' => $this->config->getAppValue('mail', 'installed_version'),
-			'external-avatars' => $this->preferences->getPreference($this->currentUserId, 'external-avatars', 'true'),
-			'layout-mode' => $this->preferences->getPreference($this->currentUserId, 'layout-mode', 'vertical-split'),
-			'layout-message-view' => $this->preferences->getPreference($this->currentUserId, 'layout-message-view', $this->config->getAppValue('mail', 'layout_message_view', 'threaded')),
-			'reply-mode' => $this->preferences->getPreference($this->currentUserId, 'reply-mode', 'top'),
-			'collect-data' => $this->preferences->getPreference($this->currentUserId, 'collect-data', 'true'),
-			'search-priority-body' => $this->preferences->getPreference($this->currentUserId, 'search-priority-body', 'false'),
-			'start-mailbox-id' => $this->preferences->getPreference($this->currentUserId, 'start-mailbox-id'),
-			'follow-up-reminders' => $this->preferences->getPreference($this->currentUserId, 'follow-up-reminders', 'true'),
-			'sort-favorites' => $this->preferences->getPreference($this->currentUserId, 'sort-favorites', 'false'),
-			'index-context-chat' => $this->contextChatSettingsService->isIndexingEnabled($this->currentUserId) ? 'true' : 'false',
-			'compact-mode' => $this->preferences->getPreference($this->currentUserId, 'compact-mode', 'false'),
+			'external-avatars' => $this->preferences->getPreference($this->userId, 'external-avatars', 'true'),
+			'layout-mode' => $this->preferences->getPreference($this->userId, 'layout-mode', 'vertical-split'),
+			'layout-message-view' => $this->preferences->getPreference($this->userId, 'layout-message-view', $this->config->getAppValue('mail', 'layout_message_view', 'threaded')),
+			'reply-mode' => $this->preferences->getPreference($this->userId, 'reply-mode', 'top'),
+			'collect-data' => $this->preferences->getPreference($this->userId, 'collect-data', 'true'),
+			'search-priority-body' => $this->preferences->getPreference($this->userId, 'search-priority-body', 'false'),
+			'start-mailbox-id' => $this->preferences->getPreference($this->userId, 'start-mailbox-id'),
+			'follow-up-reminders' => $this->preferences->getPreference($this->userId, 'follow-up-reminders', 'true'),
+			'sort-favorites' => $this->preferences->getPreference($this->userId, 'sort-favorites', 'false'),
+			'index-context-chat' => $this->contextChatSettingsService->isIndexingEnabled($this->userId) ? 'true' : 'false',
+			'compact-mode' => $this->preferences->getPreference($this->userId, 'compact-mode', 'false'),
 		]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',
-			$this->userManager->getDisplayName($this->currentUserId) ?? '',
+			$this->userManager->getDisplayName($this->userId) ?? '',
 		);
 		$this->initialStateService->provideInitialState(
 			'importance_classification_default',
@@ -283,7 +257,7 @@ class PageController extends Controller {
 		);
 		$this->initialStateService->provideInitialState(
 			'quick-actions',
-			$this->quickActionsService->findAll($this->currentUserId),
+			$this->quickActionsService->findAll($this->userId),
 		);
 		$googleOauthclientId = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_id');
 		if (!empty($googleOauthclientId)) {

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -19,19 +19,17 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class PreferencesController extends Controller {
-	private IUserPreferences $userPreference;
-	private string $userId;
-
 	/**
 	 * @param IRequest $request
 	 * @param IUserPreferences $userPreference
 	 * @param string $UserId
 	 */
-	public function __construct(IRequest $request, IUserPreferences $userPreference, string $userId) {
+	public function __construct(
+		IRequest $request,
+		private IUserPreferences $userPreference,
+		private string $userId,
+	) {
 		parent::__construct('mail', $request);
-
-		$this->userPreference = $userPreference;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/ProxyController.php
+++ b/lib/Controller/ProxyController.php
@@ -34,29 +34,23 @@ class ProxyController extends Controller {
 	private IURLGenerator $urlGenerator;
 	private ISession $session;
 	private IClientService $clientService;
-	private LoggerInterface $logger;
-	private ProxyHmacGenerator $hmacGenerator;
-	private MailManager $mailManager;
-	private ?string $userId;
 
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
 		IURLGenerator $urlGenerator,
 		ISession $session,
 		IClientService $clientService,
-		ProxyHmacGenerator $hmacGenerator,
-		LoggerInterface $logger,
-		MailManager $mailManager,
-		?string $userId) {
+		private ProxyHmacGenerator $hmacGenerator,
+		private LoggerInterface $logger,
+		private MailManager $mailManager,
+		private ?string $userId,
+	) {
 		parent::__construct($appName, $request);
 		$this->request = $request;
 		$this->urlGenerator = $urlGenerator;
 		$this->session = $session;
 		$this->clientService = $clientService;
-		$this->logger = $logger;
-		$this->hmacGenerator = $hmacGenerator;
-		$this->mailManager = $mailManager;
-		$this->userId = $userId;
 	}
 
 	/**

--- a/lib/Controller/QuickActionsController.php
+++ b/lib/Controller/QuickActionsController.php
@@ -22,16 +22,13 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\IRequest;
 
 class QuickActionsController extends Controller {
-	private ?string $uid;
-
 	public function __construct(
 		IRequest $request,
-		?string $userId,
+		private ?string $userId,
 		private QuickActionsService $quickActionsService,
 		private AccountService $accountService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->uid = $userId;
 	}
 
 	/**
@@ -41,10 +38,10 @@ class QuickActionsController extends Controller {
 	 */
 	#[TrapError]
 	public function index(): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
-		$actions = $this->quickActionsService->findAll($this->uid);
+		$actions = $this->quickActionsService->findAll($this->userId);
 
 		return JsonResponse::success($actions);
 	}
@@ -57,7 +54,7 @@ class QuickActionsController extends Controller {
 	 */
 	#[TrapError]
 	public function create(string $name, int $accountId): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
@@ -65,7 +62,7 @@ class QuickActionsController extends Controller {
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::fail('Account not found', Http::STATUS_BAD_REQUEST);
 		}
-		if ($account->getUserId() !== $this->uid) {
+		if ($account->getUserId() !== $this->userId) {
 			return JsonResponse::fail('Account not found', Http::STATUS_BAD_REQUEST);
 		}
 		try {
@@ -87,11 +84,11 @@ class QuickActionsController extends Controller {
 	#[TrapError]
 	public function update(int $id, string $name): JsonResponse {
 
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
-		$quickAction = $this->quickActionsService->find($id, $this->uid);
+		$quickAction = $this->quickActionsService->find($id, $this->userId);
 
 		if ($quickAction === null) {
 			return JsonResponse::error('Quick action not found', Http::STATUS_NOT_FOUND);
@@ -108,11 +105,11 @@ class QuickActionsController extends Controller {
 	 * @return JsonResponse
 	 */
 	public function destroy(int $id): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$this->quickActionsService->delete($id, $this->uid);
+			$this->quickActionsService->delete($id, $this->userId);
 			return JsonResponse::success();
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::fail('Quick action not found', Http::STATUS_NOT_FOUND);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -26,24 +26,18 @@ use function array_merge;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class SettingsController extends Controller {
-	private ProvisioningManager $provisioningManager;
-	private AntiSpamService $antiSpamService;
-	private ContainerInterface $container;
 	private IConfig $config;
 
 	public function __construct(
 		IRequest $request,
-		ProvisioningManager $provisioningManager,
-		AntiSpamService $antiSpamService,
+		private ProvisioningManager $provisioningManager,
+		private AntiSpamService $antiSpamService,
 		IConfig $config,
-		ContainerInterface $container,
+		private ContainerInterface $container,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->provisioningManager = $provisioningManager;
-		$this->antiSpamService = $antiSpamService;
 		$this->config = $config;
-		$this->container = $container;
 	}
 
 	public function index(): JSONResponse {

--- a/lib/Controller/SieveController.php
+++ b/lib/Controller/SieveController.php
@@ -31,31 +31,23 @@ use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class SieveController extends Controller {
-	private MailAccountMapper $mailAccountMapper;
-	private SieveClientFactory $sieveClientFactory;
-	private string $currentUserId;
 	private ICrypto $crypto;
 	private IRemoteHostValidator $hostValidator;
-	private LoggerInterface $logger;
 
 	public function __construct(
 		IRequest $request,
-		string $userId,
-		MailAccountMapper $mailAccountMapper,
-		SieveClientFactory $sieveClientFactory,
+		private string $userId,
+		private MailAccountMapper $mailAccountMapper,
+		private SieveClientFactory $sieveClientFactory,
 		ICrypto $crypto,
 		IRemoteHostValidator $hostValidator,
-		LoggerInterface $logger,
+		private LoggerInterface $logger,
 		private SieveService $sieveService,
 		private DelegationService $delegationService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->currentUserId = $userId;
-		$this->mailAccountMapper = $mailAccountMapper;
-		$this->sieveClientFactory = $sieveClientFactory;
 		$this->crypto = $crypto;
 		$this->hostValidator = $hostValidator;
-		$this->logger = $logger;
 	}
 
 	/**
@@ -71,7 +63,7 @@ class SieveController extends Controller {
 	 */
 	#[TrapError]
 	public function getActiveScript(int $id): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$activeScript = $this->sieveService->getActiveScript($effectiveUserId, $id);
 		return new JSONResponse([
 			'scriptName' => $activeScript->getName(),
@@ -92,14 +84,14 @@ class SieveController extends Controller {
 	 */
 	#[TrapError]
 	public function updateActiveScript(int $id, string $script): JSONResponse {
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		try {
 			$this->sieveService->updateActiveScript($effectiveUserId, $id, $script);
 		} catch (ManagesieveException $e) {
 			$this->logger->error('Installing sieve script failed: ' . $e->getMessage(), ['app' => 'mail', 'exception' => $e]);
 			return new JSONResponse(data: ['message' => $e->getMessage()], statusCode: Http::STATUS_UNPROCESSABLE_ENTITY);
 		}
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated the active sieve script for account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated the active sieve script for account <$id> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -141,7 +133,7 @@ class SieveController extends Controller {
 				Http::STATUS_UNPROCESSABLE_ENTITY
 			);
 		}
-		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->currentUserId);
+		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
 		$mailAccount = $this->mailAccountMapper->find($effectiveUserId, $id);
 
 		if ($sieveEnabled === false) {
@@ -153,7 +145,7 @@ class SieveController extends Controller {
 			$mailAccount->setSievePassword(null);
 
 			$this->mailAccountMapper->save($mailAccount);
-			$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated sieve settings for account <$id> on behalf of $effectiveUserId");
+			$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated sieve settings for account <$id> on behalf of $effectiveUserId");
 			return new JSONResponse(['sieveEnabled' => $mailAccount->isSieveEnabled()]);
 		}
 
@@ -185,7 +177,7 @@ class SieveController extends Controller {
 		}
 
 		$this->mailAccountMapper->save($mailAccount);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId updated sieve settings for account <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated sieve settings for account <$id> on behalf of $effectiveUserId");
 		return new JSONResponse(['sieveEnabled' => $mailAccount->isSieveEnabled()]);
 	}
 }

--- a/lib/Controller/SmimeCertificatesController.php
+++ b/lib/Controller/SmimeCertificatesController.php
@@ -24,16 +24,13 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class SmimeCertificatesController extends Controller {
-	private ?string $userId;
-	private SmimeService $certificateService;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		?string $userId,
-		SmimeService $certificateService) {
+		private ?string $userId,
+		private SmimeService $certificateService,
+	) {
 		parent::__construct($appName, $request);
-		$this->userId = $userId;
-		$this->certificateService = $certificateService;
 	}
 
 	/**

--- a/lib/Controller/TagsController.php
+++ b/lib/Controller/TagsController.php
@@ -23,21 +23,13 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class TagsController extends Controller {
-	private string $currentUserId;
-	private IMailManager $mailManager;
-
-	private AccountService $accountService;
-
-
-	public function __construct(IRequest $request,
-		string $userId,
-		IMailManager $mailManager,
-		AccountService $accountService,
+	public function __construct(
+		IRequest $request,
+		private string $userId,
+		private IMailManager $mailManager,
+		private AccountService $accountService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->currentUserId = $userId;
-		$this->mailManager = $mailManager;
-		$this->accountService = $accountService;
 	}
 
 	/**
@@ -54,7 +46,7 @@ class TagsController extends Controller {
 		$this->validateDisplayName($displayName);
 		$this->validateColor($color);
 
-		$tag = $this->mailManager->createTag($displayName, $color, $this->currentUserId);
+		$tag = $this->mailManager->createTag($displayName, $color, $this->userId);
 		return new JSONResponse($tag);
 	}
 
@@ -73,7 +65,7 @@ class TagsController extends Controller {
 		$this->validateDisplayName($displayName);
 		$this->validateColor($color);
 
-		$tag = $this->mailManager->updateTag($id, $displayName, $color, $this->currentUserId);
+		$tag = $this->mailManager->updateTag($id, $displayName, $color, $this->userId);
 		return new JSONResponse($tag);
 	}
 	/**
@@ -84,11 +76,11 @@ class TagsController extends Controller {
 	#[TrapError]
 	public function delete(int $id, int $accountId): JSONResponse {
 		try {
-			$accounts = $this->accountService->findByUserId($this->currentUserId);
+			$accounts = $this->accountService->findByUserId($this->userId);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
-		$this->mailManager->deleteTag($id, $this->currentUserId, $accounts);
+		$this->mailManager->deleteTag($id, $this->userId, $accounts);
 
 		return new JSONResponse([$id]);
 	}

--- a/lib/Controller/TextBlockController.php
+++ b/lib/Controller/TextBlockController.php
@@ -20,15 +20,12 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\IRequest;
 
 class TextBlockController extends Controller {
-	private ?string $uid;
-
 	public function __construct(
 		IRequest $request,
-		?string $userId,
+		private ?string $userId,
 		private TextBlockService $textBlockService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->uid = $userId;
 	}
 
 	/**
@@ -38,10 +35,10 @@ class TextBlockController extends Controller {
 	 */
 	#[TrapError]
 	public function index(): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
-		$textBlocks = $this->textBlockService->findAll($this->uid);
+		$textBlocks = $this->textBlockService->findAll($this->userId);
 
 		return JsonResponse::success($textBlocks);
 	}
@@ -55,10 +52,10 @@ class TextBlockController extends Controller {
 	 */
 	#[TrapError]
 	public function create(string $title, string $content): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
-		$textBlock = $this->textBlockService->create($this->uid, $title, $content);
+		$textBlock = $this->textBlockService->create($this->userId, $title, $content);
 
 		return JsonResponse::success($textBlock, Http::STATUS_CREATED);
 	}
@@ -74,17 +71,17 @@ class TextBlockController extends Controller {
 	#[TrapError]
 	public function update(int $id, string $title, string $content): JsonResponse {
 
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
-		$textBlock = $this->textBlockService->find($id, $this->uid);
+		$textBlock = $this->textBlockService->find($id, $this->userId);
 
 		if ($textBlock === null) {
 			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
 
-		$textBlock = $this->textBlockService->update($textBlock, $this->uid, $title, $content);
+		$textBlock = $this->textBlockService->update($textBlock, $this->userId, $title, $content);
 
 		return JsonResponse::success($textBlock, Http::STATUS_OK);
 	}
@@ -95,11 +92,11 @@ class TextBlockController extends Controller {
 	 * @return JsonResponse
 	 */
 	public function destroy(int $id): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$this->textBlockService->delete($id, $this->uid);
+			$this->textBlockService->delete($id, $this->userId);
 			return JsonResponse::success();
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::fail('Text block not found', Http::STATUS_NOT_FOUND);

--- a/lib/Controller/TextBlockSharesController.php
+++ b/lib/Controller/TextBlockSharesController.php
@@ -22,15 +22,12 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\IRequest;
 
 class TextBlockSharesController extends Controller {
-	private ?string $uid;
-
 	public function __construct(
 		IRequest $request,
-		?string $userId,
+		private ?string $userId,
 		private TextBlockService $textBlockService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->uid = $userId;
 	}
 
 	/**
@@ -40,11 +37,11 @@ class TextBlockSharesController extends Controller {
 	 */
 	#[TrapError]
 	public function index(): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$textBlocks = $this->textBlockService->findAllSharedWithMe($this->uid);
+			$textBlocks = $this->textBlockService->findAllSharedWithMe($this->userId);
 		} catch (UserNotFoundException $e) {
 			return JsonResponse::error('Sharee not found', Http::STATUS_UNAUTHORIZED);
 		}
@@ -59,11 +56,11 @@ class TextBlockSharesController extends Controller {
 	 */
 	#[TrapError]
 	public function create(int $textBlockId, string $shareWith, string $type): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$this->textBlockService->find($textBlockId, $this->uid);
+			$this->textBlockService->find($textBlockId, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
@@ -88,11 +85,11 @@ class TextBlockSharesController extends Controller {
 	 */
 	#[TrapError]
 	public function destroy(int $id, string $shareWith): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 		try {
-			$this->textBlockService->find($id, $this->uid);
+			$this->textBlockService->find($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}
@@ -108,12 +105,12 @@ class TextBlockSharesController extends Controller {
 	 * @return JsonResponse
 	 */
 	public function getTextBlockShares(int $id): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::error('User not found', Http::STATUS_UNAUTHORIZED);
 		}
 
 		try {
-			$this->textBlockService->find($id, $this->uid);
+			$this->textBlockService->find($id, $this->userId);
 		} catch (DoesNotExistException $e) {
 			return JsonResponse::error('Text block not found', Http::STATUS_NOT_FOUND);
 		}

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -27,32 +27,18 @@ use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ThreadController extends Controller {
-	private string $currentUserId;
-	private AccountService $accountService;
-	private IMailManager $mailManager;
-	private SnoozeService $snoozeService;
-	private AiIntegrationsService $aiIntergrationsService;
-	private LoggerInterface $logger;
-	private DelegationService $delegationService;
-
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		string $userId,
-		AccountService $accountService,
-		IMailManager $mailManager,
-		SnoozeService $snoozeService,
-		AiIntegrationsService $aiIntergrationsService,
-		LoggerInterface $logger,
-		DelegationService $delegationService) {
+		private string $userId,
+		private AccountService $accountService,
+		private IMailManager $mailManager,
+		private SnoozeService $snoozeService,
+		private AiIntegrationsService $aiIntergrationsService,
+		private LoggerInterface $logger,
+		private DelegationService $delegationService,
+	) {
 		parent::__construct($appName, $request);
-		$this->currentUserId = $userId;
-		$this->accountService = $accountService;
-		$this->mailManager = $mailManager;
-		$this->snoozeService = $snoozeService;
-		$this->aiIntergrationsService = $aiIntergrationsService;
-		$this->logger = $logger;
-		$this->delegationService = $delegationService;
 	}
 
 	/**
@@ -68,7 +54,7 @@ class ThreadController extends Controller {
 	#[TrapError]
 	public function move(int $id, int $destMailboxId): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$srcMailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$srcAccount = $this->accountService->find($effectiveUserId, $srcMailbox->getAccountId());
@@ -89,7 +75,7 @@ class ThreadController extends Controller {
 			$dstMailbox,
 			$threadRootId
 		);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId moved thread <$id> to mailbox <$destMailboxId> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId moved thread <$id> to mailbox <$destMailboxId> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -108,7 +94,7 @@ class ThreadController extends Controller {
 	#[TrapError]
 	public function snooze(int $id, int $unixTimestamp, int $destMailboxId): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$selectedMessage = $this->mailManager->getMessage($effectiveUserId, $id);
 			$srcMailbox = $this->mailManager->getMailbox($effectiveUserId, $selectedMessage->getMailboxId());
 			$srcAccount = $this->accountService->find($effectiveUserId, $srcMailbox->getAccountId());
@@ -119,7 +105,7 @@ class ThreadController extends Controller {
 		}
 
 		$this->snoozeService->snoozeThread($selectedMessage, $unixTimestamp, $srcAccount, $srcMailbox, $dstAccount, $dstMailbox);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId snoozed thread <$id> until <$unixTimestamp> in mailbox <$destMailboxId> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId snoozed thread <$id> until <$unixTimestamp> in mailbox <$destMailboxId> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -136,14 +122,14 @@ class ThreadController extends Controller {
 	#[TrapError]
 	public function unSnooze(int $id): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$selectedMessage = $this->mailManager->getMessage($effectiveUserId, $id);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$this->snoozeService->unSnoozeThread($selectedMessage, $effectiveUserId);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId unsnoozed thread <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId unsnoozed thread <$id> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}
@@ -157,7 +143,7 @@ class ThreadController extends Controller {
 	 */
 	public function summarize(int $id): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -174,7 +160,7 @@ class ThreadController extends Controller {
 				$account,
 				$threadRootId,
 				$thread,
-				$this->currentUserId,
+				$this->userId,
 			);
 		} catch (\Throwable $e) {
 			$this->logger->error('Summarizing thread failed: ' . $e->getMessage(), [
@@ -191,7 +177,7 @@ class ThreadController extends Controller {
 	 */
 	public function generateEventData(int $id): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -207,7 +193,7 @@ class ThreadController extends Controller {
 			$account,
 			$threadRootId,
 			$thread,
-			$this->currentUserId,
+			$this->userId,
 		);
 
 		return new JSONResponse(['data' => $data]);
@@ -225,7 +211,7 @@ class ThreadController extends Controller {
 	#[TrapError]
 	public function delete(int $id): JSONResponse {
 		try {
-			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->currentUserId);
+			$effectiveUserId = $this->delegationService->resolveMessageUserId($id, $this->userId);
 			$message = $this->mailManager->getMessage($effectiveUserId, $id);
 			$mailbox = $this->mailManager->getMailbox($effectiveUserId, $message->getMailboxId());
 			$account = $this->accountService->find($effectiveUserId, $mailbox->getAccountId());
@@ -242,7 +228,7 @@ class ThreadController extends Controller {
 			$mailbox,
 			$threadRootId
 		);
-		$this->delegationService->logDelegatedAction($this->currentUserId, $effectiveUserId, "$this->currentUserId deleted thread <$id> on behalf of $effectiveUserId");
+		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId deleted thread <$id> on behalf of $effectiveUserId");
 
 		return new JSONResponse();
 	}

--- a/lib/Controller/TrustedSendersController.php
+++ b/lib/Controller/TrustedSendersController.php
@@ -20,16 +20,12 @@ use OCP\IRequest;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class TrustedSendersController extends Controller {
-	private ?string $uid;
-	private ITrustedSenderService $trustedSenderService;
-
-	public function __construct(IRequest $request,
-		?string $userId,
-		ITrustedSenderService $trustedSenderService) {
+	public function __construct(
+		IRequest $request,
+		private ?string $userId,
+		private ITrustedSenderService $trustedSenderService,
+	) {
 		parent::__construct(Application::APP_ID, $request);
-
-		$this->uid = $userId;
-		$this->trustedSenderService = $trustedSenderService;
 	}
 
 	/**
@@ -41,12 +37,12 @@ class TrustedSendersController extends Controller {
 	 */
 	#[TrapError]
 	public function setTrusted(string $email, string $type): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::fail([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		$this->trustedSenderService->trust(
-			$this->uid,
+			$this->userId,
 			$email,
 			$type
 		);
@@ -63,12 +59,12 @@ class TrustedSendersController extends Controller {
 	 */
 	#[TrapError]
 	public function removeTrust(string $email, string $type): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::fail([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		$this->trustedSenderService->trust(
-			$this->uid,
+			$this->userId,
 			$email,
 			$type,
 			false
@@ -83,12 +79,12 @@ class TrustedSendersController extends Controller {
 	 */
 	#[TrapError]
 	public function list(): JsonResponse {
-		if ($this->uid === null) {
+		if ($this->userId === null) {
 			return JsonResponse::fail([], Http::STATUS_UNAUTHORIZED);
 		}
 
 		$list = $this->trustedSenderService->getTrusted(
-			$this->uid
+			$this->userId
 		);
 
 		return JsonResponse::success($list);

--- a/lib/Dashboard/MailWidget.php
+++ b/lib/Dashboard/MailWidget.php
@@ -33,25 +33,21 @@ use OCP\IUserManager;
 abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOptionWidget, IButtonWidget {
 	protected IURLGenerator $urlGenerator;
 	protected IUserManager $userManager;
-	protected AccountService $accountService;
-	protected IMailSearch $mailSearch;
 	protected IInitialState $initialState;
-	protected ?string $userId;
 	protected IL10N $l10n;
 
-	public function __construct(IL10N $l10n,
+	public function __construct(
+		IL10N $l10n,
 		IURLGenerator $urlGenerator,
 		IUserManager $userManager,
-		AccountService $accountService,
-		IMailSearch $mailSearch,
+		protected AccountService $accountService,
+		protected IMailSearch $mailSearch,
 		IInitialState $initialState,
-		?string $userId) {
+		protected ?string $userId,
+	) {
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
-		$this->accountService = $accountService;
-		$this->mailSearch = $mailSearch;
 		$this->initialState = $initialState;
-		$this->userId = $userId;
 		$this->l10n = $l10n;
 	}
 

--- a/lib/Db/LocalMessageMapper.php
+++ b/lib/Db/LocalMessageMapper.php
@@ -22,18 +22,12 @@ use function array_merge;
  * @template-extends QBMapper<LocalMessage>
  */
 class LocalMessageMapper extends QBMapper {
-	/** @var LocalAttachmentMapper */
-	private $attachmentMapper;
-
-	/** @var RecipientMapper */
-	private $recipientMapper;
-
-	public function __construct(IDBConnection $db,
-		LocalAttachmentMapper $attachmentMapper,
-		RecipientMapper $recipientMapper) {
+	public function __construct(
+		IDBConnection $db,
+		private LocalAttachmentMapper $attachmentMapper,
+		private RecipientMapper $recipientMapper,
+	) {
 		parent::__construct($db, 'mail_local_messages');
-		$this->recipientMapper = $recipientMapper;
-		$this->attachmentMapper = $attachmentMapper;
 	}
 
 	/**

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -53,20 +53,14 @@ class MessageMapper extends QBMapper {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var TagMapper */
-	private $tagMapper;
-
-	/** @var PerformanceLogger */
-	private $performanceLogger;
-
-	public function __construct(IDBConnection $db,
+	public function __construct(
+		IDBConnection $db,
 		ITimeFactory $timeFactory,
-		TagMapper $tagMapper,
-		PerformanceLogger $performanceLogger) {
+		private TagMapper $tagMapper,
+		private PerformanceLogger $performanceLogger,
+	) {
 		parent::__construct($db, 'mail_messages');
 		$this->timeFactory = $timeFactory;
-		$this->tagMapper = $tagMapper;
-		$this->performanceLogger = $performanceLogger;
 	}
 
 	/**

--- a/lib/Db/ProvisioningMapper.php
+++ b/lib/Db/ProvisioningMapper.php
@@ -20,12 +20,11 @@ use Psr\Log\LoggerInterface;
  * @template-extends QBMapper<Provisioning>
  */
 class ProvisioningMapper extends QBMapper {
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(IDBConnection $db, LoggerInterface $logger) {
+	public function __construct(
+		IDBConnection $db,
+		private LoggerInterface $logger,
+	) {
 		parent::__construct($db, 'mail_provisionings');
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Events/BeforeImapClientCreated.php
+++ b/lib/Events/BeforeImapClientCreated.php
@@ -13,12 +13,10 @@ use OCA\Mail\Account;
 use OCP\EventDispatcher\Event;
 
 class BeforeImapClientCreated extends Event {
-	/** @var Account */
-	private $account;
-
-	public function __construct(Account $account) {
+	public function __construct(
+		private Account $account,
+	) {
 		parent::__construct();
-		$this->account = $account;
 	}
 
 	/**

--- a/lib/Events/BeforeMessageDeletedEvent.php
+++ b/lib/Events/BeforeMessageDeletedEvent.php
@@ -13,20 +13,15 @@ use OCA\Mail\Account;
 use OCP\EventDispatcher\Event;
 
 class BeforeMessageDeletedEvent extends Event {
-	/** @var Account */
-	private $account;
+	private string $folderId;
 
-	/** @var string */
-	private $folderId;
-
-	/** @var int */
-	private $messageId;
-
-	public function __construct(Account $account, string $mailbox, int $messageId) {
+	public function __construct(
+		private Account $account,
+		string $mailbox,
+		private int $messageId,
+	) {
 		parent::__construct();
-		$this->account = $account;
 		$this->folderId = $mailbox;
-		$this->messageId = $messageId;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/DraftMessageCreatedEvent.php
+++ b/lib/Events/DraftMessageCreatedEvent.php
@@ -17,17 +17,11 @@ use OCP\EventDispatcher\Event;
  * @psalm-immutable
  */
 class DraftMessageCreatedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var Message */
-	private $draft;
-
-	public function __construct(Account $account,
-		Message $draft) {
+	public function __construct(
+		private Account $account,
+		private Message $draft,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->draft = $draft;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/DraftSavedEvent.php
+++ b/lib/Events/DraftSavedEvent.php
@@ -15,22 +15,12 @@ use OCA\Mail\Model\NewMessageData;
 use OCP\EventDispatcher\Event;
 
 class DraftSavedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var NewMessageData|null */
-	private $newMessageData;
-
-	/** @var Message|null */
-	private $draft;
-
-	public function __construct(Account $account,
-		?NewMessageData $newMessageData = null,
-		?Message $draft = null) {
+	public function __construct(
+		private Account $account,
+		private ?NewMessageData $newMessageData = null,
+		private ?Message $draft = null,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->newMessageData = $newMessageData;
-		$this->draft = $draft;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/MailboxesSynchronizedEvent.php
+++ b/lib/Events/MailboxesSynchronizedEvent.php
@@ -16,12 +16,10 @@ use OCP\EventDispatcher\Event;
  * @psalm-immutable
  */
 class MailboxesSynchronizedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	public function __construct(Account $account) {
+	public function __construct(
+		private Account $account,
+	) {
 		parent::__construct();
-		$this->account = $account;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/MessageDeletedEvent.php
+++ b/lib/Events/MessageDeletedEvent.php
@@ -14,22 +14,12 @@ use OCA\Mail\Db\Mailbox;
 use OCP\EventDispatcher\Event;
 
 class MessageDeletedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var Mailbox */
-	private $mailbox;
-
-	/** @var int */
-	private $messageId;
-
-	public function __construct(Account $account,
-		Mailbox $mailbox,
-		int $messageId) {
+	public function __construct(
+		private Account $account,
+		private Mailbox $mailbox,
+		private int $messageId,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->mailbox = $mailbox;
-		$this->messageId = $messageId;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/MessageFlaggedEvent.php
+++ b/lib/Events/MessageFlaggedEvent.php
@@ -14,32 +14,14 @@ use OCA\Mail\Db\Mailbox;
 use OCP\EventDispatcher\Event;
 
 class MessageFlaggedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var Mailbox */
-	private $mailbox;
-
-	/** @var int */
-	private $uid;
-
-	/** @var string */
-	private $flag;
-
-	/** @var bool */
-	private $set;
-
-	public function __construct(Account $account,
-		Mailbox $mailbox,
-		int $uid,
-		string $flag,
-		bool $set) {
+	public function __construct(
+		private Account $account,
+		private Mailbox $mailbox,
+		private int $uid,
+		private string $flag,
+		private bool $set,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->mailbox = $mailbox;
-		$this->uid = $uid;
-		$this->flag = $flag;
-		$this->set = $set;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/MessageSentEvent.php
+++ b/lib/Events/MessageSentEvent.php
@@ -17,15 +17,11 @@ use OCP\EventDispatcher\Event;
  * @psalm-immutable
  */
 class MessageSentEvent extends Event {
-	/** @var Account */
-	private $account;
-
 	public function __construct(
-		Account $account,
+		private Account $account,
 		private LocalMessage $localMessage,
 	) {
 		parent::__construct();
-		$this->account = $account;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/NewMessagesSynchronized.php
+++ b/lib/Events/NewMessagesSynchronized.php
@@ -15,27 +15,17 @@ use OCA\Mail\Db\Message;
 use OCP\EventDispatcher\Event;
 
 class NewMessagesSynchronized extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var Mailbox */
-	private $mailbox;
-
-	/** @var array|Message[] */
-	private $messages;
-
 	/**
 	 * @param Account $account
 	 * @param Mailbox $mailbox
 	 * @param Message[] $messages
 	 */
-	public function __construct(Account $account,
-		Mailbox $mailbox,
-		array $messages) {
+	public function __construct(
+		private Account $account,
+		private Mailbox $mailbox,
+		private array $messages,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->mailbox = $mailbox;
-		$this->messages = $messages;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/OutboxMessageCreatedEvent.php
+++ b/lib/Events/OutboxMessageCreatedEvent.php
@@ -17,17 +17,11 @@ use OCP\EventDispatcher\Event;
  * @psalm-immutable
  */
 class OutboxMessageCreatedEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var Message */
-	private $draft;
-
-	public function __construct(Account $account,
-		Message $draft) {
+	public function __construct(
+		private Account $account,
+		private Message $draft,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->draft = $draft;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/SaveDraftEvent.php
+++ b/lib/Events/SaveDraftEvent.php
@@ -15,22 +15,12 @@ use OCA\Mail\Model\NewMessageData;
 use OCP\EventDispatcher\Event;
 
 class SaveDraftEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var NewMessageData */
-	private $newMessageData;
-
-	/** @var Message|null */
-	private $draft;
-
-	public function __construct(Account $account,
-		NewMessageData $newMessageData,
-		?Message $draft) {
+	public function __construct(
+		private Account $account,
+		private NewMessageData $newMessageData,
+		private ?Message $draft,
+	) {
 		parent::__construct();
-		$this->account = $account;
-		$this->newMessageData = $newMessageData;
-		$this->draft = $draft;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Events/SynchronizationEvent.php
+++ b/lib/Events/SynchronizationEvent.php
@@ -14,23 +14,12 @@ use OCP\EventDispatcher\Event;
 use Psr\Log\LoggerInterface;
 
 class SynchronizationEvent extends Event {
-	/** @var Account */
-	private $account;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var bool */
-	private $rebuildThreads;
-
-	public function __construct(Account $account,
-		LoggerInterface $logger,
-		bool $rebuildThreads) {
+	public function __construct(
+		private Account $account,
+		private LoggerInterface $logger,
+		private bool $rebuildThreads,
+	) {
 		parent::__construct();
-
-		$this->account = $account;
-		$this->logger = $logger;
-		$this->rebuildThreads = $rebuildThreads;
 	}
 
 	public function getAccount(): Account {

--- a/lib/Folder.php
+++ b/lib/Folder.php
@@ -13,31 +13,18 @@ use Horde_Imap_Client_Mailbox;
 
 class Folder {
 
-	/** @var Horde_Imap_Client_Mailbox */
-	private $mailbox;
-
-	/** @var array */
-	private $attributes;
-
-	/** @var string */
-	private $delimiter;
-
-	/** @var null|array */
-	private $status;
-
 	/** @var string[] */
 	private $specialUse;
 
 	private ?string $myAcls;
 
-	public function __construct(Horde_Imap_Client_Mailbox $mailbox,
-		array $attributes,
-		?string $delimiter,
-		?array $status) {
-		$this->mailbox = $mailbox;
-		$this->attributes = $attributes;
-		$this->delimiter = $delimiter;
-		$this->status = $status;
+	public function __construct(
+		private Horde_Imap_Client_Mailbox $mailbox,
+		private array $attributes,
+		/** @var string */
+		private ?string $delimiter,
+		private ?array $status,
+	) {
 		$this->specialUse = [];
 		$this->myAcls = null;
 	}

--- a/lib/Http/AttachmentDownloadResponse.php
+++ b/lib/Http/AttachmentDownloadResponse.php
@@ -17,9 +17,6 @@ use OCP\AppFramework\Http\DownloadResponse;
  * @todo spec template with 28+
  */
 class AttachmentDownloadResponse extends DownloadResponse {
-	/** @var string */
-	private $content;
-
 	/**
 	 * Creates a response that prompts the user to download a file which
 	 * contains the passed string
@@ -28,10 +25,12 @@ class AttachmentDownloadResponse extends DownloadResponse {
 	 * @param string $filename the name that the downloaded file should have
 	 * @param string $contentType the mimetype that the downloaded file should have
 	 */
-	public function __construct(string $content, string $filename, string $contentType) {
+	public function __construct(
+		private string $content,
+		string $filename,
+		string $contentType,
+	) {
 		parent::__construct($filename, $contentType);
-
-		$this->content = $content;
 	}
 
 	/**

--- a/lib/Http/AvatarDownloadResponse.php
+++ b/lib/Http/AvatarDownloadResponse.php
@@ -16,13 +16,10 @@ use OCP\AppFramework\Http\DownloadResponse;
  * @todo spec template with 28+
  */
 class AvatarDownloadResponse extends DownloadResponse {
-	/** @var string */
-	private $content;
-
-	public function __construct(string $content) {
+	public function __construct(
+		private string $content,
+	) {
 		parent::__construct('avatar', 'application/octet-stream');
-
-		$this->content = $content;
 	}
 
 	/**

--- a/lib/Http/HtmlResponse.php
+++ b/lib/Http/HtmlResponse.php
@@ -17,33 +17,19 @@ use OCP\AppFramework\Http\Response;
  * @todo spec template with 28+
  */
 class HtmlResponse extends Response {
-	/** @var string */
-	private $content;
-
-	/** @var bool */
-	private $plain;
-
-	/** @var string|null */
-	private $nonce;
-
-	/** @var string|null */
-	private $scriptUrl;
-
 	/**
 	 * @param string $content message html content
 	 * @param bool $plain do not inject scripts if true (default=false)
 	 * @param string|null $nonce
 	 * @param string|null $scriptUrl
 	 */
-	private function __construct(string $content,
-		bool $plain = false,
-		?string $nonce = null,
-		?string $scriptUrl = null) {
+	private function __construct(
+		private string $content,
+		private bool $plain = false,
+		private ?string $nonce = null,
+		private ?string $scriptUrl = null,
+	) {
 		parent::__construct();
-		$this->content = $content;
-		$this->plain = $plain;
-		$this->nonce = $nonce;
-		$this->scriptUrl = $scriptUrl;
 	}
 
 	public static function plain(string $content): self {

--- a/lib/Http/Middleware/ErrorMiddleware.php
+++ b/lib/Http/Middleware/ErrorMiddleware.php
@@ -27,9 +27,6 @@ use ReflectionMethod;
 use Throwable;
 
 class ErrorMiddleware extends Middleware {
-	/** @var LoggerInterface */
-	private $logger;
-
 	/** @var IConfig */
 	private $config;
 
@@ -37,10 +34,11 @@ class ErrorMiddleware extends Middleware {
 	 * @param IConfig $config
 	 * @param LoggerInterface $logger
 	 */
-	public function __construct(IConfig $config,
-		LoggerInterface $logger) {
+	public function __construct(
+		IConfig $config,
+		private LoggerInterface $logger,
+	) {
 		$this->config = $config;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Http/Middleware/ProvisioningMiddleware.php
+++ b/lib/Http/Middleware/ProvisioningMiddleware.php
@@ -23,15 +23,13 @@ class ProvisioningMiddleware extends Middleware {
 	/** @var ICredentialStore */
 	private $credentialStore;
 
-	/** @var ProvisioningManager */
-	private $provisioningManager;
-
-	public function __construct(IUserSession $userSession,
+	public function __construct(
+		IUserSession $userSession,
 		ICredentialStore $credentialStore,
-		ProvisioningManager $provisioningManager) {
+		private ProvisioningManager $provisioningManager,
+	) {
 		$this->userSession = $userSession;
 		$this->credentialStore = $credentialStore;
-		$this->provisioningManager = $provisioningManager;
 	}
 
 	#[\Override]

--- a/lib/Http/ProxyDownloadResponse.php
+++ b/lib/Http/ProxyDownloadResponse.php
@@ -18,9 +18,6 @@ use OCP\AppFramework\Http\DownloadResponse;
  * @todo spec template with 28+
  */
 class ProxyDownloadResponse extends DownloadResponse {
-	/** @var string */
-	private $content;
-
 	/**
 	 * Creates a response that prompts the user to download a file which
 	 * contains the passed string
@@ -31,10 +28,12 @@ class ProxyDownloadResponse extends DownloadResponse {
 	 * @param string $filename the name that the downloaded file should have
 	 * @param string $contentType the mimetype that the downloaded file should have
 	 */
-	public function __construct(string $content, string $filename, string $contentType) {
+	public function __construct(
+		private string $content,
+		string $filename,
+		string $contentType,
+	) {
 		parent::__construct($filename, $contentType);
-
-		$this->content = $content;
 
 		$now = (new DateTime('now'))->getTimestamp();
 		$expires = (new DateTime('now + 11 months'))->getTimestamp();

--- a/lib/IMAP/FolderMapper.php
+++ b/lib/IMAP/FolderMapper.php
@@ -23,11 +23,9 @@ use function reset;
 
 class FolderMapper {
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
 	}
 	/**
 	 * This is a temporary workaround for when the sieve folder is a subfolder of

--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -28,11 +28,12 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 	private ?IMemcache $rateLimiterCache = null;
 	private ?ITimeFactory $timeFactory = null;
 	private ?string $hash = null;
-	private IMAPClientFactory $factory;
 
-	public function __construct(array $params, IMAPClientFactory $factory) {
+	public function __construct(
+		array $params,
+		private IMAPClientFactory $factory,
+	) {
 		parent::__construct($params);
-		$this->factory = $factory;
 	}
 
 	public function enableRateLimiter(

--- a/lib/IMAP/IMAPClientFactory.php
+++ b/lib/IMAP/IMAPClientFactory.php
@@ -43,20 +43,20 @@ class IMAPClientFactory {
 	private $eventDispatcher;
 
 	private ITimeFactory $timeFactory;
-	private HordeCacheFactory $hordeCacheFactory;
 
-	public function __construct(ICrypto $crypto,
+	public function __construct(
+		ICrypto $crypto,
 		IConfig $config,
 		ICacheFactory $cacheFactory,
 		IEventDispatcher $eventDispatcher,
 		ITimeFactory $timeFactory,
-		HordeCacheFactory $hordeCacheFactory) {
+		private HordeCacheFactory $hordeCacheFactory,
+	) {
 		$this->crypto = $crypto;
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
 		$this->eventDispatcher = $eventDispatcher;
 		$this->timeFactory = $timeFactory;
-		$this->hordeCacheFactory = $hordeCacheFactory;
 	}
 
 	/**

--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -40,17 +40,9 @@ class ImapMessageFetcher {
 	/** @var string[] */
 	private array $attachmentsToIgnore = ['signature.asc', 'smime.p7s'];
 
-	private Html $htmlService;
-	private SmimeService $smimeService;
-	private PhishingDetectionService $phishingDetectionService;
-	private string $userId;
-
 	private bool $runPhishingCheck = false;
 	// Conditional fetching/parsing
 	private bool $loadBody = false;
-
-	private int $uid;
-	private Horde_Imap_Client_Base $client;
 	private string $htmlMessage = '';
 	private string $plainMessage = '';
 	/** @var list<IMAPAttachment> */
@@ -60,7 +52,6 @@ class ImapMessageFetcher {
 	private bool $hasAnyAttachment = false;
 	private array $scheduling = [];
 	private bool $hasHtmlMessage = false;
-	private string $mailbox;
 	private string $rawReferences = '';
 	private string $dispositionNotificationTo = '';
 	private bool $hasDkimSignature = false;
@@ -71,22 +62,15 @@ class ImapMessageFetcher {
 	private bool $isPgpMimeEncrypted = false;
 
 	public function __construct(
-		int $uid,
-		string $mailbox,
-		Horde_Imap_Client_Base $client,
-		string $userId,
-		Html $htmlService,
-		SmimeService $smimeService,
+		private int $uid,
+		private string $mailbox,
+		private Horde_Imap_Client_Base $client,
+		private string $userId,
+		private Html $htmlService,
+		private SmimeService $smimeService,
 		private Converter $converter,
-		PhishingDetectionService $phishingDetectionService,
+		private PhishingDetectionService $phishingDetectionService,
 	) {
-		$this->uid = $uid;
-		$this->mailbox = $mailbox;
-		$this->client = $client;
-		$this->userId = $userId;
-		$this->htmlService = $htmlService;
-		$this->smimeService = $smimeService;
-		$this->phishingDetectionService = $phishingDetectionService;
 	}
 
 

--- a/lib/IMAP/ImapMessageFetcherFactory.php
+++ b/lib/IMAP/ImapMessageFetcherFactory.php
@@ -16,19 +16,12 @@ use OCA\Mail\Service\PhishingDetection\PhishingDetectionService;
 use OCA\Mail\Service\SmimeService;
 
 class ImapMessageFetcherFactory {
-	private Html $htmlService;
-	private SmimeService $smimeService;
-	private Converter $charsetConverter;
-	private PhishingDetectionService $phishingDetectionService;
-
-	public function __construct(Html $htmlService,
-		SmimeService $smimeService,
-		Converter $charsetConverter,
-		PhishingDetectionService $phishingDetectionService) {
-		$this->htmlService = $htmlService;
-		$this->smimeService = $smimeService;
-		$this->charsetConverter = $charsetConverter;
-		$this->phishingDetectionService = $phishingDetectionService;
+	public function __construct(
+		private Html $htmlService,
+		private SmimeService $smimeService,
+		private Converter $charsetConverter,
+		private PhishingDetectionService $phishingDetectionService,
+	) {
 	}
 
 	public function build(int $uid,

--- a/lib/IMAP/MailboxStats.php
+++ b/lib/IMAP/MailboxStats.php
@@ -13,12 +13,10 @@ use JsonSerializable;
 use ReturnTypeWillChange;
 
 final class MailboxStats implements JsonSerializable {
-	private int $total;
-	private int $unread;
-
-	public function __construct(int $total, int $unread) {
-		$this->total = $total;
-		$this->unread = $unread;
+	public function __construct(
+		private int $total,
+		private int $unread,
+	) {
 	}
 
 	public function getTotal(): int {

--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -39,18 +39,6 @@ use function str_starts_with;
 class MailboxSync {
 	use TTransactional;
 
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var FolderMapper */
-	private $folderMapper;
-
-	/** @var MailAccountMapper */
-	private $mailAccountMapper;
-
-	/** @var IMAPClientFactory */
-	private $imapClientFactory;
-
 	/** @var ITimeFactory */
 	private $timeFactory;
 
@@ -58,17 +46,15 @@ class MailboxSync {
 	private $dispatcher;
 	private IDBConnection $dbConnection;
 
-	public function __construct(MailboxMapper $mailboxMapper,
-		FolderMapper $folderMapper,
-		MailAccountMapper $mailAccountMapper,
-		IMAPClientFactory $imapClientFactory,
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		private FolderMapper $folderMapper,
+		private MailAccountMapper $mailAccountMapper,
+		private IMAPClientFactory $imapClientFactory,
 		ITimeFactory $timeFactory,
 		IEventDispatcher $dispatcher,
-		IDBConnection $dbConnection) {
-		$this->mailboxMapper = $mailboxMapper;
-		$this->folderMapper = $folderMapper;
-		$this->mailAccountMapper = $mailAccountMapper;
-		$this->imapClientFactory = $imapClientFactory;
+		IDBConnection $dbConnection,
+	) {
 		$this->timeFactory = $timeFactory;
 		$this->dispatcher = $dispatcher;
 		$this->dbConnection = $dbConnection;

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -50,21 +50,12 @@ use function OCA\Mail\chunk_uid_sequence;
 use function sprintf;
 
 class MessageMapper {
-	/** @var LoggerInterface */
-	private $logger;
-
-	private SMimeService $smimeService;
-	private ImapMessageFetcherFactory $imapMessageFactory;
-
 	public function __construct(
-		LoggerInterface $logger,
-		SmimeService $smimeService,
-		ImapMessageFetcherFactory $imapMessageFactory,
+		private LoggerInterface $logger,
+		private SMimeService $smimeService,
+		private ImapMessageFetcherFactory $imapMessageFactory,
 		private Converter $converter,
 	) {
-		$this->logger = $logger;
-		$this->smimeService = $smimeService;
-		$this->imapMessageFactory = $imapMessageFactory;
 	}
 
 	/**

--- a/lib/IMAP/MessageStructureData.php
+++ b/lib/IMAP/MessageStructureData.php
@@ -10,28 +10,13 @@ declare(strict_types=1);
 namespace OCA\Mail\IMAP;
 
 final class MessageStructureData {
-	/** @var bool */
-	private $hasAttachments;
-
-	/** @var string */
-	private $previewText;
-
-	/** @var bool */
-	private $isImipMessage;
-
-	private bool $isEncrypted;
-	private bool $mentionsMe;
-
-	public function __construct(bool $hasAttachments,
-		string $previewText,
-		bool $isImipMessage,
-		bool $isEncrypted,
-		bool $mentionsMe) {
-		$this->hasAttachments = $hasAttachments;
-		$this->previewText = $previewText;
-		$this->isImipMessage = $isImipMessage;
-		$this->isEncrypted = $isEncrypted;
-		$this->mentionsMe = $mentionsMe;
+	public function __construct(
+		private bool $hasAttachments,
+		private string $previewText,
+		private bool $isImipMessage,
+		private bool $isEncrypted,
+		private bool $mentionsMe,
+	) {
 	}
 
 	public function hasAttachments(): bool {

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -25,34 +25,14 @@ use function array_merge;
 use function array_reduce;
 
 class PreviewEnhancer {
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	/** @var ImapMapper */
-	private $imapMapper;
-
-	/** @var DbMapper */
-	private $mapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var AvatarService */
-	private $avatarService;
-
 	public function __construct(
-		IMAPClientFactory $clientFactory,
-		ImapMapper $imapMapper,
-		DbMapper $dbMapper,
-		LoggerInterface $logger,
-		AvatarService $avatarService,
+		private IMAPClientFactory $clientFactory,
+		private ImapMapper $imapMapper,
+		private DbMapper $mapper,
+		private LoggerInterface $logger,
+		private AvatarService $avatarService,
 		private AttachmentService $attachmentService,
 	) {
-		$this->clientFactory = $clientFactory;
-		$this->imapMapper = $imapMapper;
-		$this->mapper = $dbMapper;
-		$this->logger = $logger;
-		$this->avatarService = $avatarService;
 	}
 
 	/**

--- a/lib/IMAP/Search/Provider.php
+++ b/lib/IMAP/Search/Provider.php
@@ -19,11 +19,9 @@ use OCA\Mail\Service\Search\SearchQuery;
 use function array_reduce;
 
 class Provider {
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	public function __construct(IMAPClientFactory $clientFactory) {
-		$this->clientFactory = $clientFactory;
+	public function __construct(
+		private IMAPClientFactory $clientFactory,
+	) {
 	}
 
 	/**

--- a/lib/IMAP/Sync/Request.php
+++ b/lib/IMAP/Sync/Request.php
@@ -10,27 +10,17 @@ declare(strict_types=1);
 namespace OCA\Mail\IMAP\Sync;
 
 final class Request {
-	private string $id;
-
-	/** @var string */
-	private $mailbox;
-
-	/** @var string */
-	private $syncToken;
-
-	/** @var array */
-	private $uids;
-
 	/**
 	 * @param string $mailbox
 	 * @param string $syncToken
 	 * @param int[] $uids
 	 */
-	public function __construct(string $id, string $mailbox, string $syncToken, array $uids) {
-		$this->id = $id;
-		$this->mailbox = $mailbox;
-		$this->syncToken = $syncToken;
-		$this->uids = $uids;
+	public function __construct(
+		private string $id,
+		private string $mailbox,
+		private string $syncToken,
+		private array $uids,
+	) {
 	}
 
 	/**

--- a/lib/IMAP/Sync/Response.php
+++ b/lib/IMAP/Sync/Response.php
@@ -17,32 +17,18 @@ use ReturnTypeWillChange;
  * @psalm-template T
  */
 final class Response implements JsonSerializable {
-	/** @var T[] */
-	private $newMessages;
-
-	/** @var T[] */
-	private $changedMessages;
-
-	/** @var int[] */
-	private $vanishedMessageUids;
-
-	/** @var MailboxStats */
-	private $stats;
-
 	/**
 	 * @param T[] $newMessages
 	 * @param T[] $changedMessages
 	 * @param int[] $vanishedMessageUids
 	 * @param MailboxStats|null $stats
 	 */
-	public function __construct(array $newMessages,
-		array $changedMessages,
-		array $vanishedMessageUids,
-		?MailboxStats $stats = null) {
-		$this->newMessages = $newMessages;
-		$this->changedMessages = $changedMessages;
-		$this->vanishedMessageUids = $vanishedMessageUids;
-		$this->stats = $stats;
+	public function __construct(
+		private array $newMessages,
+		private array $changedMessages,
+		private array $vanishedMessageUids,
+		private ?MailboxStats $stats = null,
+	) {
 	}
 
 	/**
@@ -66,10 +52,7 @@ final class Response implements JsonSerializable {
 		return $this->vanishedMessageUids;
 	}
 
-	/**
-	 * @return MailboxStats
-	 */
-	public function getStats(): MailboxStats {
+	public function getStats(): ?MailboxStats {
 		return $this->stats;
 	}
 

--- a/lib/IMAP/Sync/Synchronizer.php
+++ b/lib/IMAP/Sync/Synchronizer.php
@@ -32,14 +32,12 @@ class Synchronizer {
 	 */
 	private const UID_CHUNK_MAX_BYTES = 10000;
 
-	/** @var MessageMapper */
-	private $messageMapper;
-
 	private ?string $requestId = null;
 	private ?Response $response = null;
 
-	public function __construct(MessageMapper $messageMapper) {
-		$this->messageMapper = $messageMapper;
+	public function __construct(
+		private MessageMapper $messageMapper,
+	) {
 	}
 
 	/**

--- a/lib/IMAP/Threading/Container.php
+++ b/lib/IMAP/Threading/Container.php
@@ -16,27 +16,17 @@ use function array_key_exists;
 use function spl_object_id;
 
 final class Container implements JsonSerializable {
-	/** @var Message|null */
-	private $message;
-
-	/** @var string|null */
-	private $id;
-
-	/** @var bool */
-	private $root;
-
 	/** @var Container|null */
 	private $parent;
 
 	/** @var Container[] */
 	private $children = [];
 
-	private function __construct(?Message $message,
-		?string $id = null,
-		bool $root = false) {
-		$this->message = $message;
-		$this->id = $id;
-		$this->root = $root;
+	private function __construct(
+		private ?Message $message,
+		private ?string $id = null,
+		private bool $root = false,
+	) {
 	}
 
 	public static function root(): self {

--- a/lib/IMAP/Threading/DatabaseMessage.php
+++ b/lib/IMAP/Threading/DatabaseMessage.php
@@ -16,24 +16,17 @@ use function array_merge;
 use function json_decode;
 
 final class DatabaseMessage extends Message implements JsonSerializable {
-	/** @var int */
-	private $databaseId;
-
-	/** @var string|null */
-	private $threadRootId;
-
 	/** @var bool */
 	private $dirty = false;
 
-	public function __construct(int $databaseId,
+	public function __construct(
+		private int $databaseId,
 		string $subject,
 		string $id,
 		array $references,
-		?string $threadRootId) {
+		private ?string $threadRootId,
+	) {
 		parent::__construct($subject, $id, $references);
-
-		$this->databaseId = $databaseId;
-		$this->threadRootId = $threadRootId;
 	}
 
 	public static function fromRowData(int $id,

--- a/lib/IMAP/Threading/Message.php
+++ b/lib/IMAP/Threading/Message.php
@@ -14,24 +14,14 @@ use ReturnTypeWillChange;
 use function str_replace;
 
 class Message implements JsonSerializable {
-	/** @var string */
-	private $subject;
-
-	/** @var string */
-	private $id;
-
-	/** @var string[] */
-	private $references;
-
 	/**
 	 * @param string[] $references
 	 */
-	public function __construct(string $subject,
-		string $id,
-		array $references) {
-		$this->subject = $subject;
-		$this->id = $id;
-		$this->references = $references;
+	public function __construct(
+		private string $subject,
+		private string $id,
+		private array $references,
+	) {
 	}
 
 	public function hasReSubject(): bool {

--- a/lib/IMAP/Threading/ThreadBuilder.php
+++ b/lib/IMAP/Threading/ThreadBuilder.php
@@ -15,11 +15,9 @@ use function array_key_exists;
 use function count;
 
 class ThreadBuilder {
-	/** @var PerformanceLogger */
-	private $performanceLogger;
-
-	public function __construct(PerformanceLogger $performanceLogger) {
-		$this->performanceLogger = $performanceLogger;
+	public function __construct(
+		private PerformanceLogger $performanceLogger,
+	) {
 	}
 
 	/**

--- a/lib/Integration/GoogleIntegration.php
+++ b/lib/Integration/GoogleIntegration.php
@@ -27,20 +27,20 @@ class GoogleIntegration {
 	private ICrypto $crypto;
 	private IClientService $clientService;
 	private IURLGenerator $urlGenerator;
-	private LoggerInterface $logger;
 
-	public function __construct(ITimeFactory $timeFactory,
+	public function __construct(
+		ITimeFactory $timeFactory,
 		IConfig $config,
 		ICrypto $crypto,
 		IClientService $clientService,
 		IURLGenerator $urlGenerator,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		$this->timeFactory = $timeFactory;
 		$this->clientService = $clientService;
 		$this->crypto = $crypto;
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
-		$this->logger = $logger;
 	}
 
 	public function configure(string $clientId, string $clientSecret): void {

--- a/lib/Integration/KItinerary/ItineraryExtractor.php
+++ b/lib/Integration/KItinerary/ItineraryExtractor.php
@@ -19,29 +19,15 @@ use Nextcloud\KItinerary\Sys\SysAdapter;
 use Psr\Log\LoggerInterface;
 
 class ItineraryExtractor {
-	/** @var BinaryAdapter */
-	private $binAdapter;
-
-	/** @var FlatpakAdapter */
-	private $flatpakAdapter;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var SysAdapter */
-	private $sysAdapter;
-
 	/** @var Adapter */
 	private $adapter;
 
-	public function __construct(BinaryAdapter $binAdapter,
-		FlatpakAdapter $flatpakAdapter,
-		SysAdapter $sysAdapter,
-		LoggerInterface $logger) {
-		$this->binAdapter = $binAdapter;
-		$this->flatpakAdapter = $flatpakAdapter;
-		$this->sysAdapter = $sysAdapter;
-		$this->logger = $logger;
+	public function __construct(
+		private BinaryAdapter $binAdapter,
+		private FlatpakAdapter $flatpakAdapter,
+		private SysAdapter $sysAdapter,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	private function findAvailableAdapter(): ?Adapter {

--- a/lib/Integration/MicrosoftIntegration.php
+++ b/lib/Integration/MicrosoftIntegration.php
@@ -26,20 +26,20 @@ class MicrosoftIntegration {
 	private ICrypto $crypto;
 	private IClientService $clientService;
 	private IURLGenerator $urlGenerator;
-	private LoggerInterface $logger;
 
-	public function __construct(ITimeFactory $timeFactory,
+	public function __construct(
+		ITimeFactory $timeFactory,
 		IConfig $config,
 		ICrypto $crypto,
 		IClientService $clientService,
 		IURLGenerator $urlGenerator,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		$this->timeFactory = $timeFactory;
 		$this->clientService = $clientService;
 		$this->crypto = $crypto;
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;
-		$this->logger = $logger;
 	}
 
 	public function configure(?string $tenantId, string $clientId, string $clientSecret): void {

--- a/lib/Listener/AddressCollectionListener.php
+++ b/lib/Listener/AddressCollectionListener.php
@@ -23,24 +23,12 @@ use Throwable;
  * @template-implements IEventListener<Event|MessageSentEvent>
  */
 class AddressCollectionListener implements IEventListener {
-	/** @var IUserPreferences */
-	private $preferences;
-
-	/** @var AddressCollector */
-	private $collector;
-
-	/** @var LoggerInterface */
-	private $logger;
-
 	public function __construct(
-		IUserPreferences $preferences,
-		AddressCollector $collector,
-		LoggerInterface $logger,
+		private IUserPreferences $preferences,
+		private AddressCollector $collector,
+		private LoggerInterface $logger,
 		private TransmissionService $transmissionService,
 	) {
-		$this->collector = $collector;
-		$this->logger = $logger;
-		$this->preferences = $preferences;
 	}
 
 	#[\Override]

--- a/lib/Listener/DeleteDraftListener.php
+++ b/lib/Listener/DeleteDraftListener.php
@@ -31,30 +31,16 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event|DraftSavedEvent|OutboxMessageCreatedEvent|DraftMessageCreatedEvent>
  */
 class DeleteDraftListener implements IEventListener {
-	/** @var IMAPClientFactory */
-	private $imapClientFactory;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
-	public function __construct(IMAPClientFactory $imapClientFactory,
-		MailboxMapper $mailboxMapper,
-		MessageMapper $messageMapper,
-		LoggerInterface $logger,
-		IEventDispatcher $eventDispatcher) {
-		$this->imapClientFactory = $imapClientFactory;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->messageMapper = $messageMapper;
-		$this->logger = $logger;
+	public function __construct(
+		private IMAPClientFactory $imapClientFactory,
+		private MailboxMapper $mailboxMapper,
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
+		IEventDispatcher $eventDispatcher,
+	) {
 		$this->eventDispatcher = $eventDispatcher;
 	}
 

--- a/lib/Listener/HamReportListener.php
+++ b/lib/Listener/HamReportListener.php
@@ -19,16 +19,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event|MessageFlaggedEvent>
  */
 class HamReportListener implements IEventListener {
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var AntiSpamService */
-	private $antiSpamService;
-
-	public function __construct(LoggerInterface $logger,
-		AntiSpamService $antiSpamService) {
-		$this->logger = $logger;
-		$this->antiSpamService = $antiSpamService;
+	public function __construct(
+		private LoggerInterface $logger,
+		private AntiSpamService $antiSpamService,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Listener/InteractionListener.php
+++ b/lib/Listener/InteractionListener.php
@@ -28,15 +28,13 @@ class InteractionListener implements IEventListener {
 	/** @var IUserSession */
 	private $userSession;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(IEventDispatcher $dispatcher,
+	public function __construct(
+		IEventDispatcher $dispatcher,
 		IUserSession $userSession,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		$this->dispatcher = $dispatcher;
 		$this->userSession = $userSession;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Listener/MailboxesSynchronizedSpecialMailboxesUpdater.php
+++ b/lib/Listener/MailboxesSynchronizedSpecialMailboxesUpdater.php
@@ -28,21 +28,11 @@ use function strtolower;
  * @template-implements IEventListener<Event|MailboxesSynchronizedEvent>
  */
 class MailboxesSynchronizedSpecialMailboxesUpdater implements IEventListener {
-	/** @var MailAccountMapper */
-	private $mailAccountMapper;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(MailAccountMapper $mailAccountMapper,
-		MailboxMapper $mailboxMapper,
-		LoggerInterface $logger) {
-		$this->mailAccountMapper = $mailAccountMapper;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->logger = $logger;
+	public function __construct(
+		private MailAccountMapper $mailAccountMapper,
+		private MailboxMapper $mailboxMapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Listener/MessageCacheUpdaterListener.php
+++ b/lib/Listener/MessageCacheUpdaterListener.php
@@ -20,16 +20,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event>
  */
 class MessageCacheUpdaterListener implements IEventListener {
-	/** @var MessageMapper */
-	private $mapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(MessageMapper $mapper,
-		LoggerInterface $logger) {
-		$this->mapper = $mapper;
-		$this->logger = $logger;
+	public function __construct(
+		private MessageMapper $mapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Listener/OauthTokenRefreshListener.php
+++ b/lib/Listener/OauthTokenRefreshListener.php
@@ -20,15 +20,11 @@ use OCP\EventDispatcher\IEventListener;
  * @template-implements IEventListener<Event|BeforeImapClientCreated>
  */
 class OauthTokenRefreshListener implements IEventListener {
-	private GoogleIntegration $googleIntegration;
-	private MicrosoftIntegration $microsoftIntegration;
-	private AccountService $accountService;
-	public function __construct(GoogleIntegration $googleIntegration,
-		MicrosoftIntegration $microsoftIntegration,
-		AccountService $accountService) {
-		$this->googleIntegration = $googleIntegration;
-		$this->accountService = $accountService;
-		$this->microsoftIntegration = $microsoftIntegration;
+	public function __construct(
+		private GoogleIntegration $googleIntegration,
+		private MicrosoftIntegration $microsoftIntegration,
+		private AccountService $accountService,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Listener/SpamReportListener.php
+++ b/lib/Listener/SpamReportListener.php
@@ -19,16 +19,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event|MessageFlaggedEvent>
  */
 class SpamReportListener implements IEventListener {
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var AntiSpamService */
-	private $antiSpamService;
-
-	public function __construct(LoggerInterface $logger,
-		AntiSpamService $antiSpamService) {
-		$this->logger = $logger;
-		$this->antiSpamService = $antiSpamService;
+	public function __construct(
+		private LoggerInterface $logger,
+		private AntiSpamService $antiSpamService,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -22,20 +22,12 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<Event|UserDeletedEvent>
  */
 class UserDeletedListener implements IEventListener {
-	/** @var AccountService */
-	private $accountService;
-
-	/** @var LoggerInterface */
-	private $logger;
-
 	public function __construct(
-		AccountService $accountService,
+		private AccountService $accountService,
 		private TextBlockService $textBlockService,
 		private DelegationService $delegationService,
-		LoggerInterface $logger,
+		private LoggerInterface $logger,
 	) {
-		$this->accountService = $accountService;
-		$this->logger = $logger;
 	}
 
 	#[\Override]

--- a/lib/Migration/AddMissingDefaultTags.php
+++ b/lib/Migration/AddMissingDefaultTags.php
@@ -19,17 +19,10 @@ use function sprintf;
  * @psalm-api
  */
 class AddMissingDefaultTags implements IRepairStep {
-	/** @var TagMapper */
-	private $tagMapper;
-
-	/** @var MailAccountMapper */
-	private $accountMapper;
-
-
-	public function __construct(MailAccountMapper $accountMapper,
-		TagMapper $tagMapper) {
-		$this->accountMapper = $accountMapper;
-		$this->tagMapper = $tagMapper;
+	public function __construct(
+		private MailAccountMapper $accountMapper,
+		private TagMapper $tagMapper,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Migration/AddMissingMessageIds.php
+++ b/lib/Migration/AddMissingMessageIds.php
@@ -21,16 +21,10 @@ use function sprintf;
  * @psalm-api
  */
 class AddMissingMessageIds implements IRepairStep {
-	/** @var MessageMapper */
-	private $mapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(MessageMapper $mapper,
-		LoggerInterface $logger) {
-		$this->mapper = $mapper;
-		$this->logger = $logger;
+	public function __construct(
+		private MessageMapper $mapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Migration/FixCollectedAddresses.php
+++ b/lib/Migration/FixCollectedAddresses.php
@@ -20,11 +20,9 @@ use OCP\Migration\IRepairStep;
  * @psalm-api
  */
 class FixCollectedAddresses implements IRepairStep {
-	/** @var CollectedAddressMapper */
-	private $mapper;
-
-	public function __construct(CollectedAddressMapper $mapper) {
-		$this->mapper = $mapper;
+	public function __construct(
+		private CollectedAddressMapper $mapper,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Migration/MakeItineraryExtractorExecutable.php
+++ b/lib/Migration/MakeItineraryExtractorExecutable.php
@@ -22,16 +22,14 @@ use function is_file;
  * @psalm-api
  */
 class MakeItineraryExtractorExecutable implements IRepairStep {
-	/** @var LoggerInterface */
-	private $logger;
-
 	/** @var string */
 	private $file;
 
-	public function __construct(LoggerInterface $logger,
-		?string $file = null) {
+	public function __construct(
+		private LoggerInterface $logger,
+		?string $file = null,
+	) {
 		$this->file = $file ?? (__DIR__ . '/../../vendor/nextcloud/kitinerary-bin/bin/kitinerary-extractor');
-		$this->logger = $logger;
 	}
 
 	#[\Override]

--- a/lib/Migration/MigrateImportantFromImapAndDb.php
+++ b/lib/Migration/MigrateImportantFromImapAndDb.php
@@ -25,22 +25,11 @@ use Psr\Log\LoggerInterface;
 class MigrateImportantFromImapAndDb {
 
 
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(MessageMapper $messageMapper,
-		MailboxMapper $mailboxMapper,
-		LoggerInterface $logger,
+	public function __construct(
+		private MessageMapper $messageMapper,
+		private MailboxMapper $mailboxMapper,
+		private LoggerInterface $logger,
 	) {
-		$this->messageMapper = $messageMapper;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->logger = $logger;
 	}
 
 	public function migrateImportantOnImap(Horde_Imap_Client_Socket $client, Account $account, Mailbox $mailbox): void {

--- a/lib/Migration/ProvisionAccounts.php
+++ b/lib/Migration/ProvisionAccounts.php
@@ -18,11 +18,9 @@ use OCP\Migration\IRepairStep;
  * @psalm-api
  */
 class ProvisionAccounts implements IRepairStep {
-	/** @var ProvisioningManager */
-	private $provisioningManager;
-
-	public function __construct(ProvisioningManager $provisioningManager) {
-		$this->provisioningManager = $provisioningManager;
+	public function __construct(
+		private ProvisioningManager $provisioningManager,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Migration/RepairMailTheads.php
+++ b/lib/Migration/RepairMailTheads.php
@@ -19,16 +19,10 @@ use function method_exists;
  * @psalm-api
  */
 class RepairMailTheads implements IRepairStep {
-	/** @var MessageMapper */
-	private $mapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(MessageMapper $mapper,
-		LoggerInterface $logger) {
-		$this->mapper = $mapper;
-		$this->logger = $logger;
+	public function __construct(
+		private MessageMapper $mapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Migration/Version1100Date20210512142306.php
+++ b/lib/Migration/Version1100Date20210512142306.php
@@ -20,14 +20,13 @@ use OCP\Migration\SimpleMigrationStep;
  * @psalm-api
  */
 class Version1100Date20210512142306 extends SimpleMigrationStep {
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
 	/** @var IJobList */
 	private $jobList;
 
-	public function __construct(MailboxMapper $mailboxMapper, IJobList $jobList) {
-		$this->mailboxMapper = $mailboxMapper;
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		IJobList $jobList,
+	) {
 		$this->jobList = $jobList;
 	}
 

--- a/lib/Migration/Version1105Date20210922104324.php
+++ b/lib/Migration/Version1105Date20210922104324.php
@@ -22,11 +22,12 @@ use Psr\Log\LoggerInterface;
  */
 class Version1105Date20210922104324 extends SimpleMigrationStep {
 	private $connection;
-	private $logger;
 
-	public function __construct(IDBConnection $connection, LoggerInterface $logger) {
+	public function __construct(
+		IDBConnection $connection,
+		private LoggerInterface $logger,
+	) {
 		$this->connection = $connection;
-		$this->logger = $logger;
 	}
 
 	#[\Override]

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -27,13 +27,15 @@ use Psr\Log\LoggerInterface;
  */
 class Version1130Date20220412111833 extends SimpleMigrationStep {
 	private IDBConnection $connection;
-	private LoggerInterface $logger;
 	private array $recipients = [];
 	private string $backupPath;
 
-	public function __construct(IDBConnection $connection, LoggerInterface $logger, ITempManager $tempManager) {
+	public function __construct(
+		IDBConnection $connection,
+		private LoggerInterface $logger,
+		ITempManager $tempManager,
+	) {
 		$this->connection = $connection;
-		$this->logger = $logger;
 
 		$tempBaseDir = $tempManager->getTempBaseDir();
 		$this->backupPath = tempnam($tempBaseDir, 'mail_recipients_backup');

--- a/lib/Migration/Version1140Date20220808203258.php
+++ b/lib/Migration/Version1140Date20220808203258.php
@@ -20,13 +20,10 @@ use function method_exists;
  * @psalm-api
  */
 class Version1140Date20220808203258 extends SimpleMigrationStep {
-	private LoggerInterface $logger;
-	private MessageMapper $messageMapper;
-
-	public function __construct(MessageMapper $messageMapper,
-		LoggerInterface $logger) {
-		$this->logger = $logger;
-		$this->messageMapper = $messageMapper;
+	public function __construct(
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version1140Date20221027171138.php
+++ b/lib/Migration/Version1140Date20221027171138.php
@@ -19,13 +19,10 @@ use Psr\Log\LoggerInterface;
  * @psalm-api
  */
 class Version1140Date20221027171138 extends SimpleMigrationStep {
-	private LoggerInterface $logger;
-	private MessageMapper $messageMapper;
-
-	public function __construct(MessageMapper $messageMapper,
-		LoggerInterface $logger) {
-		$this->logger = $logger;
-		$this->messageMapper = $messageMapper;
+	public function __construct(
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Migration/Version1140Date20221113205737.php
+++ b/lib/Migration/Version1140Date20221113205737.php
@@ -19,15 +19,10 @@ use Psr\Log\LoggerInterface;
  * @psalm-api
  */
 class Version1140Date20221113205737 extends SimpleMigrationStep {
-	private LoggerInterface $logger;
-	private MessageMapper $messageMapper;
-
 	public function __construct(
-		MessageMapper $messageMapper,
-		LoggerInterface $logger,
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
 	) {
-		$this->logger = $logger;
-		$this->messageMapper = $messageMapper;
 	}
 
 	/**

--- a/lib/Migration/Version1140Date20221206162029.php
+++ b/lib/Migration/Version1140Date20221206162029.php
@@ -19,15 +19,10 @@ use Psr\Log\LoggerInterface;
  * @psalm-api
  */
 class Version1140Date20221206162029 extends SimpleMigrationStep {
-	private LoggerInterface $logger;
-	private MessageMapper $messageMapper;
-
 	public function __construct(
-		MessageMapper $messageMapper,
-		LoggerInterface $logger,
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
 	) {
-		$this->logger = $logger;
-		$this->messageMapper = $messageMapper;
 	}
 
 	/**

--- a/lib/Model/EnrichedSmimeCertificate.php
+++ b/lib/Model/EnrichedSmimeCertificate.php
@@ -14,16 +14,14 @@ use OCA\Mail\Db\SmimeCertificate;
 use ReturnTypeWillChange;
 
 class EnrichedSmimeCertificate implements JsonSerializable {
-	private SmimeCertificate $certificate;
-	private SmimeCertificateInfo $info;
-
 	/**
 	 * @param SmimeCertificate $certificate
 	 * @param SmimeCertificateInfo $info
 	 */
-	public function __construct(SmimeCertificate $certificate, SmimeCertificateInfo $info) {
-		$this->certificate = $certificate;
-		$this->info = $info;
+	public function __construct(
+		private SmimeCertificate $certificate,
+		private SmimeCertificateInfo $info,
+	) {
 	}
 
 	/**

--- a/lib/Model/IMAPMessage.php
+++ b/lib/Model/IMAPMessage.php
@@ -47,104 +47,42 @@ use function trim;
 class IMAPMessage implements IMessage, JsonSerializable {
 	use ConvertAddresses;
 
-	private Html $htmlService;
-
-	/** @var string[] */
-	private array $flags;
-
-	private int $messageId;
-	private string $realMessageId;
-	private AddressList $from;
-	private AddressList $to;
-	private AddressList $cc;
-	private AddressList $bcc;
-	private AddressList $replyTo;
-	private string $subject;
-	public string $plainMessage;
-	public string $htmlMessage;
-	public array $attachments;
-	/** @var list<IMAPAttachment> */
-	public array $inlineAttachments;
-	private bool $hasAttachments;
-	public array $scheduling;
-	private bool $hasHtmlMessage;
-	private Horde_Imap_Client_DateTime $imapDate;
-	private string $rawReferences;
-	private string $dispositionNotificationTo;
-	private bool $hasDkimSignature;
-	private array $phishingDetails;
-	private ?string $unsubscribeUrl;
-	private bool $isOneClickUnsubscribe;
-	private ?string $unsubscribeMailto;
-	private string $rawInReplyTo;
-	private bool $isEncrypted;
-	private bool $isSigned;
-	private bool $signatureIsValid;
-	private bool $isPgpMimeEncrypted;
-
 	/**
 	 * @param list<IMAPAttachment> $inlineAttachments
 	 */
-	public function __construct(int $uid,
-		string $messageId,
-		array $flags,
-		AddressList $from,
-		AddressList $to,
-		AddressList $cc,
-		AddressList $bcc,
-		AddressList $replyTo,
-		string $subject,
-		string $plainMessage,
-		string $htmlMessage,
-		bool $hasHtmlMessage,
-		array $attachments,
-		array $inlineAttachments,
-		bool $hasAttachments,
-		array $scheduling,
-		Horde_Imap_Client_DateTime $imapDate,
-		string $rawReferences,
-		string $dispositionNotificationTo,
-		bool $hasDkimSignature,
-		array $phishingDetails,
-		?string $unsubscribeUrl,
-		bool $isOneClickUnsubscribe,
-		?string $unsubscribeMailto,
-		string $rawInReplyTo,
-		bool $isEncrypted,
-		bool $isSigned,
-		bool $signatureIsValid,
-		Html $htmlService,
-		bool $isPgpMimeEncrypted) {
-		$this->messageId = $uid;
-		$this->realMessageId = $messageId;
-		$this->flags = $flags;
-		$this->from = $from;
-		$this->to = $to;
-		$this->cc = $cc;
-		$this->bcc = $bcc;
-		$this->replyTo = $replyTo;
-		$this->subject = $subject;
-		$this->plainMessage = $plainMessage;
-		$this->htmlMessage = $htmlMessage;
-		$this->hasHtmlMessage = $hasHtmlMessage;
-		$this->attachments = $attachments;
-		$this->inlineAttachments = $inlineAttachments;
-		$this->hasAttachments = $hasAttachments;
-		$this->scheduling = $scheduling;
-		$this->imapDate = $imapDate;
-		$this->rawReferences = $rawReferences;
-		$this->dispositionNotificationTo = $dispositionNotificationTo;
-		$this->hasDkimSignature = $hasDkimSignature;
-		$this->phishingDetails = $phishingDetails;
-		$this->unsubscribeUrl = $unsubscribeUrl;
-		$this->isOneClickUnsubscribe = $isOneClickUnsubscribe;
-		$this->unsubscribeMailto = $unsubscribeMailto;
-		$this->rawInReplyTo = $rawInReplyTo;
-		$this->isEncrypted = $isEncrypted;
-		$this->isSigned = $isSigned;
-		$this->signatureIsValid = $signatureIsValid;
-		$this->htmlService = $htmlService;
-		$this->isPgpMimeEncrypted = $isPgpMimeEncrypted;
+	public function __construct(
+		private int $messageId,
+		private string $realMessageId,
+		/** @var string[] */
+		private array $flags,
+		private AddressList $from,
+		private AddressList $to,
+		private AddressList $cc,
+		private AddressList $bcc,
+		private AddressList $replyTo,
+		private string $subject,
+		public string $plainMessage,
+		public string $htmlMessage,
+		private bool $hasHtmlMessage,
+		public array $attachments,
+		public array $inlineAttachments,
+		private bool $hasAttachments,
+		public array $scheduling,
+		private Horde_Imap_Client_DateTime $imapDate,
+		private string $rawReferences,
+		private string $dispositionNotificationTo,
+		private bool $hasDkimSignature,
+		private array $phishingDetails,
+		private ?string $unsubscribeUrl,
+		private bool $isOneClickUnsubscribe,
+		private ?string $unsubscribeMailto,
+		private string $rawInReplyTo,
+		private bool $isEncrypted,
+		private bool $isSigned,
+		private bool $signatureIsValid,
+		private Html $htmlService,
+		private bool $isPgpMimeEncrypted,
+	) {
 	}
 
 	public static function generateMessageId(): string {

--- a/lib/Model/NewMessageData.php
+++ b/lib/Model/NewMessageData.php
@@ -18,37 +18,6 @@ use OCA\Mail\AddressList;
  * @psalm-immutable
  */
 class NewMessageData {
-	private ?int $smimeCertificateId;
-	private bool $smimeSign;
-	private bool $smimeEncrypt;
-
-	/** @var Account */
-	private $account;
-
-	/** @var AddressList */
-	private $to;
-
-	/** @var AddressList */
-	private $cc;
-
-	/** @var AddressList */
-	private $bcc;
-
-	/** @var string */
-	private $subject;
-
-	/** @var string */
-	private $body;
-
-	/** @var array */
-	private $attachments;
-
-	/** @var bool */
-	private $isHtml;
-
-	/** @var bool */
-	private $isMdnRequested;
-
 	/**
 	 * @param Account $account
 	 * @param AddressList $to
@@ -62,30 +31,20 @@ class NewMessageData {
 	 * @param bool $smimeSign
 	 * @param bool $isMdnRequested
 	 */
-	public function __construct(Account $account,
-		AddressList $to,
-		AddressList $cc,
-		AddressList $bcc,
-		string $subject,
-		string $body,
-		array $attachments = [],
-		bool $isHtml = true,
-		bool $isMdnRequested = false,
-		?int $smimeCertificateId = null,
-		bool $smimeSign = false,
-		bool $smimeEncrypt = false) {
-		$this->account = $account;
-		$this->to = $to;
-		$this->cc = $cc;
-		$this->bcc = $bcc;
-		$this->subject = $subject;
-		$this->body = $body;
-		$this->attachments = $attachments;
-		$this->isHtml = $isHtml;
-		$this->isMdnRequested = $isMdnRequested;
-		$this->smimeCertificateId = $smimeCertificateId;
-		$this->smimeSign = $smimeSign;
-		$this->smimeEncrypt = $smimeEncrypt;
+	public function __construct(
+		private Account $account,
+		private AddressList $to,
+		private AddressList $cc,
+		private AddressList $bcc,
+		private string $subject,
+		private string $body,
+		private array $attachments = [],
+		private bool $isHtml = true,
+		private bool $isMdnRequested = false,
+		private ?int $smimeCertificateId = null,
+		private bool $smimeSign = false,
+		private bool $smimeEncrypt = false,
+	) {
 	}
 
 	/**

--- a/lib/Model/RepliedMessageData.php
+++ b/lib/Model/RepliedMessageData.php
@@ -18,15 +18,10 @@ use OCA\Mail\Db\Message;
  * @psalm-immutable
  */
 final class RepliedMessageData {
-	/** @var Account */
-	private $account;
-
-	/** @var Message */
-	private $message;
-
-	public function __construct(Account $account, Message $message) {
-		$this->account = $account;
-		$this->message = $message;
+	public function __construct(
+		private Account $account,
+		private Message $message,
+	) {
 	}
 
 	public function getAccount(): Account {

--- a/lib/Model/SmimeCertificateInfo.php
+++ b/lib/Model/SmimeCertificateInfo.php
@@ -13,22 +13,13 @@ use JsonSerializable;
 use ReturnTypeWillChange;
 
 final class SmimeCertificateInfo implements JsonSerializable {
-	private ?string $commonName;
-	private ?string $emailAddress;
-	private int $notAfter;
-	private SmimeCertificatePurposes $purposes;
-	private bool $isChainVerified;
-
-	public function __construct(?string $commonName,
-		?string $emailAddress,
-		int $notAfter,
-		SmimeCertificatePurposes $purposes,
-		bool $isChainVerified) {
-		$this->commonName = $commonName;
-		$this->emailAddress = $emailAddress;
-		$this->notAfter = $notAfter;
-		$this->purposes = $purposes;
-		$this->isChainVerified = $isChainVerified;
+	public function __construct(
+		private ?string $commonName,
+		private ?string $emailAddress,
+		private int $notAfter,
+		private SmimeCertificatePurposes $purposes,
+		private bool $isChainVerified,
+	) {
 	}
 
 	/**

--- a/lib/Model/SmimeCertificatePurposes.php
+++ b/lib/Model/SmimeCertificatePurposes.php
@@ -13,12 +13,10 @@ use JsonSerializable;
 use ReturnTypeWillChange;
 
 final class SmimeCertificatePurposes implements JsonSerializable {
-	private bool $sign;
-	private bool $encrypt;
-
-	public function __construct(bool $sign, bool $encrypt) {
-		$this->sign = $sign;
-		$this->encrypt = $encrypt;
+	public function __construct(
+		private bool $sign,
+		private bool $encrypt,
+	) {
 	}
 
 	/**

--- a/lib/Model/SmimeDecryptionResult.php
+++ b/lib/Model/SmimeDecryptionResult.php
@@ -10,19 +10,12 @@ declare(strict_types=1);
 namespace OCA\Mail\Model;
 
 final class SmimeDecryptionResult {
-	private string $decryptedMessage;
-	private bool $isEncrypted;
-	private bool $isSigned;
-	private bool $isSignatureValid;
-
-	public function __construct(string $decryptedMessage,
-		bool $isEncrypted,
-		bool $isSigned,
-		bool $isSignatureValid) {
-		$this->isEncrypted = $isEncrypted;
-		$this->isSigned = $isSigned;
-		$this->isSignatureValid = $isSignatureValid;
-		$this->decryptedMessage = $decryptedMessage;
+	public function __construct(
+		private string $decryptedMessage,
+		private bool $isEncrypted,
+		private bool $isSigned,
+		private bool $isSignatureValid,
+	) {
 	}
 
 	public static function fromPlain(string $plainMessage): self {

--- a/lib/PhishingDetectionList.php
+++ b/lib/PhishingDetectionList.php
@@ -14,14 +14,12 @@ use ReturnTypeWillChange;
 
 class PhishingDetectionList implements JsonSerializable {
 
-	/** @var PhishingDetectionResult[] */
-	private array $checks;
-
 	/**
 	 * @param PhishingDetectionResult[] $checks
 	 */
-	public function __construct(array $checks = []) {
-		$this->checks = $checks;
+	public function __construct(
+		private array $checks = [],
+	) {
 	}
 
 	public function addCheck(PhishingDetectionResult $check): void {

--- a/lib/PhishingDetectionResult.php
+++ b/lib/PhishingDetectionResult.php
@@ -24,17 +24,12 @@ final class PhishingDetectionResult implements JsonSerializable {
 	public const IMAP_FLAG_CHECK = 'IMAP Flag';
 	public const TRUSTED_CHECK = 'Trusted';
 
-	private string $message = '';
-	private bool $isPhishing;
-	private array $additionalData = [];
-	private string $type;
-
-	public function __construct(string $type, bool $isPhishing, string $message = '', array $additionalData = []) {
-		$this->type = $type;
-		$this->message = $message;
-		$this->isPhishing = $isPhishing;
-		$this->additionalData = $additionalData;
-
+	public function __construct(
+		private string $type,
+		private bool $isPhishing,
+		private string $message = '',
+		private array $additionalData = [],
+	) {
 	}
 
 	public function getType(): string {

--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -26,15 +26,13 @@ class SmtpClientFactory {
 	/** @var ICrypto */
 	private $crypto;
 
-	/** @var HostNameFactory */
-	private $hostNameFactory;
-
-	public function __construct(IConfig $config,
+	public function __construct(
+		IConfig $config,
 		ICrypto $crypto,
-		HostNameFactory $hostNameFactory) {
+		private HostNameFactory $hostNameFactory,
+	) {
 		$this->config = $config;
 		$this->crypto = $crypto;
-		$this->hostNameFactory = $hostNameFactory;
 	}
 
 	/**

--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -24,9 +24,6 @@ use OCP\Search\SearchResultEntry;
 use function array_map;
 
 class Provider implements IProvider {
-	/** @var IMailSearch */
-	private $mailSearch;
-
 	/** @var IL10N */
 	private $l10n;
 
@@ -37,13 +34,12 @@ class Provider implements IProvider {
 	private $urlGenerator;
 
 	public function __construct(
-		IMailSearch $mailSearch,
+		private IMailSearch $mailSearch,
 		IL10N $l10n,
 		IDateTimeFormatter $dateTimeFormatter,
 		IURLGenerator $urlGenerator,
 		private FilterStringParser $filterStringParser,
 	) {
-		$this->mailSearch = $mailSearch;
 		$this->l10n = $l10n;
 		$this->dateTimeFormatter = $dateTimeFormatter;
 		$this->urlGenerator = $urlGenerator;

--- a/lib/Service/AccountService.php
+++ b/lib/Service/AccountService.php
@@ -31,9 +31,6 @@ use OCP\IConfig;
 use function array_map;
 
 class AccountService {
-	/** @var MailAccountMapper */
-	private $mapper;
-
 	/**
 	 * Cache accounts for multiple calls to 'findByUserId'
 	 *
@@ -41,28 +38,19 @@ class AccountService {
 	 */
 	private array $accounts = [];
 
-	/** @var AliasesService */
-	private $aliasesService;
-
 	/** @var IJobList */
 	private $jobList;
 
-	/** @var IMAPClientFactory */
-	private $imapClientFactory;
-
 	public function __construct(
-		MailAccountMapper $mapper,
-		AliasesService $aliasesService,
+		private MailAccountMapper $mapper,
+		private AliasesService $aliasesService,
 		IJobList $jobList,
-		IMAPClientFactory $imapClientFactory,
+		private IMAPClientFactory $imapClientFactory,
 		private readonly IConfig $config,
 		private readonly ITimeFactory $timeFactory,
 		private DelegationMapper $delegationMapper,
 	) {
-		$this->mapper = $mapper;
-		$this->aliasesService = $aliasesService;
 		$this->jobList = $jobList;
-		$this->imapClientFactory = $imapClientFactory;
 	}
 
 	/**

--- a/lib/Service/AliasesService.php
+++ b/lib/Service/AliasesService.php
@@ -17,15 +17,10 @@ use OCA\Mail\Exception\ClientException;
 use OCP\AppFramework\Db\DoesNotExistException;
 
 class AliasesService {
-	/** @var AliasMapper */
-	private $aliasMapper;
-
-	/** @var MailAccountMapper */
-	private $mailAccountMapper;
-
-	public function __construct(AliasMapper $aliasMapper, MailAccountMapper $mailAccountMapper) {
-		$this->aliasMapper = $aliasMapper;
-		$this->mailAccountMapper = $mailAccountMapper;
+	public function __construct(
+		private AliasMapper $aliasMapper,
+		private MailAccountMapper $mailAccountMapper,
+	) {
 	}
 
 	/**

--- a/lib/Service/AntiAbuseService.php
+++ b/lib/Service/AntiAbuseService.php
@@ -29,17 +29,15 @@ class AntiAbuseService {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(IConfig $config,
+	public function __construct(
+		IConfig $config,
 		ICacheFactory $cacheFactory,
 		ITimeFactory $timeFactory,
-		LoggerInterface $logger) {
+		private LoggerInterface $logger,
+	) {
 		$this->config = $config;
 		$this->cacheFactory = $cacheFactory;
 		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
 	}
 
 	public function onBeforeMessageSent(IUser $user, LocalMessage $localMessage): void {

--- a/lib/Service/Attachment/AttachmentService.php
+++ b/lib/Service/Attachment/AttachmentService.php
@@ -38,50 +38,27 @@ use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
 class AttachmentService implements IAttachmentService {
-	/** @var LocalAttachmentMapper */
-	private $mapper;
-
-	/** @var AttachmentStorage */
-	private $storage;
-	/**
-	 * @var IMailManager
-	 */
-	private $mailManager;
-	/**
-	 * @var MessageMapper
-	 */
-	private $messageMapper;
-
 	/**
 	 * @var Folder
 	 */
 	private $userFolder;
-	/**
-	 * @var LoggerInterface
-	 */
-	private $logger;
 
 	/**
 	 * @param Folder $userFolder
 	 */
 	public function __construct(
 		$userFolder,
-		LocalAttachmentMapper $mapper,
-		AttachmentStorage $storage,
-		IMailManager $mailManager,
-		MessageMapper $imapMessageMapper,
+		private LocalAttachmentMapper $mapper,
+		private AttachmentStorage $storage,
+		private IMailManager $mailManager,
+		private MessageMapper $messageMapper,
 		private ICacheFactory $cacheFactory,
 		private IURLGenerator $urlGenerator,
 		private IMimeTypeDetector $mimeTypeDetector,
-		LoggerInterface $logger,
+		private LoggerInterface $logger,
 		private ITimeFactory $timeFactory,
 	) {
-		$this->mapper = $mapper;
-		$this->storage = $storage;
-		$this->mailManager = $mailManager;
-		$this->messageMapper = $imapMessageMapper;
 		$this->userFolder = $userFolder;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Service/Attachment/UploadedFile.php
+++ b/lib/Service/Attachment/UploadedFile.php
@@ -10,14 +10,12 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Attachment;
 
 class UploadedFile {
-	/** @var array */
-	private $fileData;
-
 	/**
 	 * @param array $fileData
 	 */
-	public function __construct(array $fileData) {
-		$this->fileData = $fileData;
+	public function __construct(
+		private array $fileData,
+	) {
 	}
 
 	/**

--- a/lib/Service/AutoCompletion/AddressCollector.php
+++ b/lib/Service/AutoCompletion/AddressCollector.php
@@ -21,16 +21,10 @@ use Psr\Log\LoggerInterface;
 class AddressCollector {
 	use TTransactional;
 
-	/** @var CollectedAddressMapper */
-	private $mapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(CollectedAddressMapper $mapper,
-		LoggerInterface $logger) {
-		$this->mapper = $mapper;
-		$this->logger = $logger;
+	public function __construct(
+		private CollectedAddressMapper $mapper,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Service/AutoCompletion/AutoCompleteService.php
+++ b/lib/Service/AutoCompletion/AutoCompleteService.php
@@ -15,19 +15,11 @@ use OCA\Mail\Service\ContactsIntegration;
 use OCA\Mail\Service\GroupsIntegration;
 
 class AutoCompleteService {
-	/** @var ContactsIntegration */
-	private $contactsIntegration;
-
-	/** @var GroupsIntegration */
-	private $groupsIntegration;
-
-	/** @var AddressCollector */
-	private $addressCollector;
-
-	public function __construct(ContactsIntegration $ci, GroupsIntegration $gi, AddressCollector $ac) {
-		$this->contactsIntegration = $ci;
-		$this->groupsIntegration = $gi;
-		$this->addressCollector = $ac;
+	public function __construct(
+		private ContactsIntegration $contactsIntegration,
+		private GroupsIntegration $groupsIntegration,
+		private AddressCollector $addressCollector,
+	) {
 	}
 
 	public function findMatches(string $userId, string $term): array {

--- a/lib/Service/AutoConfig/Configuration.php
+++ b/lib/Service/AutoConfig/Configuration.php
@@ -16,13 +16,10 @@ use ReturnTypeWillChange;
  * @psalm-immutable
  */
 final class Configuration implements JsonSerializable {
-	private ?ServerConfiguration $imapConfig;
-	private ?ServerConfiguration $smtpConfig;
-
-	public function __construct(?ServerConfiguration $imapConfig,
-		?ServerConfiguration $smtpConfig) {
-		$this->imapConfig = $imapConfig;
-		$this->smtpConfig = $smtpConfig;
+	public function __construct(
+		private ?ServerConfiguration $imapConfig,
+		private ?ServerConfiguration $smtpConfig,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/AutoConfig/IspDb.php
+++ b/lib/Service/AutoConfig/IspDb.php
@@ -25,10 +25,6 @@ class IspDb {
 	/** @var IClient */
 	private $client;
 
-	/** @var LoggerInterface */
-	private $logger;
-	private Resolver $dnsResolver;
-
 	/** @returns string[] */
 	public function getUrls(): array {
 		return [
@@ -40,12 +36,12 @@ class IspDb {
 		];
 	}
 
-	public function __construct(IClientService $clientService,
-		Resolver $dnsResolver,
-		LoggerInterface $logger) {
+	public function __construct(
+		IClientService $clientService,
+		private Resolver $dnsResolver,
+		private LoggerInterface $logger,
+	) {
 		$this->client = $clientService->newClient();
-		$this->dnsResolver = $dnsResolver;
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Service/AutoConfig/MxRecord.php
+++ b/lib/Service/AutoConfig/MxRecord.php
@@ -15,11 +15,9 @@ use function array_combine;
 use function asort;
 
 final class MxRecord {
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		private LoggerInterface $logger,
+	) {
 	}
 
 	/**

--- a/lib/Service/AutoConfig/ServerConfiguration.php
+++ b/lib/Service/AutoConfig/ServerConfiguration.php
@@ -16,19 +16,12 @@ use ReturnTypeWillChange;
  * @psalm-immutable
  */
 final class ServerConfiguration implements JsonSerializable {
-	private string $username;
-	private string $host;
-	private int $port;
-	private string $security;
-
-	public function __construct(string $username,
-		string $host,
-		int $port,
-		string $security) {
-		$this->username = $username;
-		$this->host = $host;
-		$this->port = $port;
-		$this->security = $security;
+	public function __construct(
+		private string $username,
+		private string $host,
+		private int $port,
+		private string $security,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/Avatar/AddressbookSource.php
+++ b/lib/Service/Avatar/AddressbookSource.php
@@ -16,11 +16,9 @@ use OCA\Mail\Service\ContactsIntegration;
  * as avatar source
  */
 class AddressbookSource implements IAvatarSource {
-	/** @var ContactsIntegration */
-	private $contactsIntegration;
-
-	public function __construct(ContactsIntegration $contactsIntegration) {
-		$this->contactsIntegration = $contactsIntegration;
+	public function __construct(
+		private ContactsIntegration $contactsIntegration,
+	) {
 	}
 
 	/**

--- a/lib/Service/Avatar/Avatar.php
+++ b/lib/Service/Avatar/Avatar.php
@@ -16,24 +16,16 @@ use ReturnTypeWillChange;
  * @psalm-immutable
  */
 final class Avatar implements JsonSerializable {
-	/** @var string */
-	private $url;
-
-	/** @var string|null */
-	private $mime;
-
-	/** @var bool */
-	private $isExternal;
-
 	/**
 	 * @param string $url
 	 * @param string|null $mime
 	 * @param bool $isExternal
 	 */
-	public function __construct(string $url, ?string $mime = null, bool $isExternal = true) {
-		$this->url = $url;
-		$this->mime = $mime;
-		$this->isExternal = $isExternal;
+	public function __construct(
+		private string $url,
+		private ?string $mime = null,
+		private bool $isExternal = true,
+	) {
 	}
 
 	/**

--- a/lib/Service/Avatar/Cache.php
+++ b/lib/Service/Avatar/Cache.php
@@ -19,12 +19,11 @@ class Cache {
 	/** @var ICache */
 	private $cache;
 
-	/** @var AvatarFactory */
-	private $avatarFactory;
-
-	public function __construct(ICacheFactory $cacheFactory, AvatarFactory $avatarFactory) {
+	public function __construct(
+		ICacheFactory $cacheFactory,
+		private AvatarFactory $avatarFactory,
+	) {
 		$this->cache = $cacheFactory->createLocal('mail.avatars');
-		$this->avatarFactory = $avatarFactory;
 	}
 
 	/**

--- a/lib/Service/Avatar/FaviconSource.php
+++ b/lib/Service/Avatar/FaviconSource.php
@@ -20,19 +20,17 @@ class FaviconSource implements IAvatarSource {
 	/** @var IClientService */
 	private $clientService;
 
-	/** @var Favicon */
-	private $favicon;
-
 	/** @var IMimeTypeDetector */
 	private $mimeDetector;
 	private IRemoteHostValidator $remoteHostValidator;
 
-	public function __construct(IClientService $clientService,
-		Favicon $favicon,
+	public function __construct(
+		IClientService $clientService,
+		private Favicon $favicon,
 		IMimeTypeDetector $mimeDetector,
-		IRemoteHostValidator $remoteHostValidator) {
+		IRemoteHostValidator $remoteHostValidator,
+	) {
 		$this->clientService = $clientService;
-		$this->favicon = $favicon;
 		$this->favicon->setCacheTimeout(0);
 		$this->mimeDetector = $mimeDetector;
 		$this->remoteHostValidator = $remoteHostValidator;

--- a/lib/Service/AvatarService.php
+++ b/lib/Service/AvatarService.php
@@ -18,21 +18,6 @@ use OCA\Mail\Service\Avatar\CompositeAvatarSource;
 use OCA\Mail\Service\Avatar\Downloader;
 
 class AvatarService implements IAvatarService {
-	/** @var AvatarCache */
-	private $cache;
-
-	/** @var Downloader */
-	private $downloader;
-
-	/** @var CompositeAvatarSource */
-	private $source;
-
-	/** @var AvatarFactory */
-	private $avatarFactory;
-
-	/** @var IUserPreferences */
-	private $preferences;
-
 	/**
 	 * @param CompositeAvatarSource $source
 	 * @param Downloader $downloader
@@ -40,16 +25,13 @@ class AvatarService implements IAvatarService {
 	 * @param AvatarFactory $avatarFactory
 	 * @param IUserPreferences $preferences
 	 */
-	public function __construct(CompositeAvatarSource $source,
-		Downloader $downloader,
-		AvatarCache $cache,
-		AvatarFactory $avatarFactory,
-		IUserPreferences $preferences) {
-		$this->source = $source;
-		$this->cache = $cache;
-		$this->downloader = $downloader;
-		$this->avatarFactory = $avatarFactory;
-		$this->preferences = $preferences;
+	public function __construct(
+		private CompositeAvatarSource $source,
+		private Downloader $downloader,
+		private AvatarCache $cache,
+		private AvatarFactory $avatarFactory,
+		private IUserPreferences $preferences,
+	) {
 	}
 
 	/**

--- a/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/CompositeExtractor.php
@@ -17,8 +17,6 @@ use function OCA\Mail\array_flat_map;
  * Combines a set of DI'ed extractors so they can be used as one class
  */
 class CompositeExtractor implements IExtractor {
-	private readonly SubjectExtractor $subjectExtractor;
-
 	/** @var IExtractor[] */
 	private readonly array $extractors;
 
@@ -27,15 +25,14 @@ class CompositeExtractor implements IExtractor {
 		ReadMessagesExtractor $ex2,
 		RepliedMessagesExtractor $ex3,
 		SentMessagesExtractor $ex4,
-		SubjectExtractor $ex5,
+		private readonly SubjectExtractor $subjectExtractor,
 	) {
-		$this->subjectExtractor = $ex5;
 		$this->extractors = [
 			$ex1,
 			$ex2,
 			$ex3,
 			$ex4,
-			$ex5,
+			$this->subjectExtractor,
 		];
 	}
 

--- a/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ImportantMessagesExtractor.php
@@ -23,11 +23,9 @@ class ImportantMessagesExtractor implements IExtractor {
 	/** @var int[] */
 	private $flaggedMessages = [];
 
-	/** @var StatisticsDao */
-	private $statisticsDao;
-
-	public function __construct(StatisticsDao $statisticsDao) {
-		$this->statisticsDao = $statisticsDao;
+	public function __construct(
+		private StatisticsDao $statisticsDao,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/ReadMessagesExtractor.php
@@ -17,17 +17,15 @@ use function array_map;
 use function array_unique;
 
 class ReadMessagesExtractor implements IExtractor {
-	/** @var StatisticsDao */
-	private $statisticsDao;
-
 	/** @var int[] */
 	private $totalMessages;
 
 	/** @var int[] */
 	private $readMessages;
 
-	public function __construct(StatisticsDao $statisticsDao) {
-		$this->statisticsDao = $statisticsDao;
+	public function __construct(
+		private StatisticsDao $statisticsDao,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/RepliedMessagesExtractor.php
@@ -17,17 +17,15 @@ use function array_map;
 use function array_unique;
 
 class RepliedMessagesExtractor implements IExtractor {
-	/** @var StatisticsDao */
-	private $statisticsDao;
-
 	/** @var int[] */
 	private $totalMessages;
 
 	/** @var int[] */
 	private $repliedMessages;
 
-	public function __construct(StatisticsDao $statisticsDao) {
-		$this->statisticsDao = $statisticsDao;
+	public function __construct(
+		private StatisticsDao $statisticsDao,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
+++ b/lib/Service/Classification/FeatureExtraction/SentMessagesExtractor.php
@@ -17,17 +17,15 @@ use function array_map;
 use function array_unique;
 
 class SentMessagesExtractor implements IExtractor {
-	/** @var StatisticsDao */
-	private $statisticsDao;
-
 	/** @var int */
 	private $messagesSentTotal = 0;
 
 	/** @var int[] */
 	private $messagesSent;
 
-	public function __construct(StatisticsDao $statisticsDao) {
-		$this->statisticsDao = $statisticsDao;
+	public function __construct(
+		private StatisticsDao $statisticsDao,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/Classification/ImportanceClassifier.php
+++ b/lib/Service/Classification/ImportanceClassifier.php
@@ -92,35 +92,14 @@ class ImportanceClassifier {
 	 */
 	private const MAX_TRAINING_SET_SIZE = 300;
 
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var PersistenceService */
-	private $persistenceService;
-
-	/** @var PerformanceLogger */
-	private $performanceLogger;
-
-	/** @var ImportanceRulesClassifier */
-	private $rulesClassifier;
-
-	private ContainerInterface $container;
-
-	public function __construct(MailboxMapper $mailboxMapper,
-		MessageMapper $messageMapper,
-		PersistenceService $persistenceService,
-		PerformanceLogger $performanceLogger,
-		ImportanceRulesClassifier $rulesClassifier,
-		ContainerInterface $container) {
-		$this->mailboxMapper = $mailboxMapper;
-		$this->messageMapper = $messageMapper;
-		$this->persistenceService = $persistenceService;
-		$this->performanceLogger = $performanceLogger;
-		$this->rulesClassifier = $rulesClassifier;
-		$this->container = $container;
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		private MessageMapper $messageMapper,
+		private PersistenceService $persistenceService,
+		private PerformanceLogger $performanceLogger,
+		private ImportanceRulesClassifier $rulesClassifier,
+		private ContainerInterface $container,
+	) {
 	}
 
 	private static function createDefaultEstimator(): KNearestNeighbors {

--- a/lib/Service/Classification/ImportanceRulesClassifier.php
+++ b/lib/Service/Classification/ImportanceRulesClassifier.php
@@ -20,26 +20,12 @@ use function array_combine;
 use function array_map;
 
 class ImportanceRulesClassifier {
-	/** @var ImportantMessagesExtractor */
-	private $importantMessagesExtractor;
-
-	/** @var ReadMessagesExtractor */
-	private $readMessagesExtractor;
-
-	/** @var RepliedMessagesExtractor */
-	private $repliedMessagesExtractor;
-
-	/** @var SentMessagesExtractor */
-	private $sentMessagesExtractor;
-
-	public function __construct(ImportantMessagesExtractor $importantMessagesExtractor,
-		ReadMessagesExtractor $readMessagesExtractor,
-		RepliedMessagesExtractor $repliedMessagesExtractor,
-		SentMessagesExtractor $sentMessagesExtractor) {
-		$this->importantMessagesExtractor = $importantMessagesExtractor;
-		$this->readMessagesExtractor = $readMessagesExtractor;
-		$this->repliedMessagesExtractor = $repliedMessagesExtractor;
-		$this->sentMessagesExtractor = $sentMessagesExtractor;
+	public function __construct(
+		private ImportantMessagesExtractor $importantMessagesExtractor,
+		private ReadMessagesExtractor $readMessagesExtractor,
+		private RepliedMessagesExtractor $repliedMessagesExtractor,
+		private SentMessagesExtractor $sentMessagesExtractor,
+	) {
 	}
 
 	/**

--- a/lib/Service/CleanupService.php
+++ b/lib/Service/CleanupService.php
@@ -22,46 +22,19 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use Psr\Log\LoggerInterface;
 
 class CleanupService {
-	private MailAccountMapper $mailAccountMapper;
-
-	/** @var AliasMapper */
-	private $aliasMapper;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var CollectedAddressMapper */
-	private $collectedAddressMapper;
-
-	/** @var TagMapper */
-	private $tagMapper;
-
-	private MessageRetentionMapper $messageRetentionMapper;
-
-	private MessageSnoozeMapper $messageSnoozeMapper;
-
 	private ITimeFactory $timeFactory;
 
-	public function __construct(MailAccountMapper $mailAccountMapper,
-		AliasMapper $aliasMapper,
-		MailboxMapper $mailboxMapper,
-		MessageMapper $messageMapper,
-		CollectedAddressMapper $collectedAddressMapper,
-		TagMapper $tagMapper,
-		MessageRetentionMapper $messageRetentionMapper,
-		MessageSnoozeMapper $messageSnoozeMapper,
-		ITimeFactory $timeFactory) {
-		$this->aliasMapper = $aliasMapper;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->messageMapper = $messageMapper;
-		$this->collectedAddressMapper = $collectedAddressMapper;
-		$this->tagMapper = $tagMapper;
-		$this->messageRetentionMapper = $messageRetentionMapper;
-		$this->messageSnoozeMapper = $messageSnoozeMapper;
-		$this->mailAccountMapper = $mailAccountMapper;
+	public function __construct(
+		private MailAccountMapper $mailAccountMapper,
+		private AliasMapper $aliasMapper,
+		private MailboxMapper $mailboxMapper,
+		private MessageMapper $messageMapper,
+		private CollectedAddressMapper $collectedAddressMapper,
+		private TagMapper $tagMapper,
+		private MessageRetentionMapper $messageRetentionMapper,
+		private MessageSnoozeMapper $messageSnoozeMapper,
+		ITimeFactory $timeFactory,
+	) {
 		$this->timeFactory = $timeFactory;
 	}
 

--- a/lib/Service/ContactIntegration/ContactIntegrationService.php
+++ b/lib/Service/ContactIntegration/ContactIntegrationService.php
@@ -12,11 +12,9 @@ namespace OCA\Mail\Service\ContactIntegration;
 use OCA\Mail\Service\ContactsIntegration;
 
 class ContactIntegrationService {
-	/** @var ContactsIntegration */
-	private $contactsIntegration;
-
-	public function __construct(ContactsIntegration $ci) {
-		$this->contactsIntegration = $ci;
+	public function __construct(
+		private ContactsIntegration $contactsIntegration,
+	) {
 	}
 
 	public function findMatches(string $uid, string $mail): array {

--- a/lib/Service/DkimService.php
+++ b/lib/Service/DkimService.php
@@ -23,27 +23,16 @@ class DkimService implements IDkimService {
 	private const CACHE_PREFIX = 'mail_dkim';
 	private const CACHE_TTL = 7 * 24 * 3600;
 
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
 	/** @var ICache */
 	private $cache;
 
-	private IDkimValidator $dkimValidator;
-
 	public function __construct(
-		IMAPClientFactory $clientFactory,
-		MessageMapper $messageMapper,
+		private IMAPClientFactory $clientFactory,
+		private MessageMapper $messageMapper,
 		ICacheFactory $cacheFactory,
-		IDkimValidator $dkimValidator,
+		private IDkimValidator $dkimValidator,
 	) {
-		$this->clientFactory = $clientFactory;
-		$this->messageMapper = $messageMapper;
 		$this->cache = $cacheFactory->createLocal(self::CACHE_PREFIX);
-		$this->dkimValidator = $dkimValidator;
 	}
 
 	#[\Override]

--- a/lib/Service/DraftsService.php
+++ b/lib/Service/DraftsService.php
@@ -27,33 +27,21 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class DraftsService {
-	private IMailTransmission $transmission;
-	private LocalMessageMapper $mapper;
-	private AttachmentService $attachmentService;
 	private IEventDispatcher $eventDispatcher;
-	private IMAPClientFactory $clientFactory;
-	private IMailManager $mailManager;
-	private LoggerInterface $logger;
-	private AccountService $accountService;
 	private ITimeFactory $time;
 
-	public function __construct(IMailTransmission $transmission,
-		LocalMessageMapper $mapper,
-		AttachmentService $attachmentService,
+	public function __construct(
+		private IMailTransmission $transmission,
+		private LocalMessageMapper $mapper,
+		private AttachmentService $attachmentService,
 		IEventDispatcher $eventDispatcher,
-		IMAPClientFactory $clientFactory,
-		IMailManager $mailManager,
-		LoggerInterface $logger,
-		AccountService $accountService,
-		ITimeFactory $time) {
-		$this->transmission = $transmission;
-		$this->mapper = $mapper;
-		$this->attachmentService = $attachmentService;
+		private IMAPClientFactory $clientFactory,
+		private IMailManager $mailManager,
+		private LoggerInterface $logger,
+		private AccountService $accountService,
+		ITimeFactory $time,
+	) {
 		$this->eventDispatcher = $eventDispatcher;
-		$this->clientFactory = $clientFactory;
-		$this->mailManager = $mailManager;
-		$this->logger = $logger;
-		$this->accountService = $accountService;
 		$this->time = $time;
 	}
 

--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -44,14 +44,14 @@ class Html {
 
 	/** @var IRequest */
 	private $request;
-	private ProxyHmacGenerator $hmacGenerator;
 
-	public function __construct(IURLGenerator $urlGenerator,
+	public function __construct(
+		IURLGenerator $urlGenerator,
 		IRequest $request,
-		ProxyHmacGenerator $hmacGenerator) {
+		private ProxyHmacGenerator $hmacGenerator,
+	) {
 		$this->urlGenerator = $urlGenerator;
 		$this->request = $request;
-		$this->hmacGenerator = $hmacGenerator;
 	}
 
 	/**

--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -104,9 +104,7 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 	}
 
 	private function replaceCidWithUrl(HTMLPurifier_URI $uri): HTMLPurifier_URI {
-		$inlineAttachment = array_find($this->inlineAttachments, static function ($attachment) use ($uri) {
-			return $attachment['cid'] === $uri->path;
-		});
+		$inlineAttachment = array_find($this->inlineAttachments, static fn ($attachment) => $attachment['cid'] === $uri->path);
 
 		if ($inlineAttachment === null) {
 			return $uri;

--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -25,30 +25,18 @@ use Throwable;
 use function array_filter;
 
 class IMipService {
-	private AccountService $accountService;
 	private IManager $calendarManager;
-	private LoggerInterface $logger;
-	private MailboxMapper $mailboxMapper;
-	private MailManager $mailManager;
-	private MessageMapper $messageMapper;
-	private ServerVersion $serverVersion;
 
 	public function __construct(
-		AccountService $accountService,
+		private AccountService $accountService,
 		IManager $manager,
-		LoggerInterface $logger,
-		MailboxMapper $mailboxMapper,
-		MailManager $mailManager,
-		MessageMapper $messageMapper,
-		ServerVersion $serverVersion,
+		private LoggerInterface $logger,
+		private MailboxMapper $mailboxMapper,
+		private MailManager $mailManager,
+		private MessageMapper $messageMapper,
+		private ServerVersion $serverVersion,
 	) {
-		$this->accountService = $accountService;
 		$this->calendarManager = $manager;
-		$this->logger = $logger;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->mailManager = $mailManager;
-		$this->messageMapper = $messageMapper;
-		$this->serverVersion = $serverVersion;
 	}
 
 	public function process(): void {

--- a/lib/Service/InternalAddressService.php
+++ b/lib/Service/InternalAddressService.php
@@ -14,10 +14,9 @@ use OCA\Mail\Db\InternalAddress;
 use OCA\Mail\Db\InternalAddressMapper;
 
 class InternalAddressService implements IInternalAddressService {
-	private InternalAddressMapper $mapper;
-
-	public function __construct(InternalAddressMapper $mapper) {
-		$this->mapper = $mapper;
+	public function __construct(
+		private InternalAddressMapper $mapper,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Service/ItineraryService.php
+++ b/lib/Service/ItineraryService.php
@@ -26,31 +26,17 @@ class ItineraryService {
 	private const CACHE_PREFIX = 'mail_itinerary';
 	private const CACHE_TTL = 7 * 24 * 3600;
 
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var ItineraryExtractor */
-	private $extractor;
-
 	/** @var ICache */
 	private $cache;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(IMAPClientFactory $clientFactory,
-		MessageMapper $messageMapper,
-		ItineraryExtractor $extractor,
+	public function __construct(
+		private IMAPClientFactory $clientFactory,
+		private MessageMapper $messageMapper,
+		private ItineraryExtractor $extractor,
 		ICacheFactory $cacheFactory,
-		LoggerInterface $logger) {
-		$this->clientFactory = $clientFactory;
-		$this->messageMapper = $messageMapper;
-		$this->extractor = $extractor;
+		private LoggerInterface $logger,
+	) {
 		$this->cache = $cacheFactory->createLocal(self::CACHE_PREFIX);
-		$this->logger = $logger;
 	}
 
 	private function buildCacheKey(Account $account, Mailbox $mailbox, int $id): string {

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -58,64 +58,24 @@ class MailManager implements IMailManager {
 		'recent' => [Horde_Imap_Client::FLAG_RECENT],
 	];
 
-	/** @var IMAPClientFactory */
-	private $imapClientFactory;
-
-	/** @var MailboxSync */
-	private $mailboxSync;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var FolderMapper */
-	private $folderMapper;
-
-	/** @var ImapMessageMapper */
-	private $imapMessageMapper;
-
-	/** @var DbMessageMapper */
-	private $dbMessageMapper;
-
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var TagMapper */
-	private $tagMapper;
-
-	/** @var MessageTagsMapper */
-	private $messageTagsMapper;
-
-	/** @var ThreadMapper */
-	private $threadMapper;
-
 	public function __construct(
-		IMAPClientFactory $imapClientFactory,
-		MailboxMapper $mailboxMapper,
-		MailboxSync $mailboxSync,
-		FolderMapper $folderMapper,
-		ImapMessageMapper $messageMapper,
-		DbMessageMapper $dbMessageMapper,
+		private IMAPClientFactory $imapClientFactory,
+		private MailboxMapper $mailboxMapper,
+		private MailboxSync $mailboxSync,
+		private FolderMapper $folderMapper,
+		private ImapMessageMapper $imapMessageMapper,
+		private DbMessageMapper $dbMessageMapper,
 		IEventDispatcher $eventDispatcher,
-		LoggerInterface $logger,
-		TagMapper $tagMapper,
-		MessageTagsMapper $messageTagsMapper,
-		ThreadMapper $threadMapper,
+		private LoggerInterface $logger,
+		private TagMapper $tagMapper,
+		private MessageTagsMapper $messageTagsMapper,
+		private ThreadMapper $threadMapper,
 		private ImapFlag $imapFlag,
 	) {
-		$this->imapClientFactory = $imapClientFactory;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->mailboxSync = $mailboxSync;
-		$this->folderMapper = $folderMapper;
-		$this->imapMessageMapper = $messageMapper;
-		$this->dbMessageMapper = $dbMessageMapper;
 		$this->eventDispatcher = $eventDispatcher;
-		$this->logger = $logger;
-		$this->tagMapper = $tagMapper;
-		$this->messageTagsMapper = $messageTagsMapper;
-		$this->threadMapper = $threadMapper;
 	}
 
 	#[\Override]

--- a/lib/Service/MimeMessage.php
+++ b/lib/Service/MimeMessage.php
@@ -19,10 +19,9 @@ use OCA\Mail\Html\Parser;
 use OCA\Mail\Service\DataUri\DataUriParser;
 
 class MimeMessage {
-	private DataUriParser $uriParser;
-
-	public function __construct(DataUriParser $uriParser) {
-		$this->uriParser = $uriParser;
+	public function __construct(
+		private DataUriParser $uriParser,
+	) {
 	}
 
 	/**

--- a/lib/Service/OutboxService.php
+++ b/lib/Service/OutboxService.php
@@ -30,49 +30,25 @@ use Throwable;
 class OutboxService {
 
 
-	/** @var LocalMessageMapper */
-	private $mapper;
-
-	/** @var AttachmentService */
-	private $attachmentService;
-
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
-
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	/** @var IMailManager */
-	private $mailManager;
-
-	/** @var AccountService */
-	private $accountService;
 
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var LoggerInterface */
-	private $logger;
-
 	public function __construct(
-		LocalMessageMapper $mapper,
-		AttachmentService $attachmentService,
+		private LocalMessageMapper $mapper,
+		private AttachmentService $attachmentService,
 		IEventDispatcher $eventDispatcher,
-		IMAPClientFactory $clientFactory,
-		IMailManager $mailManager,
-		AccountService $accountService,
+		private IMAPClientFactory $clientFactory,
+		private IMailManager $mailManager,
+		private AccountService $accountService,
 		ITimeFactory $timeFactory,
-		LoggerInterface $logger,
+		private LoggerInterface $logger,
 		private Chain $sendChain,
 	) {
-		$this->mapper = $mapper;
-		$this->attachmentService = $attachmentService;
 		$this->eventDispatcher = $eventDispatcher;
-		$this->clientFactory = $clientFactory;
-		$this->mailManager = $mailManager;
 		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
-		$this->accountService = $accountService;
 	}
 
 	/**

--- a/lib/Service/PreprocessingService.php
+++ b/lib/Service/PreprocessingService.php
@@ -15,21 +15,12 @@ use OCA\Mail\IMAP\PreviewEnhancer;
 use Psr\Log\LoggerInterface;
 
 class PreprocessingService {
-	private MailboxMapper $mailboxMapper;
-	private MessageMapper $messageMapper;
-	private LoggerInterface $logger;
-	private PreviewEnhancer $previewEnhancer;
-
 	public function __construct(
-		MessageMapper $messageMapper,
-		LoggerInterface $logger,
-		MailboxMapper $mailboxMapper,
-		PreviewEnhancer $previewEnhancer,
+		private MessageMapper $messageMapper,
+		private LoggerInterface $logger,
+		private MailboxMapper $mailboxMapper,
+		private PreviewEnhancer $previewEnhancer,
 	) {
-		$this->messageMapper = $messageMapper;
-		$this->logger = $logger;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->previewEnhancer = $previewEnhancer;
 	}
 
 	public function process(int $limitTimestamp, Account $account): void {

--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -40,26 +40,11 @@ class Manager {
 	/** @var IUserManager */
 	private $userManager;
 
-	/** @var ProvisioningMapper */
-	private $provisioningMapper;
-
-	/** @var MailAccountMapper */
-	private $mailAccountMapper;
-
 	/** @var ICrypto */
 	private $crypto;
 
 	/** @var ILDAPProviderFactory */
 	private $ldapProviderFactory;
-
-	/** @var AliasMapper */
-	private $aliasMapper;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var TagMapper */
-	private $tagMapper;
 
 	/** @var ICacheFactory */
 	private $cacheFactory;
@@ -67,26 +52,21 @@ class Manager {
 	public function __construct(
 		IAppManager $appManager,
 		IUserManager $userManager,
-		ProvisioningMapper $provisioningMapper,
-		MailAccountMapper $mailAccountMapper,
+		private ProvisioningMapper $provisioningMapper,
+		private MailAccountMapper $mailAccountMapper,
 		ICrypto $crypto,
 		ILDAPProviderFactory $ldapProviderFactory,
-		AliasMapper $aliasMapper,
-		LoggerInterface $logger,
-		TagMapper $tagMapper,
+		private AliasMapper $aliasMapper,
+		private LoggerInterface $logger,
+		private TagMapper $tagMapper,
 		ICacheFactory $cacheFactory,
 		private AccountService $accountService,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
 		$this->appManager = $appManager;
 		$this->userManager = $userManager;
-		$this->provisioningMapper = $provisioningMapper;
-		$this->mailAccountMapper = $mailAccountMapper;
 		$this->crypto = $crypto;
 		$this->ldapProviderFactory = $ldapProviderFactory;
-		$this->aliasMapper = $aliasMapper;
-		$this->logger = $logger;
-		$this->tagMapper = $tagMapper;
 		$this->cacheFactory = $cacheFactory;
 	}
 

--- a/lib/Service/Quota.php
+++ b/lib/Service/Quota.php
@@ -13,16 +13,10 @@ use JsonSerializable;
 use ReturnTypeWillChange;
 
 final class Quota implements JsonSerializable {
-	/** @var int */
-	private $usage;
-
-	/** @var int */
-	private $limit;
-
-	public function __construct(int $usage,
-		int $limit) {
-		$this->usage = $usage;
-		$this->limit = $limit;
+	public function __construct(
+		private int $usage,
+		private int $limit,
+	) {
 	}
 
 	public function getUsage(): int {

--- a/lib/Service/Search/Flag.php
+++ b/lib/Service/Search/Flag.php
@@ -23,18 +23,13 @@ final class Flag {
 	public const IMPORTANT = Tag::LABEL_IMPORTANT;
 	public const DELETED = Horde_Imap_Client::FLAG_DELETED;
 
-	/** @var string */
-	private $flag;
-
-	/** @var bool */
-	private $isSet;
-
 	/**
 	 * @psalm-param Flag::* $flag
 	 */
-	private function __construct(string $flag, bool $isSet) {
-		$this->flag = $flag;
-		$this->isSet = $isSet;
+	private function __construct(
+		private string $flag,
+		private bool $isSet,
+	) {
 	}
 
 	/**

--- a/lib/Service/Search/FlagExpression.php
+++ b/lib/Service/Search/FlagExpression.php
@@ -10,25 +10,16 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Search;
 
 class FlagExpression {
-	/**
-	 * @var string
-	 * @psalm-var "and"|"or"
-	 */
-	private $operator;
-
-	/**
-	 * @var array
-	 * @psalm-var (Flag|FlagExpression)[]
-	 */
-	private $operands;
-
-	/**
-	 * @psalm-param "and"|"or" $operator
-	 * @param array $operands
-	 */
-	private function __construct(string $operator, array $operands) {
-		$this->operator = $operator;
-		$this->operands = $operands;
+	private function __construct(
+		/**
+		 * @psalm-var "and"|"or"
+		 */
+		private string $operator,
+		/**
+		 * @psalm-var (Flag|FlagExpression)[]
+		 */
+		private array $operands,
+	) {
 	}
 
 	/**

--- a/lib/Service/Search/MailSearch.php
+++ b/lib/Service/Search/MailSearch.php
@@ -26,30 +26,16 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUser;
 
 class MailSearch implements IMailSearch {
-	/** @var FilterStringParser */
-	private $filterStringParser;
-
-	/** @var ImapSearchProvider */
-	private $imapSearchProvider;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var PreviewEnhancer */
-	private $previewEnhancer;
-
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	public function __construct(FilterStringParser $filterStringParser,
-		ImapSearchProvider $imapSearchProvider,
-		MessageMapper $messageMapper,
-		PreviewEnhancer $previewEnhancer,
-		ITimeFactory $timeFactory) {
-		$this->filterStringParser = $filterStringParser;
-		$this->imapSearchProvider = $imapSearchProvider;
-		$this->messageMapper = $messageMapper;
-		$this->previewEnhancer = $previewEnhancer;
+	public function __construct(
+		private FilterStringParser $filterStringParser,
+		private ImapSearchProvider $imapSearchProvider,
+		private MessageMapper $messageMapper,
+		private PreviewEnhancer $previewEnhancer,
+		ITimeFactory $timeFactory,
+	) {
 		$this->timeFactory = $timeFactory;
 	}
 

--- a/lib/Service/SetupService.php
+++ b/lib/Service/SetupService.php
@@ -25,36 +25,18 @@ use Psr\Log\LoggerInterface;
 use function in_array;
 
 class SetupService {
-	/** @var AccountService */
-	private $accountService;
-
 	/** @var ICrypto */
 	private $crypto;
 
-	/** @var SmtpClientFactory */
-	private $smtpClientFactory;
-
-	/** @var IMAPClientFactory */
-	private $imapClientFactory;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var TagMapper */
-	private $tagMapper;
-
-	public function __construct(AccountService $accountService,
+	public function __construct(
+		private AccountService $accountService,
 		ICrypto $crypto,
-		SmtpClientFactory $smtpClientFactory,
-		IMAPClientFactory $imapClientFactory,
-		LoggerInterface $logger,
-		TagMapper $tagMapper) {
-		$this->accountService = $accountService;
+		private SmtpClientFactory $smtpClientFactory,
+		private IMAPClientFactory $imapClientFactory,
+		private LoggerInterface $logger,
+		private TagMapper $tagMapper,
+	) {
 		$this->crypto = $crypto;
-		$this->smtpClientFactory = $smtpClientFactory;
-		$this->imapClientFactory = $imapClientFactory;
-		$this->logger = $logger;
-		$this->tagMapper = $tagMapper;
 	}
 
 	/**

--- a/lib/Service/SmimeService.php
+++ b/lib/Service/SmimeService.php
@@ -39,17 +39,17 @@ class SmimeService {
 	private ITempManager $tempManager;
 	private ICertificateManager $certificateManager;
 	private ICrypto $crypto;
-	private SmimeCertificateMapper $certificateMapper;
 
 
-	public function __construct(ITempManager $tempManager,
+	public function __construct(
+		ITempManager $tempManager,
 		ICertificateManager $certificateManager,
 		ICrypto $crypto,
-		SmimeCertificateMapper $certificateMapper) {
+		private SmimeCertificateMapper $certificateMapper,
+	) {
 		$this->tempManager = $tempManager;
 		$this->certificateManager = $certificateManager;
 		$this->crypto = $crypto;
-		$this->certificateMapper = $certificateMapper;
 	}
 
 	/**

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -50,59 +50,24 @@ class ImapToDbSynchronizer {
 	/** @var int */
 	public const MAX_NEW_MESSAGES = 5000;
 
-	/** @var DatabaseMessageMapper */
-	private $dbMapper;
-
-	/** @var IMAPClientFactory */
-	private $clientFactory;
-
-	/** @var ImapMessageMapper */
-	private $imapMapper;
-
-	/** @var MailboxMapper */
-	private $mailboxMapper;
-
-	/** @var Synchronizer */
-	private $synchronizer;
-
 	/** @var IEventDispatcher */
 	private $dispatcher;
 
-	/** @var PerformanceLogger */
-	private $performanceLogger;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var IMailManager */
-	private $mailManager;
-
-	private TagMapper $tagMapper;
-	private NewMessagesClassifier $newMessagesClassifier;
-
-	public function __construct(DatabaseMessageMapper $dbMapper,
-		IMAPClientFactory $clientFactory,
-		ImapMessageMapper $imapMapper,
-		MailboxMapper $mailboxMapper,
+	public function __construct(
+		private DatabaseMessageMapper $dbMapper,
+		private IMAPClientFactory $clientFactory,
+		private ImapMessageMapper $imapMapper,
+		private MailboxMapper $mailboxMapper,
 		DatabaseMessageMapper $messageMapper,
-		Synchronizer $synchronizer,
+		private Synchronizer $synchronizer,
 		IEventDispatcher $dispatcher,
-		PerformanceLogger $performanceLogger,
-		LoggerInterface $logger,
-		IMailManager $mailManager,
-		TagMapper $tagMapper,
-		NewMessagesClassifier $newMessagesClassifier) {
-		$this->dbMapper = $dbMapper;
-		$this->clientFactory = $clientFactory;
-		$this->imapMapper = $imapMapper;
-		$this->mailboxMapper = $mailboxMapper;
-		$this->synchronizer = $synchronizer;
+		private PerformanceLogger $performanceLogger,
+		private LoggerInterface $logger,
+		private IMailManager $mailManager,
+		private TagMapper $tagMapper,
+		private NewMessagesClassifier $newMessagesClassifier,
+	) {
 		$this->dispatcher = $dispatcher;
-		$this->performanceLogger = $performanceLogger;
-		$this->logger = $logger;
-		$this->mailManager = $mailManager;
-		$this->tagMapper = $tagMapper;
-		$this->newMessagesClassifier = $newMessagesClassifier;
 	}
 
 	/**

--- a/lib/Service/Sync/SyncService.php
+++ b/lib/Service/Sync/SyncService.php
@@ -30,41 +30,15 @@ use function array_map;
 
 class SyncService {
 
-	private IMAPClientFactory $clientFactory;
-
-	/** @var ImapToDbSynchronizer */
-	private $synchronizer;
-
-	/** @var FilterStringParser */
-	private $filterStringParser;
-
-	/** @var MessageMapper */
-	private $messageMapper;
-
-	/** @var PreviewEnhancer */
-	private $previewEnhancer;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var MailboxSync */
-	private $mailboxSync;
-
 	public function __construct(
-		IMAPClientFactory $clientFactory,
-		ImapToDbSynchronizer $synchronizer,
-		FilterStringParser $filterStringParser,
-		MessageMapper $messageMapper,
-		PreviewEnhancer $previewEnhancer,
-		LoggerInterface $logger,
-		MailboxSync $mailboxSync) {
-		$this->clientFactory = $clientFactory;
-		$this->synchronizer = $synchronizer;
-		$this->filterStringParser = $filterStringParser;
-		$this->messageMapper = $messageMapper;
-		$this->previewEnhancer = $previewEnhancer;
-		$this->logger = $logger;
-		$this->mailboxSync = $mailboxSync;
+		private IMAPClientFactory $clientFactory,
+		private ImapToDbSynchronizer $synchronizer,
+		private FilterStringParser $filterStringParser,
+		private MessageMapper $messageMapper,
+		private PreviewEnhancer $previewEnhancer,
+		private LoggerInterface $logger,
+		private MailboxSync $mailboxSync,
+	) {
 	}
 
 	/**

--- a/lib/Service/TrustedSenderService.php
+++ b/lib/Service/TrustedSenderService.php
@@ -14,11 +14,9 @@ use OCA\Mail\Db\Message;
 use OCA\Mail\Db\TrustedSenderMapper;
 
 class TrustedSenderService implements ITrustedSenderService {
-	/** @var TrustedSenderMapper */
-	private $mapper;
-
-	public function __construct(TrustedSenderMapper $mapper) {
-		$this->mapper = $mapper;
+	public function __construct(
+		private TrustedSenderMapper $mapper,
+	) {
 	}
 
 	#[\Override]

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -25,38 +25,17 @@ use OCP\TextProcessing\FreePromptTaskType;
 use OCP\TextProcessing\SummaryTaskType;
 
 class AdminSettings implements ISettings {
-	/** @var IInitialState */
-	private $initialStateService;
-
-	/** @var ProvisioningManager */
-	private $provisioningManager;
-
-	/** @var AntiSpamService */
-	private $antiSpamService;
-
-	private GoogleIntegration $googleIntegration;
-	private MicrosoftIntegration $microsoftIntegration;
-	private IConfig $config;
-	private AiIntegrationsService $aiIntegrationsService;
-
 	public function __construct(
-		IInitialState $initialStateService,
-		ProvisioningManager $provisioningManager,
-		AntiSpamService $antiSpamService,
-		GoogleIntegration $googleIntegration,
-		MicrosoftIntegration $microsoftIntegration,
-		IConfig $config,
-		AiIntegrationsService $aiIntegrationsService,
+		private IInitialState $initialStateService,
+		private ProvisioningManager $provisioningManager,
+		private AntiSpamService $antiSpamService,
+		private GoogleIntegration $googleIntegration,
+		private MicrosoftIntegration $microsoftIntegration,
+		private IConfig $config,
+		private AiIntegrationsService $aiIntegrationsService,
 		private Defaults $themingDefaults,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
-		$this->initialStateService = $initialStateService;
-		$this->provisioningManager = $provisioningManager;
-		$this->antiSpamService = $antiSpamService;
-		$this->googleIntegration = $googleIntegration;
-		$this->microsoftIntegration = $microsoftIntegration;
-		$this->config = $config;
-		$this->aiIntegrationsService = $aiIntegrationsService;
 	}
 
 	#[\Override]

--- a/lib/Support/ConsoleLoggerDecorator.php
+++ b/lib/Support/ConsoleLoggerDecorator.php
@@ -13,15 +13,13 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleLoggerDecorator implements LoggerInterface {
-	/** @var LoggerInterface */
-	private $inner;
-
 	/** @var OutputInterface */
 	private $consoleOutput;
 
-	public function __construct(LoggerInterface $inner,
-		OutputInterface $consoleOutput) {
-		$this->inner = $inner;
+	public function __construct(
+		private LoggerInterface $inner,
+		OutputInterface $consoleOutput,
+	) {
 		$this->consoleOutput = $consoleOutput;
 	}
 

--- a/lib/Support/PerformanceLogger.php
+++ b/lib/Support/PerformanceLogger.php
@@ -16,13 +16,11 @@ class PerformanceLogger {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(ITimeFactory $timeFactory,
-		LoggerInterface $logger) {
+	public function __construct(
+		ITimeFactory $timeFactory,
+		private LoggerInterface $logger,
+	) {
 		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
 	}
 
 	public function start(string $task): PerformanceLoggerTask {

--- a/lib/Support/PerformanceLoggerTask.php
+++ b/lib/Support/PerformanceLoggerTask.php
@@ -18,14 +18,8 @@ use function round;
 use function sprintf;
 
 class PerformanceLoggerTask {
-	/** @var string */
-	private $task;
-
 	/** @var ITimeFactory */
 	private $timeFactory;
-
-	/** @var LoggerInterface */
-	private $logger;
 
 	/** @var int */
 	private $start;
@@ -33,12 +27,12 @@ class PerformanceLoggerTask {
 	/** @var int */
 	private $rel;
 
-	public function __construct(string $task,
+	public function __construct(
+		private string $task,
 		ITimeFactory $timeFactory,
-		LoggerInterface $logger) {
-		$this->task = $task;
+		private LoggerInterface $logger,
+	) {
 		$this->timeFactory = $timeFactory;
-		$this->logger = $logger;
 
 		$this->start = $this->rel = $timeFactory->getTime();
 	}

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Nextcloud\Rector\Set\NextcloudSets;
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\TypeDeclaration\Rector\Class_\AddTestsVoidReturnTypeWhereNoReturnRector;
 
@@ -32,4 +33,5 @@ return RectorConfig::configure()
 	)
 	->withRules([
 		AddTestsVoidReturnTypeWhereNoReturnRector::class,
+		ClassPropertyAssignToConstructorPromotionRector::class,
 	]);

--- a/tests/Integration/Framework/SimpleMessage.php
+++ b/tests/Integration/Framework/SimpleMessage.php
@@ -8,27 +8,6 @@
 namespace OCA\Mail\Tests\Integration\Framework;
 
 class SimpleMessage {
-	/** @var string */
-	private $from;
-
-	/** @var string */
-	private $to;
-
-	/** @var string|null */
-	private $cc;
-
-	/** @var string|null */
-	private $bcc;
-
-	/** @var string|null */
-	private $date;
-
-	/** @var string|null */
-	private $subject;
-
-	/** @var string|null */
-	private $body;
-
 	/**
 	 * @param string $from
 	 * @param string $to
@@ -38,20 +17,15 @@ class SimpleMessage {
 	 * @param string $subject
 	 * @param string $body
 	 */
-	public function __construct(string $from,
-		string $to,
-		?string $cc,
-		?string $bcc,
-		?string $date,
-		?string $subject,
-		?string $body) {
-		$this->from = $from;
-		$this->to = $to;
-		$this->cc = $cc;
-		$this->bcc = $bcc;
-		$this->date = $date;
-		$this->subject = $subject;
-		$this->body = $body;
+	public function __construct(
+		private string $from,
+		private string $to,
+		private ?string $cc,
+		private ?string $bcc,
+		private ?string $date,
+		private ?string $subject,
+		private ?string $body,
+	) {
 	}
 
 	public function getFrom(): string {

--- a/tests/Unit/Controller/DeepLinkControllerTest.php
+++ b/tests/Unit/Controller/DeepLinkControllerTest.php
@@ -91,7 +91,7 @@ class DeepLinkControllerTest extends TestCase {
 			->with('user123')
 			->willReturn([$lightAccount]);
 
-		$account = $this->createMock(Account::class);
+		$account = $this->createStub(Account::class);
 		$this->accountService->expects(self::once())
 			->method('find')
 			->with('user123', 1)
@@ -133,7 +133,7 @@ class DeepLinkControllerTest extends TestCase {
 			->with('user123')
 			->willReturn([$lightAccount]);
 
-		$account = $this->createMock(Account::class);
+		$account = $this->createStub(Account::class);
 		$this->accountService->expects(self::once())
 			->method('find')
 			->with('user123', 1)

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -375,7 +375,7 @@ class MessagesControllerTest extends TestCase {
 			->method('getName')
 			->with()
 			->will($this->returnValue('cat.jpg'));
-		$folderNode = $this->createMock(Folder::class);
+		$folderNode = $this->createStub(Folder::class);
 		$this->userFolder->expects($this->once())
 			->method('get')
 			->with('Downloads')
@@ -443,7 +443,7 @@ class MessagesControllerTest extends TestCase {
 			->method('getName')
 			->with()
 			->will($this->returnValue('cat.jpg'));
-		$folderNode = $this->createMock(Folder::class);
+		$folderNode = $this->createStub(Folder::class);
 		$this->userFolder->expects($this->once())
 			->method('get')
 			->with('Downloads')

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -88,8 +88,8 @@ class HtmlTest extends TestCase {
 			->method('linkToRouteAbsolute')
 			->with('mail.messages.downloadAttachment', ['id' => 42, 'attachmentId' => '7'])
 			->willReturn($attachmentUrl);
-		$request = $this->createMock(IRequest::class);
-		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+		$request = $this->createStub(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
 
 		$html = new Html($urlGenerator, $request, $hmacGenerator);
 		$inlineAttachments = [['id' => '7', 'cid' => 'image001@example.com']];
@@ -107,8 +107,8 @@ class HtmlTest extends TestCase {
 			->method('linkToRouteAbsolute')
 			->with('mail.messages.downloadAttachment', ['id' => 42, 'attachmentId' => '7'])
 			->willReturn($attachmentUrl);
-		$request = $this->createMock(IRequest::class);
-		$hmacGenerator = $this->createMock(ProxyHmacGenerator::class);
+		$request = $this->createStub(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
 
 		$html = new Html($urlGenerator, $request, $hmacGenerator);
 		$inlineAttachments = [['id' => '7', 'cid' => 'image001@example.com']];


### PR DESCRIPTION
Mechanically applied ClassPropertyAssignToConstructorPromotionRector across lib/ and tests/. Hand-corrected cases where Rector renamed the $userId DI parameter to match the internal property name, which would have broken Nextcloud's container injection.

Assisted-by: ClaudeCode:claude-sonnet-4-6

Ref https://github.com/nextcloud/mail/issues/13077

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
