### PR TITLE
perf: caching a bit missing avatars

### DIFF
--- a/lib/Controller/AvatarsController.php
+++ b/lib/Controller/AvatarsController.php
@@ -104,8 +104,7 @@ class AvatarsController extends Controller {
 	private function noAvatarFoundResponse(): Response {
 		$response = new Response();
 		$response->setStatus(Http::STATUS_NOT_FOUND);
-		// Clear cache
-		$response->cacheFor(0);
+		$response->cacheFor(60 * 60, false, true);
 		return $response;
 	}
 }

--- a/tests/Unit/Controller/AvatarControllerTest.php
+++ b/tests/Unit/Controller/AvatarControllerTest.php
@@ -107,7 +107,7 @@ class AvatarControllerTest extends TestCase {
 
 		$expected = new Response();
 		$expected->setStatus(Http::STATUS_NOT_FOUND);
-		$expected->cacheFor(0);
+		$expected->cacheFor(60 * 60, false, true);
 		$this->assertEquals($expected, $resp);
 	}
 }


### PR DESCRIPTION
`AvatarsController::url()` already caches missing contents for a full day, I've just added one hour cache also in `AvatarsController::image()`.

Comments about the interval are welcome: one hour, as suggested in #9073, or one day, as in `AvatarsController::url()`?

Fixes #9073 