### PR TITLE
fix(ui): do not mount favorites list when sorting is off

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -31,6 +31,7 @@
 					@shortkey.native="onShortcut">
 					<template v-if="!mailbox.isPriorityInbox">
 						<div
+							v-if="sortFavorites"
 							v-show="hasFavoriteEnvelopes"
 							class="app-content-list-item">
 							<SectionTitle
@@ -53,6 +54,7 @@
 							</NcPopover>
 						</div>
 						<Mailbox
+							v-if="sortFavorites"
 							v-show="hasFavoriteEnvelopes"
 							:load-more-label="t('mail', 'Load more favorites')"
 							:account="account"
@@ -76,6 +78,7 @@
 
 					<template v-else>
 						<div
+							v-if="sortFavorites"
 							v-show="hasFavoriteEnvelopes"
 							class="app-content-list-item">
 							<SectionTitle
@@ -98,6 +101,7 @@
 							</NcPopover>
 						</div>
 						<Mailbox
+							v-if="sortFavorites"
 							v-show="hasFavoriteEnvelopes"
 							:load-more-label="t('mail', 'Load more favorites')"
 							:account="unifiedAccount"


### PR DESCRIPTION
The favorites section was only hidden with v-show, so its Mailbox component stayed mounted and kept fetching and syncing is:starred envelopes on every mailbox switch even with the favorites-first preference disabled, causing duplicate requests and sync lock conflicts. Gate the section with v-if on the preference so the component only exists when the feature is enabled.

Assisted-by: Claude:claude-fable-5

Related to the feature https://github.com/nextcloud/mail/pull/12111.

## How to test

1. Disable *Sort favorites to the top* feature via app settings
2. Open a mailbox
3. Open the dev console, switch to network, clear the history
4. Switch to another mailbox

main: 4-5 XHRs
1. fetch first 20 favorite emails
2. fetch first 20 emails
3. sync the favs
4. sync the mailbox (potentially conflicts)
5. sync the mailbox again in case of conflict

here: 2 XHRs
1. fetch first 20 emails
2. sync the mailbox

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
