### PR TITLE
feat(perf):  remove window event listeners on component unmount

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -553,11 +553,15 @@ export default {
 
 	mounted() {
 		this.sortOrder = this.mainStore.getPreference('sort-order', 'newest')
-		document.addEventListener.call(window, 'mailvelope', () => this.checkMailvelope())
+		window.addEventListener('mailvelope', this.checkMailvelope)
 		if (!this.mainStore.areTextBlocksFetched()) {
 			this.mainStore.fetchMyTextBlocks()
 			this.mainStore.fetchSharedTextBlocks()
 		}
+	},
+
+	beforeUnmount() {
+		window.removeEventListener('mailvelope', this.checkMailvelope)
 	},
 
 	updated() {

--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -560,7 +560,7 @@ export default {
 		}
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		window.removeEventListener('mailvelope', this.checkMailvelope)
 	},
 

--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -803,14 +803,16 @@ export default {
 				|| (this.data.previewText && isPgpText(this.data.previewText)) // PGP/Mailvelope
 		},
 
+		envelopeAllTags() {
+			return this.mainStore.getEnvelopeTags(this.data.databaseId)
+		},
+
 		isImportant() {
-			return this.mainStore
-				.getEnvelopeTags(this.data.databaseId)
-				.some((tag) => tag.imapLabel === '$label1')
+			return this.envelopeAllTags.some((tag) => tag.imapLabel === '$label1')
 		},
 
 		tags() {
-			let tags = this.mainStore.getEnvelopeTags(this.data.databaseId).filter((tag) => tag.imapLabel && tag.imapLabel !== '$label1' && !(tag.displayName.toLowerCase() in hiddenTags))
+			let tags = this.envelopeAllTags.filter((tag) => tag.imapLabel && tag.imapLabel !== '$label1' && !(tag.displayName.toLowerCase() in hiddenTags))
 
 			// Don't show follow-up tag in unified mailbox as it has its own section at the top
 			if (this.mailbox.isUnified) {
@@ -991,6 +993,10 @@ export default {
 	mounted() {
 		this.onWindowResize()
 		window.addEventListener('resize', this.onWindowResize)
+	},
+
+	beforeUnmount() {
+		window.removeEventListener('resize', this.onWindowResize)
 	},
 
 	methods: {

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -291,7 +291,7 @@ export default {
 					return a.dateInt < b.dateInt ? -1 : 1
 				})
 			}
-			return [...this.envelopes]
+			return this.envelopes
 		},
 
 		selectMode() {
@@ -307,22 +307,18 @@ export default {
 			return this.selectedEnvelopes.some((env) => env.flags.seen === false)
 		},
 
+		selectedEnvelopeTags() {
+			return this.selectedEnvelopes.map((env) => this.mainStore.getEnvelopeTags(env.databaseId))
+		},
+
 		isAtLeastOneSelectedImportant() {
 			// returns true if at least one selected message is marked as important
-			return this.selectedEnvelopes.some((env) => {
-				return this.mainStore
-					.getEnvelopeTags(env.databaseId)
-					.some((tag) => tag.imapLabel === '$label1')
-			})
+			return this.selectedEnvelopeTags.some((tags) => tags.some((tag) => tag.imapLabel === '$label1'))
 		},
 
 		isAtLeastOneSelectedUnimportant() {
 			// returns true if at least one selected message is not marked as important
-			return this.selectedEnvelopes.some((env) => {
-				return !this.mainStore
-					.getEnvelopeTags(env.databaseId)
-					.some((tag) => tag.imapLabel === '$label1')
-			})
+			return this.selectedEnvelopeTags.some((tags) => !tags.some((tag) => tag.imapLabel === '$label1'))
 		},
 
 		isAtLeastOneSelectedJunk() {


### PR DESCRIPTION
Changes in this PR:

Envelope.vue — deduplicate store getter calls + resize listener leak       
                                                                             
  getEnvelopeTags(this.data.databaseId) was being called separately inside   
  both _isImportant_ and _tags_ on every render. Since _Envelope_ is rendered once 
  per message in a list, this doubles the store lookups per envelope per     
  render cycle. The new _envelopeAllTags_ computed property calls it once and Vue caches the result, both isImportant and tags then read from the cache and only recompute when the store data actually changes. The resize listener had the same leak as above  added in mounted() but never removed. The new beforeUnmount hook fixes that.                      

-----

EnvelopeList.vue—remove unnecessary array copy + deduplicate tag lookups 
                                                                             
  [...this.envelopes] was creating a full array copy on every computed       
  evaluation with no reason to, the spread was defensive but the computed   
  property is read-only. With large mailboxes, this is a pointless allocation on every render.      

-------

isAtLeastOneSelectedImportant and isAtLeastOneSelectedUnimportant were each
  iterating _selectedEnvelopes_ and calling getEnvelopeTags per envelope, so N selected envelopes meant 2N store calls. The new selectedEnvelopeTags computed property fetches tags once for all selected envelopes, and both computed properties read from that cache.   

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
