### PR TITLE
feat: add preview support for local composer attachments

### DIFF
--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<li class="composer-attachment" :class="{ 'composer-attachment--with-error': attachment.error }">
+	<li class="composer-attachment" :class="{ 'composer-attachment--with-error': attachment.error }" @click="onPreview">
 		<div class="attachment-preview">
 			<img :src="previewSrc" class="attachment-preview-image">
 			<span v-if="attachment.type === 'cloud'" class="cloud-attachment-icon">
@@ -87,7 +87,15 @@ export default {
 		onDelete(attachment) {
 			this.$emit('on-delete-attachment', attachment)
 		},
+
+		onPreview() {
+			this.$emit('preview', this.attachment)
+		}
 	},
+
+	mounted() {
+		console.log("attachment", this.attachment)
+	}
 
 }
 </script>

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -3,7 +3,13 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<li class="composer-attachment" :class="{ 'composer-attachment--with-error': attachment.error }" @click="onPreview">
+	<li
+		class="composer-attachment"
+		:class="{
+			'composer-attachment--with-error': attachment.error,
+			'composer-attachment--previewable': isPreviewable,
+		}"
+		@click="onPreview">
 		<div class="attachment-preview">
 			<img
 				:src="previewSrc"
@@ -80,6 +86,10 @@ export default {
 			return OC.MimeType.getIconUrl(this.attachment.fileType)
 		},
 
+		isPreviewable() {
+			return this.attachment.finished && !!this.attachment.previewBlobUrl
+		},
+
 		extension() {
 			return this.attachment.fileName.split('.').pop()
 		},
@@ -92,7 +102,7 @@ export default {
 
 		onPreview() {
 			this.$emit('preview', this.attachment)
-		}
+		},
 	},
 }
 </script>
@@ -111,6 +121,17 @@ export default {
 	&--with-error {
 		color:red;
 		opacity: 0.5;
+	}
+
+	&--previewable {
+		cursor: pointer;
+		.attachment-preview,
+		.attachment-preview img,
+		.attachment-inner,
+		.new-message-attachment-name,
+		.new-message-attachment-size {
+			cursor: pointer;
+		}
 	}
 
 	.cloud-attachment-icon {

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -5,7 +5,9 @@
 <template>
 	<li class="composer-attachment" :class="{ 'composer-attachment--with-error': attachment.error }" @click="onPreview">
 		<div class="attachment-preview">
-			<img :src="previewSrc" class="attachment-preview-image">
+			<img
+				:src="previewSrc"
+				class="attachment-preview-image">
 			<span v-if="attachment.type === 'cloud'" class="cloud-attachment-icon">
 				<Cloud :size="20" />
 			</span>
@@ -92,11 +94,6 @@ export default {
 			this.$emit('preview', this.attachment)
 		}
 	},
-
-	mounted() {
-		console.log("attachment", this.attachment)
-	}
-
 }
 </script>
 

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -87,7 +87,7 @@ export default {
 		},
 
 		isPreviewable() {
-			return this.attachment.finished && !!this.attachment.previewBlobUrl
+			return this.attachment.finished && !!this.attachment.previewBlobUrl && !!OCA?.Viewer
 		},
 
 		extension() {

--- a/src/components/ComposerAttachment.vue
+++ b/src/components/ComposerAttachment.vue
@@ -87,7 +87,15 @@ export default {
 		},
 
 		isPreviewable() {
-			return this.attachment.finished && !!this.attachment.previewBlobUrl && !!OCA?.Viewer
+			if (!this.attachment.finished || !OCA?.Viewer) {
+				return false
+			}
+
+			if (this.attachment.type === 'cloud') {
+				return !!this.attachment.hasPreview && !!this.attachment.davSource
+			}
+
+			return !!this.attachment.previewBlobUrl
 		},
 
 		extension() {

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -28,7 +28,9 @@
 				:key="attachment.id"
 				:attachment="attachment"
 				:uploading="uploading"
-				@on-delete-attachment="onDelete(attachment)" />
+				@on-delete-attachment="onDelete(attachment)"
+				@preview="onPreviewAttachment(attachment)"
+			/>
 		</ul>
 
 		<input
@@ -501,6 +503,13 @@ export default {
 		isImage(file) {
 			return file.type && mimes.indexOf(file.type) !== -1
 		},
+
+		onPreviewAttachment(attachment) {
+			if(!attachment.finished) {
+				return
+			}
+		}
+
 	},
 }
 </script>

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -563,7 +563,6 @@ export default {
 			}
 
 			if (!OCA.Viewer) {
-				showWarning(t('mail', 'File Viewer is not enabled'))
 				return
 			}
 

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -29,8 +29,7 @@
 				:attachment="attachment"
 				:uploading="uploading"
 				@on-delete-attachment="onDelete(attachment)"
-				@preview="onPreviewAttachment"
-			/>
+				@preview="onPreviewAttachment" />
 		</ul>
 
 		<input
@@ -164,12 +163,12 @@ export default {
 			return this.attachments
 				.filter((attachment) => {
 					const mime = attachment.mime || attachment.fileType
-					return mime &&
-						(
-							mime.startsWith('image/') ||
-							mime.startsWith('video/') ||
-							mime.startsWith('audio/') ||
-							mime === 'application/pdf'
+					return mime
+						&& (
+							mime.startsWith('image/')
+							|| mime.startsWith('video/')
+							|| mime.startsWith('audio/')
+							|| mime === 'application/pdf'
 						)
 				})
 				.map((attachment) => ({
@@ -539,7 +538,6 @@ export default {
 				|| file.type.startsWith('video/')
 				|| file.type.startsWith('audio/')
 				|| file.type === 'application/pdf'
-
 		},
 
 		isImage(file) {
@@ -555,20 +553,24 @@ export default {
 				return
 			}
 
-			let fileInfo = {
+			const fileInfo = {
 				filename: attachment?.previewBlobUrl,
 				source: attachment?.previewBlobUrl,
 				basename: attachment?.fileName,
 				mime: attachment?.mime || attachment?.fileType,
 				etag: 'fixme',
 				hasPreview: false,
-				fileid: parseInt(attachment.id, 10),
 			}
 
-				OCA.Viewer.open({
-					fileInfo,
-					list: this.previewableFilesInfos
-				})
+			if (!OCA.Viewer) {
+				showWarning(t('mail', 'File Viewer is not enabled'))
+				return
+			}
+
+			OCA.Viewer.open({
+				fileInfo,
+				list: this.previewableFilesInfos,
+			})
 		},
 
 	},

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -159,6 +159,29 @@ export default {
 			}
 			return total
 		},
+
+		previewableFilesInfos() {
+			return this.attachments
+				.filter((attachment) => {
+					const mime = attachment.mime || attachment.fileType
+					return mime &&
+						(
+							mime.startsWith('image/') ||
+							mime.startsWith('video/') ||
+							mime.startsWith('audio/') ||
+							mime === 'application/pdf'
+						)
+				})
+				.map((attachment) => ({
+					filename: attachment.previewBlobUrl,
+					source: attachment.previewBlobUrl,
+					basename: attachment.fileName,
+					mime: attachment.mime || attachment.fileType,
+					etag: 'fixme',
+					hasPreview: false,
+					fileid: parseInt(attachment.id, 10),
+				}))
+		},
 	},
 
 	watch: {
@@ -358,6 +381,7 @@ export default {
 						size: filesFromCloud[i].size,
 
 					}
+
 					const _toAttachmentData = {
 						finished: true,
 						imageBlobURL: this.generatePreview(_cloudFile),
@@ -514,9 +538,7 @@ export default {
 			return file.type.startsWith('image/')
 				|| file.type.startsWith('video/')
 				|| file.type.startsWith('audio/')
-				|| file.type.startsWith('text/')
 				|| file.type === 'application/pdf'
-				|| file.type === 'application/json'
 
 		},
 
@@ -529,10 +551,24 @@ export default {
 				return
 			}
 
-			const url = attachment.previewBlobUrl
-			if (url) {
-				window.open(url, '_blank')
+			if (!attachment.previewBlobUrl) {
+				return
 			}
+
+			let fileInfo = {
+				filename: attachment?.previewBlobUrl,
+				source: attachment?.previewBlobUrl,
+				basename: attachment?.fileName,
+				mime: attachment?.mime || attachment?.fileType,
+				etag: 'fixme',
+				hasPreview: false,
+				fileid: parseInt(attachment.id, 10),
+			}
+
+				OCA.Viewer.open({
+					fileInfo,
+					list: this.previewableFilesInfos
+				})
 		},
 
 	},

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -29,7 +29,7 @@
 				:attachment="attachment"
 				:uploading="uploading"
 				@on-delete-attachment="onDelete(attachment)"
-				@preview="onPreviewAttachment(attachment)"
+				@preview="onPreviewAttachment"
 			/>
 		</ul>
 
@@ -245,7 +245,6 @@ export default {
 			this.uploading = true
 			// BUG - if choose again - progress lost/ move to complete()
 			Vue.set(this, 'uploads', {})
-
 			const toUpload = sumBy(prop('size'), Object.values(e.target.files))
 			const newTotal = toUpload + this.totalSizeOfUpload()
 			logger.debug('checking upload size limit', {
@@ -277,6 +276,7 @@ export default {
 					fileName: file.name,
 					fileType: file.type,
 					imageBlobURL: this.generatePreview(file),
+					previewBlobUrl: this.generatePreviewBlobUrl(file),
 					displayName: trimStart('/', file.name),
 					progress: null,
 					percent: 0,
@@ -427,6 +427,10 @@ export default {
 				attachment.controller.abort()
 			}
 
+			if (attachment.previewBlobUrl) {
+				URL.revokeObjectURL(attachment.previewBlobUrl)
+			}
+
 			const val = {
 				fileName: attachment.fileName,
 				displayName: attachment.displayName,
@@ -500,15 +504,36 @@ export default {
 			}
 		},
 
+		generatePreviewBlobUrl(file) {
+			return this.isPreviewable(file)
+				? URL.createObjectURL(file)
+				: null
+		},
+
+		isPreviewable(file) {
+			return file.type.startsWith('image/')
+				|| file.type.startsWith('video/')
+				|| file.type.startsWith('audio/')
+				|| file.type.startsWith('text/')
+				|| file.type === 'application/pdf'
+				|| file.type === 'application/json'
+
+		},
+
 		isImage(file) {
 			return file.type && mimes.indexOf(file.type) !== -1
 		},
 
 		onPreviewAttachment(attachment) {
-			if(!attachment.finished) {
+			if (!attachment.finished) {
 				return
 			}
-		}
+
+			const url = attachment.previewBlobUrl
+			if (url) {
+				window.open(url, '_blank')
+			}
+		},
 
 	},
 }

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -70,7 +70,7 @@ import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import ComposerAttachment from './ComposerAttachment.vue'
 import logger from '../logger.js'
 import { uploadLocalAttachment } from '../service/AttachmentService.js'
-import { getFileData } from '../service/FileService.js'
+import { getFileData, getFileDavUrl } from '../service/FileService.js'
 import { shareFile } from '../service/FileSharingService.js'
 
 const mimes = [
@@ -162,7 +162,7 @@ export default {
 		previewableFilesInfos() {
 			return this.attachments
 				.filter((attachment) => {
-					const mime = attachment.mime || attachment.fileType
+					const mime = attachment?.mime || attachment?.fileType
 					return mime
 						&& (
 							mime.startsWith('image/')
@@ -172,13 +172,12 @@ export default {
 						)
 				})
 				.map((attachment) => ({
-					filename: attachment.previewBlobUrl,
-					source: attachment.previewBlobUrl,
-					basename: attachment.fileName,
-					mime: attachment.mime || attachment.fileType,
-					etag: 'fixme',
-					hasPreview: false,
-					fileid: parseInt(attachment.id, 10),
+					filename: attachment?.previewBlobUrl || attachment?.davSource,
+					source: attachment?.previewBlobUrl || attachment?.davSource,
+					basename: attachment?.fileName,
+					mime: attachment?.mime || attachment?.fileType,
+					etag: attachment?.etag || 'fixme',
+					hasPreview: attachment?.hasPreview || false,
 				}))
 		},
 	},
@@ -390,6 +389,10 @@ export default {
 						// dont know, may be it will be conflict if cloud & local has equal IDs?
 						id: filesFromCloud[i].fileid,
 						uploaded: 0,
+						mime: filesFromCloud[i].getcontenttype,
+						etag: filesFromCloud[i].getetag,
+						davSource: getFileDavUrl(name),
+
 					}
 
 					this.attachments.push(Object.assign(_toAttachmentData, _cloudFile))
@@ -549,21 +552,24 @@ export default {
 				return
 			}
 
-			if (!attachment.previewBlobUrl) {
-				return
-			}
+			const isCloudPreviewable = attachment?.type === 'cloud' && attachment?.hasPreview && attachment?.davSource
+			const isLocalPreviewable = attachment?.type !== 'cloud' && attachment?.previewBlobUrl
 
-			const fileInfo = {
-				filename: attachment?.previewBlobUrl,
-				source: attachment?.previewBlobUrl,
-				basename: attachment?.fileName,
-				mime: attachment?.mime || attachment?.fileType,
-				etag: 'fixme',
-				hasPreview: false,
+			if (!isCloudPreviewable && !isLocalPreviewable) {
+				return
 			}
 
 			if (!OCA.Viewer) {
 				return
+			}
+
+			const fileInfo = {
+				filename: attachment?.previewBlobUrl || attachment?.davSource,
+				source: attachment?.previewBlobUrl || attachment?.davSource,
+				basename: attachment?.fileName,
+				mime: attachment?.mime || attachment?.fileType,
+				etag: attachment?.etag || 'fixme',
+				hasPreview: attachment?.hasPreview || false,
 			}
 
 			OCA.Viewer.open({

--- a/src/service/FileService.js
+++ b/src/service/FileService.js
@@ -31,10 +31,16 @@ export async function getFileData(path) {
 					<oc:size />
 					<oc:fileid />
 					<nc:has-preview />
+					<d:getcontenttype />
+					<d:getetag />
 				</d:prop>
 			</d:propfind>`,
 		details: true,
 	})
 
 	return response?.data?.props
+}
+
+export function getFileDavUrl(path) {
+	return getClient('files').getFileDownloadLink(path)
 }


### PR DESCRIPTION
Enables browser preview for some uploaded attachments directly from the composer.
Fixes #10278 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added attachment previews for images, videos, audio files, and PDFs.
  * Preview actions are available only for completed attachments with supported content.
  * Added visual cues to indicate when an attachment can be previewed.

* **Bug Fixes**
  * Preview resources are cleaned up when attachments are removed.
  * Unsupported or unfinished attachments no longer trigger preview actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->