### PR TITLE
[stable5.10] fix(delegation): clean delegations on user deletion

### DIFF
--- a/lib/Db/DelegationMapper.php
+++ b/lib/Db/DelegationMapper.php
@@ -46,6 +46,13 @@ class DelegationMapper extends QBMapper {
 		return $this->findEntity($qb);
 	}
 
+	public function deleteByUserId(string $userId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
+		$qb->executeStatement();
+	}
+
 	/**
 	 * @throws DoesNotExistException
 	 */

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Listener;
 
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\DelegationService;
 use OCA\Mail\Service\TextBlockService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -30,6 +31,7 @@ class UserDeletedListener implements IEventListener {
 	public function __construct(
 		AccountService $accountService,
 		private TextBlockService $textBlockService,
+		private DelegationService $delegationService,
 		LoggerInterface $logger,
 	) {
 		$this->accountService = $accountService;
@@ -57,6 +59,9 @@ class UserDeletedListener implements IEventListener {
 			}
 		}
 		$this->textBlockService->deleteByUserId(
+			$user->getUID()
+		);
+		$this->delegationService->deleteByUserId(
 			$user->getUID()
 		);
 	}

--- a/lib/Service/DelegationService.php
+++ b/lib/Service/DelegationService.php
@@ -61,6 +61,10 @@ class DelegationService {
 		return $result;
 	}
 
+	public function deleteByUserId(string $userId): void {
+		$this->delegationMapper->deleteByUserId($userId);
+	}
+
 	public function findDelegatedToUsersForAccount(int $accountId): array {
 		return array_map(function (Delegation $delegation) {
 			$displayName = $this->userManager->get($delegation->getUserId())?->getDisplayName();

--- a/tests/Integration/Db/DelegationMapperTest.php
+++ b/tests/Integration/Db/DelegationMapperTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Integration\Db;
+
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Db\Delegation;
+use OCA\Mail\Db\DelegationMapper;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\MailAccountMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IDBConnection;
+use OCP\Server;
+
+/**
+ * @group DB
+ * @covers \OCA\Mail\Db\DelegationMapper
+ */
+class DelegationMapperTest extends TestCase {
+	use DatabaseTransaction;
+
+	private IDBConnection $db;
+	private DelegationMapper $mapper;
+	private MailAccountMapper $accountMapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = Server::get(IDBConnection::class);
+		$this->mapper = new DelegationMapper($this->db);
+		$this->accountMapper = new MailAccountMapper($this->db);
+	}
+
+	private function createDelegation(int $accountId, string $userId): Delegation {
+		$delegation = new Delegation();
+		$delegation->setAccountId($accountId);
+		$delegation->setUserId($userId);
+		return $this->mapper->insert($delegation);
+	}
+
+	private function createAccount(string $ownerUid): MailAccount {
+		$account = new MailAccount();
+		$account->setName('Owner');
+		$account->setEmail('owner@example.com');
+		$account->setUserId($ownerUid);
+		return $this->accountMapper->insert($account);
+	}
+
+	public function testFindDelegatedToUsers(): void {
+		$accountId = $this->createAccount('owner-a')->getId();
+		$otherAccountId = $this->createAccount('owner-b')->getId();
+		$this->createDelegation($accountId, 'alice');
+		$this->createDelegation($accountId, 'bob');
+		$this->createDelegation($otherAccountId, 'carol');
+
+		$result = $this->mapper->findDelegatedToUsers($accountId);
+
+		$this->assertCount(2, $result);
+		$uids = array_map(static fn (Delegation $d) => $d->getUserId(), $result);
+		$this->assertEqualsCanonicalizing(['alice', 'bob'], $uids);
+	}
+
+	public function testFindDelegatedToUsersReturnsEmpty(): void {
+		$accountId = $this->createAccount('owner-empty')->getId();
+
+		$this->assertSame([], $this->mapper->findDelegatedToUsers($accountId));
+	}
+
+	public function testFind(): void {
+		$accountId = $this->createAccount('owner-c')->getId();
+		$inserted = $this->createDelegation($accountId, 'dave');
+
+		$result = $this->mapper->find($accountId, 'dave');
+
+		$this->assertSame($inserted->getId(), $result->getId());
+		$this->assertSame('dave', $result->getUserId());
+		$this->assertSame($accountId, $result->getAccountId());
+	}
+
+	public function testFindThrowsWhenMissing(): void {
+		$accountId = $this->createAccount('owner-d')->getId();
+
+		$this->expectException(DoesNotExistException::class);
+
+		$this->mapper->find($accountId, 'nobody');
+	}
+
+	public function testFindAccountOwnerForDelegatedUser(): void {
+		$account = $this->createAccount('owner-uid');
+		$this->createDelegation($account->getId(), 'delegate');
+
+		$owner = $this->mapper->findAccountOwnerForDelegatedUser($account->getId(), 'delegate');
+
+		$this->assertSame('owner-uid', $owner);
+	}
+
+	public function testFindAccountOwnerThrowsWhenNoDelegation(): void {
+		$account = $this->createAccount('owner-uid');
+
+		$this->expectException(DoesNotExistException::class);
+
+		$this->mapper->findAccountOwnerForDelegatedUser($account->getId(), 'delegate');
+	}
+
+	public function testDeleteByUserId(): void {
+		$accountA = $this->createAccount('owner-a')->getId();
+		$accountB = $this->createAccount('owner-b')->getId();
+		$this->createDelegation($accountA, 'delegate');
+		$this->createDelegation($accountB, 'delegate');
+		$this->createDelegation($accountA, 'other');
+
+		$this->mapper->deleteByUserId('delegate');
+
+		$remaining = array_map(
+			static fn (Delegation $d) => $d->getUserId(),
+			$this->mapper->findDelegatedToUsers($accountA),
+		);
+		$this->assertSame(['other'], $remaining);
+		$this->assertSame([], $this->mapper->findDelegatedToUsers($accountB));
+	}
+
+	public function testDeleteByUserIdNoMatch(): void {
+		$accountId = $this->createAccount('owner-uid')->getId();
+		$this->createDelegation($accountId, 'delegate');
+
+		$this->mapper->deleteByUserId('nobody');
+
+		$this->assertCount(1, $this->mapper->findDelegatedToUsers($accountId));
+	}
+}

--- a/tests/Unit/Listener/UserDeletedListenerTest.php
+++ b/tests/Unit/Listener/UserDeletedListenerTest.php
@@ -15,6 +15,7 @@ use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Listener\UserDeletedListener;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\DelegationService;
 use OCA\Mail\Service\TextBlockService;
 use OCP\EventDispatcher\Event;
 use OCP\IUser;
@@ -26,6 +27,7 @@ class UserDeletedListenerTest extends TestCase {
 	private AccountService&MockObject $accountService;
 
 	private TextBlockService&MockObject $textBlockService;
+	private DelegationService&MockObject $delegationService;
 	private LoggerInterface&MockObject $logger;
 	private UserDeletedListener $listener;
 
@@ -35,10 +37,12 @@ class UserDeletedListenerTest extends TestCase {
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->textBlockService = $this->createMock(TextBlockService::class);
+		$this->delegationService = $this->createMock(DelegationService::class);
 
 		$this->listener = new UserDeletedListener(
 			$this->accountService,
 			$this->textBlockService,
+			$this->delegationService,
 			$this->logger
 		);
 	}
@@ -68,6 +72,9 @@ class UserDeletedListenerTest extends TestCase {
 		$this->textBlockService->expects($this->never())
 			->method('deleteByUserId');
 
+		$this->delegationService->expects($this->never())
+			->method('deleteByUserId');
+
 		$this->listener->handle($event);
 
 		$this->addToAssertionCount(1);
@@ -92,6 +99,10 @@ class UserDeletedListenerTest extends TestCase {
 			->method('deleteByUserId')
 			->with('test-user');
 
+		$this->delegationService->expects($this->once())
+			->method('deleteByUserId')
+			->with('test-user');
+
 		$this->listener->handle($event);
 	}
 
@@ -109,11 +120,14 @@ class UserDeletedListenerTest extends TestCase {
 			->method('delete')
 			->with('test-user', 42);
 
-
 		$this->logger->expects($this->never())
 			->method('error');
 
 		$this->textBlockService->expects($this->once())
+			->method('deleteByUserId')
+			->with('test-user');
+
+		$this->delegationService->expects($this->once())
 			->method('deleteByUserId')
 			->with('test-user');
 
@@ -146,6 +160,10 @@ class UserDeletedListenerTest extends TestCase {
 			->method('deleteByUserId')
 			->with('test-user');
 
+		$this->delegationService->expects($this->once())
+			->method('deleteByUserId')
+			->with('test-user');
+
 		$this->listener->handle($event);
 	}
 
@@ -174,6 +192,10 @@ class UserDeletedListenerTest extends TestCase {
 			);
 
 		$this->textBlockService->expects($this->once())
+			->method('deleteByUserId')
+			->with('test-user');
+
+		$this->delegationService->expects($this->once())
 			->method('deleteByUserId')
 			->with('test-user');
 
@@ -209,7 +231,12 @@ class UserDeletedListenerTest extends TestCase {
 				'Could not delete user\'s Mail account: Failed to delete account 2',
 				['exception' => $exception]
 			);
+
 		$this->textBlockService->expects($this->once())
+			->method('deleteByUserId')
+			->with('test-user');
+
+		$this->delegationService->expects($this->once())
 			->method('deleteByUserId')
 			->with('test-user');
 


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/mail/pull/13147.

Git cherry-pick applied clean locally.