### PR TITLE
fix: fixed "ORGANIZER" in ICS generated by "Reply with meeting" and delivered to DAV endpoint

### DIFF
--- a/src/components/EventModal.vue
+++ b/src/components/EventModal.vue
@@ -314,7 +314,7 @@ export default {
 						event.addProperty(new AttendeeProperty('ATTENDEE', `mailto:${att}`))
 					})
 
-					event.addProperty(new AttendeeProperty('ORGANIZER', organizerEmail))
+					event.addProperty(new AttendeeProperty('ORGANIZER', `mailto:${organizerEmail}`))
 				}
 
 				for (const vObject of calendar.getVObjectIterator()) {


### PR DESCRIPTION
Without a "mailto:" prefix in the ORGANIZER email property, the NextCloud server fails ([exactly here](https://github.com/nextcloud/3rdparty/blob/69b1534909f2abd81621d03e3660398743c38ae5/sabre/vobject/lib/ITip/Broker.php#L244)) to properly handle the ICS payload and generate invitations to attendees.

Fixes #12213