### PR TITLE
Fix search provider replace URL with URL with deeplink

### DIFF
--- a/lib/Search/Provider.php
+++ b/lib/Search/Provider.php
@@ -116,10 +116,9 @@ class Provider implements IProvider {
 					]),
 					$message->getSubject(),
 					$subline,
-					$this->urlGenerator->linkToRouteAbsolute('mail.page.thread', [
-						'mailboxId' => $message->getMailboxId(),
-						'id' => $message->getId(),
-					]), // TODO: deep URL
+					$this->urlGenerator->linkToRouteAbsolute('mail.deep_link.open', [
+						'messageId' => $message->getMessageId(),
+					]),
 					'icon-mail',
 					!is_null($from)
 				);


### PR DESCRIPTION

I do not know which other apps use this search provider, but this is used by the tables app. This change replace the URL with a deeplink URL (there was a todo)

This has been tested with the tables app, this will allow sharing links between multiple mailboxes.

see the screenshots  below
<img width="900" height="535" alt="image" src="https://github.com/user-attachments/assets/3de16623-3866-4c15-bea0-1ba0596d9384" />

<img width="987" height="476" alt="image" src="https://github.com/user-attachments/assets/3e7360f0-9e90-4a2c-b972-0f24615fc3dc" />



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

@SoleroTG for review