### PR TITLE
fix(ai): migrate AiIntegrationsService off deprecated TextProcessing API

### DIFF
--- a/lib/BackgroundJob/FollowUpClassifierJob.php
+++ b/lib/BackgroundJob/FollowUpClassifierJob.php
@@ -13,6 +13,7 @@ use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\ThreadMapper;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -84,12 +85,19 @@ class FollowUpClassifierJob extends QueuedJob {
 			return;
 		}
 
-		$requiresFollowup = $this->aiService->requiresFollowUp(
-			$account,
-			$mailbox,
-			$message,
-			$userId,
-		);
+		try {
+			$requiresFollowup = $this->aiService->requiresFollowUp(
+				$account,
+				$mailbox,
+				$message,
+				$userId,
+			);
+		} catch (ServiceException $e) {
+			$this->logger->error('Failed to classify message for follow-up: ' . $e->getMessage(), [
+				'exception' => $e,
+			]);
+			return;
+		}
 		if (!$requiresFollowup) {
 			return;
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -43,8 +43,8 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
-use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\SummaryTaskType;
+use OCP\TaskProcessing\TaskTypes\TextToText;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
 use OCP\User\IAvailabilityCoordinator;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -311,7 +311,7 @@ class PageController extends Controller {
 
 		$this->initialStateService->provideInitialState(
 			'llm_summaries_available',
-			$this->aiIntegrationsService->isLlmProcessingEnabled() && $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
+			$this->aiIntegrationsService->isLlmProcessingEnabled() && $this->aiIntegrationsService->isLlmAvailable(TextToTextSummary::ID)
 		);
 
 		$this->initialStateService->provideInitialState(
@@ -321,13 +321,13 @@ class PageController extends Controller {
 
 		$this->initialStateService->provideInitialState(
 			'llm_freeprompt_available',
-			$this->aiIntegrationsService->isLlmProcessingEnabled() && $this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
+			$this->aiIntegrationsService->isLlmProcessingEnabled() && $this->aiIntegrationsService->isLlmAvailable(TextToText::ID)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'llm_followup_available',
 			$this->aiIntegrationsService->isLlmProcessingEnabled()
-			&& $this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
+			&& $this->aiIntegrationsService->isLlmAvailable(TextToText::ID)
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/lib/Controller/ThreadController.php
+++ b/lib/Controller/ThreadController.php
@@ -189,12 +189,19 @@ class ThreadController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 		$thread = $this->mailManager->getThread($account, $threadRootId);
-		$data = $this->aiIntergrationsService->generateEventData(
-			$account,
-			$threadRootId,
-			$thread,
-			$this->userId,
-		);
+		try {
+			$data = $this->aiIntergrationsService->generateEventData(
+				$account,
+				$threadRootId,
+				$thread,
+				$this->userId,
+			);
+		} catch (ServiceException $e) {
+			$this->logger->error('Generating event data failed: ' . $e->getMessage(), [
+				'exception' => $e,
+			]);
+			return new JSONResponse([], Http::STATUS_NO_CONTENT);
+		}
 
 		return new JSONResponse(['data' => $data]);
 	}

--- a/lib/Listener/FollowUpClassifierListener.php
+++ b/lib/Listener/FollowUpClassifierListener.php
@@ -17,7 +17,7 @@ use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\TextProcessing\FreePromptTaskType;
+use OCP\TaskProcessing\TaskTypes\TextToText;
 
 /**
  * @template-implements IEventListener<Event|NewMessagesSynchronized>
@@ -46,7 +46,7 @@ class FollowUpClassifierListener implements IEventListener {
 			return;
 		}
 
-		if (!$this->aiService->isLlmAvailable(FreePromptTaskType::class)) {
+		if (!$this->aiService->isLlmAvailable(TextToText::ID)) {
 			return;
 		}
 

--- a/lib/Listener/TaskProcessingListener.php
+++ b/lib/Listener/TaskProcessingListener.php
@@ -16,6 +16,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
 use OCP\TaskProcessing\TaskTypes\TextToText;
 use Psr\Log\LoggerInterface;
+use function strlen;
 
 /**
  * @template-implements IEventListener<Event>
@@ -45,16 +46,15 @@ class TaskProcessingListener implements IEventListener {
 			return;
 		}
 
-		if ($task->getCustomId() && str_contains($task->getCustomId(), ':')) {
-			[$type, $id] = explode(':', $task->getCustomId());
-		} else {
-			$this->logger->info('Error handling task processing event custom id missing', ['taskCustomId' => $task->getCustomId()]);
+		$customId = $task->getCustomId();
+		if ($customId === null) {
 			return;
 		}
-		if ($type === null || $id === null) {
-			$this->logger->info('Error handling task processing event custom id is invalid', ['taskCustomId' => $task->getCustomId()]);
+		if (!str_starts_with($customId, 'message:')) {
 			return;
 		}
+		$id = substr($customId, strlen('message:'));
+
 		if ($task->getUserId() !== null) {
 			$userId = $task->getUserId();
 		} else {
@@ -74,10 +74,7 @@ class TaskProcessingListener implements IEventListener {
 			return;
 		}
 
-		if ($type === 'message') {
-			$this->handleMessageSummary($userId, (int)$id, $summary);
-		}
-
+		$this->handleMessageSummary($userId, (int)$id, $summary);
 	}
 
 	private function handleMessageSummary(string $userId, int $id, string $summary): void {

--- a/lib/Service/AiIntegrations/AiIntegrationsService.php
+++ b/lib/Service/AiIntegrations/AiIntegrationsService.php
@@ -23,27 +23,20 @@ use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\TaskProcessing\Exception\Exception as TaskProcessingException;
 use OCP\TaskProcessing\IManager as TaskProcessingManager;
 use OCP\TaskProcessing\Task as TaskProcessingTask;
 use OCP\TaskProcessing\TaskTypes\TextToText;
-use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\IManager as TextProcessingManager;
-use OCP\TextProcessing\SummaryTaskType;
-use OCP\TextProcessing\Task as TextProcessingTask;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
 use Psr\Log\LoggerInterface;
 use function array_map;
 use function implode;
-use function in_array;
+use function is_array;
+use function is_string;
 use function json_decode;
+use function sprintf;
 
 class AiIntegrationsService {
-
-	private const EVENT_DATA_PROMPT_PREAMBLE = <<<PROMPT
-I am scheduling an event based on an email thread and need an event title and agenda. Provide the result as JSON with keys for "title" and "agenda". For example ```{ "title": "Project kick-off meeting", "agenda": "* Introduction\\n* Project goals\\n* Next steps" }```.
-
-The email contents are:
-
-PROMPT;
 
 	public function __construct(
 		private LoggerInterface $logger,
@@ -51,7 +44,6 @@ PROMPT;
 		private IMAPClientFactory $clientFactory,
 		private IMailManager $mailManager,
 		private TaskProcessingManager $taskProcessingManager,
-		private TextProcessingManager $textProcessingManager,
 		private IL10N $l,
 		private IFactory $l10nFactory,
 		private IUserManager $userManager,
@@ -100,12 +92,7 @@ PROMPT;
 				}
 				// construct prompt and task
 				$messageBody = $message->getPlainBody();
-				$prompt = "You are tasked with formulating a helpful summary of a email message. \r\n"
-						  . 'The summary should be in the language of this language code ' . $language . ". \r\n"
-						  . "The summary should be less than 160 characters. \r\n"
-						  . "Output *ONLY* the summary itself, leave out any introduction. \r\n"
-						  . "Here is the ***E-MAIL*** for which you must generate a helpful summary: \r\n"
-						  . "***START_OF_E-MAIL***\r\n$messageBody\r\n***END_OF_E-MAIL***\r\n";
+				$prompt = sprintf(DefaultPrompts::SUMMARIZE_MESSAGE, $language, $messageBody);
 				$task = new TaskProcessingTask(
 					TextToText::ID,
 					[
@@ -134,7 +121,7 @@ PROMPT;
 	 * @throws ServiceException
 	 */
 	public function summarizeThread(Account $account, string $threadId, array $messages, string $currentUserId): ?string {
-		if (in_array(SummaryTaskType::class, $this->textProcessingManager->getAvailableTaskTypes(), true)) {
+		if (isset($this->taskProcessingManager->getAvailableTaskTypes()[TextToTextSummary::ID])) {
 			$messageIds = array_map(fn ($message) => $message->getMessageId(), $messages);
 			$cachedSummary = $this->cache->getValue($this->cache->buildUrlKey($messageIds));
 			if ($cachedSummary) {
@@ -158,9 +145,18 @@ PROMPT;
 			}
 
 			$taskPrompt = implode("\n", $messagesBodies);
-			$summaryTask = new TextProcessingTask(SummaryTaskType::class, $taskPrompt, 'mail', $currentUserId, $threadId);
-			$this->textProcessingManager->runTask($summaryTask);
-			$summary = $summaryTask->getOutput();
+			$summaryTask = new TaskProcessingTask(
+				TextToTextSummary::ID,
+				['input' => $taskPrompt],
+				Application::APP_ID,
+				$currentUserId,
+				$threadId,
+			);
+			$summaryTask = $this->runTask($summaryTask);
+			$output = $summaryTask->getOutput()['output'] ?? null;
+			// output could be array<array<numeric|string>|numeric|string>|null depending on task type
+			// We expect Text in TextToTextSummary so should always resolve to (string)$output
+			$summary = $output !== null && !is_array($output) ? (string)$output : null;
 
 			$this->cache->addValue($this->cache->buildUrlKey($messageIds), $summary);
 
@@ -172,9 +168,10 @@ PROMPT;
 
 	/**
 	 * @param Message[] $messages
+	 * @throws ServiceException
 	 */
 	public function generateEventData(Account $account, string $threadId, array $messages, string $currentUserId): ?EventData {
-		if (!in_array(FreePromptTaskType::class, $this->textProcessingManager->getAvailableTaskTypes(), true)) {
+		if (!isset($this->taskProcessingManager->getAvailableTaskTypes()[TextToText::ID])) {
 			return null;
 		}
 		$client = $this->clientFactory->getClient($account);
@@ -193,16 +190,26 @@ PROMPT;
 			$client->logout();
 		}
 
-		$task = new TextProcessingTask(
-			FreePromptTaskType::class,
-			self::EVENT_DATA_PROMPT_PREAMBLE . implode("\n\n---\n\n", $messageBodies),
-			'mail',
+		$task = new TaskProcessingTask(
+			TextToText::ID,
+			['input' => DefaultPrompts::EVENT_DATA_PREAMBLE . implode("\n\n---\n\n", $messageBodies)],
+			Application::APP_ID,
 			$currentUserId,
 			"event_data_$threadId",
 		);
-		$result = $this->textProcessingManager->runTask($task);
+		$task = $this->runTask($task);
+		$result = $task->getOutput()['output'] ?? null;
+		if (!is_string($result)) {
+			return null;
+		}
 		try {
 			$decoded = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+			if (!is_array($decoded)
+				|| !isset($decoded['title'], $decoded['agenda'])
+				|| !is_string($decoded['title'])
+				|| !is_string($decoded['agenda'])) {
+				return null;
+			}
 			return new EventData($decoded['title'], $decoded['agenda']);
 		} catch (JsonException $e) {
 			return null;
@@ -214,7 +221,7 @@ PROMPT;
 	 * @throws ServiceException
 	 */
 	public function getSmartReply(Account $account, Mailbox $mailbox, Message $message, string $currentUserId): ?array {
-		if (in_array(FreePromptTaskType::class, $this->textProcessingManager->getAvailableTaskTypes(), true)) {
+		if (isset($this->taskProcessingManager->getAvailableTaskTypes()[TextToText::ID])) {
 			$cachedReplies = $this->cache->getValue("smartReplies_{$message->getId()}");
 			if ($cachedReplies) {
 				try {
@@ -240,27 +247,20 @@ PROMPT;
 			} finally {
 				$client->logout();
 			}
-			$prompt = "You are tasked with formulating helpful replies or reply templates to e-mails provided that have been sent to me. If you don't know some relevant information for answering the e-mails (like my schedule) leave blanks in the text that can later be filled by me. You must write the replies from my point of view as replies to the original sender of the provided e-mail!
-
-			Formulate two extremely succinct reply suggestions to the provided ***E-MAIL***. Please, do not invent any context for the replies but, rather, leave blanks for me to fill in with relevant information where necessary. Provide the output formatted as valid JSON with the keys 'reply1' and 'reply2' for the reply suggestions.
-
-			Each suggestion must be of 25 characters or less.
-
-			Here is the ***E-MAIL*** for which you must suggest the replies to:
-
-			***START_OF_E-MAIL***" . $messageBody . "
-
-			***END_OF_E-MAIL***
-
-			Please, output *ONLY* a valid JSON string with the keys 'reply1' and 'reply2' for the reply suggestions. Leave out any other text besides the JSON! Be extremely succinct and write the replies from my point of view.
-			 ";
-			$task = new TextProcessingTask(FreePromptTaskType::class, $prompt, 'mail,', $currentUserId);
-			$this->textProcessingManager->runTask($task);
-			$replies = $task->getOutput();
+			$prompt = sprintf(DefaultPrompts::SMART_REPLY, $messageBody);
+			$task = new TaskProcessingTask(TextToText::ID, ['input' => $prompt], Application::APP_ID, $currentUserId);
+			$task = $this->runTask($task);
+			$output = $task->getOutput()['output'] ?? null;
+			$replies = is_string($output) ? trim($output) : '';
+			if ($replies === '') {
+				// The task can fail or return nothing (e.g. provider timeout); treat as no replies
+				$this->logger->warning('Smart reply task returned no output', ['status' => $task->getStatus(), 'errorMessage' => $task->getErrorMessage()]);
+				return [];
+			}
 			try {
-				$cleaned = preg_replace('/^```json\s*|\s*```$/', '', trim($replies));
+				$cleaned = preg_replace('/^```json\s*|\s*```$/', '', $replies);
 				$decoded = json_decode($cleaned, true, 512, JSON_THROW_ON_ERROR);
-				$this->cache->addValue("smartReplies_{$message->getId()}", $replies);
+				$this->cache->addValue("smartReplies_{$message->getId()}", $cleaned);
 				return $decoded;
 			} catch (JsonException $e) {
 				throw new ServiceException('Failed to decode smart replies JSON output', previous: $e);
@@ -281,7 +281,7 @@ PROMPT;
 		Message $message,
 		string $currentUserId,
 	): bool {
-		if (!in_array(FreePromptTaskType::class, $this->textProcessingManager->getAvailableTaskTypes(), true)) {
+		if (!isset($this->taskProcessingManager->getAvailableTaskTypes()[TextToText::ID])) {
 			throw new ServiceException('No language model available for smart replies');
 		}
 
@@ -305,27 +305,18 @@ PROMPT;
 		$messageBody = $imapMessage->getPlainBody();
 		$messageBody = str_replace('"', '\"', $messageBody);
 
-		$prompt = "Consider the following TypeScript function prototype:
----
-/**
- * This function takes in an email text and returns a boolean indicating whether the email author expects a response.
- *
- * @param emailText - string with the email text
- * @returns boolean true if the email expects a reply, false if not
- */
-declare function doesEmailExpectReply(emailText: string): Promise<boolean>;
----
-Tell me what the function outputs for the following parameters.
+		$prompt = sprintf(DefaultPrompts::REQUIRES_FOLLOW_UP, $messageBody);
+		$task = new TaskProcessingTask(TextToText::ID, ['input' => $prompt], Application::APP_ID, $currentUserId);
 
-emailText: \"$messageBody\"
-The JSON output should be in the form: {\"expectsReply\": true}
-Never return null or undefined.";
-		$task = new TextProcessingTask(FreePromptTaskType::class, $prompt, Application::APP_ID, $currentUserId);
-
-		$this->textProcessingManager->runTask($task);
+		$task = $this->runTask($task);
+		$output = $task->getOutput()['output'] ?? null;
+		if ($task->getStatus() === TaskProcessingTask::STATUS_FAILED || !is_string($output) || trim($output) === '') {
+			$this->logger->warning('Follow-up classification task returned no usable output', ['status' => $task->getStatus(), 'errorMessage' => $task->getErrorMessage()]);
+			throw new ServiceException('Follow-up classification task returned no usable output');
+		}
 
 		// Can't use json_decode() here because the output contains additional garbage
-		return preg_match('/{\s*"expectsReply"\s*:\s*true\s*}/i', $task->getOutput()) === 1;
+		return preg_match('/{\s*"expectsReply"\s*:\s*true\s*}/i', $output) === 1;
 	}
 
 	/**
@@ -339,7 +330,7 @@ Never return null or undefined.";
 		Message $message,
 		string $currentUserId,
 	): ?bool {
-		if (!in_array(FreePromptTaskType::class, $this->textProcessingManager->getAvailableTaskTypes(), true)) {
+		if (!isset($this->taskProcessingManager->getAvailableTaskTypes()[TextToText::ID])) {
 			$this->logger->info('No language model available for checking translation needs');
 			return null;
 		}
@@ -371,34 +362,14 @@ Never return null or undefined.";
 		$messageBody = $imapMessage->getPlainBody();
 		$messageBody = str_replace('"', '\"', $messageBody);
 
-		$prompt = "Consider the following TypeScript function prototype:
----
-/**
- * This function takes in an email text and returns a boolean indicating whether the email needs translation from a specific language.
- *
- * @param emailText - string with the email text
- * @param language - the language code to check against (e.g., 'en', 'de', etc.)
- * @returns boolean true if the email is written in a different language than the one specified and needs translation, false if it is written in the specified language.
- * only return true if whole sentences are written in a different language, not just a word or two.
- */
-declare function isEmailWrittenInLanguage(emailText: string, language: string): Promise<boolean>;
----
-Tell me what the function outputs for the following parameters.
+		$prompt = sprintf(DefaultPrompts::REQUIRES_TRANSLATION, $messageBody, $language);
+		$task = new TaskProcessingTask(TextToText::ID, ['input' => $prompt], Application::APP_ID, $currentUserId);
 
-emailText: \"$messageBody\"
-language: \"$language\"
-The JSON output should be in the form: {\"needsTranslation\": true}
-Never return null or undefined.";
-		$task = new TextProcessingTask(FreePromptTaskType::class, $prompt, Application::APP_ID, $currentUserId);
-
-		$this->textProcessingManager->runTask($task);
-		$output = $task->getOutput();
-		if ($output === null) {
-			throw new ServiceException('Task output is null, possibly due to an error in the task processing', [
-				'messageId' => $message->getId(),
-				'language' => $language,
-				'output' => $output,
-			]);
+		$task = $this->runTask($task);
+		$output = $task->getOutput()['output'] ?? null;
+		if ($task->getStatus() === TaskProcessingTask::STATUS_FAILED || !is_string($output) || trim($output) === '') {
+			$this->logger->warning('Translation check task returned no usable output', ['status' => $task->getStatus(), 'errorMessage' => $task->getErrorMessage()]);
+			throw new ServiceException('Translation check task returned no usable output');
 		}
 		// Can't use json_decode() here because the output contains additional garbage
 		$result = preg_match('/{\s*"needsTranslation"\s*:\s*true\s*}/i', $output) === 1;
@@ -407,7 +378,7 @@ Never return null or undefined.";
 	}
 
 	public function isLlmAvailable(string $taskType): bool {
-		return in_array($taskType, $this->textProcessingManager->getAvailableTaskTypes(), true);
+		return array_key_exists($taskType, $this->taskProcessingManager->getAvailableTaskTypes());
 	}
 
 	public function isTaskAvailable(string $taskName): bool {
@@ -420,6 +391,17 @@ Never return null or undefined.";
 	 */
 	public function isLlmProcessingEnabled(): bool {
 		return $this->appConfig->getValueString(Application::APP_ID, 'llm_processing', 'no') === 'yes';
+	}
+
+	/**
+	 * @throws ServiceException
+	 */
+	private function runTask(TaskProcessingTask $task): TaskProcessingTask {
+		try {
+			return $this->taskProcessingManager->runTask($task);
+		} catch (TaskProcessingException $e) {
+			throw new ServiceException('AI task processing failed', previous: $e);
+		}
 	}
 
 	private function isPersonalEmail(IMAPMessage $imapMessage): bool {

--- a/lib/Service/AiIntegrations/DefaultPrompts.php
+++ b/lib/Service/AiIntegrations/DefaultPrompts.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Service\AiIntegrations;
+
+/**
+ * Default prompt templates for the AI integrations.
+ *
+ * Templates use sprintf placeholders (%s); see the referenced argument order
+ * in the doc block of each constant.
+ */
+final class DefaultPrompts {
+
+	/**
+	 * Preamble prepended to the thread contents when generating event data.
+	 */
+	public const EVENT_DATA_PREAMBLE = <<<PROMPT
+		I am scheduling an event based on an email thread and need an event title and agenda. Provide the result as JSON with keys for "title" and "agenda". For example ```{ "title": "Project kick-off meeting", "agenda": "* Introduction\\n* Project goals\\n* Next steps" }```.
+
+		The email contents are:
+
+		PROMPT;
+
+	/**
+	 * Arguments (in order): language code, message body.
+	 */
+	public const SUMMARIZE_MESSAGE = "You are tasked with formulating a helpful summary of a email message. \r\nThe summary should be in the language of this language code %s. \r\nThe summary should be less than 160 characters. \r\nOutput *ONLY* the summary itself, leave out any introduction. \r\nHere is the ***E-MAIL*** for which you must generate a helpful summary: \r\n***START_OF_E-MAIL***\r\n%s\r\n***END_OF_E-MAIL***\r\n";
+
+	/**
+	 * Arguments (in order): message body.
+	 */
+	public const SMART_REPLY = <<<PROMPT
+		You are tasked with formulating helpful replies or reply templates to e-mails provided that have been sent to me. If you don't know some relevant information for answering the e-mails (like my schedule) leave blanks in the text that can later be filled by me. You must write the replies from my point of view as replies to the original sender of the provided e-mail!
+
+		Formulate two extremely succinct reply suggestions to the provided ***E-MAIL***. Please, do not invent any context for the replies but, rather, leave blanks for me to fill in with relevant information where necessary. Provide the output formatted as valid JSON with the keys 'reply1' and 'reply2' for the reply suggestions.
+
+		Each suggestion must be of 25 characters or less.
+
+		Here is the ***E-MAIL*** for which you must suggest the replies to:
+
+		***START_OF_E-MAIL***%s
+
+		***END_OF_E-MAIL***
+
+		Please, output *ONLY* a valid JSON string with the keys 'reply1' and 'reply2' for the reply suggestions. Leave out any other text besides the JSON! Be extremely succinct and write the replies from my point of view.
+		PROMPT;
+
+	/**
+	 * Arguments (in order): message body.
+	 */
+	public const REQUIRES_FOLLOW_UP = <<<PROMPT
+		Consider the following TypeScript function prototype:
+		---
+		/**
+		 * This function takes in an email text and returns a boolean indicating whether the email author expects a response.
+		 *
+		 * @param emailText - string with the email text
+		 * @returns boolean true if the email expects a reply, false if not
+		 */
+		declare function doesEmailExpectReply(emailText: string): Promise<boolean>;
+		---
+		Tell me what the function outputs for the following parameters.
+
+		emailText: "%s"
+		The JSON output should be in the form: {"expectsReply": true}
+		Never return null or undefined.
+		PROMPT;
+
+	/**
+	 * Arguments (in order): message body, language code.
+	 */
+	public const REQUIRES_TRANSLATION = <<<PROMPT
+		Consider the following TypeScript function prototype:
+		---
+		/**
+		 * This function takes in an email text and returns a boolean indicating whether the email needs translation from a specific language.
+		 *
+		 * @param emailText - string with the email text
+		 * @param language - the language code to check against (e.g., 'en', 'de', etc.)
+		 * @returns boolean true if the email is written in a different language than the one specified and needs translation, false if it is written in the specified language.
+		 * only return true if whole sentences are written in a different language, not just a word or two.
+		 */
+		declare function isEmailWrittenInLanguage(emailText: string, language: string): Promise<boolean>;
+		---
+		Tell me what the function outputs for the following parameters.
+
+		emailText: "%s"
+		language: "%s"
+		The JSON output should be in the form: {"needsTranslation": true}
+		Never return null or undefined.
+		PROMPT;
+}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -21,8 +21,8 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\Settings\ISettings;
-use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\SummaryTaskType;
+use OCP\TaskProcessing\TaskTypes\TextToText;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
 
 class AdminSettings implements ISettings {
 	public function __construct(
@@ -70,12 +70,12 @@ class AdminSettings implements ISettings {
 
 		$this->initialStateService->provideInitialState(
 			'enabled_llm_free_prompt_backend',
-			$this->aiIntegrationsService->isLlmAvailable(FreePromptTaskType::class)
+			$this->aiIntegrationsService->isLlmAvailable(TextToText::ID)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'enabled_llm_summary_backend',
-			$this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class)
+			$this->aiIntegrationsService->isLlmAvailable(TextToTextSummary::ID)
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -1385,6 +1385,38 @@ class MessagesControllerTest extends TestCase {
 		$this->assertEquals($expectedResponse, $actualResponse);
 	}
 
+	public function testNeedsTranslationFailureIsNotCached(): void {
+		$message = new \OCA\Mail\Db\Message();
+		$message->setId(100);
+		$message->setMailboxId(1);
+		$mailbox = new Mailbox();
+		$mailbox->setId(1);
+		$mailbox->setAccountId(1);
+		$this->mailManager->expects(self::once())
+			->method('getMessage')
+			->with($this->userId, 100)
+			->willReturn($message);
+		$this->mailManager->expects(self::once())
+			->method('getMailbox')
+			->with($this->userId, $message->getMailboxId())
+			->willReturn($mailbox);
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with($this->userId, $mailbox->getAccountId())
+			->willReturn(new Account(new MailAccount()));
+		$this->aiIntegrationsService->expects(self::once())
+			->method('isLlmProcessingEnabled')
+			->willReturn(true);
+		$this->aiIntegrationsService->expects(self::once())
+			->method('requiresTranslation')
+			->willThrowException(new ServiceException('Provider timeout'));
+
+		$actualResponse = $this->controller->needsTranslation(100);
+
+		$this->assertEquals(new JSONResponse([], Http::STATUS_NO_CONTENT), $actualResponse);
+		$this->assertSame('no-cache, no-store, must-revalidate', $actualResponse->getHeaders()['Cache-Control']);
+	}
+
 	public function testNeedsTranslation() {
 		$message = new \OCA\Mail\Db\Message();
 		$message->setId(100);

--- a/tests/Unit/Controller/ThreadControllerTest.php
+++ b/tests/Unit/Controller/ThreadControllerTest.php
@@ -16,6 +16,7 @@ use OCA\Mail\Controller\ThreadController;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Model\EventData;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
@@ -327,4 +328,34 @@ class ThreadControllerTest extends TestCase {
 		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
 	}
 
+	public function testGenerateEventDataServiceFailure(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$account = new Account($mailAccount);
+		$this->accountService->method('find')->willReturn($account);
+		$mailbox = new Mailbox();
+		$mailbox->setId(20);
+		$mailbox->setAccountId($mailAccount->getId());
+		$this->mailManager->method('getMailbox')->willReturn($mailbox);
+		$message = new Message();
+		$message->setId(300);
+		$message->setMailboxId($mailbox->getId());
+		$message->setThreadRootId('some-thread-root-id-1');
+		$this->mailManager->method('getMessage')->willReturn($message);
+		$this->mailManager->method('getThread')->willReturn([]);
+		$exception = new ServiceException('AI task processing failed');
+		$this->aiIntergrationsService
+			->expects(self::once())
+			->method('generateEventData')
+			->with($account, $message->getThreadRootId(), [], $this->userId)
+			->willThrowException($exception);
+		$this->logger
+			->expects(self::once())
+			->method('error')
+			->with('Generating event data failed: AI task processing failed', ['exception' => $exception]);
+
+		$response = $this->controller->generateEventData(300);
+
+		$this->assertSame(Http::STATUS_NO_CONTENT, $response->getStatus());
+	}
 }

--- a/tests/Unit/Job/FollowUpClassifierJobTest.php
+++ b/tests/Unit/Job/FollowUpClassifierJobTest.php
@@ -18,6 +18,7 @@ use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\ThreadMapper;
+use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\AccountService;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -403,6 +404,56 @@ class FollowUpClassifierJobTest extends TestCase {
 			->method('createTag');
 		$this->mailManager->expects(self::never())
 			->method('tagMessage');
+
+		$this->job->run($argument);
+	}
+
+	public function testRunServiceFailure(): void {
+		$argument = [
+			'messageId' => '<message1@foo.bar>',
+			'mailboxId' => 200,
+			'userId' => 'user',
+		];
+		$mailbox = new Mailbox();
+		$mailbox->setId(200);
+		$mailbox->setAccountId(100);
+		$mailbox->setName('sent');
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(100);
+		$account = new Account($mailAccount);
+		$message = new Message();
+		$message->setMailboxId(200);
+		$message->setMessageId('<message1@foo.bar>');
+		$exception = new ServiceException('AI task processing failed');
+
+		$this->aiService->method('isLlmProcessingEnabled')->willReturn(true);
+		$this->mailManager
+			->method('getMailbox')
+			->with('user', 200)
+			->willReturn($mailbox);
+		$this->accountService
+			->method('find')
+			->with('user', 100)
+			->willReturn($account);
+		$this->mailManager
+			->method('getByMessageId')
+			->with($account, '<message1@foo.bar>')
+			->willReturn([$message]);
+		$this->threadMapper
+			->method('findNewerMessageIdsInThread')
+			->with(100, $message)
+			->willReturn([]);
+		$this->aiService
+			->expects(self::once())
+			->method('requiresFollowUp')
+			->with($account, $mailbox, $message, 'user')
+			->willThrowException($exception);
+		$this->logger
+			->expects(self::once())
+			->method('error')
+			->with('Failed to classify message for follow-up: AI task processing failed', ['exception' => $exception]);
+		$this->mailManager->expects(self::never())->method('createTag');
+		$this->mailManager->expects(self::never())->method('tagMessage');
 
 		$this->job->run($argument);
 	}

--- a/tests/Unit/Listener/FollowUpClassifierListenerTest.php
+++ b/tests/Unit/Listener/FollowUpClassifierListenerTest.php
@@ -22,7 +22,7 @@ use OCA\Mail\Events\NewMessagesSynchronized;
 use OCA\Mail\Listener\FollowUpClassifierListener;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCP\BackgroundJob\IJobList;
-use OCP\TextProcessing\FreePromptTaskType;
+use OCP\TaskProcessing\TaskTypes\TextToText;
 
 class FollowUpClassifierListenerTest extends TestCase {
 	private FollowUpClassifierListener $listener;
@@ -69,7 +69,7 @@ class FollowUpClassifierListenerTest extends TestCase {
 			->willReturn(true);
 		$this->aiService->expects(self::once())
 			->method('isLlmAvailable')
-			->with(FreePromptTaskType::class)
+			->with(TextToText::ID)
 			->willReturn(true);
 		$this->jobList->expects(self::once())
 			->method('scheduleAfter')
@@ -136,7 +136,7 @@ class FollowUpClassifierListenerTest extends TestCase {
 			->willReturn(true);
 		$this->aiService->expects(self::once())
 			->method('isLlmAvailable')
-			->with(FreePromptTaskType::class)
+			->with(TextToText::ID)
 			->willReturn(false);
 		$this->jobList->expects(self::never())
 			->method('scheduleAfter');
@@ -169,7 +169,7 @@ class FollowUpClassifierListenerTest extends TestCase {
 			->willReturn(true);
 		$this->aiService->expects(self::once())
 			->method('isLlmAvailable')
-			->with(FreePromptTaskType::class)
+			->with(TextToText::ID)
 			->willReturn(true);
 		$this->jobList->expects(self::never())
 			->method('scheduleAfter');
@@ -201,7 +201,7 @@ class FollowUpClassifierListenerTest extends TestCase {
 			->willReturn(true);
 		$this->aiService->expects(self::once())
 			->method('isLlmAvailable')
-			->with(FreePromptTaskType::class)
+			->with(TextToText::ID)
 			->willReturn(true);
 		$this->jobList->expects(self::never())
 			->method('scheduleAfter');

--- a/tests/Unit/Listener/TaskProcessingListenerTest.php
+++ b/tests/Unit/Listener/TaskProcessingListenerTest.php
@@ -11,11 +11,13 @@ namespace OCA\Mail\Tests\Unit\Listener;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Listener\TaskProcessingListener;
 use OCP\TaskProcessing\Events\TaskSuccessfulEvent;
 use OCP\TaskProcessing\Task as TaskProcessingTask;
 use OCP\TaskProcessing\TaskTypes\TextToText;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
 use Psr\Log\LoggerInterface;
 
 class TaskProcessingListenerTest extends TestCase {
@@ -42,37 +44,56 @@ class TaskProcessingListenerTest extends TestCase {
 	public function testNoCustomIdNull(): void {
 		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', null);
 		$event = new TaskSuccessfulEvent($task);
-		$this->logger->expects($this->once())
-			->method('info')
-			->with('Error handling task processing event custom id missing', ['taskCustomId' => null]);
+		$this->messageMapper->expects($this->never())
+			->method('findByIds');
+
 		$this->listener->handle($event);
 	}
 
-	public function testEmptyCustomId(): void {
-		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', '');
+	public function testNonMessageCustomIdIsIgnored(): void {
+		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', 'some-thread-id');
 		$event = new TaskSuccessfulEvent($task);
-		$this->logger->expects($this->once())
-			->method('info')
-			->with('Error handling task processing event custom id missing', ['taskCustomId' => '']);
+		$this->messageMapper->expects($this->never())
+			->method('findByIds');
+
 		$this->listener->handle($event);
 	}
 
-	public function testCorrectCustomId(): void {
-		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', 'followup:12345');
+	public function testThreadSummaryTaskIsIgnored(): void {
+		$task = new TaskProcessingTask(TextToTextSummary::ID, [], Application::APP_ID, 'batman', 'some-thread-id');
+		$event = new TaskSuccessfulEvent($task);
+		$this->messageMapper->expects($this->never())
+			->method('findByIds');
+
+		$this->listener->handle($event);
+	}
+
+	public function testMessageCustomIdMissingOutput(): void {
+		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', 'message:12345');
 		$task->setOutput(null);
 		$event = new TaskSuccessfulEvent($task);
 		$this->logger->expects($this->once())
 			->method('info')
 			->with('Error handling task processing event output missing');
+
 		$this->listener->handle($event);
 	}
 
-	public function testIncorrectCustomId(): void {
-		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', 'followup12345');
+	public function testMessageSummaryIsStored(): void {
+		$task = new TaskProcessingTask(TextToText::ID, [], Application::APP_ID, 'batman', 'message:12345');
+		$task->setOutput(['output' => 'a summary']);
 		$event = new TaskSuccessfulEvent($task);
-		$this->logger->expects($this->once())
-			->method('info')
-			->with('Error handling task processing event custom id missing', ['taskCustomId' => 'followup12345']);
+		$message = new Message();
+		$this->messageMapper->expects($this->once())
+			->method('findByIds')
+			->with('batman', [12345], '')
+			->willReturn([$message]);
+		$this->messageMapper->expects($this->once())
+			->method('update')
+			->with($message);
+
 		$this->listener->handle($event);
+
+		$this->assertSame('a summary', $message->getSummary());
 	}
 }

--- a/tests/Unit/Service/AiIntegrationsServiceTest.php
+++ b/tests/Unit/Service/AiIntegrationsServiceTest.php
@@ -23,24 +23,23 @@ use OCA\Mail\IMAP\IMAPClientFactory;
 use OCA\Mail\Model\IMAPMessage;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
 use OCA\Mail\Service\AiIntegrations\Cache;
+use OCA\Mail\Service\AiIntegrations\DefaultPrompts;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\TaskProcessing\Exception\ValidationException;
 use OCP\TaskProcessing\IManager as TaskProcessingManager;
 use OCP\TaskProcessing\IProvider as TaskProcessingProvider;
-use OCP\TextProcessing\FreePromptTaskType;
-use OCP\TextProcessing\IManager as TextProcessingManager;
-use OCP\TextProcessing\SummaryTaskType;
-use OCP\TextProcessing\Task as TextProcessingTask;
-use OCP\TextProcessing\TopicsTaskType;
+use OCP\TaskProcessing\Task as TaskProcessingTask;
+use OCP\TaskProcessing\TaskTypes\TextToText;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 
 class AiIntegrationsServiceTest extends TestCase {
 
-	private TextProcessingManager|MockObject $textProcessingManager;
 	private IAppConfig|MockObject $appConfig;
 	private NullLogger|MockObject $logger;
 	private AiIntegrationsService $aiIntegrationsService;
@@ -49,7 +48,6 @@ class AiIntegrationsServiceTest extends TestCase {
 	private IMailManager|MockObject $mailManager;
 	private TaskProcessingManager|MockObject $taskProcessingManager;
 	private TaskProcessingProvider|MockObject $taskProcessingProvider;
-	private TextProcessingProvider|MockObject $textProcessingProvider;
 	private IL10N|MockObject $l10n;
 	private IFactory|MockObject $l10nFactory;
 	private IUserManager|MockObject $userManager;
@@ -63,7 +61,6 @@ class AiIntegrationsServiceTest extends TestCase {
 		$this->clientFactory = $this->createMock(IMAPClientFactory::class);
 		$this->mailManager = $this->createMock(IMailManager::class);
 		$this->taskProcessingManager = $this->createMock(TaskProcessingManager::class);
-		$this->textProcessingManager = $this->createMock(TextProcessingManager::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -73,7 +70,6 @@ class AiIntegrationsServiceTest extends TestCase {
 			$this->clientFactory,
 			$this->mailManager,
 			$this->taskProcessingManager,
-			$this->textProcessingManager,
 			$this->l10n,
 			$this->l10nFactory,
 			$this->userManager,
@@ -85,17 +81,40 @@ class AiIntegrationsServiceTest extends TestCase {
 
 	public function testSummarizeThreadNoBackend(): void {
 		$account = new Account(new MailAccount());
-		$this->textProcessingManager->method('getAvailableTaskTypes')->willReturn([]);
+		$this->taskProcessingManager->method('getAvailableTaskTypes')->willReturn([]);
 		$this->expectException(ServiceException::class);
 		$this->expectExceptionMessage('No language model available for summary');
 		$this->aiIntegrationsService->summarizeThread($account, '', [], '');
+	}
+	public function testTaskProcessingExceptionIsMappedToServiceException(): void {
+		$account = new Account(new MailAccount());
+		$taskProcessingException = new ValidationException('Invalid task input');
+		$this->taskProcessingManager
+			->method('getAvailableTaskTypes')
+			->willReturn([TextToTextSummary::ID => $this->taskProcessingProvider]);
+		$this->cache->method('getValue')->willReturn(false);
+		$this->clientFactory
+			->method('getClient')
+			->with($account)
+			->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
+		$this->taskProcessingManager
+			->method('runTask')
+			->willThrowException($taskProcessingException);
+
+		try {
+			$this->aiIntegrationsService->summarizeThread($account, 'thread-id', [], 'user');
+			self::fail('Expected task processing exception to be mapped');
+		} catch (ServiceException $e) {
+			self::assertSame('AI task processing failed', $e->getMessage());
+			self::assertSame($taskProcessingException, $e->getPrevious());
+		}
 	}
 
 	public function testSmartReplyNoBackend(): void {
 		$account = new Account(new MailAccount());
 		$mailbox = new Mailbox();
 		$message = new Message();
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
 			->willReturn([]);
 		$this->expectException(ServiceException::class);
@@ -110,9 +129,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$message->setUid(1);
 		$currentUserId = 'user';
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$this->cache->method('getValue')->willReturn(false);
 		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
 		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
@@ -122,11 +141,11 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage->method('getFrom')->willReturn($fromList);
 		$imapMessage->method('getPlainBody')->willReturn('This is a test message');
 
-		$this->textProcessingManager->expects($this->once())
+		$this->taskProcessingManager->expects($this->once())
 			->method('runTask')
-			->will($this->returnCallback(function (TextProcessingTask $task) {
-				$task->setOutput('{"reply1":"reply1","reply2":"reply2"}');
-				return '';
+			->will($this->returnCallback(function (TaskProcessingTask $task) {
+				$task->setOutput(['output' => '{"reply1":"reply1","reply2":"reply2"}']);
+				return $task;
 			}));
 
 		$result = $this->aiIntegrationsService->getSmartReply($account, $mailbox, $message, $currentUserId);
@@ -146,11 +165,25 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message = new Message();
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$message->setUid(1);
+		$message->setId(42);
 		$currentUserId = 'user';
-		$this->textProcessingManager
+		$cachedReplies = false;
+		$cacheKey = 'smartReplies_42';
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
-		$this->cache->method('getValue')->willReturn(false);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
+		$this->cache->expects(self::exactly(2))
+			->method('getValue')
+			->with($cacheKey)
+			->willReturnCallback(function () use (&$cachedReplies) {
+				return $cachedReplies;
+			});
+		$this->cache->expects(self::once())
+			->method('addValue')
+			->with($cacheKey, '{"reply1":"reply1","reply2":"reply2"}')
+			->willReturnCallback(function (string $_key, ?string $value) use (&$cachedReplies): void {
+				$cachedReplies = $value;
+			});
 		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
 		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
 		$imapMessage->method('isOneClickUnsubscribe')->willReturn(false);
@@ -159,22 +192,22 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage->method('getFrom')->willReturn($fromList);
 		$imapMessage->method('getPlainBody')->willReturn('This is a test message');
 
-		$this->textProcessingManager->expects($this->once())
+		$this->taskProcessingManager->expects($this->once())
 			->method('runTask')
-			->will($this->returnCallback(function (TextProcessingTask $task) {
-				$task->setOutput('```json{"reply1":"reply1","reply2":"reply2"}```');
-				return '';
+			->will($this->returnCallback(function (TaskProcessingTask $task) {
+				$task->setOutput(['output' => '```json{"reply1":"reply1","reply2":"reply2"}```']);
+				return $task;
 			}));
 
-		$result = $this->aiIntegrationsService->getSmartReply($account, $mailbox, $message, $currentUserId);
+		$firstResult = $this->aiIntegrationsService->getSmartReply($account, $mailbox, $message, $currentUserId);
+		$cachedResult = $this->aiIntegrationsService->getSmartReply($account, $mailbox, $message, $currentUserId);
+		$expected = [
+			'reply1' => 'reply1',
+			'reply2' => 'reply2',
+		];
 
-		$this->assertEquals(
-			[
-				'reply1' => 'reply1',
-				'reply2' => 'reply2'
-			],
-			$result
-		);
+		$this->assertSame($expected, $firstResult);
+		$this->assertSame($expected, $cachedResult);
 	}
 
 	public function testGeneratedMessage(): void {
@@ -184,9 +217,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message->setUid(1);
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$imapMessage->method('isOneClickUnsubscribe')->willReturn(true);
 		$replies = $this->aiIntegrationsService->getSmartReply($account, $mailbox, $message, '');
 		$this->assertEquals($replies, []);
@@ -201,19 +234,22 @@ class AiIntegrationsServiceTest extends TestCase {
 	}
 
 	public function testLlmAvailable(): void {
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([SummaryTaskType::class, TopicsTaskType::class, FreePromptTaskType::class]);
-		$isAvailable = $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class);
+			->willReturn([
+				TextToTextSummary::ID => $this->taskProcessingProvider,
+				TextToText::ID => $this->taskProcessingProvider,
+			]);
+		$isAvailable = $this->aiIntegrationsService->isLlmAvailable(TextToTextSummary::ID);
 		$this->assertTrue($isAvailable);
 
 	}
 
 	public function testLlmUnavailable(): void {
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([TopicsTaskType::class, FreePromptTaskType::class]);
-		$isAvailable = $this->aiIntegrationsService->isLlmAvailable(SummaryTaskType::class);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
+		$isAvailable = $this->aiIntegrationsService->isLlmAvailable(TextToTextSummary::ID);
 		$this->assertFalse($isAvailable);
 
 	}
@@ -257,9 +293,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message3->setThreadRootId('some-thread-root-id-1');
 
 		$messages = [ $message1,$message2,$message3];
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([SummaryTaskType::class]);
+			->willReturn([TextToTextSummary::ID => $this->taskProcessingProvider]);
 
 		$messageIds = [ $message1->getMessageId(),$message2->getMessageId(),$message3->getMessageId()];
 		$key = $this->cache->buildUrlKey($messageIds);
@@ -275,7 +311,7 @@ class AiIntegrationsServiceTest extends TestCase {
 		$account = $this->createStub(Account::class);
 		$message1 = new Message();
 		$message2 = new Message();
-		$this->textProcessingManager->expects(self::once())
+		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
 			->willReturn([]);
 
@@ -289,7 +325,22 @@ class AiIntegrationsServiceTest extends TestCase {
 		self::assertNull($result);
 	}
 
-	public function testGenerateEventDataInvalidJson(): void {
+	public static function provideInvalidEventDataOutput(): array {
+		return [
+			'invalid JSON' => ['Jason'],
+			'missing title' => ['{"agenda":"* Q&A"}'],
+			'missing agenda' => ['{"title":"Meeting"}'],
+			'null title' => ['{"title":null,"agenda":"* Q&A"}'],
+			'numeric agenda' => ['{"title":"Meeting","agenda":123}'],
+			'list' => ['[]'],
+			'scalar' => ['"Meeting"'],
+		];
+	}
+
+	/**
+	 * @dataProvider provideInvalidEventDataOutput
+	 */
+	public function testGenerateEventDataInvalidJson(string $output): void {
 
 		$account = $this->createStub(Account::class);
 		$message1 = new Message();
@@ -298,9 +349,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message2 = new Message();
 		$message2->setUid(2);
 		$message2->setMailboxId(456);
-		$this->textProcessingManager->expects(self::once())
+		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$this->mailManager->expects(self::exactly(2))
 			->method('getImapMessage')
@@ -308,9 +359,12 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage->expects(self::exactly(2))
 			->method('getPlainBody')
 			->willReturn('plain');
-		$this->textProcessingManager->expects(self::once())
+		$this->taskProcessingManager->expects(self::once())
 			->method('runTask')
-			->willReturn('Jason');
+			->willReturnCallback(function (TaskProcessingTask $task) use ($output) {
+				$task->setOutput(['output' => $output]);
+				return $task;
+			});
 
 		$result = $this->aiIntegrationsService->generateEventData(
 			$account,
@@ -331,9 +385,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message2 = new Message();
 		$message2->setUid(2);
 		$message2->setMailboxId(456);
-		$this->textProcessingManager->expects(self::once())
+		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$this->mailManager->expects(self::exactly(2))
 			->method('getImapMessage')
@@ -341,9 +395,12 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage->expects(self::exactly(2))
 			->method('getPlainBody')
 			->willReturn('plain');
-		$this->textProcessingManager->expects(self::once())
+		$this->taskProcessingManager->expects(self::once())
 			->method('runTask')
-			->willReturn('{"title":"Meeting", "agenda":"* Q&A"}');
+			->willReturnCallback(function (TaskProcessingTask $task) {
+				$task->setOutput(['output' => '{"title":"Meeting", "agenda":"* Q&A"}']);
+				return $task;
+			});
 
 		$result = $this->aiIntegrationsService->generateEventData(
 			$account,
@@ -397,7 +454,7 @@ class AiIntegrationsServiceTest extends TestCase {
 
 		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
-			->willReturn(['core:text2text' => $this->taskProcessingProvider]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$this->clientFactory->expects(self::once())
 			->method('getClient');
 
@@ -434,6 +491,7 @@ class AiIntegrationsServiceTest extends TestCase {
 			->method('getUserLanguage')
 			->with($user)
 			->willReturn('en');
+
 		$imapClient = $this->clientFactory->getClient($account);
 
 		$imapMessage = $this->createMock(IMAPMessage::class);
@@ -445,7 +503,7 @@ class AiIntegrationsServiceTest extends TestCase {
 
 		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
-			->willReturn(['core:text2text' => $this->taskProcessingProvider]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$this->taskProcessingManager->expects(self::never())
 			->method('scheduleTask');
 
@@ -492,7 +550,6 @@ class AiIntegrationsServiceTest extends TestCase {
 		$message->setId(1);
 		$message->setUid(100);
 		$message->setMailboxId(1);
-
 		$user = $this->createStub(IUser::class);
 
 		$this->userManager->expects(self::once())
@@ -503,7 +560,7 @@ class AiIntegrationsServiceTest extends TestCase {
 		$this->l10nFactory->expects(self::once())
 			->method('getUserLanguage')
 			->with($user)
-			->willReturn('en');
+			->willReturn('de_DE');
 
 		$imapClient = $this->clientFactory->getClient($account);
 
@@ -516,9 +573,17 @@ class AiIntegrationsServiceTest extends TestCase {
 
 		$this->taskProcessingManager->expects(self::once())
 			->method('getAvailableTaskTypes')
-			->willReturn(['core:text2text' => $this->taskProcessingProvider]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$this->taskProcessingManager->expects(self::once())
-			->method('scheduleTask');
+			->method('scheduleTask')
+			->willReturnCallback(function (TaskProcessingTask $task): void {
+				self::assertSame(TextToText::ID, $task->getTaskTypeId());
+				self::assertSame(1024, $task->getInput()['max_tokens']);
+				self::assertSame(
+					sprintf(DefaultPrompts::SUMMARIZE_MESSAGE, 'de', 'This is a test message'),
+					$task->getInput()['input'],
+				);
+			});
 
 		$this->clientFactory->expects(self::once())
 			->method('getClient');
@@ -549,7 +614,7 @@ class AiIntegrationsServiceTest extends TestCase {
 		$mailbox = new Mailbox();
 		$message = new Message();
 
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
 			->willReturn([]);
 		$result = $this->aiIntegrationsService->requiresTranslation($account, $mailbox, $message, '');
@@ -564,9 +629,9 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage = $this->createMock(IMAPMessage::class);
 		$message->setUid(1);
 		$currentUserId = 'user';
-		$this->textProcessingManager
+		$this->taskProcessingManager
 			->method('getAvailableTaskTypes')
-			->willReturn([FreePromptTaskType::class]);
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
 		$this->cache->method('getValue')->willReturn(false);
 		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
 		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
@@ -576,16 +641,155 @@ class AiIntegrationsServiceTest extends TestCase {
 		$imapMessage->method('getFrom')->willReturn($fromList);
 		$imapMessage->method('getPlainBody')->willReturn('Ceci n\'est pas un message');
 
-		$this->textProcessingManager->expects($this->once())
+		$this->taskProcessingManager->expects($this->once())
 			->method('runTask')
-			->will($this->returnCallback(function (TextProcessingTask $task) {
-				$task->setOutput('{"needsTranslation": true}, the message is in French that is the value returned is true ');
-				return '';
+			->will($this->returnCallback(function (TaskProcessingTask $task) {
+				$task->setOutput(['output' => '{"needsTranslation": true}, the message is in French that is the value returned is true ']);
+				return $task;
 			}));
 
 		$result = $this->aiIntegrationsService->requiresTranslation($account, $mailbox, $message, $currentUserId);
 
 		$this->assertTrue($result);
+	}
+
+	public static function provideUnusableTranslationOutput(): array {
+		return [
+			'missing output' => [null],
+			'empty output' => [''],
+			'whitespace-only output' => ['   '],
+		];
+	}
+
+	/**
+	 * @dataProvider provideUnusableTranslationOutput
+	 */
+	public function testRequiresTranslationRejectsUnusableOutput(?string $output): void {
+		$account = new Account(new MailAccount());
+		$mailbox = new Mailbox();
+		$message = new Message();
+		$message->setId(123);
+		$message->setUid(1);
+		$currentUserId = 'user';
+		$imapMessage = $this->createMock(IMAPMessage::class);
+
+		$this->taskProcessingManager
+			->method('getAvailableTaskTypes')
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
+		$this->cache->method('getValue')->willReturn(false);
+		$this->cache->expects(self::never())->method('addValue');
+		$this->l10n->method('getLanguageCode')->willReturn('en_US');
+		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
+		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
+		$imapMessage->method('isOneClickUnsubscribe')->willReturn(false);
+		$imapMessage->method('getUnsubscribeUrl')->willReturn(null);
+		$imapMessage->method('getFrom')->willReturn(new AddressList([
+			Address::fromRaw('personal@example.com', 'personal@example.com'),
+		]));
+		$imapMessage->method('getPlainBody')->willReturn('Ceci n\'est pas un message');
+
+		$this->taskProcessingManager->expects(self::once())
+			->method('runTask')
+			->willReturnCallback(function (TaskProcessingTask $task) use ($output) {
+				$task->setOutput($output === null ? null : ['output' => $output]);
+				$task->setStatus($output === null ? TaskProcessingTask::STATUS_FAILED : TaskProcessingTask::STATUS_SUCCESSFUL);
+				$task->setErrorMessage($output === null ? 'Provider timeout' : null);
+				return $task;
+			});
+		$this->logger->expects(self::once())
+			->method('warning')
+			->with(
+				'Translation check task returned no usable output',
+				self::arrayHasKey('status'),
+			);
+
+		$this->expectException(ServiceException::class);
+		$this->expectExceptionMessage('Translation check task returned no usable output');
+
+		$this->aiIntegrationsService->requiresTranslation($account, $mailbox, $message, $currentUserId);
+	}
+
+	public function testRequiresFollowUp(): void {
+		$account = new Account(new MailAccount());
+		$mailbox = new Mailbox();
+		$message = new Message();
+		$message->setUid(1);
+		$currentUserId = 'user';
+		$imapMessage = $this->createMock(IMAPMessage::class);
+
+		$this->taskProcessingManager
+			->method('getAvailableTaskTypes')
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
+		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
+		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
+		$imapMessage->method('isOneClickUnsubscribe')->willReturn(false);
+		$imapMessage->method('getUnsubscribeUrl')->willReturn(null);
+		$imapMessage->method('getFrom')->willReturn(new AddressList([
+			Address::fromRaw('personal@example.com', 'personal@example.com'),
+		]));
+		$imapMessage->method('getPlainBody')->willReturn('Can you send the report?');
+		$this->taskProcessingManager->expects(self::once())
+			->method('runTask')
+			->willReturnCallback(function (TaskProcessingTask $task) {
+				$task->setOutput(['output' => 'The result is {"expectsReply": true}']);
+				return $task;
+			});
+
+		$result = $this->aiIntegrationsService->requiresFollowUp($account, $mailbox, $message, $currentUserId);
+
+		$this->assertTrue($result);
+	}
+
+	public static function provideUnusableFollowUpOutput(): array {
+		return [
+			'failed task' => ['{"expectsReply": false}', TaskProcessingTask::STATUS_FAILED],
+			'missing output' => [null, TaskProcessingTask::STATUS_SUCCESSFUL],
+			'empty output' => ['', TaskProcessingTask::STATUS_SUCCESSFUL],
+			'whitespace-only output' => ['   ', TaskProcessingTask::STATUS_SUCCESSFUL],
+		];
+	}
+
+	/**
+	 * @dataProvider provideUnusableFollowUpOutput
+	 */
+	public function testRequiresFollowUpRejectsUnusableOutput(?string $output, int $status): void {
+		$account = new Account(new MailAccount());
+		$mailbox = new Mailbox();
+		$message = new Message();
+		$message->setUid(1);
+		$currentUserId = 'user';
+		$imapMessage = $this->createMock(IMAPMessage::class);
+
+		$this->taskProcessingManager
+			->method('getAvailableTaskTypes')
+			->willReturn([TextToText::ID => $this->taskProcessingProvider]);
+		$this->clientFactory->method('getClient')->with($account)->willReturn($this->createMock(Horde_Imap_Client_Socket::class));
+		$this->mailManager->method('getImapMessage')->willReturn($imapMessage);
+		$imapMessage->method('isOneClickUnsubscribe')->willReturn(false);
+		$imapMessage->method('getUnsubscribeUrl')->willReturn(null);
+		$imapMessage->method('getFrom')->willReturn(new AddressList([
+			Address::fromRaw('personal@example.com', 'personal@example.com'),
+		]));
+		$imapMessage->method('getPlainBody')->willReturn('Can you send the report?');
+		$this->taskProcessingManager->expects(self::once())
+			->method('runTask')
+			->willReturnCallback(function (TaskProcessingTask $task) use ($output, $status) {
+				$task->setOutput($output === null ? null : ['output' => $output]);
+				$task->setStatus($status);
+				$task->setErrorMessage($status === TaskProcessingTask::STATUS_FAILED ? 'Provider timeout' : null);
+				return $task;
+			});
+		$this->logger->expects(self::once())
+			->method('warning')
+			->with(
+				'Follow-up classification task returned no usable output',
+				self::arrayHasKey('status'),
+			);
+
+		$this->expectException(ServiceException::class);
+		$this->expectExceptionMessage('Follow-up classification task returned no usable output');
+
+		$this->aiIntegrationsService->requiresFollowUp($account, $mailbox, $message, $currentUserId);
 	}
 
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -239,12 +239,6 @@
       <code><![CDATA[$client]]></code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="lib/Service/AiIntegrations/AiIntegrationsService.php">
-    <PossiblyNullArgument>
-      <code><![CDATA[$replies]]></code>
-      <code><![CDATA[$task->getOutput()]]></code>
-    </PossiblyNullArgument>
-  </file>
   <file src="lib/Service/AntiAbuseService.php">
     <PossiblyNullArgument>
       <code><![CDATA[$message->getRecipients()]]></code>


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/10042

- Replace the OCP\TextProcessing API (deprecated since Nextcloud 30.0.0) with OCP\TaskProcessing 
- extract prompts into  a centralized `lib/Service/AiIntegrations/DefaultPrompts.php`


Assisted-by: ClaudeCode:claude-opus-4-8
Assisted-by: ClaudeCode:fable5
Assisted-by: OMP:GPT-5.6-Sol

Signed-off-by: Hamza <hamzamahjoubi221@gmail.com>
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
