### PR TITLE
fix: use From address for reply-to-sender-only on mailing list emails

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -523,7 +523,13 @@ export default function mainStoreActions() {
 					if (reply.mode === 'reply') {
 						logger.debug('Show simple reply composer', { reply })
 						const account = this.getAccount(reply.data.accountId)
-						let to = original.replyTo !== undefined ? original.replyTo : reply.data.from
+						// For mailing list emails, "Reply to sender" must use From because
+						// Reply-To points to the list address, not the original sender.
+						// For regular emails, honor Reply-To if the sender set one.
+						const isMailingList = !!(original.unsubscribeUrl || original.unsubscribeMailto)
+						let to = (!isMailingList && original.replyTo !== undefined)
+							? original.replyTo
+							: reply.data.from
 						// Replying to a message we sent ourselves: follow up with the
 						// original recipient(s) instead of addressing ourselves.
 						const isOwnMessage = to.length > 0

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -739,4 +739,107 @@ describe('Vuex store actions', () => {
 			expect(MailboxService.fetchAll).toHaveBeenCalledWith(7, true)
 		})
 	})
+
+	describe('startComposerSession reply-to resolution', () => {
+		const account = {
+			id: 1,
+			emailAddress: 'me@example.com',
+			personalNamespace: '',
+			mailboxes: [],
+			name: 'Me',
+		}
+		const from = [{ email: 'sender@example.com', label: 'Sender' }]
+		const to = [{ email: 'me@example.com', label: 'Me' }]
+		const replyTo = [{ email: 'personal-replyto@example.com', label: 'Reply Here' }]
+
+		const makeEnvelope = (overrides = {}) => ({
+			databaseId: 42,
+			accountId: 1,
+			from,
+			to,
+			replyTo: undefined,
+			subject: 'Test subject',
+			...overrides,
+		})
+
+		const makeOriginal = (overrides = {}) => ({
+			databaseId: 42,
+			hasHtmlBody: false,
+			body: 'Message body',
+			replyTo: undefined,
+			unsubscribeUrl: null,
+			unsubscribeMailto: null,
+			...overrides,
+		})
+
+		beforeEach(() => {
+			store.addAccountMutation(account)
+			vi.spyOn(store, 'startComposerSessionMutation')
+		})
+
+		it('uses From for mailing list emails even when Reply-To is set', async () => {
+			MessageService.fetchMessage.mockResolvedValue(makeOriginal({
+				replyTo,
+				unsubscribeUrl: 'https://list.example.com/unsubscribe',
+			}))
+
+			await store.startComposerSession({
+				reply: {
+					mode: 'reply',
+					data: makeEnvelope({ replyTo }),
+				},
+			})
+
+			expect(store.startComposerSessionMutation).toHaveBeenCalledWith(expect.objectContaining({
+				data: expect.objectContaining({ to: from }),
+			}))
+		})
+
+		it('honours Reply-To for regular emails with a personal Reply-To', async () => {
+			MessageService.fetchMessage.mockResolvedValue(makeOriginal({ replyTo }))
+
+			await store.startComposerSession({
+				reply: {
+					mode: 'reply',
+					data: makeEnvelope({ replyTo }),
+				},
+			})
+
+			expect(store.startComposerSessionMutation).toHaveBeenCalledWith(expect.objectContaining({
+				data: expect.objectContaining({ to: replyTo }),
+			}))
+		})
+
+		it('uses To for own sent messages (isOwnMessage follow-up)', async () => {
+			const ownFrom = [{ email: 'me@example.com', label: 'Me' }]
+			MessageService.fetchMessage.mockResolvedValue(makeOriginal())
+
+			await store.startComposerSession({
+				reply: {
+					mode: 'reply',
+					data: makeEnvelope({ from: ownFrom }),
+				},
+			})
+
+			expect(store.startComposerSessionMutation).toHaveBeenCalledWith(expect.objectContaining({
+				data: expect.objectContaining({ to }),
+			}))
+		})
+
+		it('uses To when followUp flag is set', async () => {
+			MessageService.fetchMessage.mockResolvedValue(makeOriginal())
+
+			await store.startComposerSession({
+				reply: {
+					mode: 'reply',
+					data: makeEnvelope(),
+					followUp: true,
+				},
+			})
+
+			expect(store.startComposerSessionMutation).toHaveBeenCalledWith(expect.objectContaining({
+				data: expect.objectContaining({ to }),
+			}))
+		})
+	})
 })


### PR DESCRIPTION
fixes: #11089 
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
