### PR TITLE
feat: adds heading shortcuts

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -230,6 +230,9 @@
 						<NcHotkey :label="t('mail', 'Search')" hotkey="Control F" />
 						<NcHotkey :label="t('mail', 'Send')" hotkey="Control Enter" />
 						<NcHotkey :label="t('mail', 'Refresh')" hotkey="R" />
+						<NcHotkey :label="t('mail', 'Heading1')" hotkey="Control Alt 1" />
+						<NcHotkey :label="t('mail', 'Heading2')" hotkey="Control Alt 2" />
+						<NcHotkey :label="t('mail', 'Heading3')" hotkey="Control Alt 3" />
 					</NcHotkeyList>
 				</NcAppSettingsShortcutsSection>
 

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -581,6 +581,21 @@ export default {
 
 			if (this.html) {
 				this.addToFocusTrap('.ck-body-wrapper')
+
+				editor.keystrokes.set('Ctrl+Alt+1', (event, cancel) => {
+					editor.execute('heading', { value: 'heading1' })
+					cancel()
+				})
+
+				editor.keystrokes.set('Ctrl+Alt+2', (event, cancel) => {
+					editor.execute('heading', { value: 'heading2' })
+					cancel()
+				})
+
+				editor.keystrokes.set('Ctrl+Alt+3', (event, cancel) => {
+					editor.execute('heading', { value: 'heading3' })
+					cancel()
+				})
 			}
 
 			this.bus.on('append-to-body-at-cursor', this.appendToBodyAtCursor)


### PR DESCRIPTION
Added keyboard shortcuts for applying heading styles while composing in HTML mode

Ctrl+Alt+1 — Heading 1
Ctrl+Alt+2 — Heading 2
Ctrl+Alt+3 — Heading 3

On macOS, use Cmd+Alt+1, Cmd+Alt+2, and Cmd+Alt+3.

Fixes #10008