### PR TITLE
fix: moved "Delete thread" at the end of the contextual actions menu

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -328,20 +328,6 @@
 					</template>
 				</ActionButton>
 				<ActionButton
-					v-if="hasDeleteAcl"
-					:close-after-click="true"
-					@click.prevent="onDelete">
-					<template #icon>
-						<DeleteIcon :size="20" />
-					</template>
-					<template v-if="layoutMessageViewThreaded">
-						{{ t('mail', 'Delete thread') }}
-					</template>
-					<template v-else>
-						{{ t('mail', 'Delete message') }}
-					</template>
-				</ActionButton>
-				<ActionButton
 					:close-after-click="false"
 					@click="showMoreActionOptions">
 					<template #icon>
@@ -437,6 +423,20 @@
 					</template>
 					{{ t('mail', 'Download message') }}
 				</ActionLink>
+				<ActionButton
+					v-if="hasDeleteAcl"
+					:close-after-click="true"
+					@click.prevent="onDelete">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					<template v-if="layoutMessageViewThreaded">
+						{{ t('mail', 'Delete thread') }}
+					</template>
+					<template v-else>
+						{{ t('mail', 'Delete message') }}
+					</template>
+				</ActionButton>
 			</template>
 			<template v-if="quickActionMenu">
 				<ActionButton


### PR DESCRIPTION
The "Delete" option has been moved at the end of the actions' menu, under the "More actions" submenu.

Unsure if this was the actually desired behavior, as "Delete" is also one of the primary action buttons (so: anyway, it is well visible and clickable by the distracted user...).

Fixes #10071 