### PR TITLE
fix: unify mail printing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "node-forge": "^1.4.0",
         "p-limit": "^7.3.0",
         "pinia": "^2.3.1",
-        "printscout": "2.0.3",
         "process": "^0.11.10",
         "ramda": "^0.32.0",
         "raw-loader": "^4.0.2",
@@ -14327,11 +14326,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/printscout": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/printscout/-/printscout-2.0.3.tgz",
-      "integrity": "sha512-tn48Vp/Rdyq0oobGmvtX44ZOOCm36Ec7e1LQQUGAr+1caG/pLomAykg+OL4JmK+FJNnN0rZMY6ZNES+8IztIow=="
     },
     "node_modules/process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "node-forge": "^1.4.0",
     "p-limit": "^7.3.0",
     "pinia": "^2.3.1",
-    "printscout": "2.0.3",
     "process": "^0.11.10",
     "ramda": "^0.32.0",
     "raw-loader": "^4.0.2",

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -4,7 +4,8 @@
 -->
 
 <template>
-	<div class="mailbox"
+	<div
+		class="mailbox"
 		:class="{ 'empty-content': (!hasMessages && !loadingEnvelopes) || error }">
 		<Error
 			v-if="error"

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -35,6 +35,7 @@
 			:message="message"
 			:full-height="fullHeight"
 			@load="$emit('load', $event)"
+			@print-shortcut="$emit('print-shortcut')"
 			@translate="$emit('translate')" />
 		<MessageEncryptedBody
 			v-else-if="isEncrypted || isPgpMimeEncrypted"

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -52,7 +52,6 @@
 import iframeResize from '@iframe-resizer/parent'
 import { loadState } from '@nextcloud/initial-state'
 import { NcActionButton as ActionButton, NcActions as Actions } from '@nextcloud/vue'
-import PrintScout from 'printscout'
 import IconDomain from 'vue-material-design-icons/Domain.vue'
 import IconMail from 'vue-material-design-icons/EmailOutline.vue'
 import IconImage from 'vue-material-design-icons/ImageSizeSelectActual.vue'
@@ -61,8 +60,7 @@ import NeedsTranslationInfo from './NeedsTranslationInfo.vue'
 import logger from '../logger.js'
 import { needsTranslation } from '../service/AiIntergrationsService.js'
 import { trustSender } from '../service/TrustedSenderService.js'
-
-const scout = new PrintScout()
+import { isPrintShortcut } from '../util/printMessage.ts'
 
 export default {
 	name: 'MessageHTMLBody',
@@ -100,7 +98,6 @@ export default {
 			isSenderTrusted: this.message.isSenderTrusted,
 			needsTranslation: false,
 			enabledFreePrompt: loadState('mail', 'llm_freeprompt_available', false),
-			printOriginalHeight: null,
 		}
 	},
 
@@ -112,11 +109,6 @@ export default {
 		domain() {
 			return this.sender?.split('@').pop()
 		},
-	},
-
-	beforeMount() {
-		scout.on('beforeprint', this.onBeforePrint)
-		scout.on('afterprint', this.onAfterPrint)
 	},
 
 	async mounted() {
@@ -132,19 +124,30 @@ export default {
 	},
 
 	beforeDestroy() {
-		scout.off('beforeprint', this.onBeforePrint)
-		scout.off('afterprint', this.onAfterPrint)
-		this.$refs.iframe.iFrameResizer.close()
+		// The frame's document goes away with the frame, so this is housekeeping
+		// rather than a fix for a leak. It is done because the listener is added
+		// to a document this component does not own: nothing guarantees the frame
+		// is torn down right away, and until it is, a keydown in it would still
+		// reach a destroyed component.
+		this.getIframeDoc()?.removeEventListener('keydown', this.onFrameKeyDown)
+		this.$refs.iframe?.iFrameResizer?.close()
 	},
 
 	methods: {
 		getIframeDoc() {
 			const iframe = this.$refs.iframe
-			return iframe.contentDocument || iframe.contentWindow.document
+			return iframe?.contentDocument ?? iframe?.contentWindow?.document ?? null
 		},
 
 		onMessageFrameLoad() {
 			const iframeDoc = this.getIframeDoc()
+
+			// A frame has a window of its own, and a keydown is delivered to the
+			// window of whatever is focused. So while the reader has the message
+			// focused, the app's own window listener never sees the print
+			// shortcut and the browser would take it instead.
+			iframeDoc.addEventListener('keydown', this.onFrameKeyDown)
+
 			this.hasBlockedContent
 				= iframeDoc.querySelectorAll('[data-original-src]').length > 0
 					|| iframeDoc.querySelectorAll('[data-original-style]').length > 0
@@ -156,17 +159,17 @@ export default {
 			}
 		},
 
-		onBeforePrint() {
-			const iframe = this.$refs.iframe
-			this.printOriginalHeight = iframe.style.height
-			iframe.style.setProperty('height', `${this.getIframeDoc().body.scrollHeight}px`, 'important')
-		},
-
-		onAfterPrint() {
-			if (this.printOriginalHeight !== null) {
-				this.$refs.iframe.style.height = this.printOriginalHeight
-				this.printOriginalHeight = null
+		/**
+		 * Hand the print shortcut to the app, from inside the message frame.
+		 *
+		 * @param {KeyboardEvent} event the frame's keydown event
+		 */
+		onFrameKeyDown(event) {
+			if (!isPrintShortcut(event)) {
+				return
 			}
+			event.preventDefault()
+			this.$emit('print-shortcut')
 		},
 
 		displayIframe() {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -21,6 +21,7 @@
 			<ThreadSummary v-if="showSummaryBox" :loading="summaryLoading" :summary="summaryText" />
 			<ThreadEnvelope
 				v-for="(env, index) in thread"
+				ref="envelopeRefs"
 				:key="env.databaseId"
 				:envelope="env"
 				:mailbox-id="$route.params.mailboxId"
@@ -29,8 +30,8 @@
 				:full-height="thread.length === 1"
 				:thread-index="index"
 				@delete="$emit('delete', env.databaseId)"
-				@loaded="addLoadedThread"
 				@move="onMove(env.databaseId)"
+				@print-shortcut="printThread"
 				@toggle-expand="toggleExpand(env.databaseId)"
 				@print="print" />
 		</template>
@@ -50,7 +51,33 @@ import logger from '../logger.js'
 import { summarizeThread } from '../service/AiIntergrationsService.js'
 import useMainStore from '../store/mainStore.js'
 import { getRandomMessageErrorMessage } from '../util/ErrorMessageFactory.js'
-import { formatDateTimeFromUnix } from '../util/formatDateTime.js'
+import {
+	BROWSER_PRINT_NOTICE_ID,
+	buildBrowserPrintNotice,
+	buildMessageHeader,
+	isPrintShortcut,
+	PRINT_CONTENT_HEIGHT,
+	PRINT_DOCUMENT_STYLE,
+	PRINT_FRAME_ID,
+	PRINT_STAGING_STYLE,
+	renderHtmlMessage,
+	renderPlainTextMessage,
+	waitForImages,
+} from '../util/printMessage.ts'
+import { wait } from '../util/wait.js'
+
+/**
+ * How long Ctrl/Cmd+P waits for the messages it expanded to render before it
+ * prints the ones that did.
+ */
+const THREAD_RENDER_TIMEOUT = 30000
+const THREAD_RENDER_POLL_INTERVAL = 100
+
+/**
+ * How long a print rendering is kept around in case the browser emits no
+ * `afterprint`. Long enough not to interrupt a print dialog that is still open.
+ */
+const PRINT_CLEANUP_TIMEOUT = 60000
 
 export default {
 	name: 'Thread',
@@ -73,7 +100,7 @@ export default {
 			enabledThreadSummary: loadState('mail', 'llm_summaries_available', false),
 			summaryText: '',
 			summaryError: false,
-			loadedThreads: 0,
+			isolatedPrint: false,
 		}
 	},
 
@@ -135,22 +162,21 @@ export default {
 			return thread[0].subject || this.t('mail', 'No subject')
 		},
 
-		threadParticipants() {
-			const seen = new Set()
-			return this.thread.flatMap((envelope) => [
-				...(envelope.from ?? []),
-				...(envelope.to ?? []),
-			]).filter(({ email }) => {
-				if (seen.has(email)) {
-					return false
-				}
-				seen.add(email)
-				return true
-			})
-		},
-
 		showSummaryBox() {
 			return this.thread.length > 2 && this.enabledThreadSummary && !this.summaryError
+		},
+
+		/**
+		 * Thread indices of the currently expanded messages, in thread order.
+		 * Those are the messages that are rendered, and therefore the ones that
+		 * can be printed.
+		 *
+		 * @return {number[]}
+		 */
+		expandedIndices() {
+			return this.thread.flatMap((envelope, index) => (
+				this.expandedThreads.includes(envelope.databaseId) ? [index] : []
+			))
 		},
 	},
 
@@ -175,8 +201,20 @@ export default {
 		window.addEventListener('keydown', this.handleKeyDown)
 	},
 
+	mounted() {
+		// A print started from the browser itself (its menu, or right-click →
+		// Print) cannot be served, see `buildBrowserPrintNotice`. The notice that
+		// says so is put up once and shown for print media only, rather than
+		// staged from a `beforeprint` handler, so that it is also there for a
+		// print the browser announces late or not at all.
+		if (!document.getElementById(BROWSER_PRINT_NOTICE_ID)) {
+			document.body.appendChild(buildBrowserPrintNotice(document))
+		}
+	},
+
 	beforeDestroy() {
 		window.removeEventListener('keydown', this.handleKeyDown)
+		document.getElementById(BROWSER_PRINT_NOTICE_ID)?.remove()
 	},
 
 	methods: {
@@ -232,7 +270,6 @@ export default {
 				await this.fetchThread()
 			}
 			this.updateSummary()
-			this.loadedThreads = 0
 		},
 
 		async fetchThread() {
@@ -277,224 +314,217 @@ export default {
 			}
 		},
 
+		/**
+		 * Take the print shortcut while the app itself has the focus. A message
+		 * has a window of its own and its keydowns never reach here, so
+		 * `MessageHTMLBody` listens in its frame and emits `print-shortcut`
+		 * instead — both end up in `printThread`.
+		 *
+		 * @param {KeyboardEvent} event the app window's keydown event
+		 */
 		async handleKeyDown(event) {
-			if ((event.ctrlKey || event.metaKey) && event.key === 'p') {
-				event.preventDefault()
+			if (!isPrintShortcut(event)) {
+				return
+			}
+			event.preventDefault()
 
-				try {
-					this.thread.forEach((thread) => {
-						if (!this.expandedThreads.includes(thread.databaseId)) {
-							this.expandedThreads.push(thread.databaseId)
-						}
-					})
+			await this.printThread()
+		},
 
-					while (true) {
-						if (this.loadedThreads === this.thread.length) {
-							break
-						}
-						await new Promise((resolve) => setTimeout(resolve, 100))
-					}
+		/**
+		 * Print every message of the thread, expanding the ones that are still
+		 * collapsed so that there is something to print of them.
+		 *
+		 * @return {Promise<void>}
+		 */
+		async printThread() {
+			// Asking again while the previous print is still being prepared, or
+			// while its dialog is still open, would stage the thread a second time
+			// and expand it all over again.
+			if (this.isolatedPrint) {
+				return
+			}
 
-					const virtualIframe = document.createElement('iframe')
-					virtualIframe.style.position = 'absolute'
-					document.body.appendChild(virtualIframe)
-					const virtualIframeDocument = virtualIframe.contentDocument || virtualIframe.contentWindow.document
-					virtualIframeDocument.open()
-					virtualIframeDocument.write(`<html><head><title>${t('mail', 'Print')}</title></head><body></body></html>`)
-					virtualIframeDocument.close()
-
-					virtualIframeDocument.body.appendChild(this.addThreadInfo(virtualIframeDocument))
-
-					const messageContainers = document.querySelectorAll('#message-container')
-					for (const [index, messageContainer] of messageContainers.entries()) {
-						const iframe = messageContainer.querySelector('iframe')
-
-						this.addMessageInfo(virtualIframeDocument, index)
-
-						if (!iframe) {
-							const div = virtualIframeDocument.createElement('div')
-							div.innerHTML = messageContainer.innerHTML
-							virtualIframeDocument.body.appendChild(div)
-							continue
-						}
-
-						if (iframe.contentWindow.document.readyState !== 'complete') {
-							await new Promise((resolve) => {
-								iframe.contentWindow.onload = resolve
-							})
-						}
-
-						const iframeDocument = iframe.contentDocument || iframe.contentWindow.document
-						const iframeContent = iframeDocument.body.innerHTML
-						const div = virtualIframeDocument.createElement('div')
-
-						div.innerHTML = iframeContent
-						virtualIframeDocument.body.appendChild(div)
-					}
-
-					const images = virtualIframeDocument.querySelectorAll('img')
-					let imagesLoaded = 0
-
-					images.forEach((img) => {
-						img.addEventListener('load', () => {
-							imagesLoaded++
-							if (imagesLoaded === images.length) {
-								virtualIframe.contentWindow.print()
-								this.removeIframe(virtualIframe)
-							}
-						})
-						img.addEventListener('error', () => {
-							imagesLoaded++
-							if (imagesLoaded === images.length) {
-								virtualIframe.contentWindow.print()
-								this.removeIframe(virtualIframe)
-							}
-						})
-					})
-
-					if (images.length === 0) {
-						virtualIframe.contentWindow.print()
-						this.removeIframe(virtualIframe)
-					}
-				} catch (error) {
-					logger.error('Could not print message', { error })
-					showError(t('mail', 'Could not print message'))
+			this.thread.forEach((envelope) => {
+				if (!this.expandedThreads.includes(envelope.databaseId)) {
+					this.expandedThreads.push(envelope.databaseId)
 				}
+			})
+
+			// Expanding a message loads it from the backend, and only a rendered
+			// message can be printed. Give up eventually so that one message
+			// failing to load doesn't hold the print back for good.
+			const deadline = Date.now() + THREAD_RENDER_TIMEOUT
+			while (!this.threadPrintable() && Date.now() < deadline) {
+				await wait(THREAD_RENDER_POLL_INTERVAL)
+			}
+
+			await this.printMessages(this.expandedIndices)
+		},
+
+		/**
+		 * Whether every message of the thread is rendered and can be printed.
+		 *
+		 * The messages are asked themselves rather than counted as they report
+		 * being loaded: a message emits `loaded` whenever its loading state
+		 * settles, which is neither once per message nor once per thread.
+		 *
+		 * @return {boolean}
+		 */
+		threadPrintable() {
+			const envelopes = this.$refs.envelopeRefs
+			return envelopes?.length === this.thread.length
+				&& envelopes.every((component) => component.printable)
+		},
+
+		async print(threadIndex) {
+			await this.printMessages([threadIndex])
+		},
+
+		/**
+		 * Print the given thread messages by rendering them into a dedicated,
+		 * hidden iframe and printing that iframe's own document.
+		 *
+		 * This is deliberately isolated from the main document: the app layout is
+		 * never mutated, so nothing needs to be reloaded afterwards, and the
+		 * messages are printed as a standalone page instead of inside the
+		 * surrounding UI. The frame is only a container for that document — what
+		 * the browser prints and paginates is the document itself, so the print
+		 * still follows the paper size and orientation of the print dialog.
+		 *
+		 * @param {number[]} indices thread indices to print, in order
+		 * @return {Promise<void>}
+		 */
+		async printMessages(indices) {
+			// Set for as long as a print of our own is being prepared or is
+			// waiting on its dialog, so that a second print does not stage the
+			// thread once more on top of the first.
+			if (this.isolatedPrint) {
+				return
+			}
+			this.isolatedPrint = true
+
+			const frame = document.createElement('iframe')
+			frame.id = PRINT_FRAME_ID
+			// The frame is parked off-screen rather than hidden, see
+			// `PRINT_STAGING_STYLE`, so it stays in the accessibility tree and
+			// would be announced without this.
+			frame.setAttribute('aria-hidden', 'true')
+			// The messages are copied in from the sanitized message frames, but
+			// unlike those this frame is not protected by the backend's
+			// Content-Security-Policy. The sandbox stands in for it: without
+			// `allow-scripts` no script or inline event handler in the content can
+			// run. The two capabilities that are granted are the ones this frame
+			// needs — `allow-same-origin` to let us populate it, `allow-modals` to
+			// let it open the print dialog.
+			frame.setAttribute('sandbox', 'allow-same-origin allow-modals')
+			frame.style.cssText = `${PRINT_STAGING_STYLE} height: ${PRINT_CONTENT_HEIGHT}; border: 0;`
+			document.body.appendChild(frame)
+
+			let cleanupTimeout = null
+			let cleanedUp = false
+			const cleanup = () => {
+				if (cleanedUp) {
+					return
+				}
+				cleanedUp = true
+				clearTimeout(cleanupTimeout)
+				this.isolatedPrint = false
+				frame.remove()
+			}
+
+			try {
+				const doc = frame.contentDocument
+				doc.open()
+				doc.write('<!DOCTYPE html><html><head><meta charset="utf-8"></head><body></body></html>')
+				doc.close()
+				doc.title = this.threadSubject
+
+				const style = doc.createElement('style')
+				style.textContent = PRINT_DOCUMENT_STYLE
+				doc.head.appendChild(style)
+
+				indices.forEach((index) => this.appendPrintMessage(doc.body, index))
+
+				if (!await waitForImages(doc)) {
+					logger.warn('Printing without the images that did not load in time')
+				}
+
+				frame.contentWindow.addEventListener('afterprint', cleanup, { once: true })
+				// A backstop for a browser that never delivers `afterprint`, armed
+				// only now: it must not be able to take the frame away while the
+				// print is still being prepared. Long enough not to interrupt a
+				// print dialog that is still open.
+				cleanupTimeout = setTimeout(cleanup, PRINT_CLEANUP_TIMEOUT)
+
+				// Firefox prints whatever window has the focus, and would print the
+				// app around the frame without this.
+				frame.contentWindow.focus()
+				// Blocking in every browser that matters, but `afterprint` is what
+				// the cleanup waits for: the spec allows `print()` to return before
+				// the dialog is dismissed, and removing the frame while its
+				// document is still being printed empties the print.
+				frame.contentWindow.print()
+			} catch (error) {
+				cleanup()
+				logger.error('Could not print message', { error })
+				showError(t('mail', 'Could not print message'))
 			}
 		},
 
-		removeIframe(virtualIframe) {
-			setTimeout(() => {
-				document.body.removeChild(virtualIframe)
-			}, 500)
-		},
+		/**
+		 * Append the printable rendering of one thread message to `parent`: its
+		 * print header followed by the message body as it is currently rendered.
+		 *
+		 * The body goes into a shadow root of its own, so that the messages of a
+		 * thread cannot restyle one another while all of them still share — and
+		 * paginate over — the pages of one print document. The header stays
+		 * outside of it, out of reach of the message's own CSS.
+		 *
+		 * `parent` always belongs to the sandboxed print frame's document: the
+		 * email markup is never copied into the app's own document.
+		 *
+		 * @param {HTMLElement} parent element to append the message to
+		 * @param {number} index thread index of the message to append
+		 */
+		appendPrintMessage(parent, index) {
+			const envelope = this.thread[index]
+			// Looked up by envelope rather than by index: a `ref` in a `v-for`
+			// collects the components as they render, in an order Vue does not
+			// promise to be the one of the source array.
+			const envelopeComponent = this.$refs.envelopeRefs?.find((component) => component.envelope?.databaseId === envelope?.databaseId)
+			if (!envelope || !envelopeComponent) {
+				return
+			}
 
-		addMessageInfo(virtualIframeDocument, index) {
-			const hr = virtualIframeDocument.createElement('hr')
-			hr.style.border = '1px solid black'
+			const doc = parent.ownerDocument
+			const messageEl = envelopeComponent.$el
+			const message = doc.createElement('div')
+			message.className = 'print-message'
+			message.appendChild(buildMessageHeader(doc, envelope))
+			parent.appendChild(message)
 
-			const subjectSpan = virtualIframeDocument.createElement('p')
-			subjectSpan.style.fontWeight = 'bold'
-			subjectSpan.textContent = t('mail', 'Subject') + ': ' + this.thread[index].subject
+			const iframe = messageEl.querySelector('iframe')
+			if (iframe?.contentDocument) {
+				renderHtmlMessage(message, iframe.contentDocument)
+				return
+			}
+			if (iframe) {
+				// Mailvelope renders a decrypted PGP message into a frame of
+				// its own, served from the extension. That document belongs to
+				// another origin and cannot be read, let alone copied, so such
+				// a message prints as its header alone rather than taking the
+				// print of the whole thread down with it.
+				logger.warn('Message body is in a frame of another origin and cannot be printed', {
+					databaseId: envelope.databaseId,
+				})
+				return
+			}
 
-			const senderSpan = virtualIframeDocument.createElement('p')
-			senderSpan.style.fontWeight = 'bold'
-			senderSpan.textContent = t('mail', 'From') + ': ' + this.thread[index].from[0].label + ' <' + this.thread[index].from[0].email + '>'
-
-			const dateSpan = virtualIframeDocument.createElement('p')
-			dateSpan.style.fontWeight = 'bold'
-			dateSpan.textContent = t('mail', 'Date') + ': ' + formatDateTimeFromUnix(this.thread[index].dateInt)
-
-			const recipientSpan = virtualIframeDocument.createElement('p')
-			recipientSpan.style.fontWeight = 'bold'
-			recipientSpan.textContent = t('mail', 'To') + ': ' + this.thread[index].to[0].label + this.thread[index].to[0].email
-
-			virtualIframeDocument.body.appendChild(hr)
-			virtualIframeDocument.body.appendChild(subjectSpan)
-			virtualIframeDocument.body.appendChild(senderSpan)
-			virtualIframeDocument.body.appendChild(dateSpan)
-			virtualIframeDocument.body.appendChild(recipientSpan)
-		},
-
-		addThreadInfo(document) {
-			const threadInfo = document.createElement('div')
-			threadInfo.style.marginTop = '20px'
-			threadInfo.style.marginBottom = '20px'
-			threadInfo.className = 'mail-thread-info'
-
-			const subjectLine = document.createElement('h2')
-			subjectLine.textContent = `${this.threadSubject}`
-			threadInfo.appendChild(subjectLine)
-
-			const participantsLine = document.createElement('p')
-			participantsLine.textContent = this.threadParticipants
-				.map((participant) => `${participant.label} <${participant.email}>`)
-				.join(', ')
-			threadInfo.appendChild(participantsLine)
-
-			return threadInfo
-		},
-
-		addLoadedThread() {
-			this.loadedThreads++
-		},
-
-		print(threadIndex) {
-			setTimeout(() => {
-				try {
-					const messages = Array.from(document.querySelectorAll('.html-message-body, .mail-message-body'))
-
-					let message
-
-					if (threadIndex !== undefined) {
-						message = messages[threadIndex * 2] ?? messages.pop()
-					} else {
-						// By default, we print the last opened message in the thread
-						message = messages.pop()
-					}
-
-					const iframe = message.querySelector('iframe')
-
-					if (iframe === null) {
-						// Handle plain text messages
-						const messageContainer = message.querySelector('#message-container')
-
-						if (messageContainer) {
-							// Create a new iframe
-							const newIframe = document.createElement('iframe')
-							newIframe.style.display = 'none' // Hide the iframe
-							document.body.appendChild(newIframe)
-
-							// Insert the message content into the iframe
-							const iframeDocument = newIframe.contentDocument || newIframe.contentWindow.document
-							iframeDocument.open()
-							iframeDocument.write(`
-								<html>
-									<head>
-										<title></title>
-									</head>
-									<body>
-										<div class="message-container">${messageContainer.innerHTML}</div>
-									</body>
-								</html>
-							`)
-							iframeDocument.title = this.threadSubject
-
-							const threadInfo = this.addThreadInfo(iframeDocument)
-							iframeDocument.body.insertBefore(threadInfo, iframeDocument.body.firstChild)
-
-							setTimeout(() => {
-								threadInfo.remove()
-							}, 5000)
-
-							iframeDocument.close()
-
-							newIframe.contentWindow.print()
-
-							// Clean up: remove the iframe after printing
-							setTimeout(() => {
-								document.body.removeChild(newIframe)
-							}, 500)
-						}
-
-						return
-					}
-
-					const iframeDocument = iframe.contentDocument || iframe.contentWindow.document
-
-					const threadInfo = this.addThreadInfo(iframeDocument)
-					iframeDocument.body.insertBefore(threadInfo, iframeDocument.body.firstChild)
-
-					setTimeout(() => {
-						threadInfo.remove()
-					}, 200)
-
-					iframe.contentWindow.print()
-				} catch (error) {
-					logger.error('Could not print message', { error })
-					showError(t('mail', 'Could not print message'))
-				}
-			}, 100)
+			const messageContainer = messageEl.querySelector('#message-container')
+			if (messageContainer) {
+				renderPlainTextMessage(message, messageContainer)
+			}
 		},
 	},
 }

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -344,6 +344,7 @@
 			:smart-replies="showFollowUpHeader ? [] : smartReplies"
 			:reply-button-label="replyButtonLabel"
 			@load="onMessageLoaded"
+			@print-shortcut="$emit('print-shortcut')"
 			@translate="onOpenTranslationModal"
 			@reply="(body) => onReply(body, showFollowUpHeader)" />
 		<Error
@@ -580,6 +581,17 @@ export default {
 
 		account() {
 			return this.mainStore.getAccount(this.envelope.accountId)
+		},
+
+		/**
+		 * Whether this message is rendered and can therefore be printed. The
+		 * message body is only in the DOM once the message itself has been
+		 * fetched and its loading state has settled.
+		 *
+		 * @return {boolean}
+		 */
+		printable() {
+			return this.loading === Loading.Done && this.message !== undefined
 		},
 
 		senderEmailColor() {

--- a/src/tests/unit/components/MessageHTMLBody.vue.spec.js
+++ b/src/tests/unit/components/MessageHTMLBody.vue.spec.js
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import MessageHTMLBody from '../../../components/MessageHTMLBody.vue'
+import Nextcloud from '../../../mixins/Nextcloud.js'
+
+vi.mock('@iframe-resizer/parent', () => ({ default: vi.fn() }))
+vi.mock('@nextcloud/initial-state', () => ({ loadState: vi.fn().mockReturnValue(false) }))
+vi.mock('../../../service/AiIntergrationsService.js', () => ({ needsTranslation: vi.fn().mockResolvedValue(false) }))
+vi.mock('../../../service/TrustedSenderService.js', () => ({ trustSender: vi.fn() }))
+
+const localVue = createLocalVue()
+
+localVue.mixin(Nextcloud)
+
+describe('MessageHTMLBody', () => {
+	// Attached, because only an iframe that is part of a document has a
+	// `contentDocument` to listen on.
+	const mountBody = () => shallowMount(MessageHTMLBody, {
+		attachTo: document.body,
+		propsData: {
+			url: 'https://cloud.example.com/apps/mail/api/messages/1/html',
+			message: {
+				databaseId: 1,
+				from: [{ email: 'alice@example.com' }],
+				isSenderTrusted: false,
+			},
+		},
+		localVue,
+	})
+
+	const keydown = (key, modifiers = { ctrlKey: true }) => new KeyboardEvent('keydown', {
+		key,
+		code: `Key${key.toUpperCase()}`,
+		cancelable: true,
+		...modifiers,
+	})
+
+	describe('print shortcut', () => {
+		it('takes the shortcut from inside the frame, where the app window cannot see it', () => {
+			const view = mountBody()
+			view.vm.onMessageFrameLoad()
+
+			const event = keydown('p')
+			view.vm.getIframeDoc().dispatchEvent(event)
+
+			expect(view.emitted('print-shortcut')).toHaveLength(1)
+		})
+
+		it('keeps the browser from printing the page itself', () => {
+			const view = mountBody()
+			view.vm.onMessageFrameLoad()
+
+			const event = keydown('p')
+			view.vm.getIframeDoc().dispatchEvent(event)
+
+			expect(event.defaultPrevented).toBe(true)
+		})
+
+		it('leaves every other key in the message alone', () => {
+			const view = mountBody()
+			view.vm.onMessageFrameLoad()
+
+			const event = keydown('a')
+			view.vm.getIframeDoc().dispatchEvent(event)
+
+			expect(view.emitted('print-shortcut')).toBeUndefined()
+			expect(event.defaultPrevented).toBe(false)
+		})
+
+		it('does not take the shortcut twice when the frame loads again', () => {
+			const view = mountBody()
+			view.vm.onMessageFrameLoad()
+			view.vm.onMessageFrameLoad()
+
+			view.vm.getIframeDoc().dispatchEvent(keydown('p'))
+
+			expect(view.emitted('print-shortcut')).toHaveLength(1)
+		})
+
+		it('stops listening once the message is gone', () => {
+			const view = mountBody()
+			view.vm.onMessageFrameLoad()
+			const doc = view.vm.getIframeDoc()
+			view.vm.$refs.iframe.iFrameResizer = { close: vi.fn() }
+
+			view.destroy()
+			doc.dispatchEvent(keydown('p'))
+
+			expect(view.emitted('print-shortcut')).toBeUndefined()
+		})
+	})
+})

--- a/src/tests/unit/components/Thread.vue.spec.js
+++ b/src/tests/unit/components/Thread.vue.spec.js
@@ -9,6 +9,11 @@ import Thread from '../../../components/Thread.vue'
 import Nextcloud from '../../../mixins/Nextcloud.js'
 import useMainStore from '../../../store/mainStore.js'
 
+vi.mock('@nextcloud/dialogs', async (importOriginal) => ({
+	...await importOriginal(),
+	showError: vi.fn(),
+}))
+
 const localVue = createLocalVue()
 
 localVue.mixin(Nextcloud)
@@ -297,5 +302,375 @@ describe('Thread', () => {
 		const envelopes = view.vm.thread
 		expect(envelopes).toHaveLength(1)
 		expect(envelopes[0].mailboxId).toBe(23)
+	})
+
+	describe('printing a message', () => {
+		let parent
+		let renderedMessages
+
+		const mountThread = () => {
+			const view = shallowMount(Thread, {
+				mocks: {
+					$route: {
+						params: {
+							threadId: 200,
+						},
+					},
+				},
+				store,
+				localVue,
+			})
+			view.vm.$refs.envelopeRefs = view.vm.thread.map((envelope) => ({
+				envelope,
+				$el: document.createElement('div'),
+			}))
+			return view
+		}
+
+		/**
+		 * Element of a rendered message component, attached to the document so
+		 * that anything below it has a document of its own.
+		 *
+		 * @return {HTMLElement} the component's element
+		 */
+		const messageElement = () => {
+			const el = document.createElement('div')
+			document.body.appendChild(el)
+			renderedMessages.push(el)
+			return el
+		}
+
+		/**
+		 * Stand in for a rendered HTML message: a component whose element holds
+		 * the message iframe.
+		 *
+		 * @param {number} databaseId database id of the message's envelope
+		 * @param {string} color color the message's stylesheet paints with
+		 * @param {string} text the message's body text
+		 * @return {object} the envelope component stub
+		 */
+		const renderedMessage = (databaseId, color, text) => {
+			const el = messageElement()
+
+			const iframe = document.createElement('iframe')
+			el.appendChild(iframe)
+			iframe.contentDocument.open()
+			iframe.contentDocument.write(`<html><head><style>p { color: ${color}; }</style></head><body><p>${text}</p></body></html>`)
+			iframe.contentDocument.close()
+
+			return { envelope: { databaseId }, $el: el }
+		}
+
+		/**
+		 * Stand in for a rendered plain text message: a component whose element
+		 * holds the message body as light DOM, the way the app renders it.
+		 *
+		 * @param {number} databaseId database id of the message's envelope
+		 * @param {string} text the message's body text
+		 * @return {object} the envelope component stub
+		 */
+		const renderedPlainTextMessage = (databaseId, text) => {
+			const el = messageElement()
+
+			const container = document.createElement('div')
+			container.id = 'message-container'
+			container.textContent = text
+			el.appendChild(container)
+
+			return { envelope: { databaseId }, $el: el }
+		}
+
+		beforeEach(() => {
+			renderedMessages = []
+			parent = document.createElement('div')
+			document.body.appendChild(parent)
+		})
+
+		afterEach(() => {
+			parent.remove()
+			renderedMessages.forEach((el) => el.remove())
+		})
+
+		it('opens a message with its header', () => {
+			const view = mountThread()
+
+			view.vm.appendPrintMessage(parent, 0)
+
+			expect(parent.querySelectorAll('.print-message')).toHaveLength(1)
+			expect(parent.querySelector('.print-message').firstElementChild.className).toBe('print-message-header')
+		})
+
+		it('gives every message a shadow root of its own so they cannot restyle each other', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [
+				renderedMessage(1001, 'red', 'first'),
+				renderedMessage(1002, 'blue', 'second'),
+				{ envelope: { databaseId: 1003 }, $el: document.createElement('div') },
+			]
+
+			view.vm.appendPrintMessage(parent, 0)
+			view.vm.appendPrintMessage(parent, 1)
+
+			const hosts = parent.querySelectorAll('.print-message-content')
+			expect(hosts).toHaveLength(2)
+			expect(hosts[0].shadowRoot.querySelector('p').textContent).toBe('first')
+			expect(hosts[0].shadowRoot.querySelector('style').textContent).toContain('red')
+			expect(hosts[1].shadowRoot.querySelector('p').textContent).toBe('second')
+			expect(hosts[1].shadowRoot.querySelector('style').textContent).toContain('blue')
+		})
+
+		it('prints the messages as part of the document, so they follow whatever paper is picked', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [renderedMessage(1001, 'red', 'first')]
+
+			view.vm.appendPrintMessage(parent, 0)
+
+			expect(parent.querySelector('iframe')).toBeNull()
+			expect(parent.querySelector('.print-message-content').style.height).toBe('')
+		})
+
+		it('keeps the header out of reach of the message styles', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [renderedMessage(1001, 'red', 'first')]
+
+			view.vm.appendPrintMessage(parent, 0)
+
+			const message = parent.querySelector('.print-message')
+			expect(message.firstElementChild.className).toBe('print-message-header')
+			expect(message.querySelector('.print-message-content').shadowRoot.querySelector('.print-message-header')).toBeNull()
+		})
+
+		it('keeps the messages own styles out of the print document', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [renderedMessage(1001, 'red', 'first')]
+
+			view.vm.appendPrintMessage(parent, 0)
+
+			expect(parent.querySelectorAll('style')).toHaveLength(0)
+		})
+
+		it('renders a plain text message the same way, so both kinds print alike', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [
+				renderedPlainTextMessage(1001, 'plain'),
+				renderedMessage(1002, 'blue', 'html'),
+			]
+
+			view.vm.appendPrintMessage(parent, 0)
+			view.vm.appendPrintMessage(parent, 1)
+
+			const hosts = parent.querySelectorAll('.print-message-content')
+			expect(hosts).toHaveLength(2)
+			expect(hosts[0].shadowRoot.textContent).toContain('plain')
+			expect(hosts[1].shadowRoot.querySelector('p').textContent).toBe('html')
+		})
+
+		it('prints the header alone when the message frame belongs to another origin', () => {
+			const view = mountThread()
+			const el = messageElement()
+			const iframe = document.createElement('iframe')
+			el.appendChild(iframe)
+			Object.defineProperty(iframe, 'contentDocument', { value: null })
+			view.vm.$refs.envelopeRefs = [
+				{ envelope: { databaseId: 1001 }, $el: el },
+				renderedMessage(1002, 'blue', 'second'),
+			]
+
+			view.vm.appendPrintMessage(parent, 0)
+			view.vm.appendPrintMessage(parent, 1)
+
+			const messages = parent.querySelectorAll('.print-message')
+			expect(messages).toHaveLength(2)
+			expect(messages[0].querySelector('.print-message-header')).not.toBeNull()
+			expect(messages[0].querySelector('.print-message-content')).toBeNull()
+			expect(messages[1].querySelector('.print-message-content').shadowRoot.querySelector('p').textContent).toBe('second')
+		})
+
+		it('pairs a message with its own body, whatever order the refs came in', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = [
+				renderedMessage(1002, 'blue', 'second'),
+				{ envelope: { databaseId: 1003 }, $el: document.createElement('div') },
+				renderedMessage(1001, 'red', 'first'),
+			]
+
+			view.vm.appendPrintMessage(parent, 0)
+			view.vm.appendPrintMessage(parent, 1)
+
+			const hosts = parent.querySelectorAll('.print-message-content')
+			expect(hosts[0].shadowRoot.querySelector('p').textContent).toBe('first')
+			expect(hosts[1].shadowRoot.querySelector('p').textContent).toBe('second')
+		})
+
+		it('prints the messages in thread order, not in the order they were expanded', () => {
+			const view = mountThread()
+			view.vm.expandedThreads = [1003, 1001]
+
+			expect(view.vm.expandedIndices).toEqual([0, 2])
+		})
+	})
+
+	describe('print shortcut', () => {
+		const mountThread = (printable = true) => {
+			const view = shallowMount(Thread, {
+				mocks: {
+					$route: {
+						params: {
+							threadId: 200,
+						},
+					},
+				},
+				store,
+				localVue,
+			})
+			view.vm.$refs.envelopeRefs = view.vm.thread.map((envelope) => ({
+				envelope,
+				printable,
+				$el: document.createElement('div'),
+			}))
+			return view
+		}
+
+		const printShortcut = () => ({
+			code: 'KeyP',
+			key: 'p',
+			ctrlKey: true,
+			metaKey: false,
+			preventDefault: vi.fn(),
+		})
+
+		it('prints the thread', async () => {
+			const view = mountThread()
+			const printMessages = vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+
+			await view.vm.handleKeyDown(printShortcut())
+
+			expect(printMessages).toHaveBeenCalledWith([0, 1, 2])
+		})
+
+		it('prints the thread when the shortcut came from inside a message frame', async () => {
+			const view = mountThread()
+			const printMessages = vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+
+			await view.vm.printThread()
+
+			expect(printMessages).toHaveBeenCalledWith([0, 1, 2])
+		})
+
+		it('expands the collapsed messages so there is something to print of them', async () => {
+			const view = mountThread()
+			vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+
+			await view.vm.handleKeyDown(printShortcut())
+
+			expect(view.vm.expandedThreads).toEqual(expect.arrayContaining([1001, 1002, 1003]))
+		})
+
+		it('waits for the messages it expanded to be rendered before printing', async () => {
+			const view = mountThread(false)
+			const printMessages = vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+
+			const printed = view.vm.printThread()
+
+			await new Promise((resolve) => setTimeout(resolve, 150))
+			expect(printMessages).not.toHaveBeenCalled()
+
+			view.vm.$refs.envelopeRefs.forEach((component) => {
+				component.printable = true
+			})
+			await printed
+			expect(printMessages).toHaveBeenCalledWith([0, 1, 2])
+		})
+
+		it('leaves the shortcut alone when it is not the print one', async () => {
+			const view = mountThread()
+			const printMessages = vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+			const event = { ...printShortcut(), code: 'KeyA', key: 'a' }
+
+			await view.vm.handleKeyDown(event)
+
+			expect(printMessages).not.toHaveBeenCalled()
+			expect(event.preventDefault).not.toHaveBeenCalled()
+		})
+
+		it('does not stage the thread again while a print is still going on', async () => {
+			const view = mountThread()
+			const printMessages = vi.spyOn(view.vm, 'printMessages').mockResolvedValue()
+			const expandedThreads = [...view.vm.expandedThreads]
+			view.vm.isolatedPrint = true
+
+			await view.vm.handleKeyDown(printShortcut())
+
+			expect(printMessages).not.toHaveBeenCalled()
+			expect(view.vm.expandedThreads).toEqual(expandedThreads)
+		})
+	})
+
+	describe('browser print', () => {
+		const notice = () => document.getElementById('mail-browser-print-notice')
+
+		const mountThread = () => shallowMount(Thread, {
+			mocks: {
+				$route: {
+					params: {
+						threadId: 200,
+					},
+				},
+			},
+			store,
+			localVue,
+		})
+
+		afterEach(() => {
+			notice()?.remove()
+		})
+
+		it('prints a notice instead of the thread, because the page cannot print it correctly', () => {
+			mountThread()
+
+			expect(notice()).not.toBeNull()
+			expect(notice().textContent).toContain('not supported')
+		})
+
+		it('never copies a message into the app document', () => {
+			const view = mountThread()
+			view.vm.$refs.envelopeRefs = view.vm.thread.map((envelope) => ({
+				envelope,
+				$el: document.createElement('div'),
+			}))
+
+			expect(notice().querySelector('.print-message')).toBeNull()
+			expect(document.querySelector('.print-message')).toBeNull()
+		})
+
+		it('brings its own stylesheet, which hides the app for print media', () => {
+			mountThread()
+
+			const style = notice().querySelector('style').textContent
+			expect(style).toContain('@media print')
+			expect(style).toContain('body > *:not(#mail-browser-print-notice):not(#mail-print-frame) { display: none !important; }')
+		})
+
+		it('is shown for print media only, so it never takes part in the app', () => {
+			mountThread()
+
+			const style = notice().querySelector('style').textContent
+			expect(style.slice(0, style.indexOf('@media print'))).toContain('#mail-browser-print-notice { display: none; }')
+		})
+
+		it('does not put up a second notice', () => {
+			mountThread()
+			mountThread()
+
+			expect(document.querySelectorAll('#mail-browser-print-notice')).toHaveLength(1)
+		})
+
+		it('cleans up the notice when the thread goes away', () => {
+			const view = mountThread()
+
+			view.destroy()
+
+			expect(notice()).toBeNull()
+		})
 	})
 })

--- a/src/tests/unit/util/printMessage.spec.js
+++ b/src/tests/unit/util/printMessage.spec.js
@@ -1,0 +1,526 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { formatDateTimeFromUnix } from '../../../util/formatDateTime.js'
+import {
+	BROWSER_PRINT_NOTICE_ID,
+	BROWSER_PRINT_STYLE,
+	buildBrowserPrintNotice,
+	buildMessageContent,
+	buildMessageHeader,
+	isPrintShortcut,
+	PRINT_DOCUMENT_STYLE,
+	PRINT_FRAME_ID,
+	renderHtmlMessage,
+	renderPlainTextMessage,
+	waitForImages,
+} from '../../../util/printMessage.ts'
+
+describe('printMessage', () => {
+	describe('buildMessageHeader', () => {
+		const envelope = {
+			subject: 'Hello there',
+			from: [{ label: 'Alice', email: 'alice@example.com' }],
+			to: [{ label: 'Bob', email: 'bob@example.com' }],
+			cc: [],
+			bcc: [],
+			dateInt: 1700000000,
+		}
+
+		it('renders the subject first', () => {
+			const header = buildMessageHeader(document, envelope)
+
+			expect(header.firstChild.textContent).toBe('Hello there')
+		})
+
+		it('falls back to "No subject" when the subject is empty', () => {
+			const header = buildMessageHeader(document, { ...envelope, subject: '' })
+
+			expect(header.firstChild.textContent).toBe('No subject')
+		})
+
+		it('falls back to "No subject" when the subject is only whitespace', () => {
+			const header = buildMessageHeader(document, { ...envelope, subject: '   \t\n' })
+
+			expect(header.firstChild.textContent).toBe('No subject')
+		})
+
+		it('falls back to "No subject" when the subject is missing', () => {
+			const header = buildMessageHeader(document, { ...envelope, subject: undefined })
+
+			expect(header.firstChild.textContent).toBe('No subject')
+		})
+
+		it('gives the subject its own class', () => {
+			const header = buildMessageHeader(document, envelope)
+
+			expect(header.firstChild.className).toBe('print-message-header__subject')
+		})
+
+		it('brings its own looks, so it does not depend on a stylesheet reaching it', () => {
+			const header = buildMessageHeader(document, envelope)
+
+			expect(header.style.margin).not.toBe('')
+			expect(header.firstChild.style.fontSize).not.toBe('')
+			expect(header.querySelector('.print-message-header__line').style.fontSize).not.toBe('')
+		})
+
+		it('lists From, To and Date in that order', () => {
+			const header = buildMessageHeader(document, envelope)
+
+			const lines = Array.from(header.querySelectorAll('.print-message-header > div'))
+				.slice(1)
+				.map((line) => line.textContent)
+			expect(lines).toEqual([
+				'From: Alice <alice@example.com>',
+				'To: Bob <bob@example.com>',
+				`Date: ${formatDateTimeFromUnix(envelope.dateInt)}`,
+			])
+		})
+
+		it('omits Cc and Bcc lines when there are no such recipients', () => {
+			const header = buildMessageHeader(document, envelope)
+
+			expect(header.innerHTML).not.toContain('Cc:')
+			expect(header.innerHTML).not.toContain('Bcc:')
+		})
+
+		it('includes Cc and Bcc lines when present, with all recipients', () => {
+			const header = buildMessageHeader(document, {
+				...envelope,
+				cc: [{ label: 'Carol', email: 'carol@example.com' }],
+				bcc: [{ label: 'Dave', email: 'dave@example.com' }, { label: '', email: 'eve@example.com' }],
+			})
+
+			const lines = Array.from(header.querySelectorAll('div')).map((line) => line.textContent)
+			expect(lines).toContain('Cc: Carol <carol@example.com>')
+			expect(lines).toContain('Bcc: Dave <dave@example.com>, eve@example.com')
+		})
+
+		it('omits the To line when there are no recipients', () => {
+			const header = buildMessageHeader(document, { ...envelope, to: [] })
+
+			expect(header.innerHTML).not.toContain('To:')
+		})
+
+		it('renders a crafted subject as literal text, never as markup', () => {
+			const header = buildMessageHeader(document, {
+				...envelope,
+				subject: '<img src=x onerror=alert(1)>',
+			})
+
+			expect(header.firstChild.textContent).toBe('<img src=x onerror=alert(1)>')
+			expect(header.querySelector('img')).toBeNull()
+		})
+
+		it('renders a crafted sender name as literal text, never as markup', () => {
+			const header = buildMessageHeader(document, {
+				...envelope,
+				from: [{ label: '<script>alert(1)</script>', email: 'x@example.com' }],
+			})
+
+			expect(header.querySelector('script')).toBeNull()
+			expect(header.textContent).toContain('<script>alert(1)</script> <x@example.com>')
+		})
+	})
+
+	describe('buildMessageContent', () => {
+		const parse = (html) => new DOMParser().parseFromString(html, 'text/html')
+
+		it('keeps the message body and its styles so it does not fall back to unstyled defaults', () => {
+			const source = parse('<html><head><style>p { color: red; }</style></head><body><p>hello</p></body></html>')
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('style').textContent).toContain('color: red')
+			expect(content.querySelector('p').textContent).toBe('hello')
+		})
+
+		it('keeps head and body, so the selectors an email styles them with keep matching', () => {
+			const source = parse('<html><head><style>body { color: red; }</style></head><body><p>hello</p></body></html>')
+
+			const content = buildMessageContent(source)
+
+			expect(content.tagName).toBe('HTML')
+			expect(content.querySelector('head')).not.toBeNull()
+			expect(content.querySelector('body')).not.toBeNull()
+		})
+
+		it('keeps a style block that the backend injected at the start of the body', () => {
+			const source = parse('<html><head></head><body><style>p { color: green; }</style><p>hi</p></body></html>')
+
+			const content = buildMessageContent(source)
+
+			expect(content.textContent).toContain('hi')
+			expect(content.querySelector('style').textContent).toContain('color: green')
+		})
+
+		it('strips scripts and the iframe-resizer marker from the printed content', () => {
+			const source = parse('<html><head></head><body><p>hi</p><script>alert(1)</script><div data-iframe-size></div></body></html>')
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('script')).toBeNull()
+			expect(content.querySelector('[data-iframe-size]')).toBeNull()
+			expect(content.querySelector('p').textContent).toBe('hi')
+		})
+
+		it('prints the images the reader unblocked, not the blocked originals', () => {
+			const source = parse('<html><head></head><body><img data-original-src="/cat.png"></body></html>')
+			source.querySelector('img').setAttribute('src', '/cat.png')
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('img').getAttribute('src')).toContain('/cat.png')
+		})
+
+		it('resolves relative urls against the message, not against the app', () => {
+			const source = parse('<html><head></head><body><img src="cat.png"><a href="/inbox">back</a></body></html>')
+			Object.defineProperty(source, 'baseURI', { value: 'https://cloud.example.com/apps/mail/message/1/html' })
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('img').getAttribute('src')).toBe('https://cloud.example.com/apps/mail/message/1/cat.png')
+			expect(content.querySelector('a').getAttribute('href')).toBe('https://cloud.example.com/inbox')
+		})
+
+		it('resolves every candidate of a srcset', () => {
+			const source = parse('<html><head></head><body><img srcset="cat.png 1x, cat@2x.png 2x"></body></html>')
+			Object.defineProperty(source, 'baseURI', { value: 'https://cloud.example.com/apps/mail/message/1/html' })
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('img').getAttribute('srcset')).toBe('https://cloud.example.com/apps/mail/message/1/cat.png 1x, https://cloud.example.com/apps/mail/message/1/cat@2x.png 2x')
+		})
+
+		it('leaves an url that is not relative to anything alone', () => {
+			const source = parse('<html><head></head><body><img src="cid:part1@example.com"><a href="mailto:alice@example.com">mail</a></body></html>')
+			Object.defineProperty(source, 'baseURI', { value: 'https://cloud.example.com/apps/mail/message/1/html' })
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('img').getAttribute('src')).toBe('cid:part1@example.com')
+			expect(content.querySelector('a').getAttribute('href')).toBe('mailto:alice@example.com')
+		})
+
+		it('applies a base the message carries and drops it, because it has no effect in a shadow root', () => {
+			const source = parse('<html><head><base href="https://cloud.example.com/original/"></head><body><img src="cat.png"></body></html>')
+
+			const content = buildMessageContent(source)
+
+			expect(content.querySelector('base')).toBeNull()
+			expect(content.querySelector('img').getAttribute('src')).toBe('https://cloud.example.com/original/cat.png')
+		})
+
+		it('does not touch the live message document', () => {
+			const source = parse('<html><head><base href="https://cloud.example.com/original/"></head><body><p>hi</p><script>alert(1)</script><img src="cat.png"></body></html>')
+
+			buildMessageContent(source)
+
+			expect(source.querySelector('script')).not.toBeNull()
+			expect(source.querySelector('base')).not.toBeNull()
+			expect(source.querySelector('img').getAttribute('src')).toBe('cat.png')
+		})
+	})
+
+	describe('renderHtmlMessage', () => {
+		let parent
+
+		beforeEach(() => {
+			parent = document.createElement('div')
+			document.body.appendChild(parent)
+		})
+
+		afterEach(() => {
+			parent.remove()
+		})
+
+		const source = () => new DOMParser().parseFromString(
+			'<html><head><style>p { color: red; }</style></head><body><p>hello</p></body></html>',
+			'text/html',
+		)
+
+		it('renders the message into a shadow root of its own', () => {
+			const host = renderHtmlMessage(parent, source())
+
+			expect(host.className).toBe('print-message-content')
+			expect(host.shadowRoot.querySelector('p').textContent).toBe('hello')
+		})
+
+		it('renders the message as part of the print document, so it can break across pages', () => {
+			renderHtmlMessage(parent, source())
+
+			expect(parent.querySelector('iframe')).toBeNull()
+			expect(parent.firstElementChild.style.height).toBe('')
+		})
+
+		it('keeps a message stylesheet out of the printed document', () => {
+			const host = renderHtmlMessage(parent, source())
+
+			expect(parent.ownerDocument.querySelector('style')).toBeNull()
+			expect(host.querySelector('style')).toBeNull()
+		})
+
+		it('keeps the messages of a thread from restyling each other', () => {
+			const other = new DOMParser().parseFromString(
+				'<html><head><style>p { color: blue; }</style></head><body><p>other</p></body></html>',
+				'text/html',
+			)
+
+			const first = renderHtmlMessage(parent, source())
+			const second = renderHtmlMessage(parent, other)
+
+			expect(first.shadowRoot.querySelectorAll('style')).toHaveLength(1)
+			expect(first.shadowRoot.querySelector('style').textContent).toContain('color: red')
+			expect(second.shadowRoot.querySelectorAll('style')).toHaveLength(1)
+			expect(second.shadowRoot.querySelector('style').textContent).toContain('color: blue')
+		})
+
+		it('keeps a print header next to it out of reach of the message styles', () => {
+			const header = buildMessageHeader(document, { subject: 'Grazie da Italo!', from: [], to: [] })
+			const message = document.createElement('div')
+			message.appendChild(header)
+			parent.appendChild(message)
+
+			const host = renderHtmlMessage(message, source())
+
+			expect(host.shadowRoot.querySelector('.print-message-header')).toBeNull()
+			expect(message.firstElementChild).toBe(header)
+		})
+	})
+
+	describe('renderPlainTextMessage', () => {
+		let parent
+
+		beforeEach(() => {
+			parent = document.createElement('div')
+			document.body.appendChild(parent)
+		})
+
+		afterEach(() => {
+			parent.remove()
+		})
+
+		const source = () => {
+			const container = document.createElement('div')
+			container.id = 'message-container'
+			container.innerHTML = 'hello<br />  indented'
+			return container
+		}
+
+		it('renders the message into a shadow root of its own', () => {
+			const host = renderPlainTextMessage(parent, source())
+
+			expect(host.className).toBe('print-message-content')
+			expect(host.shadowRoot.textContent).toContain('indented')
+		})
+
+		it('brings the whitespace handling the app stylesheet cannot reach into the shadow root', () => {
+			const host = renderPlainTextMessage(parent, source())
+
+			expect(host.shadowRoot.querySelector('style').textContent).toContain('white-space: pre-wrap')
+			expect(host.shadowRoot.querySelector('.print-message-text')).not.toBeNull()
+		})
+
+		it('drops the id, which only ever identified the live message body', () => {
+			const host = renderPlainTextMessage(parent, source())
+
+			expect(host.shadowRoot.querySelector('#message-container')).toBeNull()
+		})
+
+		it('does not touch the live message body', () => {
+			const container = source()
+
+			renderPlainTextMessage(parent, container)
+
+			expect(container.id).toBe('message-container')
+			expect(container.parentNode).toBeNull()
+		})
+	})
+
+	describe('isPrintShortcut', () => {
+		it('matches Ctrl+P on non-Apple platforms', () => {
+			expect(isPrintShortcut({ code: 'KeyP', key: 'p', ctrlKey: true, metaKey: false }, false)).toBe(true)
+		})
+
+		it('ignores Cmd+P on non-Apple platforms', () => {
+			expect(isPrintShortcut({ code: 'KeyP', key: 'p', ctrlKey: false, metaKey: true }, false)).toBe(false)
+		})
+
+		it('matches Cmd+P on Apple platforms', () => {
+			expect(isPrintShortcut({ code: 'KeyP', key: 'p', ctrlKey: false, metaKey: true }, true)).toBe(true)
+		})
+
+		it('ignores Ctrl+P on Apple platforms so native bindings keep working', () => {
+			expect(isPrintShortcut({ code: 'KeyP', key: 'p', ctrlKey: true, metaKey: false }, true)).toBe(false)
+		})
+
+		it('matches the P key whatever character it produces', () => {
+			expect(isPrintShortcut({ code: 'KeyP', key: 'P', ctrlKey: true, metaKey: false }, false)).toBe(true)
+			expect(isPrintShortcut({ code: 'KeyP', key: 'з', ctrlKey: true, metaKey: false }, false)).toBe(true)
+		})
+
+		it('ignores another key that produces a p', () => {
+			expect(isPrintShortcut({ code: 'KeyZ', key: 'p', ctrlKey: true, metaKey: false }, false)).toBe(false)
+		})
+
+		it('ignores the modifier on its own', () => {
+			expect(isPrintShortcut({ code: 'KeyA', key: 'a', ctrlKey: true, metaKey: false }, false)).toBe(false)
+			expect(isPrintShortcut({ code: 'KeyA', key: 'a', ctrlKey: false, metaKey: true }, true)).toBe(false)
+		})
+	})
+
+	describe('buildBrowserPrintNotice', () => {
+		const printRules = () => BROWSER_PRINT_STYLE.slice(BROWSER_PRINT_STYLE.indexOf('@media print'))
+
+		it('turns away the browser menu only, not the shortcut', () => {
+			const notice = buildBrowserPrintNotice(document)
+
+			expect(notice.textContent).toContain('Printing from the browser menu is not supported')
+		})
+
+		it('points at the shortcut and the action, both of which do print', () => {
+			const notice = buildBrowserPrintNotice(document)
+
+			expect(notice.textContent).toContain('Ctrl+P')
+			expect(notice.textContent).toContain('Print message')
+		})
+
+		it('carries no message, so no email markup reaches the app document', () => {
+			const notice = buildBrowserPrintNotice(document)
+
+			expect(notice.querySelector('.print-message')).toBeNull()
+			expect(notice.querySelector('.print-message-content')).toBeNull()
+		})
+
+		it('brings its own stylesheet so it survives being removed again', () => {
+			const notice = buildBrowserPrintNotice(document)
+
+			expect(notice.querySelector('style').textContent).toContain('@media print')
+		})
+
+		it('pins its looks with inline styles, which the app stylesheet cannot outrank', () => {
+			const notice = buildBrowserPrintNotice(document)
+
+			expect(notice.querySelector('.print-notice__title').getAttribute('style')).toContain('!important')
+			expect(notice.querySelector('.print-notice__text').getAttribute('style')).toContain('!important')
+		})
+
+		it('takes the place of the app while printing', () => {
+			expect(printRules()).toContain(`body > *:not(#${BROWSER_PRINT_NOTICE_ID}):not(#${PRINT_FRAME_ID}) { display: none !important; }`)
+			expect(printRules()).toContain(`#${BROWSER_PRINT_NOTICE_ID} { display: block !important; }`)
+		})
+
+		it('leaves the print frame alone, so a print of our own is not hidden from itself', () => {
+			expect(printRules()).toContain(`:not(#${PRINT_FRAME_ID})`)
+		})
+
+		it('prints on white, so the app theme does not darken the page', () => {
+			expect(printRules()).toContain('html, body { background: #fff !important; }')
+		})
+
+		it('stays out of the app on screen', () => {
+			const screenRules = BROWSER_PRINT_STYLE.slice(0, BROWSER_PRINT_STYLE.indexOf('@media print'))
+
+			expect(screenRules).toContain(`#${BROWSER_PRINT_NOTICE_ID} { display: none; }`)
+		})
+
+		it('applies the same page setup as the print document', () => {
+			expect(printRules()).toContain('@page { margin: 15mm; }')
+			expect(PRINT_DOCUMENT_STYLE).toContain('@page { margin: 15mm; }')
+		})
+	})
+
+	describe('waitForImages', () => {
+		it('resolves immediately when there are no images', async () => {
+			const container = document.createElement('div')
+
+			await expect(waitForImages(container)).resolves.toBe(true)
+		})
+
+		it('resolves immediately when every image is already complete', async () => {
+			const container = document.createElement('div')
+			const img = document.createElement('img')
+			Object.defineProperty(img, 'complete', { value: true })
+			container.appendChild(img)
+
+			await expect(waitForImages(container)).resolves.toBe(true)
+		})
+
+		it('waits for pending images to load or error before resolving', async () => {
+			const container = document.createElement('div')
+			const loadingImg = document.createElement('img')
+			Object.defineProperty(loadingImg, 'complete', { value: false })
+			const erroringImg = document.createElement('img')
+			Object.defineProperty(erroringImg, 'complete', { value: false })
+			container.appendChild(loadingImg)
+			container.appendChild(erroringImg)
+
+			let resolved = false
+			waitForImages(container).then(() => {
+				resolved = true
+			})
+
+			await Promise.resolve()
+			expect(resolved).toBe(false)
+
+			loadingImg.dispatchEvent(new Event('load'))
+			await Promise.resolve()
+			expect(resolved).toBe(false)
+
+			erroringImg.dispatchEvent(new Event('error'))
+			await new Promise((resolve) => setTimeout(resolve))
+			expect(resolved).toBe(true)
+		})
+
+		it('waits for the images of a message behind a shadow boundary', async () => {
+			const container = document.createElement('div')
+			const host = document.createElement('div')
+			container.appendChild(host)
+			const img = document.createElement('img')
+			Object.defineProperty(img, 'complete', { value: false })
+			host.attachShadow({ mode: 'open' }).appendChild(img)
+
+			let resolved = false
+			waitForImages(container).then(() => {
+				resolved = true
+			})
+
+			await Promise.resolve()
+			expect(resolved).toBe(false)
+
+			img.dispatchEvent(new Event('load'))
+			await new Promise((resolve) => setTimeout(resolve))
+			expect(resolved).toBe(true)
+		})
+
+		it('gives up on an image that never loads nor errors', async () => {
+			const container = document.createElement('div')
+			const img = document.createElement('img')
+			Object.defineProperty(img, 'complete', { value: false })
+			container.appendChild(img)
+
+			let resolved = false
+			waitForImages(container, 10).then(() => {
+				resolved = true
+			})
+
+			await Promise.resolve()
+			expect(resolved).toBe(false)
+
+			await new Promise((resolve) => setTimeout(resolve, 20))
+			expect(resolved).toBe(true)
+		})
+
+		it('says whether it gave up, so the caller can report an incomplete print', async () => {
+			const container = document.createElement('div')
+			const img = document.createElement('img')
+			Object.defineProperty(img, 'complete', { value: false })
+			container.appendChild(img)
+
+			await expect(waitForImages(container, 10)).resolves.toBe(false)
+		})
+	})
+})

--- a/src/util/printMessage.ts
+++ b/src/util/printMessage.ts
@@ -1,0 +1,515 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { translate as t } from '@nextcloud/l10n'
+import { formatDateTimeFromUnix } from './formatDateTime.js'
+
+export interface PrintRecipient {
+	email: string
+	label?: string
+}
+
+export interface PrintEnvelope {
+	bcc?: PrintRecipient[]
+	cc?: PrintRecipient[]
+	dateInt?: number
+	from?: PrintRecipient[]
+	subject?: string
+	to?: PrintRecipient[]
+}
+
+/**
+ * Id of the print-only notice a browser-initiated print prints instead of the
+ * thread, see `buildBrowserPrintNotice`.
+ */
+export const BROWSER_PRINT_NOTICE_ID = 'mail-browser-print-notice'
+
+/**
+ * Id of the frame the print document is staged in, see `printMessages`. The
+ * browser print stylesheet knows it so that it does not hide the frame out from
+ * under a print of our own, should a browser format the app document for print
+ * media while the frame's own document is being printed.
+ */
+export const PRINT_FRAME_ID = 'mail-print-frame'
+
+const PRINT_PAGE_MARGIN = '15mm'
+
+/**
+ * Width the print document is staged at while its frame sits off-screen: A4
+ * minus the page margins.
+ *
+ * Nothing is measured at this width. The messages are part of the print
+ * document's own flow and are laid out again for whatever paper the print
+ * dialog is set to — including a paper the reader picks after the dialog is
+ * already open. This only keeps the staged rendering roughly page-shaped.
+ */
+export const PRINT_CONTENT_WIDTH = `calc(210mm - 2 * ${PRINT_PAGE_MARGIN})`
+
+/** Height the print document is staged at: one A4 page. */
+export const PRINT_CONTENT_HEIGHT = '297mm'
+
+/**
+ * Off-screen staging for the print frame. It is parked out of sight rather than
+ * hidden with `display: none`, because a frame that is not displayed has no
+ * rendering of its own and browsers have long printed such a frame blank.
+ */
+export const PRINT_STAGING_STYLE = `position: fixed; top: 0; inset-inline-start: -9999px; width: ${PRINT_CONTENT_WIDTH};`
+
+/**
+ * Page setup shared by every print rendering: margins and a black-on-white
+ * base, because the app's own (possibly dark) theme must not bleed into a
+ * printed page.
+ *
+ * The print styles spell their values out instead of using the Nextcloud CSS
+ * variables: those do not reach the standalone print document, and a theme
+ * color would print a dark theme's white text onto white paper.
+ */
+const PRINT_PAGE_STYLE = `
+	@page { margin: ${PRINT_PAGE_MARGIN}; }
+	html { color: #000; }
+	body { margin: 0; font-family: sans-serif; color: #000; }
+`
+
+/**
+ * Layout of the printed messages: the spacing between the messages of a thread,
+ * the block each message body is rendered into, and keeping a message header
+ * attached to the start of its content.
+ *
+ * A message body lives in a shadow root, which an email's CSS cannot reach out
+ * of — but the inherited properties of the host reach in, so the host pins the
+ * text color rather than letting a dark theme's white text through.
+ */
+const PRINT_MESSAGE_STYLE = `
+	.print-message + .print-message { margin-top: 24px; }
+	.print-message-content {
+		display: block;
+		color: #000;
+	}
+	.print-message-header {
+		break-inside: avoid;
+		break-after: avoid;
+	}
+`
+
+/**
+ * Looks of a message's print header, as inline styles.
+ *
+ * A header is rendered next to its message rather than inside its shadow root,
+ * so that the (untrusted) email CSS cannot restyle it, that is what produced
+ * the oversized "big letters" header in the old implementation. Nothing else
+ * can reach it either — it only ever goes into the standalone print document,
+ * which brings no stylesheet but `PRINT_DOCUMENT_STYLE` — so plain inline
+ * declarations are enough and no `!important` is needed.
+ */
+const PRINT_HEADER_STYLES = {
+	header: 'margin: 0 0 16px 0;',
+	subject: 'font-size: 18px; font-weight: bold; margin: 0 0 8px 0;',
+	line: 'font-size: 13px; font-weight: normal; line-height: 1.4; margin: 0;',
+	label: 'font-weight: bold;',
+}
+
+/** Declarations every part of the browser print notice repeats, see `PRINT_NOTICE_STYLES`. */
+const PRINT_NOTICE_BASE_STYLE = 'color: #000 !important; font-family: sans-serif !important;'
+
+/**
+ * Looks of the browser print notice, as inline styles.
+ *
+ * Unlike a message header the notice sits in the app's own document, where the
+ * app stylesheet would otherwise style it. Inline declarations outrank every
+ * declaration a stylesheet can make, `!important` ones included, but only for
+ * the element they sit on, so every part of the notice carries its own.
+ */
+const PRINT_NOTICE_STYLES = {
+	title: `${PRINT_NOTICE_BASE_STYLE} font-size: 18px !important; font-weight: bold !important; margin: 0 0 8px 0 !important;`,
+	text: `${PRINT_NOTICE_BASE_STYLE} font-size: 13px !important; font-weight: normal !important; line-height: 1.4 !important; margin: 0 !important;`,
+}
+
+/**
+ * Styles a plain text message needs to print the way it is shown. The app's own
+ * stylesheet does not reach into a shadow root, and a plain text body relies on
+ * it for `pre-wrap`: without it, the message's indentation and its runs of
+ * blank lines collapse.
+ */
+const PLAIN_TEXT_MESSAGE_STYLE = `
+	.print-message-text {
+		white-space: pre-wrap;
+		font-family: sans-serif;
+	}
+`
+
+/**
+ * Base stylesheet for the standalone print document that the "Print message"
+ * action and Ctrl/Cmd+P render into.
+ */
+export const PRINT_DOCUMENT_STYLE = `${PRINT_PAGE_STYLE}${PRINT_MESSAGE_STYLE}`
+
+/**
+ * Stylesheet for the notice a browser-initiated print prints, see
+ * `buildBrowserPrintNotice`. The notice exists for print media only, and takes
+ * the place of the app, which is hidden for the duration — the print frame
+ * excepted, so that a print of our own is never hidden out from under itself.
+ *
+ * The app's own (possibly dark) background is painted over, because a reader
+ * who prints backgrounds would otherwise get the notice on a dark page.
+ */
+export const BROWSER_PRINT_STYLE = `
+	#${BROWSER_PRINT_NOTICE_ID} { display: none; }
+	@media print {
+		body > *:not(#${BROWSER_PRINT_NOTICE_ID}):not(#${PRINT_FRAME_ID}) { display: none !important; }
+		#${BROWSER_PRINT_NOTICE_ID} { display: block !important; }
+		html, body { background: #fff !important; }
+		${PRINT_PAGE_STYLE}
+	}
+`
+
+function formatRecipients(recipients?: PrintRecipient[]): string {
+	return (recipients ?? [])
+		.map(({ label, email }) => (label ? `${label} <${email}>` : email))
+		.join(', ')
+}
+
+/**
+ * Build a single, self-contained print header for a message: Subject, From,
+ * To, Cc, Bcc and Date/time. Empty fields are omitted so a plain message
+ * doesn't show blank lines.
+ *
+ * All values are inserted as text, never as HTML, so a crafted subject or
+ * display name can only ever appear as literal text. The header takes its looks
+ * from inline styles (see `PRINT_HEADER_STYLES`), out of reach of the email's
+ * own CSS.
+ *
+ * @param doc document to create the header elements in
+ * @param envelope the envelope/message to build a header for
+ */
+export function buildMessageHeader(doc: Document, envelope: PrintEnvelope): HTMLElement {
+	const header = doc.createElement('div')
+	header.className = 'print-message-header'
+	header.style.cssText = PRINT_HEADER_STYLES.header
+
+	const subject = doc.createElement('div')
+	subject.className = 'print-message-header__subject'
+	subject.style.cssText = PRINT_HEADER_STYLES.subject
+	subject.textContent = envelope.subject?.trim() ? envelope.subject : t('mail', 'No subject')
+	header.appendChild(subject)
+
+	const addLine = (label: string, value: string): void => {
+		if (!value) {
+			return
+		}
+		const line = doc.createElement('div')
+		line.className = 'print-message-header__line'
+		line.style.cssText = PRINT_HEADER_STYLES.line
+		const name = doc.createElement('span')
+		name.className = 'print-message-header__label'
+		name.style.cssText = PRINT_HEADER_STYLES.label
+		name.textContent = `${label} `
+		line.appendChild(name)
+		line.appendChild(doc.createTextNode(value))
+		header.appendChild(line)
+	}
+
+	addLine(t('mail', 'From:'), formatRecipients(envelope.from))
+	addLine(t('mail', 'To:'), formatRecipients(envelope.to))
+	addLine(t('mail', 'Cc:'), formatRecipients(envelope.cc))
+	addLine(t('mail', 'Bcc:'), formatRecipients(envelope.bcc))
+	addLine(t('mail', 'Date:'), envelope.dateInt ? formatDateTimeFromUnix(envelope.dateInt) : '')
+
+	return header
+}
+
+/** Headline of the browser print notice. */
+function browserPrintTitle(): string {
+	return t('mail', 'Printing from the browser menu is not supported')
+}
+
+/**
+ * The way to print that is supported, naming the platform's own shortcut —
+ * Ctrl+P and Cmd+P are intercepted by the app and print the thread themselves,
+ * so the reader is being pointed at a shortcut, not away from one.
+ */
+function browserPrintHint(): string {
+	return t('mail', 'To print this email, press {shortcut}, or use the "Print message" action in the message menu.', {
+		shortcut: isAppleDevice() ? 'Cmd+P' : 'Ctrl+P',
+	})
+}
+
+/**
+ * Build the notice that a print started from the browser itself (its menu, or
+ * right-click → Print) prints in place of the thread.
+ *
+ * Only this one way of printing is turned away, and only because it cannot be
+ * served: it always renders the top-level document, it cannot be cancelled from
+ * `beforeprint`, and there is no way to point it at a document of ours. Nor can
+ * the app page stand in for that document — a message is rendered in a frame,
+ * which is a single box that the printer cuts off at the end of a page instead
+ * of breaking it across pages, and putting the email markup in the page
+ * directly would take it out of the sandboxed frame that confines it. Ctrl/Cmd+P
+ * is intercepted long before any of this and prints normally.
+ *
+ * The notice lives in the page for as long as a thread is open and is shown for
+ * print media only — no `beforeprint` handling is needed to put it up, and a
+ * print the browser never announces is covered too. It brings its own
+ * stylesheet, so that removing the notice takes the stylesheet along.
+ *
+ * @param doc document to create the notice in
+ */
+export function buildBrowserPrintNotice(doc: Document): HTMLElement {
+	const notice = doc.createElement('div')
+	notice.id = BROWSER_PRINT_NOTICE_ID
+
+	const style = doc.createElement('style')
+	style.textContent = BROWSER_PRINT_STYLE
+	notice.appendChild(style)
+
+	const title = doc.createElement('div')
+	title.className = 'print-notice__title'
+	title.style.cssText = PRINT_NOTICE_STYLES.title
+	title.textContent = browserPrintTitle()
+	notice.appendChild(title)
+
+	const text = doc.createElement('div')
+	text.className = 'print-notice__text'
+	text.style.cssText = PRINT_NOTICE_STYLES.text
+	text.textContent = browserPrintHint()
+	notice.appendChild(text)
+
+	return notice
+}
+
+/** Attributes that carry a single URL relative to the message's own document. */
+const URL_ATTRIBUTES = ['src', 'href', 'poster', 'background']
+
+/** Attribute that carries a comma-separated list of such URLs. */
+const SRCSET_ATTRIBUTE = 'srcset'
+
+/** Selector for every element carrying one of the attributes above. */
+const URL_SELECTOR = [...URL_ATTRIBUTES, SRCSET_ATTRIBUTE].map((attribute) => `[${attribute}]`).join(', ')
+
+/**
+ * Resolve a possibly relative URL against a base, leaving anything that is not
+ * a URL at all untouched.
+ *
+ * @param value the attribute value to resolve
+ * @param baseUrl the URL to resolve it against
+ */
+function resolveUrl(value: string, baseUrl: string): string {
+	try {
+		return new URL(value, baseUrl).href
+	} catch {
+		return value
+	}
+}
+
+/**
+ * Rewrite every relative URL below `root` to an absolute one.
+ *
+ * A message is rendered from an endpoint of its own, so its relative URLs
+ * resolve against that endpoint rather than against the app. A frame could be
+ * told so with a `<base>`; a shadow root cannot — it has no base of its own and
+ * inherits the one of the document it sits in — so the URLs are resolved here
+ * while the copy still belongs to the message's document.
+ *
+ * @param root the copied message to rewrite in place
+ * @param baseUrl the message document's base URL
+ */
+function absolutizeUrls(root: Element, baseUrl: string): void {
+	root.querySelectorAll(URL_SELECTOR).forEach((node) => {
+		for (const attribute of URL_ATTRIBUTES) {
+			const value = node.getAttribute(attribute)
+			if (value) {
+				node.setAttribute(attribute, resolveUrl(value, baseUrl))
+			}
+		}
+
+		const srcset = node.getAttribute(SRCSET_ATTRIBUTE)
+		if (srcset) {
+			node.setAttribute(SRCSET_ATTRIBUTE, srcset.split(',').map((candidate) => {
+				const [url, ...descriptors] = candidate.trim().split(/\s+/)
+				return url ? [resolveUrl(url, baseUrl), ...descriptors].join(' ') : candidate
+			}).join(', '))
+		}
+	})
+}
+
+/**
+ * Copy a rendered HTML message for printing. The message frame's *current*
+ * document is taken, not its source, so that images the reader unblocked with
+ * "Show images temporarily" are printed the way they are shown.
+ *
+ * The markup is already server-sanitized. `<script>` and the iframe-resizer
+ * marker are stripped as a safeguard; the document this is rendered into must
+ * additionally be unable to run scripts, because unlike the live message frame
+ * it is not protected by the backend's Content-Security-Policy.
+ *
+ * The whole `<html>` element is kept, `<head>` and `<body>` included, so that
+ * the `html` and `body` selectors an email's stylesheet uses keep matching once
+ * the message no longer has a document of its own. A `<base>` the message
+ * carries is dropped instead — it has no effect outside a document's head, and
+ * `absolutizeUrls` has already applied it.
+ *
+ * @param sourceDocument the message frame's own document
+ */
+export function buildMessageContent(sourceDocument: Document): HTMLElement {
+	const html = sourceDocument.documentElement.cloneNode(true) as HTMLElement
+	html.querySelectorAll('script, base, [data-iframe-size]').forEach((node) => node.remove())
+	absolutizeUrls(html, sourceDocument.baseURI)
+
+	return html
+}
+
+/**
+ * Add a shadow host for one message body to `parent`.
+ *
+ * @param parent element to add the host to
+ */
+function attachMessageShadow(parent: HTMLElement): ShadowRoot {
+	const host = parent.ownerDocument.createElement('div')
+	host.className = 'print-message-content'
+	parent.appendChild(host)
+
+	return host.attachShadow({ mode: 'open' })
+}
+
+/**
+ * Render an HTML message into a shadow root of its own inside `parent`.
+ *
+ * Every message needs a tree of its own because an email's CSS is global to the
+ * tree it lives in: in a shared print document the `<style>` blocks of one
+ * message would restyle every other message of the thread. A shadow root
+ * contains that CSS the way a frame did, but — unlike a frame, which is a
+ * single box of a fixed size that neither breaks nor grows — its content is
+ * part of the print document's own flow. That is what lets a long message break
+ * across pages and lay itself out again when the reader picks another paper
+ * size or orientation in the already open print dialog.
+ *
+ * @param parent element to render the message into
+ * @param sourceDocument the message frame's own document
+ */
+export function renderHtmlMessage(parent: HTMLElement, sourceDocument: Document): HTMLElement {
+	const shadow = attachMessageShadow(parent)
+	shadow.appendChild(parent.ownerDocument.importNode(buildMessageContent(sourceDocument), true))
+
+	return shadow.host as HTMLElement
+}
+
+/**
+ * Render a plain text message into a shadow root of its own inside `parent`.
+ *
+ * A plain text body carries no CSS of its own and could not restyle anything,
+ * but it is rendered the same way as an HTML one so that both print paths hand
+ * the browser the same markup — and so that the app's stylesheet, which the
+ * live page brings along for a native browser print, cannot reach it either.
+ * What the body does need of that stylesheet, `PLAIN_TEXT_MESSAGE_STYLE`
+ * replaces.
+ *
+ * @param parent element to render the message into
+ * @param sourceElement the rendered message body in the app document
+ */
+export function renderPlainTextMessage(parent: HTMLElement, sourceElement: Element): HTMLElement {
+	const doc = parent.ownerDocument
+	const shadow = attachMessageShadow(parent)
+
+	const style = doc.createElement('style')
+	style.textContent = PLAIN_TEXT_MESSAGE_STYLE
+	shadow.appendChild(style)
+
+	const content = doc.importNode(sourceElement, true) as HTMLElement
+	content.removeAttribute('id')
+	content.className = 'print-message-text'
+	shadow.appendChild(content)
+
+	return shadow.host as HTMLElement
+}
+
+/**
+ * Collect every `<img>` below a root, shadow roots included: `querySelectorAll`
+ * stops at a shadow boundary, and every message body sits behind one.
+ *
+ * @param root root to look for images in
+ */
+function collectImages(root: ParentNode): HTMLImageElement[] {
+	const images = Array.from(root.querySelectorAll<HTMLImageElement>('img'))
+
+	root.querySelectorAll('*').forEach((element) => {
+		if (element.shadowRoot) {
+			images.push(...collectImages(element.shadowRoot))
+		}
+	})
+
+	return images
+}
+
+/**
+ * How long `waitForImages` waits for the images of a print rendering before it
+ * prints without them.
+ */
+export const IMAGE_LOAD_TIMEOUT = 10000
+
+/**
+ * Wait until every <img> in a root has finished loading (or errored). Freshly
+ * rendered content needs at least one tick to load/decode its images, even when
+ * they're cached, so printing right away can produce blank images.
+ *
+ * A remote image that neither loads nor errors — one served by a host that
+ * simply never answers — would hold this back for as long as the browser keeps
+ * the request open, so the wait gives up eventually and prints what is there.
+ *
+ * @param root root to look for images in
+ * @param timeout how long to wait before printing without the pending images
+ * @return whether every image settled, or `false` if the wait gave up on some
+ */
+export async function waitForImages(root: ParentNode, timeout: number = IMAGE_LOAD_TIMEOUT): Promise<boolean> {
+	const pending = collectImages(root).filter((img) => !img.complete)
+	if (pending.length === 0) {
+		return true
+	}
+
+	let expire: ReturnType<typeof setTimeout>
+	const expired = new Promise<boolean>((resolve) => {
+		expire = setTimeout(() => resolve(false), timeout)
+	})
+
+	const settled = await Promise.race([
+		Promise.all(pending.map((img) => new Promise<void>((resolve) => {
+			img.addEventListener('load', () => resolve(), { once: true })
+			img.addEventListener('error', () => resolve(), { once: true })
+		}))).then(() => true),
+		expired,
+	])
+
+	clearTimeout(expire!)
+
+	return settled
+}
+
+/**
+ * Whether the current platform is macOS, where the conventional shortcut
+ * modifier is Cmd (`metaKey`) rather than Ctrl.
+ */
+export function isAppleDevice(): boolean {
+	const nav = navigator as Navigator & { userAgentData?: { platform?: string } }
+	return /mac/i.test(nav.userAgentData?.platform ?? nav.platform ?? '')
+}
+
+/**
+ * Whether a keydown event is the platform's "print" shortcut: Cmd+P on macOS,
+ * Ctrl+P everywhere else. Binding the platform-appropriate modifier avoids
+ * hijacking native bindings — on macOS Ctrl+P moves the cursor up a line in text
+ * fields, so we must not swallow it there.
+ *
+ * The physical key is matched rather than the character it produces: `key` is
+ * `'P'` with CapsLock or Shift held, and whatever the reader's layout puts
+ * there in a non-Latin one, while `code` is the same key the browser itself
+ * binds its print shortcut to.
+ *
+ * @param event the keydown event to test
+ * @param appleDevice whether the platform is macOS (defaults to auto-detection)
+ */
+export function isPrintShortcut(event: KeyboardEvent, appleDevice: boolean = isAppleDevice()): boolean {
+	if (event.code !== 'KeyP') {
+		return false
+	}
+	return appleDevice ? event.metaKey : event.ctrlKey
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -177,28 +177,7 @@ export default {
 
 </script>
 
-<style lang="scss">
-@media print {
-	body {
-		/*
-		 * Nextcloud uses an inner scrolling but we need the
-		 * full page to scroll for print
-		 */
-		position: relative;
-		height: initial;
-	}
-}
-</style>
-
 <style lang="scss" scoped>
-@media print {
-	.mail-content {
-		height: initial;
-		/* needs important because of a more specific selector */
-		position: relative !important;
-	}
-}
-
 :deep(.app-content-details) {
 	margin: 0 auto;
 	display: flex;


### PR DESCRIPTION
Fix mail printing... again

This makes emails with multiple images not be all forced into one page

<img width="986" height="1187" alt="2026-07-03-181738_2560x1440_scrot" src="https://github.com/user-attachments/assets/5441db17-1166-401f-a6ee-3e79804bf0a3" />

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
