### PR TITLE
perf(frontend): prevent overlapping background inbox syncs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,12 @@ import useMainStore from './store/mainStore.js'
 
 export default {
 	name: 'App',
+	data() {
+		return {
+			syncing: false,
+		}
+	},
+
 	computed: {
 		...mapStores(useMainStore),
 		...mapState(useMainStore, [
@@ -64,6 +70,13 @@ export default {
 
 		sync() {
 			setTimeout(async () => {
+				// Don't sync a previous sync is still running
+				if (this.syncing) {
+					this.sync()
+					return
+				}
+
+				this.syncing = true
 				try {
 					await this.mainStore.syncInboxes()
 
@@ -78,6 +91,7 @@ export default {
 						},
 					})
 				} finally {
+					this.syncing = false
 					// Start over
 					this.sync()
 				}

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -217,7 +217,7 @@ export default {
 		this.mainStore.setHasFetchedInitialEnvelopesMutation(true)
 	},
 
-	unmounted() {
+	destroyed() {
 		this.bus.off('load-more', this.onScroll)
 		this.bus.off('delete', this.onDelete)
 		this.bus.off('archive', this.onArchive)

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -90,7 +90,7 @@ export default {
 		await this.fetchMessages()
 	},
 
-	unmounted() {
+	destroyed() {
 		clearInterval(this.refreshInterval)
 	},
 


### PR DESCRIPTION
The impact is probably tiny, just to avoid a few api calls that we now will respond with `MailboxLockedError` 

Also fix the cleanup hooks in Mailbox.vue and Outbox.vue, which used the Vue 3 "unmounted" name and therefore never ran under Vue 2.7; renamed to "destroyed" so the interval and event-bus teardown actually execute. 
->https://v2.vuejs.org/v2/guide/instance#Lifecycle-Diagram 

Assisted-by: ClaudeCode:claude-opus-4-8[1m]

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox synchronization so only one sync run can happen at a time, reducing duplicate work and race conditions.
  * Fixed background cleanup behavior when leaving mailbox and outbox screens, helping keep polling and event handling from lingering unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->