### PR TITLE
fix(attachments): store uploads under account owner for delegated sends

### DIFF
--- a/lib/Controller/LocalAttachmentsController.php
+++ b/lib/Controller/LocalAttachmentsController.php
@@ -13,6 +13,7 @@ use OCA\Mail\Contracts\IAttachmentService;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Http\TrapError;
 use OCA\Mail\Service\Attachment\UploadedFile;
+use OCA\Mail\Service\DelegationService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -25,12 +26,14 @@ class LocalAttachmentsController extends Controller {
 	 * @param string $appName
 	 * @param IRequest $request
 	 * @param IAttachmentService $attachmentService
+	 * @param DelegationService $delegationService
 	 * @param string $UserId
 	 */
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private IAttachmentService $attachmentService,
+		private DelegationService $delegationService,
 		private string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -42,15 +45,21 @@ class LocalAttachmentsController extends Controller {
 	 * @return JSONResponse
 	 */
 	#[TrapError]
-	public function create(): JSONResponse {
+	public function create(?int $accountId = null): JSONResponse {
 		$file = $this->request->getUploadedFile('attachment');
 
 		if (is_null($file)) {
 			throw new ClientException('no file attached');
 		}
 
+		// Store the attachment under the account owner so it can be linked and
+		// sent when composing on behalf of a delegated account.
+		$userId = $accountId !== null
+			? $this->delegationService->resolveAccountUserId($accountId, $this->userId)
+			: $this->userId;
+
 		$uploadedFile = new UploadedFile($file);
-		$attachment = $this->attachmentService->addFile($this->userId, $uploadedFile);
+		$attachment = $this->attachmentService->addFile($userId, $uploadedFile);
 
 		return new JSONResponse($attachment, Http::STATUS_CREATED);
 	}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -277,6 +277,7 @@
 		<ComposerAttachments
 			v-model="attachments"
 			:bus="bus"
+			:account-id="selectedAlias.id"
 			:upload-size-limit="attachmentSizeLimit"
 			@upload="$emit('upload-attachment', $event, getMessageData())" />
 		<div class="composer-actions-right composer-actions">

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -104,6 +104,11 @@ export default {
 			type: Number,
 			default: 0,
 		},
+
+		accountId: {
+			type: Number,
+			default: null,
+		},
 	},
 
 	data() {
@@ -292,7 +297,7 @@ export default {
 					uploaded: 0,
 				})
 				try {
-					return uploadLocalAttachment(file, progress(file.name), controller)
+					return uploadLocalAttachment(file, this.accountId, progress(file.name), controller)
 						.catch(() => {
 							this.attachments.some((attachment) => {
 								if (attachment.displayName === file.name && !attachment.error) {

--- a/src/service/AttachmentService.js
+++ b/src/service/AttachmentService.js
@@ -29,7 +29,7 @@ export function downloadAttachment(url) {
 	return Axios.get(url).then((res) => res.data)
 }
 
-export function uploadLocalAttachment(file, progress, controller) {
+export function uploadLocalAttachment(file, accountId, progress, controller) {
 	const url = generateUrl('/apps/mail/api/attachments')
 	const data = new FormData()
 	const opts = {
@@ -39,6 +39,10 @@ export function uploadLocalAttachment(file, progress, controller) {
 		opts.signal = controller.signal
 	}
 	data.append('attachment', file)
+
+	if (accountId) {
+		data.append('accountId', accountId)
+	}
 
 	return Axios.post(url, data, opts)
 		.then((resp) => resp.data)

--- a/tests/Unit/Controller/LocalAttachmentsControllerTest.php
+++ b/tests/Unit/Controller/LocalAttachmentsControllerTest.php
@@ -13,6 +13,7 @@ use OCA\Mail\Controller\LocalAttachmentsController;
 use OCA\Mail\Db\LocalAttachment;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\Attachment\UploadedFile;
+use OCA\Mail\Service\DelegationService;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,6 +24,9 @@ class LocalAttachmentsControllerTest extends TestCase {
 
 	/** @var IAttachmentService|MockObject */
 	private $service;
+
+	/** @var DelegationService|MockObject */
+	private $delegationService;
 
 	/** @var string */
 	private $userId;
@@ -35,9 +39,10 @@ class LocalAttachmentsControllerTest extends TestCase {
 
 		$this->request = $this->createMock(IRequest::class);
 		$this->service = $this->createMock(IAttachmentService::class);
+		$this->delegationService = $this->createMock(DelegationService::class);
 		$this->userId = 'jane';
 
-		$this->controller = new LocalAttachmentsController('mail', $this->request, $this->service, $this->userId);
+		$this->controller = new LocalAttachmentsController('mail', $this->request, $this->service, $this->delegationService, $this->userId);
 	}
 
 	public function testCreateWithoutFile() {
@@ -60,12 +65,38 @@ class LocalAttachmentsControllerTest extends TestCase {
 			->willReturn($fileData);
 		$attachment = new LocalAttachment();
 		$uploadedFile = new UploadedFile($fileData);
+		$this->delegationService->expects($this->never())
+			->method('resolveAccountUserId');
 		$this->service->expects($this->once())
 			->method('addFile')
 			->with($this->equalTo($this->userId), $this->equalTo($uploadedFile))
 			->willReturn($attachment);
 
 		$actual = $this->controller->create();
+
+		$this->assertEquals(new JSONResponse($attachment, 201), $actual);
+	}
+
+	public function testCreateForDelegatedAccount() {
+		$fileData = [
+			'name' => 'cat.jpg',
+		];
+		$this->request->expects($this->once())
+			->method('getUploadedFile')
+			->with('attachment')
+			->willReturn($fileData);
+		$attachment = new LocalAttachment();
+		$uploadedFile = new UploadedFile($fileData);
+		$this->delegationService->expects($this->once())
+			->method('resolveAccountUserId')
+			->with(42, $this->userId)
+			->willReturn('owner');
+		$this->service->expects($this->once())
+			->method('addFile')
+			->with($this->equalTo('owner'), $this->equalTo($uploadedFile))
+			->willReturn($attachment);
+
+		$actual = $this->controller->create(42);
 
 		$this->assertEquals(new JSONResponse($attachment, 201), $actual);
 	}


### PR DESCRIPTION
fix #13127

Use effective user when saving uploaded attachments in db 

Assisted-by: Claude:claude-opus-4-8
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
