### PR TITLE
fix(drafts): preserve Bcc header when saving drafts

### DIFF
--- a/lib/Service/MailTransmission.php
+++ b/lib/Service/MailTransmission.php
@@ -14,7 +14,6 @@ use Horde_Imap_Client;
 use Horde_Imap_Client_Data_Fetch;
 use Horde_Imap_Client_Fetch_Query;
 use Horde_Imap_Client_Ids;
-use Horde_Mail_Rfc822_Address;
 use Horde_Mail_Rfc822_List;
 use Horde_Mail_Transport_Null;
 use Horde_Mail_Transport_Smtphorde;
@@ -235,36 +234,30 @@ class MailTransmission implements IMailTransmission {
 			$this->transmissionService->handleAttachment($account, $attachment);
 		}
 
-		// build mime body
-		$headers = $this->buildHeaders(
-			$from,
-			$to,
-			$cc,
-			$bcc,
-			$message->getSubject()
-		);
+		$draftHeaders = $this->buildMimeHeaders($from, $to, $cc, $bcc, $message->getSubject());
 
 		$mail = new Horde_Mime_Mail();
-		$mail->addHeaders($headers);
 		if ($message->isHtml()) {
 			$mail->setHtmlBody($message->getBodyHtml());
 		} else {
 			$mail->setBody($message->getBodyPlain());
 		}
-		$mail->addHeaderOb(Horde_Mime_Headers_MessageId::create());
 		$perfLogger->step('build local draft message');
 
-		// 'Send' the message
+		// Use a null transport to trigger MIME body encoding without sending
 		$client = $this->imapClientFactory->getClient($account);
 		try {
-			$transport = new Horde_Mail_Transport_Null();
-			$mail->send($transport, false, false);
+			$mail->send(new Horde_Mail_Transport_Null(), false, false);
 			$perfLogger->step('create IMAP draft message');
 			$draftsMailbox = $this->findOrCreateDraftsMailbox($account);
 			$this->messageMapper->save(
 				$client,
 				$draftsMailbox,
-				$mail->getRaw(false),
+				$mail->getBasePart()->toString([
+					'encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY,
+					'headers' => $draftHeaders,
+					'stream' => false,
+				]),
 				[Horde_Imap_Client::FLAG_DRAFT]
 			);
 			$perfLogger->step('save local draft message on IMAP');
@@ -317,7 +310,7 @@ class MailTransmission implements IMailTransmission {
 		$account = $message->getAccount();
 		$from = Address::fromRaw($account->getName(), $account->getEMailAddress());
 
-		$headers = $this->buildHeaders(
+		$draftHeaders = $this->buildMimeHeaders(
 			$from,
 			$message->getTo(),
 			$message->getCc(),
@@ -326,22 +319,19 @@ class MailTransmission implements IMailTransmission {
 		);
 
 		$mail = new Horde_Mime_Mail();
-		$mail->addHeaders($headers);
 		if ($message->isHtml()) {
 			$mail->setHtmlBody($message->getBody());
 		} else {
 			$mail->setBody($message->getBody());
 		}
-		$mail->addHeaderOb(Horde_Mime_Headers_MessageId::create());
 		$perfLogger->step('build draft message');
 
-		// 'Send' the message
+		// Use a null transport to trigger MIME body encoding without sending
 		$client = $this->imapClientFactory->getClient($account);
 		try {
-			$transport = new Horde_Mail_Transport_Null();
-			$mail->send($transport, false, false);
+			$mail->send(new Horde_Mail_Transport_Null(), false, false);
 			$perfLogger->step('create IMAP message');
-			// save the message in the drafts folder
+			// save the message in the drafts mailbox
 			$draftsMailboxId = $account->getMailAccount()->getDraftsMailboxId();
 			if ($draftsMailboxId === null) {
 				throw new ClientException('No drafts mailbox configured');
@@ -350,7 +340,11 @@ class MailTransmission implements IMailTransmission {
 			$newUid = $this->messageMapper->save(
 				$client,
 				$draftsMailbox,
-				$mail->getRaw(false),
+				$mail->getBasePart()->toString([
+					'encode' => Horde_Mime_Part::ENCODE_7BIT | Horde_Mime_Part::ENCODE_8BIT | Horde_Mime_Part::ENCODE_BINARY,
+					'headers' => $draftHeaders,
+					'stream' => false,
+				]),
 				[Horde_Imap_Client::FLAG_DRAFT]
 			);
 			$perfLogger->step('save message on IMAP');
@@ -372,29 +366,21 @@ class MailTransmission implements IMailTransmission {
 		return [$account, $draftsMailbox, $newUid];
 	}
 
-	/**
-	 * @return array{
-	 *     From: Horde_Mail_Rfc822_Address,
-	 *     To: Horde_Mail_Rfc822_List,
-	 *     Subject: string|null,
-	 *     Cc?: Horde_Mail_Rfc822_List,
-	 *     Bcc?: Horde_Mail_Rfc822_List,
-	 * }
-	 */
-	private function buildHeaders(Address $from, AddressList $to, AddressList $cc, AddressList $bcc, ?string $subject): array {
-		$headers = [
-			'From' => $from->toHorde(),
-			'To' => $to->toHorde(),
-			'Subject' => $subject,
-		];
-
+	private function buildMimeHeaders(Address $from, AddressList $to, AddressList $cc, AddressList $bcc, ?string $subject): Horde_Mime_Headers {
+		$headers = new Horde_Mime_Headers();
+		$headers->addHeaderOb(Horde_Mime_Headers_Date::create());
+		$headers->addHeaderOb(Horde_Mime_Headers_MessageId::create());
+		$headers->addHeaderOb(new Horde_Mime_Headers_Addresses('From', $from->toHorde()));
+		$headers->addHeaderOb(new Horde_Mime_Headers_Addresses('To', $to->toHorde()));
 		if (count($cc) > 0) {
-			$headers['Cc'] = $cc->toHorde();
+			$headers->addHeaderOb(new Horde_Mime_Headers_Addresses('Cc', $cc->toHorde()));
 		}
 		if (count($bcc) > 0) {
-			$headers['Bcc'] = $bcc->toHorde();
+			$headers->addHeaderOb(new Horde_Mime_Headers_Addresses('Bcc', $bcc->toHorde()));
 		}
-
+		if ($subject !== null) {
+			$headers->addHeader('Subject', $subject);
+		}
 		return $headers;
 	}
 


### PR DESCRIPTION
Somewhat related to https://github.com/nextcloud/mail/pull/13180.

## How to test

1. Start a new email
2. Enter a bcc recipient
3. Save the draft
4. Open the draft mailbox
5. Open the new draft email

main: empty Bcc
here: restored Bcc

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
