### PR TITLE
fix(ui): remove redundant envelope fetch on mailbox switch

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -454,7 +454,6 @@ export default {
 		mailbox() {
 			clearTimeout(this.startMailboxTimer)
 			setTimeout(this.saveStartMailbox, START_MAILBOX_DEBOUNCE)
-			this.fetchEnvelopes()
 		},
 	},
 


### PR DESCRIPTION
The mailbox watcher fetch was introduced in fe12a2943 to fix threads disappearing after a refresh, but that case is fully covered by the guarded calls in mounted() and the route watcher. On every switch to an uninitialized or empty mailbox it duplicated the fetch that the child Mailbox component already performs and threw an unhandled MailboxNotCachedError for mailboxes that were not initialized yet.

Ref https://github.com/nextcloud/mail/pull/10084#pullrequestreview-2275294323

Assisted-by: Claude:claude-fable-5

## How to test

1. Add a new account
2. Open the browser console and network tab
3. Navigate to one of its mailboxes (other than inbox if it's opened by default)
4. Observe the XHRs

main: two identical GETs to fetch messages of the mailbox
here: only one request

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
