### PR TITLE
fix(imap): render inline images referenced only by Content-ID

### DIFF
--- a/lib/IMAP/ImapMessageFetcher.php
+++ b/lib/IMAP/ImapMessageFetcher.php
@@ -344,11 +344,20 @@ class ImapMessageFetcher {
 		}
 
 		// Inline attachments
-		// Horde doesn't consider parts with content-disposition set to inline as
-		// attachment so we need to use another way to get them.
-		// We use these inline attachments to render a message's html body in $this->getHtmlBody()
+		// Horde doesn't consider parts with content-disposition set to inline as attachments,
+		// so we detect them ourselves to render the message's html body in $this->getHtmlBody().
+		// A part qualifies when it has a filename, is an embedded message, or carries a Content-ID.
+		// The Content-ID case covers clients (e.g. IBM Notes/HCL Domino) that reference inline
+		// images solely by Content-ID, without a filename or content-disposition. text/* and
+		// multipart parts are excluded from it so the body parts still reach the handlers below.
 		$filename = $p->getName();
-		if ($p->getType() === 'message/rfc822' || isset($filename)) {
+		$primaryType = $p->getPrimaryType();
+
+		$hasContentId = $p->getContentId() !== null && !in_array($primaryType, ['text', 'multipart'], true);
+		$hasFilename = isset($filename);
+		$isEmbeddedMessage = $p->getType() === 'message/rfc822';
+
+		if ($hasContentId || $hasFilename || $isEmbeddedMessage) {
 			if (in_array($filename, $this->attachmentsToIgnore)) {
 				return;
 			}
@@ -364,7 +373,7 @@ class ImapMessageFetcher {
 			return;
 		}
 
-		if ($p->getPrimaryType() === 'multipart') {
+		if ($primaryType === 'multipart') {
 			$this->handleMultiPartMessage($p, $partNo, $isFetched);
 			return;
 		}

--- a/tests/Integration/IMAP/ImapMessageFetcherIntegrationTest.php
+++ b/tests/Integration/IMAP/ImapMessageFetcherIntegrationTest.php
@@ -168,6 +168,50 @@ class ImapMessageFetcherIntegrationTest extends TestCase {
 		$this->assertTrue($message->isSignatureValid());
 	}
 
+	public function testFetchMessageWithInlineImageWithoutFilename(): void {
+		$mimeMessage = file_get_contents(__DIR__ . '/../../data/mime-html-cid-no-filename.txt');
+		$uid = $this->saveMimeMessage('INBOX', $mimeMessage);
+		$fetcher = $this->fetcherFactory
+			->build(
+				$uid,
+				'INBOX',
+				$this->getTestClient(),
+				$this->account->getUserId()
+			)
+			->withBody(true);
+
+		$message = $fetcher->fetchMessage();
+
+		$this->assertCount(0, $message->attachments);
+		$this->assertCount(1, $message->inlineAttachments);
+		$inlineAttachment = $message->inlineAttachments[0];
+		$this->assertSame('_1_0FAD84280FACDD0C0038DE9FC1258E02', $inlineAttachment['cid']);
+		$this->assertNull($inlineAttachment['fileName']);
+		$this->assertSame('image/gif', $inlineAttachment['mime']);
+		$this->assertTrue($message->hasHtmlMessage());
+	}
+
+	public function testFetchMessageDoesNotTreatHtmlBodyWithCidAsInlineAttachment(): void {
+		$mimeMessage = file_get_contents(__DIR__ . '/../../data/mime-html-body-with-cid.txt');
+		$uid = $this->saveMimeMessage('INBOX', $mimeMessage);
+		$fetcher = $this->fetcherFactory
+			->build(
+				$uid,
+				'INBOX',
+				$this->getTestClient(),
+				$this->account->getUserId()
+			)
+			->withBody(true);
+
+		$message = $fetcher->fetchMessage();
+
+		$this->assertCount(0, $message->attachments);
+		$this->assertCount(1, $message->inlineAttachments);
+		$this->assertSame('image/gif', $message->inlineAttachments[0]['mime']);
+		$this->assertTrue($message->hasHtmlMessage());
+		$this->assertStringContainsString('Hello', $message->getHtmlBody($uid));
+	}
+
 	public function testFetchMessageWithOpaqueSignedMessage(): void {
 		$encryptedMessage = file_get_contents(__DIR__ . '/../../data/signed-opaque-message.txt');
 		$uid = $this->saveMimeMessage('INBOX', $encryptedMessage);

--- a/tests/data/mime-html-body-with-cid.txt
+++ b/tests/data/mime-html-body-with-cid.txt
@@ -1,0 +1,20 @@
+From: debug@imap.localhost
+To: user@imap.localhost
+Subject: HTML body carrying a Content-ID
+Message-ID: <html-body-with-cid@imap.localhost>
+Date: Wed, 25 Jun 2026 08:54:28 +0000
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="=_related body_="; start="<root@imap.localhost>"
+
+--=_related body_=
+Content-Type: text/html; charset="UTF-8"
+Content-ID: <root@imap.localhost>
+
+<p>Hello <img src=cid:_1_0FAD84280FACDD0C0038DE9FC1258E02></p>
+--=_related body_=
+Content-Type: image/gif
+Content-ID: <_1_0FAD84280FACDD0C0038DE9FC1258E02>
+Content-Transfer-Encoding: base64
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--=_related body_=--

--- a/tests/data/mime-html-body-with-cid.txt.license
+++ b/tests/data/mime-html-body-with-cid.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/data/mime-html-cid-no-filename.txt
+++ b/tests/data/mime-html-cid-no-filename.txt
@@ -1,0 +1,29 @@
+From: debug@imap.localhost
+To: user@imap.localhost
+Subject: Inline image without filename
+Message-ID: <inline-cid-no-filename@imap.localhost>
+X-Mailer: IBM Notes Release 9.0.1FP4 June 08, 2015
+Date: Wed, 25 Jun 2026 08:54:28 +0000
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="=_related 0038DE9FC1258E02_="
+
+--=_related 0038DE9FC1258E02_=
+Content-Type: multipart/alternative; boundary="=_alternative 0038DE9FC1258E02_="
+
+--=_alternative 0038DE9FC1258E02_=
+Content-Type: text/plain; charset="US-ASCII"
+
+Hello
+
+--=_alternative 0038DE9FC1258E02_=
+Content-Type: text/html; charset="US-ASCII"
+
+<img src=cid:_1_0FAD84280FACDD0C0038DE9FC1258E02 style="border:0px solid;">
+--=_alternative 0038DE9FC1258E02_=--
+--=_related 0038DE9FC1258E02_=
+Content-Type: image/gif
+Content-ID: <_1_0FAD84280FACDD0C0038DE9FC1258E02>
+Content-Transfer-Encoding: base64
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--=_related 0038DE9FC1258E02_=--

--- a/tests/data/mime-html-cid-no-filename.txt.license
+++ b/tests/data/mime-html-cid-no-filename.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Fix #12925 

Inline images from clients like IBM Notes/HCL Domino carry only a Content-ID, with no filename and no Content-Disposition.

getPart() dropped such parts because the inline-attachment branch required a filename, so the cid: reference in the HTML body had nothing to resolve against and the image rendered as broken.

Treat a part as inline when it carries a Content-ID, excluding text/* and multipart parts so message bodies still reach the body handlers.

Assisted-by: ClaudeCode:claude-opus-4-8[1m]



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
