### PR TITLE
fix(oauth): generate state token server-side before redirect

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -476,6 +476,11 @@ return [
 			'verb' => 'GET',
 		],
 		[
+			'name' => 'oauth#generateState',
+			'url' => '/api/oauth/state',
+			'verb' => 'POST',
+		],
+		[
 			'name' => 'list#unsubscribe',
 			'url' => '/api/list/unsubscribe/{id}',
 			'verb' => 'POST',

--- a/lib/Controller/GoogleIntegrationController.php
+++ b/lib/Controller/GoogleIntegrationController.php
@@ -11,11 +11,13 @@ namespace OCA\Mail\Controller;
 
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\InvalidOauthStateException;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Http\JsonResponse;
 use OCA\Mail\IMAP\MailboxSync;
 use OCA\Mail\Integration\GoogleIntegration;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\OauthStateService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -23,10 +25,6 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
-
-
-
-use function filter_var;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class GoogleIntegrationController extends Controller {
@@ -37,6 +35,7 @@ class GoogleIntegrationController extends Controller {
 		private AccountService $accountService,
 		private LoggerInterface $logger,
 		private MailboxSync $mailboxSync,
+		private OauthStateService $oauthStateService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}
@@ -97,26 +96,11 @@ class GoogleIntegrationController extends Controller {
 				'guest',
 			);
 		}
-		if (!filter_var($state, FILTER_VALIDATE_INT)) {
-			$this->logger->warning('Can not link Google account due to invalid state/account id {state}', [
-				'state' => $state,
-			]);
-			// TODO: redirect to main nextcloud page
-			return new StandaloneTemplateResponse(
-				Application::APP_ID,
-				'oauth_done',
-				[],
-				'guest',
-			);
-		}
-
 		try {
-			$account = $this->accountService->find(
-				$this->userId,
-				(int)$state,
-			);
-		} catch (ClientException $e) {
-			$this->logger->warning('Attempted Google authentication redirect for account: ' . $e->getMessage(), [
+			$accountId = $this->oauthStateService->validateAndConsume($state, $this->userId);
+			$account = $this->accountService->find($this->userId, $accountId);
+		} catch (InvalidOauthStateException|ClientException $e) {
+			$this->logger->warning('Cannot link Google account: invalid OAuth state', [
 				'exception' => $e,
 			]);
 			// TODO: redirect to main nextcloud page

--- a/lib/Controller/MicrosoftIntegrationController.php
+++ b/lib/Controller/MicrosoftIntegrationController.php
@@ -11,9 +11,11 @@ namespace OCA\Mail\Controller;
 
 use OCA\Mail\AppInfo\Application;
 use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Exception\InvalidOauthStateException;
 use OCA\Mail\Http\JsonResponse;
 use OCA\Mail\Integration\MicrosoftIntegration;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\OauthStateService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -21,7 +23,6 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\StandaloneTemplateResponse;
 use OCP\IRequest;
 use Psr\Log\LoggerInterface;
-use function filter_var;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class MicrosoftIntegrationController extends Controller {
@@ -31,6 +32,7 @@ class MicrosoftIntegrationController extends Controller {
 		private AccountService $accountService,
 		private MicrosoftIntegration $microsoftIntegration,
 		private LoggerInterface $logger,
+		private OauthStateService $oauthStateService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}
@@ -98,26 +100,11 @@ class MicrosoftIntegrationController extends Controller {
 				'guest',
 			);
 		}
-		if (!filter_var($state, FILTER_VALIDATE_INT)) {
-			$this->logger->warning('Can not link Microsoft account due to invalid state/account id {state}', [
-				'state' => $state,
-			]);
-			// TODO: redirect to main nextcloud page
-			return new StandaloneTemplateResponse(
-				Application::APP_ID,
-				'oauth_done',
-				[],
-				'guest',
-			);
-		}
-
 		try {
-			$account = $this->accountService->find(
-				$this->userId,
-				(int)$state,
-			);
-		} catch (ClientException $e) {
-			$this->logger->warning('Attempted Microsoft authentication redirect for account: ' . $e->getMessage(), [
+			$accountId = $this->oauthStateService->validateAndConsume($state, $this->userId);
+			$account = $this->accountService->find($this->userId, $accountId);
+		} catch (InvalidOauthStateException|ClientException $e) {
+			$this->logger->warning('Cannot link Microsoft account: invalid OAuth state', [
 				'exception' => $e,
 			]);
 			// TODO: redirect to main nextcloud page

--- a/lib/Controller/OauthController.php
+++ b/lib/Controller/OauthController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Controller;
+
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Http\JsonResponse;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\OauthStateService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\IRequest;
+
+#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
+class OauthController extends Controller {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ?string $userId,
+		private AccountService $accountService,
+		private OauthStateService $oauthStateService,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	#[NoAdminRequired]
+	public function generateState(int $accountId): JsonResponse {
+		if ($this->userId === null) {
+			return JsonResponse::fail(null, Http::STATUS_UNAUTHORIZED);
+		}
+
+		try {
+			$this->accountService->find($this->userId, $accountId);
+		} catch (ClientException) {
+			return JsonResponse::fail(null, Http::STATUS_NOT_FOUND);
+		}
+
+		$state = $this->oauthStateService->createState($accountId, $this->userId);
+		return JsonResponse::success(['state' => $state]);
+	}
+}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -268,7 +268,7 @@ class PageController extends Controller {
 					'redirect_uri' => $this->urlGenerator->linkToRouteAbsolute('mail.googleIntegration.oauthRedirect'),
 					'response_type' => 'code',
 					'prompt' => 'consent',
-					'state' => '_accountId_', // Replaced by frontend
+					'state' => '_state_', // Replaced by frontend
 					'scope' => 'https://mail.google.com/',
 					'access_type' => 'offline',
 					'login_hint' => '_email_', // Replaced by frontend
@@ -285,7 +285,7 @@ class PageController extends Controller {
 					'redirect_uri' => $this->urlGenerator->linkToRouteAbsolute('mail.microsoftIntegration.oauthRedirect'),
 					'response_type' => 'code',
 					'response_mode' => 'query',
-					'state' => '_accountId_', // Replaced by frontend
+					'state' => '_state_', // Replaced by frontend
 					'scope' => 'offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/SMTP.Send',
 					'access_type' => 'offline',
 					'login_hint' => '_email_', // Replaced by frontend

--- a/lib/Exception/InvalidOauthStateException.php
+++ b/lib/Exception/InvalidOauthStateException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Exception;
+
+class InvalidOauthStateException extends ServiceException {
+}

--- a/lib/Service/OauthStateService.php
+++ b/lib/Service/OauthStateService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Service;
+
+use OCA\Mail\Exception\InvalidOauthStateException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Security\ICrypto;
+
+class OauthStateService {
+	public const TTL = 600;
+
+	public function __construct(
+		private ICrypto $crypto,
+		private ITimeFactory $time,
+	) {
+	}
+
+	public function createState(int $accountId, string $userId): string {
+		$timestamp = $this->time->getTime();
+		$hmac = bin2hex($this->crypto->calculateHMAC("$accountId.$userId.$timestamp"));
+		return "$accountId.$timestamp.$hmac";
+	}
+
+	/**
+	 * @throws InvalidOauthStateException
+	 */
+	public function validateAndConsume(string $state, string $userId): int {
+		$parts = explode('.', $state, 3);
+		if (count($parts) !== 3) {
+			throw new InvalidOauthStateException('Malformed OAuth state');
+		}
+		[$accountId, $timestamp, $hmac] = $parts;
+
+		$expected = bin2hex($this->crypto->calculateHMAC("$accountId.$userId.$timestamp"));
+		if (!hash_equals($expected, $hmac)) {
+			throw new InvalidOauthStateException('OAuth state HMAC mismatch');
+		}
+
+		if (($this->time->getTime() - (int)$timestamp) > self::TTL) {
+			throw new InvalidOauthStateException('OAuth state expired');
+		}
+
+		return (int)$accountId;
+	}
+}

--- a/src/components/AccountForm.vue
+++ b/src/components/AccountForm.vue
@@ -289,6 +289,7 @@ import {
 	queryMx,
 	testConnectivity,
 } from '../service/AutoConfigService.js'
+import { generateOauthState } from '../service/OauthStateService.js'
 import useMainStore from '../store/mainStore.js'
 
 export default {
@@ -631,12 +632,12 @@ export default {
 							if (this.isGoogleAccount) {
 								this.feedback = t('mail', 'Account created. Please follow the pop-up instructions to link your Google account')
 								await getUserConsent(this.googleOauthUrl
-									.replace('_accountId_', account.id)
+									.replace('_state_', await generateOauthState(account.id))
 									.replace('_email_', encodeURIComponent(account.emailAddress)))
 							} else {
 								this.feedback = t('mail', 'Account created. Please follow the pop-up instructions to link your Microsoft account')
 								await getUserConsent(this.microsoftOauthUrl
-									.replace('_accountId_', account.id)
+									.replace('_state_', await generateOauthState(account.id))
 									.replace('_email_', encodeURIComponent(account.emailAddress)))
 							}
 						} catch (e) {
@@ -662,12 +663,12 @@ export default {
 							if (this.isGoogleAccount) {
 								this.feedback = t('mail', 'Account updated. Please follow the pop-up instructions to reconnect your Google account')
 								await getUserConsent(this.googleOauthUrl
-									.replace('_accountId_', account.id)
+									.replace('_state_', await generateOauthState(account.id))
 									.replace('_email_', encodeURIComponent(account.emailAddress)))
 							} else {
 								this.feedback = t('mail', 'Account updated. Please follow the pop-up instructions to reconnect your Microsoft account')
 								await getUserConsent(this.microsoftOauthUrl
-									.replace('_accountId_', account.id)
+									.replace('_state_', await generateOauthState(account.id))
 									.replace('_email_', encodeURIComponent(account.emailAddress)))
 							}
 						} catch (e) {

--- a/src/service/OauthStateService.js
+++ b/src/service/OauthStateService.js
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+export async function generateOauthState(accountId) {
+	const response = await axios.post(
+		generateUrl('/apps/mail/api/oauth/state'),
+		{ accountId },
+		{
+			headers: {
+				Accept: 'application/json',
+			},
+		},
+	)
+
+	return response.data.data.state
+}

--- a/tests/Unit/Controller/OauthControllerTest.php
+++ b/tests/Unit/Controller/OauthControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Controller;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Controller\OauthController;
+use OCA\Mail\Exception\ClientException;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\OauthStateService;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class OauthControllerTest extends TestCase {
+	private IRequest&MockObject $request;
+	private AccountService&MockObject $accountService;
+	private OauthStateService&MockObject $oauthStateService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->oauthStateService = $this->createMock(OauthStateService::class);
+	}
+
+	private function buildController(?string $userId): OauthController {
+		return new OauthController(
+			'mail',
+			$this->request,
+			$userId,
+			$this->accountService,
+			$this->oauthStateService,
+		);
+	}
+
+	public function testGenerateStateSuccess(): void {
+		$this->accountService->expects($this->once())
+			->method('find')
+			->with('alice', 42);
+
+		$this->oauthStateService->expects($this->once())
+			->method('createState')
+			->with(42, 'alice')
+			->willReturn('42.1000.somehmac');
+
+		$response = $this->buildController('alice')->generateState(42);
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertEquals('42.1000.somehmac', $response->getData()['data']['state']);
+	}
+
+	public function testGenerateStateReturnsUnauthorizedWithoutUser(): void {
+		$response = $this->buildController(null)->generateState(42);
+
+		$this->assertEquals(Http::STATUS_UNAUTHORIZED, $response->getStatus());
+	}
+
+	public function testGenerateStateReturnsNotFoundForUnknownAccount(): void {
+		$this->accountService->expects($this->once())
+			->method('find')
+			->with('alice', 99)
+			->willThrowException(new ClientException('not found'));
+
+		$response = $this->buildController('alice')->generateState(99);
+
+		$this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+}

--- a/tests/Unit/Service/OauthStateServiceTest.php
+++ b/tests/Unit/Service/OauthStateServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Exception\InvalidOauthStateException;
+use OCA\Mail\Service\OauthStateService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class OauthStateServiceTest extends TestCase {
+	private ICrypto&MockObject $crypto;
+	private ITimeFactory&MockObject $time;
+	private OauthStateService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->time = $this->createMock(ITimeFactory::class);
+
+		$this->service = new OauthStateService(
+			$this->crypto,
+			$this->time,
+		);
+	}
+
+	public function testCreateStateReturnsThreeParts(): void {
+		$this->time->method('getTime')->willReturn(1000);
+		$this->crypto->method('calculateHMAC')->willReturn('abc123');
+
+		$state = $this->service->createState(42, 'alice');
+
+		$parts = explode('.', $state);
+		$this->assertCount(3, $parts);
+		$this->assertEquals('42', $parts[0]);
+		$this->assertEquals('1000', $parts[1]);
+		$this->assertEquals(bin2hex('abc123'), $parts[2]);
+	}
+
+	public function testCreateStateBindsUserId(): void {
+		$this->time->method('getTime')->willReturn(1000);
+
+		$this->crypto->expects($this->exactly(2))
+			->method('calculateHMAC')
+			->willReturnOnConsecutiveCalls('hmac-alice', 'hmac-bob');
+
+		$stateAlice = $this->service->createState(42, 'alice');
+		$stateBob = $this->service->createState(42, 'bob');
+
+		$this->assertNotEquals($stateAlice, $stateBob);
+	}
+
+	public function testValidateAndConsumeSuccess(): void {
+		$this->time->method('getTime')->willReturn(1000);
+		$this->crypto->method('calculateHMAC')
+			->with('42.alice.900')
+			->willReturn('validhmac');
+
+		$accountId = $this->service->validateAndConsume('42.900.' . bin2hex('validhmac'), 'alice');
+
+		$this->assertEquals(42, $accountId);
+	}
+
+	public function testValidateAndConsumeThrowsOnMalformedState(): void {
+		$this->expectException(InvalidOauthStateException::class);
+
+		$this->service->validateAndConsume('notvalid', 'alice');
+	}
+
+	public function testValidateAndConsumeThrowsOnTwoParts(): void {
+		$this->expectException(InvalidOauthStateException::class);
+
+		$this->service->validateAndConsume('42.900', 'alice');
+	}
+
+	public function testValidateAndConsumeThrowsOnHmacMismatch(): void {
+		$this->time->method('getTime')->willReturn(1000);
+		$this->crypto->method('calculateHMAC')
+			->with('42.alice.900')
+			->willReturn('expected-hmac');
+
+		$this->expectException(InvalidOauthStateException::class);
+
+		$this->service->validateAndConsume('42.900.tampered-hmac', 'alice');
+	}
+
+	public function testValidateAndConsumeThrowsOnExpiredToken(): void {
+		$this->time->method('getTime')->willReturn(1700);
+		$this->crypto->method('calculateHMAC')
+			->with('42.alice.900')
+			->willReturn('validhmac');
+
+		$this->expectException(InvalidOauthStateException::class);
+
+		$this->service->validateAndConsume('42.900.' . bin2hex('validhmac'), 'alice');
+	}
+
+	public function testValidateAndConsumeThrowsOnUserMismatch(): void {
+		$this->time->method('getTime')->willReturn(1000);
+		$this->crypto->method('calculateHMAC')
+			->willReturnCallback(static fn (string $message): string => str_contains($message, 'alice') ? 'hmac-alice' : 'hmac-mallory');
+
+		$this->expectException(InvalidOauthStateException::class);
+
+		$this->service->validateAndConsume('42.900.' . bin2hex('hmac-alice'), 'mallory');
+	}
+}


### PR DESCRIPTION
Add a dedicated endpoint that produces an HMAC-signed state token binding the account ID and a timestamp to the current user session. The token expires after 10 minutes. Both Google and Microsoft OAuth flows use this token instead of constructing the state client-side.

Assisted-by: Claude:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
