### PR TITLE
fix(ui): show favorites section based on the current folder

### DIFF
--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -355,8 +355,9 @@ export default {
 			if (!this.sortFavorites) {
 				return false
 			}
+			const mailbox = this.mailbox.isPriorityInbox ? this.unifiedInbox : this.mailbox
 			const envelopes = this.mainStore.getEnvelopes(
-				this.unifiedInbox.databaseId,
+				mailbox.databaseId,
 				this.appendToSearch(this.favoriteQuery),
 			)
 			return envelopes.length > 0


### PR DESCRIPTION
The visibility of the favorites section was driven by the unified inbox's starred envelopes for regular folders too, while the section itself renders the current folder's starred messages. Folders with starred mail hid the section until something populated the unified inbox list, and folders without starred mail showed an empty section once it was populated.

Assisted-by: Claude:claude-fable-5

Realization from https://github.com/nextcloud/mail/issues/12953#issuecomment-4890036138.

## How to test

1. Have a mailbox with favs
2. Enable the option to pin favs
3. Open the mailbox (NOT unified inbox!)
4. Reload the page

main: no favs on top unless you navigate to the unified inbox and back (assuming you have favs there)
here: favs are shown on top

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
