### PR TITLE
fix: validating email addresses from Contacts

### DIFF
--- a/lib/Service/ContactsIntegration.php
+++ b/lib/Service/ContactsIntegration.php
@@ -66,6 +66,12 @@ class ContactsIntegration {
 				if ($e === '') {
 					continue;
 				}
+
+				$mightBeValidEmail = filter_var($e, FILTER_VALIDATE_EMAIL);
+				if ($mightBeValidEmail === false) {
+					continue;
+				}
+
 				$receivers[] = [
 					'id' => $id,
 					// Show full name if possible or fall back to email


### PR DESCRIPTION
The Contacts app now validates email addresses on his own (https://github.com/nextcloud/contacts/pull/4380) so #7121 may be considered obsolete.

Yet, an extra check in `ContactsIntegration` may prevent broken imports or other issues on the Contacts side.

Fixes #7121 