### PR TITLE
fix: hide "create task" option when no task calendar is available

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -422,6 +422,7 @@
 					{{ t('mail', 'Reply with meeting') }}
 				</ActionButton>
 				<ActionButton
+					v-if="tasksEnabled"
 					:close-after-click="true"
 					@click.prevent="showTaskModal = true">
 					<template #icon>
@@ -899,6 +900,10 @@ export default {
 
 		archiveMailbox() {
 			return this.mainStore.getMailbox(this.account.archiveMailboxId)
+		},
+
+		tasksEnabled() {
+			return this.mainStore.getTaskCalendarsForCurrentUser.length > 0
 		},
 
 		isSnoozedMailbox() {

--- a/src/components/MenuEnvelope.vue
+++ b/src/components/MenuEnvelope.vue
@@ -165,6 +165,7 @@
 				{{ t('mail', 'Reply with meeting') }}
 			</ActionButton>
 			<ActionButton
+				v-if="tasksEnabled"
 				:close-after-click="true"
 				@click.prevent="$emit('open-task-modal')">
 				<template #icon>
@@ -459,6 +460,10 @@ export default {
 
 		hasDeleteAcl() {
 			return mailboxHasRights(this.mailbox, 'te')
+		},
+
+		tasksEnabled() {
+			return this.mainStore.getTaskCalendarsForCurrentUser.length > 0
 		},
 
 		isSnoozedMailbox() {


### PR DESCRIPTION
The "Create task" modal ask for the calendar to which append the new task, but if none is available it is not possible to select anything and the whole operation cannot be concluded.

Fixes #9884 