### PR TITLE
Do not re-insert signature when opening a draft

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -705,6 +705,11 @@ export default {
 			required: true,
 		},
 
+		isDraft: {
+			type: Boolean,
+			default: false,
+		},
+
 		requestMdn: {
 			type: Boolean,
 			default: false,
@@ -1329,7 +1334,12 @@ export default {
 
 		onEditorReady(editor) {
 			this.bodyVal = editor.getData()
-			this.insertSignature()
+
+			// Only append signature on opening drafts if alias changed.
+			// Otherwise leads to unwanted or even duplicate signatures.
+			if (!this.isDraft || this.changeSignature) {
+				this.insertSignature()
+			}
 			if (this.smartReply) {
 				this.bus.emit('append-to-body-at-cursor', this.smartReply)
 			}

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -90,6 +90,7 @@
 						:smime-sign="composerData.smimeSign"
 						:smime-encrypt="composerData.smimeEncrypt"
 						:is-first-open="modalFirstOpen"
+						:is-draft="composerData.draftId !== undefined"
 						:request-mdn="composerData.requestMdn"
 						:accounts="accounts"
 						@update:from-account="patchComposerData({ accountId: $event })"

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -432,4 +432,86 @@ describe('Composer', () => {
 			search: 'alice',
 		})).toEqual(true)
 	})
+
+	it('inserts the signature when composing a new message', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				isDraft: false,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+		const insertSignature = vi.spyOn(view.vm, 'insertSignature').mockImplementation(() => {})
+
+		view.vm.onEditorReady({ getData: () => '' })
+
+		expect(insertSignature).toHaveBeenCalled()
+	})
+
+	it('does not insert the signature when opening a draft', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				isDraft: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+		const insertSignature = vi.spyOn(view.vm, 'insertSignature').mockImplementation(() => {})
+
+		view.vm.onEditorReady({ getData: () => '' })
+
+		expect(insertSignature).not.toHaveBeenCalled()
+	})
+
+	it('inserts the signature on alias change even when opening a draft', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				isDraft: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+		const insertSignature = vi.spyOn(view.vm, 'insertSignature').mockImplementation(() => {})
+		view.vm.changeSignature = true
+
+		view.vm.onEditorReady({ getData: () => '' })
+
+		expect(insertSignature).toHaveBeenCalled()
+	})
 })


### PR DESCRIPTION
When you have a signature enabled and open a draft, that signature gets inserted. This can even result in multiple insertions of the signature if you open the draft multiple times. When opening a draft, the signature should never be inserted, as this is already done at initial composition.

Initial composer (with signature removed) | Before when reopening draft | Bonus: Multiple draft reopening | After when reopening draft
-|-|-|-
<img width="547" height="398" alt="Screenshot From 2026-06-23 12-17-50" src="https://github.com/user-attachments/assets/693efb39-0a5f-49a4-a3ca-84822a70aa24" />|<img width="547" height="398" alt="Screenshot From 2026-06-23 11-57-49" src="https://github.com/user-attachments/assets/cce14444-2738-43c1-a9fe-e9b8eea34360" />|<img width="547" height="398" alt="Screenshot From 2026-06-23 12-10-10" src="https://github.com/user-attachments/assets/426c108c-58c2-4acf-917d-ceed20ac05f1" />|<img width="547" height="398" alt="Screenshot From 2026-06-23 11-57-04" src="https://github.com/user-attachments/assets/a67dec85-6220-4a0a-be62-491203ab770c" />




## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


Assisted-by: ClaudeCode:claude-opus-4-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature handling when editing draft messages. Signatures no longer auto-insert when reopening a draft, reducing signature duplication issues. Manually changing the signature selection will still insert the new signature correctly. Draft editing now has separate behavior from new message composition, where signatures continue to auto-insert as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->