### PR TITLE
perf: reduce multiple ID IMAP commands by Horde client

### DIFF
--- a/lib/IMAP/HordeImapClient.php
+++ b/lib/IMAP/HordeImapClient.php
@@ -48,9 +48,10 @@ class HordeImapClient extends Horde_Imap_Client_Socket {
 
 	#[\Override]
 	public function login() {
+		$initiallyAutheticated = $this->_isAuthenticated;
 		parent::login();
 
-		if ($this->capability->query('ID')) {
+		if ($initiallyAutheticated === false && $this->capability->query('ID')) {
 			try {
 				$this->sendID();
 				/* ID is queued - force sending the queued command. */


### PR DESCRIPTION
Fix to avoid multiple (and avoidable) ID commands to the IMAP server, as discussed in #13163 