### PR TITLE
fix: signature editor on mobile, enlarged menu for formatting options

### DIFF
--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -257,9 +257,15 @@ export default {
 .warning-large-signature {
 	color: darkorange;
 }
+
 /* it's a bit hard to make it work without this max-width in the modal because it overlaps with the sidebar of the modal */
 :deep(.ck.ck-toolbar-dropdown>.ck-dropdown__panel) {
 	max-width: 19vw;
+}
+@media only screen and (max-width: 580px) {
+	:deep(.ck.ck-toolbar-dropdown>.ck-dropdown__panel) {
+		max-width: 70vw;
+	}
 }
 
 </style>


### PR DESCRIPTION
In the Signature editor, the width of formatting options menu has been (correctly) limited to avoid overlaps with the configurations' modal sidebar (in 0eaad6f).

But on mobile it is squeezed to barely two columns of icons overflowing the menu itself. This PR defines a larger width for small screens.

Ref. #12096 