### PR TITLE
fix(unified-inbox): don't discard every account's envelopes if one account fails

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -722,6 +722,12 @@ export default function mainStoreActions() {
 				const mailbox = this.getMailbox(mailboxId)
 
 				if (mailbox.isUnified) {
+					// One account's fetch rejecting must not discard every
+					// other account's already-successful envelopes. Promise.all()
+					// rejects as soon as any single promise rejects, so a single
+					// slow/unreachable account used to make the whole unified
+					// mailbox render nothing at all instead of everything except
+					// that one account. See #9072.
 					const fetchIndividualLists = pipe(
 						map((mb) => this.fetchEnvelopes({
 							mailboxId: mb.databaseId,
@@ -729,6 +735,9 @@ export default function mainStoreActions() {
 							addToUnifiedMailboxes: false,
 							sort: this.getPreference('sort-order'),
 							view: this.getPreference('layout-message-view'),
+						}).catch((error) => {
+							logger.error(`Failed to fetch envelopes for unified constituent mailbox ${mb.databaseId}: ${error}`, { error })
+							return []
 						})),
 						Promise.all.bind(Promise),
 						andThen(map(sliceToPage)),
@@ -825,12 +834,18 @@ export default function mainStoreActions() {
 						logger.debug('not enough local envelopes for the next unified page. ' + mbs.length + ' fetches required', {
 							mailboxes: mbs.map((mb) => mb.databaseId),
 						})
+						// Same reasoning as fetchEnvelopes() above: one account
+						// failing must not fail pagination for every other
+						// account sharing this unified mailbox.
 						return pipe(
 							map((mb) => this.fetchNextEnvelopes({
 								mailboxId: mb.databaseId,
 								query,
 								quantity,
 								addToUnifiedMailboxes: false,
+							}).catch((error) => {
+								logger.error(`Failed to fetch next envelopes for unified constituent mailbox ${mb.databaseId}: ${error}`, { error })
+								return []
 							})),
 							Promise.all.bind(Promise),
 							andThen(() => this.fetchNextEnvelopes({

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -197,6 +197,73 @@ describe('Vuex store actions', () => {
 		})
 	})
 
+	it('creates a unified page from the accounts that succeed even if another account fails', async () => {
+		const account13 = {
+			id: 13,
+			personalNamespace: '',
+			mailboxes: [],
+		}
+		const account14 = {
+			id: 14,
+			personalNamespace: '',
+			mailboxes: [],
+		}
+
+		store.addAccountMutation(account13)
+		store.addAccountMutation(account14)
+		store.addMailboxMutation({
+			account: account13,
+			mailbox: {
+				id: 'INBOX',
+				name: 'INBOX',
+				databaseId: 21,
+				accountId: 13,
+				specialRole: 'inbox',
+			},
+		})
+		store.addMailboxMutation({
+			account: account14,
+			mailbox: {
+				id: 'INBOX',
+				name: 'INBOX',
+				databaseId: 31,
+				accountId: 14,
+				specialRole: 'inbox',
+			},
+		})
+
+		store.addEnvelopesMutation = vi.fn()
+
+		MessageService.fetchEnvelopes.mockImplementation(async (accountId) => {
+			if (accountId === 14) {
+				throw new Error('account 14 is temporarily unavailable')
+			}
+
+			return [{
+				databaseId: 123,
+				mailboxId: 21,
+				uid: 321,
+				subject: 'msg1',
+			}]
+		})
+
+		const envelopes = await store.fetchEnvelopes({
+			mailboxId: UNIFIED_INBOX_ID,
+		})
+
+		// The unreachable account (14) contributes nothing, but the
+		// reachable one (13) still renders instead of the whole unified
+		// fetch coming back empty.
+		expect(envelopes).toEqual([
+			{
+				databaseId: 123,
+				mailboxId: 21,
+				uid: 321,
+				subject: 'msg1',
+			},
+		])
+	})
+
 	it('fetches the next individual page', async () => {
 		const msgs1 = reverse(range(30, 40))
 		const page1 = reverse(range(10, 30))


### PR DESCRIPTION
## Summary

`fetchEnvelopes()` and `fetchNextEnvelopes()` combine every constituent account's envelope fetch into the unified/priority inbox via `Promise.all()`, which rejects as soon as any single promise rejects. A single account that's temporarily unreachable (throttled provider, network hiccup, provisioned account with an unavailable server, etc.) was therefore enough to make the whole unified mailbox render nothing at all, discarding every other account's already-successful envelopes too.

This matches the failure shape described in #9072 ("Other section of unified inbox doesn't load for new accounts") — one account's IMAP server being unavailable breaking the combined view for every account.

## Fix

Catches each individual account's fetch before it reaches `Promise.all()`, so a failing account contributes an empty list instead of failing the whole batch. Same reasoning applied to the pagination path in `fetchNextEnvelopes()`.

## Test plan

- [x] Added a unit test with two accounts where one throws — confirms the working account's envelopes still render.
- [x] Verified the new test fails without the fix (reproduces the original bug) and passes with it.
- [x] `npx vitest --run src/tests/unit/store/actions.spec.js` — 24/24 passing.
- [x] `npx eslint src/store/mainStore/actions.js` — 0 errors (pre-existing unrelated jsdoc warnings only).

Fixes #9072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified inboxes now continue displaying available messages when fetching mail from one account fails.
  * Pagination can proceed using successful mailbox results even if another mailbox encounters an error.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->