### PR TITLE
fix(page): use cached mailboxes for the initial bootstrap

### DIFF
--- a/lib/Contracts/IMailManager.php
+++ b/lib/Contracts/IMailManager.php
@@ -45,6 +45,19 @@ interface IMailManager {
 	public function getMailboxes(Account $account, bool $forceSync = false): array;
 
 	/**
+	 * Like getMailboxes(), but reads only the locally cached mailbox list --
+	 * no live IMAP sync. Useful for callers that need to list an account's
+	 * mailboxes quickly and don't need (or can't afford to wait for) an
+	 * up-to-date view, e.g. a page bootstrap iterating over every connected
+	 * account.
+	 *
+	 * @param Account $account
+	 *
+	 * @return Mailbox[]
+	 */
+	public function getCachedMailboxes(Account $account): array;
+
+	/**
 	 * @param Account $account
 	 * @param string $name
 	 * @param string[] $specialUse

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -139,6 +139,13 @@ class PageController extends Controller {
 			$this->appManager->getAppVersion('mail'),
 		);
 
+		// Uses getCachedMailboxes() (DB read only) rather than getMailboxes()
+		// (which does a live IMAP sync first): this loop is synchronous
+		// across every connected account, so one account with a slow or
+		// unreachable IMAP server used to delay/block the whole page load
+		// for every other account too. The existing try/catch below only
+		// ever helped if the call threw quickly -- it did nothing for a
+		// hang, since a hang never reaches the catch block at all.
 		$mailAccounts = $this->accountService->findByUserId($this->userId);
 		$accountsJson = [];
 		foreach ($mailAccounts as $mailAccount) {
@@ -147,7 +154,7 @@ class PageController extends Controller {
 			$json['aliases'] = $this->aliasesService->findAll($mailAccount->getId(),
 				$this->userId);
 			try {
-				$mailboxes = $this->mailManager->getMailboxes($mailAccount);
+				$mailboxes = $this->mailManager->getCachedMailboxes($mailAccount);
 				$json['mailboxes'] = $mailboxes;
 			} catch (Throwable $ex) {
 				$this->logger->critical('Could not load account mailboxes: ' . $ex->getMessage(), [
@@ -166,7 +173,7 @@ class PageController extends Controller {
 			$json['aliases'] = $this->aliasesService->findAll($delegatedAccount->getId(),
 				$delegatedAccount->getUserId());
 			try {
-				$mailboxes = $this->mailManager->getMailboxes($delegatedAccount);
+				$mailboxes = $this->mailManager->getCachedMailboxes($delegatedAccount);
 				$json['mailboxes'] = $mailboxes;
 			} catch (Throwable $ex) {
 				$this->logger->critical('Could not load delegated account mailboxes: ' . $ex->getMessage(), [

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -102,6 +102,11 @@ class MailManager implements IMailManager {
 	}
 
 	#[\Override]
+	public function getCachedMailboxes(Account $account): array {
+		return $this->mailboxMapper->findAll($account);
+	}
+
+	#[\Override]
 	public function createMailbox(Account $account, string $name, array $specialUse = []): Mailbox {
 		$client = $this->imapClientFactory->getClient($account);
 		try {

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -210,7 +210,7 @@ class PageControllerTest extends TestCase {
 			->with($this->userId)
 			->willReturn([]);
 		$this->mailManager->expects($this->exactly(2))
-			->method('getMailboxes')
+			->method('getCachedMailboxes')
 			->withConsecutive(
 				[$account1],
 				[$account2]

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -126,6 +126,25 @@ class MailManagerTest extends TestCase {
 		$this->assertSame($mailboxes, $result);
 	}
 
+	public function testGetCachedMailboxesDoesNotSync() {
+		/** @var Account|MockObject $account */
+		$account = $this->createStub(Account::class);
+		$mailboxes = [
+			$this->createMock(Mailbox::class),
+			$this->createMock(Mailbox::class),
+		];
+		$this->mailboxSync->expects($this->never())
+			->method('sync');
+		$this->mailboxMapper->expects($this->once())
+			->method('findAll')
+			->with($this->equalTo($account))
+			->willReturn($mailboxes);
+
+		$result = $this->manager->getCachedMailboxes($account);
+
+		$this->assertSame($mailboxes, $result);
+	}
+
 	public function testCreateFolder() {
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);
 		$account = $this->createStub(Account::class);


### PR DESCRIPTION
## Summary

`PageController::index()` loops over every connected account synchronously in a single request to build the initial page bootstrap state, calling `getMailboxes()` for each one:

```php
foreach ($mailAccounts as $mailAccount) {
    try {
        $mailboxes = $this->mailManager->getMailboxes($mailAccount); // does a live IMAP sync
        $json['mailboxes'] = $mailboxes;
    } catch (Throwable $ex) {
        $json['mailboxes'] = [];
        $json['error'] = true; // never reached on a hang, only on a thrown exception
    }
}
```

`getMailboxes()` calls `mailboxSync->sync()` first (a live IMAP touch) before reading the cached list. One account with a slow-to-respond or temporarily unreachable IMAP server was therefore enough to delay/block the bootstrap for **every** other account too, since this loop is synchronous. The existing `try`/`catch` only helps if the call throws quickly — it does nothing for a hang, since the loop never reaches the `catch` until the call actually returns or errors.

## Fix

Adds `getCachedMailboxes()` to `IMailManager`/`MailManager` — a DB-only read with no live IMAP touch — and switches both account loops in `PageController::index()` (regular and delegated accounts) to use it. The bootstrap's speed is now fully decoupled from any account's live IMAP health. Periodic background sync jobs and opening an account's own mailbox view still do the live sync work and keep things up to date; the bootstrap just no longer needs to wait on it.

## Test plan

- [x] Updated the existing `PageControllerTest::testIndex()` mock expectation from `getMailboxes` to `getCachedMailboxes`.
- [x] Added `MailManagerTest::testGetCachedMailboxesDoesNotSync()` confirming the new method never calls `MailboxSync::sync()`.
- [x] `php -l` clean on all changed files. I don't have a local PHP/Composer/PHPUnit environment to run the full suite in this session — happy to iterate if CI surfaces anything.
- [x] Ran this exact change against a live production instance for several hours (an account with an intermittently unresponsive IMAP provider) — the bootstrap loads instantly regardless of that account's live IMAP state, matching the intended behavior.