### PR TITLE
feat: ability to cancel a draft

### DIFF
--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -269,6 +269,10 @@ export default {
 		this.updateCookedComposerData()
 		await this.openModalSize()
 		window.addEventListener('resize', this.checkScreenSize)
+
+		if (this.composerData.draftId !== undefined) {
+			this.onDraft(this.cookedComposerData, { showToast: false })
+		}
 	},
 
 	beforeUnmount() {


### PR DESCRIPTION
The ingenuous solution here provided is to explicitely trigger the draft-saving function immediately when the `NewMessageModal` is opened, so to move the whole component in the canonical "draft saved" state (displaying the explicit trash button).

Alternative solutions would imply a more complex integration with `MessageService.deleteMessage()` (instead of `DraftService.deleteDraft()`) when required.

Fixes #2492 