### PR TITLE
fix(ui): restore message loading position and slow hint

### DIFF
--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -11,9 +11,11 @@
 			<template #icon>
 				<IconLoading />
 			</template>
-			<transition name="fade">
-				<em v-if="slowHint && slow">{{ slowHint }}</em>
-			</transition>
+			<template #description>
+				<transition name="fade">
+					<em v-if="slowHint && slow">{{ slowHint }}</em>
+				</transition>
+			</template>
 		</EmptyContent>
 		<IconLoading v-else class="container" />
 	</div>
@@ -85,6 +87,6 @@ export default {
 	flex-direction: column;
 	flex: 1 auto;
 	align-items: center;
-	height: 100vh;
+	height: 100%;
 }
 </style>

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -4,7 +4,8 @@
 -->
 
 <template>
-	<div :class="{ 'empty-content': (!hasMessages && !loadingEnvelopes) || error }">
+	<div class="mailbox"
+		:class="{ 'empty-content': (!hasMessages && !loadingEnvelopes) || error }">
 		<Error
 			v-if="error"
 			:error="t('mail', 'Could not open folder')"
@@ -625,6 +626,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.mailbox {
+	height: 100%;
+}
+
 // Fix vertical space between sections in priority inbox
 .nameimportant {
 	:deep(#load-more-mail-messages) {


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/337f64ef-3e41-460e-9185-ea6fc4c3b161

## After, with fixed position

https://github.com/user-attachments/assets/cea69113-3c27-4509-8f72-a3ff0b16afd1

I was skeptical if this could break the *scroll to load more* feature but it still works :relieved: 

## After, with slow hint

https://github.com/user-attachments/assets/aabd4895-b9cd-464f-ae57-c264515a602f

## How to test

For me it was easiest to force drop the local cache entries for my testing account, then reload the page and navigate to another mailbox:

```sql
DELETE FROM oc_mail_messages m
WHERE mailbox_id IN (SELECT id FROM oc_mail_mailboxes WHERE account_id = <id>);
UPDATE oc_mail_mailboxes SET sync_new_lock = null, sync_new_token = null, sync_changed_lock = null, sync_changed_token = null, sync_vanished_lock = null, sync_vanished_token = null
WHERE account_id = <id>;
```

Note: there is a bug that the loading never stops. That's why I started looking into this. Mandatory reference for this situation: https://www.youtube.com/watch?v=AbSehcT19u0.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI