### PR TITLE
fix(mailbox): auto-refresh the INBOX in the background like every other folder

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -587,8 +587,13 @@ export default {
 		},
 
 		async loadMailbox() {
-			// When the account is unified or inbox, return nothing, else sync the mailbox
-			if (this.account.isUnified || this.mailbox.specialRole === 'inbox') {
+			// Unified mailboxes combine multiple real mailboxes and don't map
+			// to the single-folder sync this method calls, so they're still
+			// skipped here. The INBOX itself has no such reason to be
+			// skipped: every other folder gets this periodic background
+			// refresh, but the INBOX previously only ever synced once, on
+			// mount, and never again for as long as the view stayed open.
+			if (this.account.isUnified) {
 				return
 			}
 			try {


### PR DESCRIPTION
## Summary

`loadMailbox()` runs on a 60s interval (`setInterval(this.loadMailbox, 60000)` in `mounted()`) to keep the currently open folder up to date in the background. It explicitly returned early for the INBOX (in addition to unified mailboxes):

```js
if (this.account.isUnified || this.mailbox.specialRole === 'inbox') {
    return
}
```

So unlike every other folder, the INBOX only ever synced once, when the view was first mounted, and never again for as long as it stayed open. In practice: a new message's unread-count badge updates (via a separate, lighter-weight path), but the open INBOX message list itself never picks it up without a manual full page reload.

I checked `git blame`/history on this line — it goes back to the feature's original introduction in 2020 (`9ed84f8ac`) with no explanation in the commit message for excluding the INBOX specifically, and I couldn't find any other mechanism in the codebase (searched for other `setInterval` usage and any INBOX-specific refresh path) that covers refreshing it instead. If there's a reason I'm missing for the original exclusion, happy to adjust.

## Fix

Drops the INBOX-specific half of the condition. Kept the `isUnified` skip as-is — a unified mailbox combines multiple real mailboxes and doesn't map to the single-folder `sync()` call this method makes.

## Test plan

- [x] `npx eslint src/components/Mailbox.vue` — clean, no errors or warnings.
- [x] No existing component-level test file for `Mailbox.vue` to extend; verified manually against a real instance with a large, occasionally slow-to-sync IMAP account — INBOX now picks up new mail within the 60s interval without a manual reload, matching every other folder's existing behavior.