### PR TITLE
fix(ui): build valid search query when toggling favorites sort

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -433,9 +433,9 @@ export default {
 
 		sortFavorites(enabled) {
 			if (enabled) {
-				this.searchQuery = this.searchQuery ? 'not:starred' : this.searchQuery + ' not:starred'
-			} else if (this.searchQuery.includes('not:starred')) {
-				this.searchQuery = this.searchQuery.replace('not:starred', '')
+				this.searchQuery = this.searchQuery ? this.searchQuery + ' not:starred' : 'not:starred'
+			} else if (this.searchQuery?.includes('not:starred')) {
+				this.searchQuery = this.searchQuery.replace('not:starred', '').trim() || undefined
 			}
 		},
 
@@ -508,7 +508,7 @@ export default {
 		},
 
 		appendToSearch(str) {
-			if (this.searchQuery === undefined) {
+			if (!this.searchQuery) {
 				return str
 			}
 


### PR DESCRIPTION
Enabling the favorites-first preference while no search was active set the query to the literal string "undefined not:starred", hiding all messages until the next reload. Disabling it left an empty string behind, which produced filters with a leading space and split the envelope cache into separate lists.

## How to test

1. Enable sorting favorites on top
2. Open a mailbox with favs and non favs
3. Toggle the feature off
4. Toggle the feature back on
5. Toggle the feature off
6. Toggle the feature back on

main: the UI will alternate between fav/non-fav split and a single list, but the single list will sometimes only have the non-favs and no favs.
here: the UI will alternate between fav/no-fav split and a single list that always contains the favs too

You can also pay close attention to the XHR URLs that happen on goggle. On main there is a message fetch with `filter=+not:starred` -> notice the leading `+`. That means empty string + a filter. The frontend will therefore store the result in separate array keys.

Assisted-by: Claude:claude-fable-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
