### PR TITLE
fix: only pin favorites when it s not part of the query

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -348,7 +348,7 @@ export default {
 		},
 
 		sortFavorites() {
-			return this.mainStore.getPreference('sort-favorites', 'false') === 'true'
+			return this.mainStore.getPreference('sort-favorites', 'false') === 'true' && this.$route.params.filter !== 'starred'
 		},
 
 		hasFavoriteEnvelopes() {


### PR DESCRIPTION
fix  #12953
## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Favorites are now sorted consistently based on the saved preference, including when viewing starred items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->