### PR TITLE
[WIP] perf: make mailbox prefetch selection more selective

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -362,18 +362,16 @@ export default {
 
 			const selectedIds = new Set(alwaysVisibleMailboxes.map((mailbox) => mailbox.databaseId))
 
-			const topLevelMailboxes = this.sortMailboxesByDisplayName(
-				subscribedMailboxes
-					.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
-					.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
-					.filter((mailbox) => this.isTopLevelMailbox(mailbox))
+			const topLevelMailboxes = this.sortMailboxesByDisplayName(subscribedMailboxes
+				.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
+				.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
+				.filter((mailbox) => this.isTopLevelMailbox(mailbox))
 			)
 
-			const remainingMailboxes = this.sortMailboxesByDisplayName(
-				subscribedMailboxes
-					.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
-					.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
-					.filter((mailbox) => !this.isTopLevelMailbox(mailbox))
+			const remainingMailboxes = this.sortMailboxesByDisplayName(subscribedMailboxes
+				.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
+				.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
+				.filter((mailbox) => !this.isTopLevelMailbox(mailbox))
 			)
 
 			const result = [...alwaysVisibleMailboxes]

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -67,6 +67,10 @@ import useMainStore from '../store/mainStore.js'
 import { mailboxHasRights } from '../util/acl.js'
 import { wait } from '../util/wait.js'
 
+const ALWAYS_VISIBLE_SPECIAL_ROLES = ['draft', 'sent', 'trash']
+const MAX_PREFETCH_MAILBOXES = 5
+const MAX_ALWAYS_VISIBLE_PREFETCH = 3
+
 export default {
 	name: 'Mailbox',
 	components: {
@@ -319,16 +323,81 @@ export default {
 			}
 		},
 
+		isAlwaysVisiblePrefetchCandidate(mailbox) {
+			return ALWAYS_VISIBLE_SPECIAL_ROLES.includes(mailbox.specialRole)
+		},
+
+		isTopLevelMailbox(mailbox) {
+			return mailbox.path === '' || mailbox.path === this.account.personalNamespace
+		},
+
+		getMailboxDisplayName(mailbox) {
+			return mailbox.displayName ?? mailbox.name ?? ''
+		},
+
+		sortMailboxesByDisplayName(mailboxes) {
+			return [...mailboxes].sort((a, b) => {
+				return this.getMailboxDisplayName(a).localeCompare(this.getMailboxDisplayName(b))
+			})
+		},
+
+		getMailboxesToPrefetch() {
+			const subscribedMailboxes = [...this.mainStore.getRecursiveMailboxIterator(this.account.id)]
+				.filter((mailbox) => mailbox.databaseId !== this.mailbox.databaseId)
+				.filter((mailbox) => mailbox.isSubscribed)
+
+			const alwaysVisibleMailboxes = subscribedMailboxes
+				.filter((mailbox) => this.isAlwaysVisiblePrefetchCandidate(mailbox))
+				.sort((a, b) => {
+					const aIndex = ALWAYS_VISIBLE_SPECIAL_ROLES.indexOf(a.specialRole)
+					const bIndex = ALWAYS_VISIBLE_SPECIAL_ROLES.indexOf(b.specialRole)
+
+					if (aIndex !== bIndex) {
+						return aIndex - bIndex
+					}
+
+					return this.getMailboxDisplayName(a).localeCompare(this.getMailboxDisplayName(b))
+				})
+				.slice(0, MAX_ALWAYS_VISIBLE_PREFETCH)
+
+			const selectedIds = new Set(alwaysVisibleMailboxes.map((mailbox) => mailbox.databaseId))
+
+			const topLevelMailboxes = this.sortMailboxesByDisplayName(
+				subscribedMailboxes
+					.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
+					.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
+					.filter((mailbox) => this.isTopLevelMailbox(mailbox))
+			)
+
+			const remainingMailboxes = this.sortMailboxesByDisplayName(
+				subscribedMailboxes
+					.filter((mailbox) => !selectedIds.has(mailbox.databaseId))
+					.filter((mailbox) => !this.isAlwaysVisiblePrefetchCandidate(mailbox))
+					.filter((mailbox) => !this.isTopLevelMailbox(mailbox))
+			)
+
+			const result = [...alwaysVisibleMailboxes]
+
+			for (const mailbox of topLevelMailboxes) {
+				if (result.length >= MAX_PREFETCH_MAILBOXES) {
+					break
+				}
+				result.push(mailbox)
+				selectedIds.add(mailbox.databaseId)
+			}
+
+			for (const mailbox of remainingMailboxes) {
+				if (result.length >= MAX_PREFETCH_MAILBOXES) {
+					break
+				}
+				result.push(mailbox)
+			}
+
+			return result
+		},
+
 		async prefetchOtherMailboxes() {
-			for (const mailbox of this.mainStore.getRecursiveMailboxIterator(this.account.id)) {
-				if (mailbox.databaseId === this.mailbox.databaseId) {
-					continue
-				}
-
-				if (!mailbox.isSubscribed) {
-					continue
-				}
-
+			for (const mailbox of this.getMailboxesToPrefetch()) {
 				try {
 					const envelopes = await this.mainStore.fetchEnvelopes({
 						mailboxId: mailbox.databaseId,


### PR DESCRIPTION
Identified this while using AI to poke around for relatively low-risk, high return performance opportunities.

This adjusts mailbox prefetching to be more selective.

I'm not convinced yet this is the right approach or beneficial enough. Experimenting...

Today we prefetch the first page for every subscribed mailbox in the current account. That improves perceived folder switching, but it also creates speculative work for folders the user may never open in the session. This changeset keeps the existing prefetch mechanism, including the HTTP cache behavior added in #11293, but narrows the candidate set toward more prominent/likely-next folders.

The main goal is to reduce startup/background work while preserving most of the “open folder instantly” benefit from #10986.

This is intentionally experimental. The selection heuristic and cap are meant as a first pass, not a final tuning. If the trade-off looks wrong in practice, we can adjust the candidate ranking, the cap, or revert to broader prefetching.

Notes:
- keeps prefetching enabled
- keeps cache-buster based HTTP caching intact
- changes only which folders are chosen for speculative prefetch

What to validate:
- perceived responsiveness when opening Mail
- whether common next folder opens still feel instant
- whether users with many subscribed folders see less unnecessary startup work

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
