### PR TITLE
feat(ui): promote archive to an envelope primary action

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -237,6 +237,22 @@
 						isImportant ? t('mail', 'Unimportant') : t('mail', 'Important')
 					}}
 				</ActionButton>
+				<ActionButton
+					v-if="showArchiveButton && hasArchiveAcl"
+					class="action--primary"
+					:close-after-click="true"
+					:disabled="disableArchiveButton"
+					@click.prevent="onArchive">
+					<template #icon>
+						<ArchiveIcon :size="24" />
+					</template>
+					<template v-if="layoutMessageViewThreaded">
+						{{ t('mail', 'Archive thread') }}
+					</template>
+					<template v-else>
+						{{ t('mail', 'Archive message') }}
+					</template>
+				</ActionButton>
 			</EnvelopePrimaryActions>
 			<template v-if="!moreActionsOpen && !snoozeOptions && !quickActionMenu">
 				<ActionText>
@@ -310,21 +326,6 @@
 					</template>
 					<template v-else>
 						{{ t('mail', 'Move Message') }}
-					</template>
-				</ActionButton>
-				<ActionButton
-					v-if="showArchiveButton && hasArchiveAcl"
-					:close-after-click="true"
-					:disabled="disableArchiveButton"
-					@click.prevent="onArchive">
-					<template #icon>
-						<ArchiveIcon :size="20" />
-					</template>
-					<template v-if="layoutMessageViewThreaded">
-						{{ t('mail', 'Archive thread') }}
-					</template>
-					<template v-else>
-						{{ t('mail', 'Archive message') }}
 					</template>
 				</ActionButton>
 				<ActionButton


### PR DESCRIPTION
## Summary

Favorite, read and important are available as one-click primary action
buttons at the top of the envelope actions menu, but archiving — a core
step of inbox-zero style workflows — sits further down the entry list.

This PR promotes the existing archive entry to a fourth primary action
button:

* Reuses the existing `onArchive()` handler, `showArchiveButton` /
  `disableArchiveButton` computed properties and the `hasArchiveAcl`
  check — no behavioral changes.
* The button only appears when an archive mailbox is configured for the
  account and the ACLs allow it, exactly like the previous menu entry.
* The entry is moved (not duplicated): the old list entry is removed so
  the same action does not appear twice in one open menu.
* No new translatable strings — the existing "Archive thread" /
  "Archive message" strings are reused.

If the design team prefers to keep the primary row at three buttons, I
am happy to adjust (e.g. make the fourth button conditional or move it
behind a setting) — feedback welcome.

## Screenshots

Screenshots of the envelope actions menu before/after will follow.

## Checklist

- [x] Code is properly formatted (`npx eslint src/components/Envelope.vue` — no new warnings)
- [x] Frontend builds (`npm run build`)
- [x] Sign-off message and `AI-assisted` trailer are added
