### PR TITLE
feat: expand groups to individual addresses

### DIFF
--- a/lib/Service/Group/ContactsGroupService.php
+++ b/lib/Service/Group/ContactsGroupService.php
@@ -97,7 +97,9 @@ class ContactsGroupService implements IGroupService {
 			}
 			foreach ($emails as $email) {
 				$receivers[] = [
-					'email' => $email
+					'id' => $r['UID'],
+					'name' => $r['FN'] ?: $email,
+					'email' => $email,
 				];
 			}
 		}

--- a/lib/Service/GroupsIntegration.php
+++ b/lib/Service/GroupsIntegration.php
@@ -51,6 +51,7 @@ class GroupsIntegration {
 					'label' => $g['name'] . ' (' . $gs->getNamespace() . ')',
 					'email' => $gid,
 					'source' => 'groups',
+					'contents' => $gs->getUsers($g['id']),
 				];
 			}
 		}

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1523,11 +1523,24 @@ export default {
 
 			let changed = false
 			if (option.id) {
-				if (!existing.has(option.email.toLowerCase())) {
-					const recipient = { ...option }
-					this.newRecipients.push(recipient)
-					list.push(recipient)
-					changed = true
+				let toAdd
+
+				if (option.contents) {
+					toAdd = option.contents.map((content) => ({
+						email: content.email,
+						label: content.name,
+					}))
+				} else {
+					toAdd = [option]
+				}
+
+				for (const opt of toAdd) {
+					if (!existing.has(opt.email.toLowerCase())) {
+						const recipient = { ...opt }
+						this.newRecipients.push(recipient)
+						list.push(recipient)
+						changed = true
+					}
 				}
 			} else {
 				const emailList = parseEmailList(option.email)


### PR DESCRIPTION
Considers this a proof-of-concept, as some more work is required including:

- handle contacts' avatars
- suppress the no-longer required `GroupsIntegration::expand()` function (and adjust `TransmissionService`)

Fixes #2723 
Fixes #9075 
Fixes #3132 