### PR TITLE
fix: remove beforeunload and resize listener when closing composer

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -631,6 +631,9 @@ export default {
 			this.mainStore.setComposerIndicatorDisabledMutation(true)
 			await this.onMinimize()
 
+			window.removeEventListener('beforeunload', this.onBeforeUnload)
+			window.removeEventListener('resize', this.checkScreenSize)
+
 			// End the session only if all unsaved changes have been saved
 			if (this.canSaveDraft && ((this.changed && this.draftSaved) || !this.changed)) {
 				logger.debug('Closing composer session due to close button click')

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -631,9 +631,6 @@ export default {
 			this.mainStore.setComposerIndicatorDisabledMutation(true)
 			await this.onMinimize()
 
-			window.removeEventListener('beforeunload', this.onBeforeUnload)
-			window.removeEventListener('resize', this.checkScreenSize)
-
 			// End the session only if all unsaved changes have been saved
 			if (this.canSaveDraft && ((this.changed && this.draftSaved) || !this.changed)) {
 				logger.debug('Closing composer session due to close button click')
@@ -643,6 +640,9 @@ export default {
 					id: this.composerData.id,
 				})
 			}
+
+			window.removeEventListener('beforeunload', this.onBeforeUnload)
+			window.removeEventListener('resize', this.checkScreenSize)
 		},
 	},
 }


### PR DESCRIPTION
Removed beforeunload and resize listeners

Fixes #13031