### PR TITLE
feat: unified attachments (as file and as link) from Files

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -350,14 +350,6 @@
 							t('mail', 'Add attachment from Files')
 						}}
 					</ActionButton>
-					<ActionButton :close-after-click="true" :disabled="encrypt" @click="onAddCloudAttachmentLink">
-						<template #icon>
-							<IconPublic :size="20" />
-						</template>
-						{{
-							t('mail', 'Add share link from Files')
-						}}
-					</ActionButton>
 				</Actions>
 
 				<Actions
@@ -523,7 +515,6 @@ import { NcReferencePickerModal } from '@nextcloud/vue/components/NcRichText'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import IconFolder from 'vue-material-design-icons/FolderOutline.vue'
 import IconFormat from 'vue-material-design-icons/FormatSize.vue'
-import IconPublic from 'vue-material-design-icons/Link.vue'
 import Paperclip from 'vue-material-design-icons/Paperclip.vue'
 import SendClock from 'vue-material-design-icons/SendClockOutline.vue'
 import Send from 'vue-material-design-icons/SendOutline.vue'
@@ -573,7 +564,6 @@ export default {
 		Download,
 		IconUpload,
 		IconFolder,
-		IconPublic,
 		IconLinkPicker,
 		NcSelect,
 		NcIconSvgWrapper,
@@ -1411,10 +1401,6 @@ export default {
 		onAddCloudAttachment() {
 			this.bus.emit('on-add-cloud-attachment')
 			this.saveDraftDebounced()
-		},
-
-		onAddCloudAttachmentLink() {
-			this.bus.emit('on-add-cloud-attachment-link')
 		},
 
 		onAutocomplete(term, addressType) {

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -39,17 +39,10 @@
 			@change="onLocalAttachmentSelected">
 		<FilePicker
 			v-if="isAttachmentPickerOpen"
-			:name="t('mail', 'Choose a file to add as attachment')"
+			:name="t('mail', 'Choose a file')"
 			:buttons="attachmentPickerButtons"
 			:filter-fn="filterAttachements"
 			@close="() => isAttachmentPickerOpen = false" />
-		<FilePicker
-			v-if="isLinkPickerOpen"
-			:name="t('mail', 'Choose a file to share as a link')"
-			:multiselect="false"
-			:buttons="linkPickerButtons"
-			:filter-fn="filterAttachements"
-			@close="() => isLinkPickerOpen = false" />
 	</div>
 </template>
 
@@ -120,18 +113,14 @@ export default {
 			isToggle: false,
 			hasNextLine: false,
 			isAttachmentPickerOpen: false,
-			isLinkPickerOpen: false,
 			attachmentPickerButtons: [
 				{
-					label: t('mail', 'Choose'),
+					label: t('mail', 'Add as attachment'),
 					callback: this.onAddCloudAttachment,
 					type: 'primary',
 				},
-			],
-
-			linkPickerButtons: [
 				{
-					label: t('mail', 'Choose'),
+					label: t('mail', 'Add as share link'),
 					callback: this.onAddCloudAttachmentLink,
 					type: 'primary',
 				},
@@ -193,7 +182,6 @@ export default {
 	created() {
 		this.bus.on('on-add-local-attachment', this.onAddLocalAttachment)
 		this.bus.on('on-add-cloud-attachment', this.openAttachementPicker)
-		this.bus.on('on-add-cloud-attachment-link', this.OpenLinkPicker)
 		this.bus.on('on-add-message-as-attachment', this.onAddMessageAsAttachment)
 		this.value.map((attachment) => {
 			this.attachments.push({
@@ -219,10 +207,6 @@ export default {
 
 		openAttachementPicker() {
 			this.isAttachmentPickerOpen = true
-		},
-
-		OpenLinkPicker() {
-			this.isLinkPickerOpen = true
 		},
 
 		onAddLocalAttachment() {


### PR DESCRIPTION
As `FilePickerVue` permits to customize action buttons, it is easy to pack multiple attachment stategies in a single modal.

Fixes #6080 