### PR TITLE
feat(ui): Add option to disable auto mark as read

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -240,6 +240,7 @@ class PageController extends Controller {
 			'sort-favorites' => $this->preferences->getPreference($this->userId, 'sort-favorites', 'false'),
 			'index-context-chat' => $this->contextChatSettingsService->isIndexingEnabled($this->userId) ? 'true' : 'false',
 			'compact-mode' => $this->preferences->getPreference($this->userId, 'compact-mode', 'false'),
+			'auto-mark-as-read' => $this->preferences->getPreference($this->userId, 'auto-mark-as-read', '3000'),
 		]);
 		$this->initialStateService->provideInitialState(
 			'prefill_displayName',

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -153,6 +153,13 @@
 					</NcFormBoxSwitch>
 				</NcFormBox>
 
+				<NcRadioGroup :model-value="autoMarkAsRead" :label="t('mail', 'Mark messages as read')" @update:modelValue="onToggleAutoMarkAsRead">
+					<NcRadioGroupButton :label="t('mail', 'Immediately')" value="0" :disabled="hasLoadingState('auto-mark-as-read')" />
+					<NcRadioGroupButton :label="n('mail', 'After %n second', 'After %n seconds', 3)" value="3000" :disabled="hasLoadingState('auto-mark-as-read')" />
+					<NcRadioGroupButton :label="n('mail', 'After %n second', 'After %n seconds', 30)" value="30000" :disabled="hasLoadingState('auto-mark-as-read')" />
+					<NcRadioGroupButton :label="t('mail', 'Manually')" value="-1" :disabled="hasLoadingState('auto-mark-as-read')" />
+				</NcRadioGroup>
+
 				<NcRadioGroup :model-value="useBottomReplies" :label="t('mail', 'Reply position')" @update:modelValue="onToggleButtonReplies">
 					<NcRadioGroupButton :label="t('mail', 'Top')" :value="false" :disabled="hasLoadingState('reply-mode')" />
 					<NcRadioGroupButton :label="t('mail', 'Bottom')" :value="true" :disabled="hasLoadingState('reply-mode')" />
@@ -449,6 +456,16 @@ export default {
 			},
 		},
 
+		autoMarkAsRead: {
+			get() {
+				return this.mainStore.getPreference('auto-mark-as-read', '3000')
+			},
+
+			set(value) {
+				this.onToggleAutoMarkAsRead(value)
+			},
+		},
+
 		useExternalAvatars: {
 			get() {
 				return this.mainStore.getPreference('external-avatars', 'true') === 'true'
@@ -672,6 +689,22 @@ export default {
 				Logger.error('could not save preferences', { error })
 			} finally {
 				this.setLoadingState('search-priority-body', false)
+			}
+		},
+
+		async onToggleAutoMarkAsRead(value) {
+			this.setLoadingState('auto-mark-as-read', true)
+
+			try {
+				await this.mainStore.savePreference({
+					key: 'auto-mark-as-read',
+					value: String(value),
+				})
+			} catch (error) {
+				Logger.error('could not save preferences', { error })
+				showError(t('mail', 'Could not update preference'))
+			} finally {
+				this.setLoadingState('auto-mark-as-read', false)
 			}
 		},
 

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -853,12 +853,17 @@ export default {
 					clearTimeout(loadingTimeout)
 				}
 
-				if (!this.envelope.flags.seen && this.hasSeenAcl) {
-					logger.info('Starting timer to mark message as seen/read')
+				const autoMarkReadSetting = this.mainStore.getPreference('auto-mark-as-read', '3000')
+				const delay = parseInt(autoMarkReadSetting, 10)
+
+				if (!this.envelope.flags.seen && this.hasSeenAcl && delay >= 0) {
+					logger.info(`Starting timer (${delay}ms) to mark message as seen/read`)
 					this.seenTimer = setTimeout(() => {
-						this.mainStore.toggleEnvelopeSeen({ envelope: this.envelope })
+						if (!this.envelope.flags.seen) {
+							this.mainStore.toggleEnvelopeSeen({ envelope: this.envelope })
+						}
 						this.seenTimer = undefined
-					}, 2000)
+					}, delay)
 				}
 
 				if (this.message.hasHtmlBody) {

--- a/src/init.js
+++ b/src/init.js
@@ -98,6 +98,10 @@ export default function initAfterAppCreation() {
 		key: 'compact-mode',
 		value: preferences['compact-mode'],
 	})
+	mainStore.savePreferenceMutation({
+		key: 'auto-mark-as-read',
+		value: preferences['auto-mark-as-read'],
+	})
 
 	mainStore.setQuickActions(loadState('mail', 'quick-actions', []))
 

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -188,7 +188,7 @@ class PageControllerTest extends TestCase {
 		$account1 = $this->createMock(Account::class);
 		$account2 = $this->createMock(Account::class);
 		$mailbox = $this->createStub(Mailbox::class);
-		$this->preferences->expects($this->exactly(14))
+		$this->preferences->expects($this->exactly(15))
 			->method('getPreference')
 			->willReturnMap([
 				[$this->userId, 'account-settings', '[]', json_encode([])],
@@ -205,6 +205,7 @@ class PageControllerTest extends TestCase {
 				[$this->userId, 'smime-sign-aliases', '[]', '[]'],
 				[$this->userId, 'sort-favorites', 'false', 'false'],
 				[$this->userId, 'compact-mode', 'false', 'false'],
+				[$this->userId, 'auto-mark-as-read', '3000', '3000'],
 			]);
 		$this->accountService->expects($this->once())
 			->method('findByUserId')
@@ -373,7 +374,8 @@ class PageControllerTest extends TestCase {
 					'follow-up-reminders' => 'true',
 					'sort-favorites' => 'false',
 					'index-context-chat' => 'true',
-					'compact-mode' => 'false'
+					'compact-mode' => 'false',
+					'auto-mark-as-read' => '3000',
 				]],
 				['prefill_displayName', 'Jane Doe'],
 				['importance_classification_default', true],


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/13061

## Summary
 This Pull Request introduces a user preference option to fully disable the "auto mark as read" feature when opening a message in Nextcloud Mail (#13061). When disabled, viewing/skimming messages does not automatically change their status to read, making "mark as read" an explicitly manual action.

## Key Changes
1. **Settings Switch:** Added an option switch labeled `"Automatically mark messages as read when opened"` in the App Settings Menu under the "Messages" section.
2. **Preference Storage:** Registered `auto-mark-as-read` user preference key, integrated it into the backend PHP initial state payload (`PageController`), and synced it with the frontend Vue Pinia store state on application bootstrap (`init.js`).
3. **Seen Timer Check:** Modified the timing logic in `ThreadEnvelope.vue` (`fetchMessage()`) to retrieve and check the value of `auto-mark-as-read` (defaulting to `true`) before starting the 2000ms delay timer that toggles the envelope to `seen`.

## How to Test
1. Compile front-end changes (`npm run dev` or `npm run watch`).
2. Open Nextcloud Mail.
3. Open **Mail settings** -> **Messages**.
4. Disable the toggle: **"Automatically mark messages as read when opened"**.
5. Select/click an unread message in the envelope list.
6. Verify that:
   - The message loads and displays its body.
   - The message remains unread (no timer is started, no `seen` flag is sent to the server).
   - Reloading the page persists the disabled toggle and state correctly.
7. Enable the toggle and verify that opening an unread message automatically marks it as read after the standard 2-second delay.

## Checklist
- [x] Code passes linting (`npm run lint` and `composer run cs:check`)
- [x] Unit tests pass successfully (`npm run test:unit`)
- [x] Signed-off commits (DCO check compliant)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

CC: @GretaD (as you [previously expressed interest](https://github.com/nextcloud/mail/issues/13061#issuecomment-4716598486) in this feature/discussion)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to control when messages are automatically marked as read: immediately, after 3 or 30 seconds, or manually.
  * Applied the selected preference when viewing messages.

* **Bug Fixes**
  * Added error handling when saving the automatic read-status preference fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->