### PR TITLE
fix(sync): tolerate PERMANENTFLAGS IMAP errors

### DIFF
--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -759,11 +759,12 @@ class MailManager implements IMailManager {
 		try {
 			$capabilities = $client->status($mailbox, Horde_Imap_Client::STATUS_PERMFLAGS);
 		} catch (Horde_Imap_Client_Exception $e) {
-			throw new ServiceException(
-				'Could not get message flag options from IMAP: ' . $e->getMessage(),
-				$e->getCode(),
-				$e
-			);
+			$this->logger->debug('Could not get IMAP PERMANENTFLAGS support; treating custom flags as unsupported', [
+				'exception' => $e,
+				'mailbox' => $mailbox,
+			]);
+
+			return false;
 		}
 		return (is_array($capabilities) === true && array_key_exists('permflags', $capabilities) === true && in_array("\*", $capabilities['permflags'], true) === true);
 	}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Attachment;
@@ -400,6 +401,24 @@ class MailManagerTest extends TestCase {
 		$client->expects($this->once())
 			->method('status')
 			->willReturn([]);
+
+		$this->assertFalse($this->manager->isPermflagsEnabled($client, $account, 'INBOX'));
+	}
+
+	public function testIsPermflagsEnabledReturnsFalseOnImapError(): void {
+		$account = $this->createStub(Account::class);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
+		$client->expects($this->once())
+			->method('status')
+			->with('INBOX', \Horde_Imap_Client::STATUS_PERMFLAGS)
+			->willThrowException(new Horde_Imap_Client_Exception('IMAP error reported by server.'));
+		$this->logger->expects($this->once())
+			->method('debug')
+			->with(
+				'Could not get IMAP PERMANENTFLAGS support; treating custom flags as unsupported',
+				$this->callback(static fn (array $context): bool => $context['mailbox'] === 'INBOX' && $context['exception'] instanceof Horde_Imap_Client_Exception),
+			);
 
 		$this->assertFalse($this->manager->isPermflagsEnabled($client, $account, 'INBOX'));
 	}


### PR DESCRIPTION
## Summary

- Treat IMAP `STATUS PERMANENTFLAGS` failures as custom flags being unsupported instead of aborting account sync
- Log the server failure at debug level with mailbox context
- Add unit coverage for the fallback

## Motivation

Some IMAP servers can return an error for the `PERMANENTFLAGS` status query while regular mailbox sync otherwise works. On iCloud this causes account sync to abort with `Could not get message flag options from IMAP: IMAP error reported by server` and can also trigger the log spam reported in #12506.

If the server cannot report permanent flag support, Mail can safely continue with custom keyword sync disabled for that mailbox.

Fixes #12506
