### PR TITLE
fix: whitespaces in visualization of plaintext email

### DIFF
--- a/src/components/MessagePlainTextBody.vue
+++ b/src/components/MessagePlainTextBody.vue
@@ -106,7 +106,7 @@ export default {
 </style>
 
 <style lang="scss" scoped>
-.message-container,
+#message-container,
 .mail-signature {
 	white-space: pre-wrap;
 }


### PR DESCRIPTION
The right CSS rule was already in place, but with the wrong CSS selector!

Fixes #10914 