### PR TITLE
refactor(php): replace strpos and switch with modern idioms

### DIFF
--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -1192,16 +1192,12 @@ class MessageMapper extends QBMapper {
 			throw new RuntimeException('Invalid operand type ' . get_class($operand));
 		}, $expr->getOperands());
 
-		switch ($expr->getOperator()) {
-			case 'and':
-				/** @psalm-suppress InvalidCast */
-				return (string)$qb->expr()->andX(...$operands);
-			case 'or':
-				/** @psalm-suppress InvalidCast */
-				return (string)$qb->expr()->orX(...$operands);
-			default:
-				throw new RuntimeException('Unknown operator ' . $expr->getOperator());
-		}
+		/** @psalm-suppress InvalidCast */
+		return match ($expr->getOperator()) {
+			'and' => (string)$qb->expr()->andX(...$operands),
+			'or' => (string)$qb->expr()->orX(...$operands),
+			default => throw new RuntimeException('Unknown operator ' . $expr->getOperator()),
+		};
 	}
 
 	private function flagToColumnName(Flag $flag): string {

--- a/lib/Exception/CouldNotConnectException.php
+++ b/lib/Exception/CouldNotConnectException.php
@@ -63,18 +63,15 @@ class CouldNotConnectException extends ServiceException {
 			return 'OTHER';
 		}
 
-		switch ($this->previous->getCode()) {
-			case Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED:
-				return match ($this->previous->getMessage()) {
-					'Authentication failed.' => 'AUTHENTICATION_WRONG_PASSWORD',
-					'Mail server denied authentication.' => 'AUTHENTICATION_DENIED',
-					default => 'AUTHENTICATION',
-				};
-			case Horde_Imap_Client_Exception::SERVER_CONNECT:
-			case Horde_Imap_Client_Exception::SERVER_READERROR:
-				return 'CONNECTION_ERROR';
-			default:
-				return 'OTHER';
-		}
+		return match ($this->previous->getCode()) {
+			Horde_Imap_Client_Exception::LOGIN_AUTHENTICATIONFAILED => match ($this->previous->getMessage()) {
+				'Authentication failed.' => 'AUTHENTICATION_WRONG_PASSWORD',
+				'Mail server denied authentication.' => 'AUTHENTICATION_DENIED',
+				default => 'AUTHENTICATION',
+			},
+			Horde_Imap_Client_Exception::SERVER_CONNECT,
+			Horde_Imap_Client_Exception::SERVER_READERROR => 'CONNECTION_ERROR',
+			default => 'OTHER',
+		};
 	}
 }

--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -16,7 +16,6 @@ use OCA\Mail\Service\Group\IGroupService;
 use OCA\Mail\Service\Group\NextcloudGroupService;
 use function array_map;
 use function mb_strlen;
-use function mb_strpos;
 use function mb_substr;
 use function OCA\Mail\array_flat_map;
 
@@ -82,7 +81,7 @@ class GroupsIntegration {
 	public function expand(array $recipients): array {
 		return array_flat_map(function (Recipient $recipient) {
 			foreach ($this->groupServices as $service) {
-				if (mb_strpos($recipient->getEmail(), $this->servicePrefix($service)) !== false) {
+				if (str_contains($recipient->getEmail(), $this->servicePrefix($service))) {
 					$groupId = mb_substr(
 						$recipient->getEmail(),
 						mb_strlen($this->servicePrefix($service))


### PR DESCRIPTION
- Replace mb_strpos() !== false with str_contains() in GroupsIntegration (email addresses are ASCII so the multibyte variant is unnecessary)
- Convert switch on FlagExpression operator to match in MessageMapper
- Convert switch on IMAP error code to nested match in CouldNotConnectException

Assisted-by: ClaudeCode:claude-sonnet-4-6

Ref https://github.com/nextcloud/mail/issues/13077

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
