### PR TITLE
refactor: migrate AdminSettings off deprecated IInitialStateService

### DIFF
--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -17,15 +17,15 @@ use OCA\Mail\Service\AntiSpamService;
 use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
 use OCP\IConfig;
-use OCP\IInitialStateService;
 use OCP\Settings\ISettings;
 use OCP\TextProcessing\FreePromptTaskType;
 use OCP\TextProcessing\SummaryTaskType;
 
 class AdminSettings implements ISettings {
-	/** @var IInitialStateService */
+	/** @var IInitialState */
 	private $initialStateService;
 
 	/** @var ProvisioningManager */
@@ -40,7 +40,7 @@ class AdminSettings implements ISettings {
 	private AiIntegrationsService $aiIntegrationsService;
 
 	public function __construct(
-		IInitialStateService $initialStateService,
+		IInitialState $initialStateService,
 		ProvisioningManager $provisioningManager,
 		AntiSpamService $antiSpamService,
 		GoogleIntegration $googleIntegration,
@@ -62,13 +62,11 @@ class AdminSettings implements ISettings {
 	#[\Override]
 	public function getForm() {
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'provisioning_settings',
 			$this->provisioningManager->getConfigs()
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'antispam_setting',
 			[
 				'spam' => $this->antiSpamService->getSpamEmail(),
@@ -77,67 +75,55 @@ class AdminSettings implements ISettings {
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'allow_new_mail_accounts',
 			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'layout_message_view',
 			$this->config->getAppValue('mail', 'layout_message_view', 'threaded')
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'llm_processing',
 			$this->aiIntegrationsService->isLlmProcessingEnabled(),
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'enabled_llm_free_prompt_backend',
 			$this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'enabled_llm_summary_backend',
 			$this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
 		);
 
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'google_oauth_client_id',
 			$this->googleIntegration->getClientId(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'google_oauth_redirect_url',
 			$this->googleIntegration->getRedirectUrl(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'importance_classification_default',
 			$this->classificationSettingsService->isClassificationEnabledByDefault(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'microsoft_oauth_tenant_id',
 			$this->microsoftIntegration->getTenantId(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'microsoft_oauth_client_id',
 			$this->microsoftIntegration->getClientId(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'microsoft_oauth_redirect_url',
 			$this->microsoftIntegration->getRedirectUrl(),
 		);
 		$this->initialStateService->provideInitialState(
-			Application::APP_ID,
 			'microsoft_oauth_docs',
 			$this->themingDefaults->buildDocLinkToKey('admin-groupware-oauth-microsoft'),
 		);

--- a/tests/Unit/Settings/AdminSettingsTest.php
+++ b/tests/Unit/Settings/AdminSettingsTest.php
@@ -41,72 +41,58 @@ class AdminSettingsTest extends TestCase {
 			->method('provideInitialState')
 			->withConsecutive(
 				[
-					Application::APP_ID,
 					'provisioning_settings',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'antispam_setting',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'allow_new_mail_accounts',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'layout_message_view',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'llm_processing',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'enabled_llm_free_prompt_backend',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'enabled_llm_summary_backend',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'google_oauth_client_id',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'google_oauth_redirect_url',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'importance_classification_default',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'microsoft_oauth_tenant_id',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'microsoft_oauth_client_id',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'microsoft_oauth_redirect_url',
 					$this->anything()
 				],
 				[
-					Application::APP_ID,
 					'microsoft_oauth_docs',
 					$this->anything()
 				],


### PR DESCRIPTION
Use OCP\AppFramework\Services\IInitialState instead of the deprecated OCP\IInitialStateService; the app-scoped API drops the APP_ID argument.

Assisted-by: Claude:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
