### PR TITLE
fix(ui): rename beforeUnmount hooks back to beforeDestroy

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1129,7 +1129,7 @@ export default {
 		}
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		window.removeEventListener('mailvelope', this.onMailvelopeLoaded)
 	},
 

--- a/src/components/DisplayContactDetails.vue
+++ b/src/components/DisplayContactDetails.vue
@@ -35,7 +35,7 @@ export default {
 		}
 	},
 
-	async beforeUnmount() {
+	async beforeDestroy() {
 		if (this.vm) {
 			this.vm.$destroy()
 		}

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -377,7 +377,7 @@ export default {
 		dragEventBus.on('envelopes-dropped', this.unselectAll)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		dragEventBus.off('envelopes-dropped', this.unselectAll)
 	},
 

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -59,7 +59,7 @@ export default {
 		}, 3500)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		clearTimeout(this.slowTimer)
 	},
 }

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -473,7 +473,7 @@ export default {
 		}
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		clearTimeout(this.startMailboxTimer)
 	},
 

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -206,7 +206,7 @@ export default {
 		document.addEventListener('click', this.handleClickOutside)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		document.removeEventListener('click', this.handleClickOutside)
 	},
 

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -131,7 +131,7 @@ export default {
 		}
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		scout.off('beforeprint', this.onBeforePrint)
 		scout.off('afterprint', this.onAfterPrint)
 		this.$refs.iframe.iFrameResizer.close()

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -518,7 +518,7 @@ export default {
 		dragEventBus.on('envelopes-moved', this.onEnvelopesMoved)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		dragEventBus.off('drag-start', this.onDragStart)
 		dragEventBus.off('drag-end', this.onDragEnd)
 		dragEventBus.off('envelopes-moved', this.onEnvelopesMoved)

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -271,7 +271,7 @@ export default {
 		window.addEventListener('resize', this.checkScreenSize)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		window.removeEventListener('beforeunload', this.onBeforeUnload)
 		window.removeEventListener('resize', this.checkScreenSize)
 	},

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -175,7 +175,7 @@ export default {
 		window.addEventListener('keydown', this.handleKeyDown)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		window.removeEventListener('keydown', this.handleKeyDown)
 	},
 

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -803,7 +803,7 @@ export default {
 		}, 100)
 	},
 
-	beforeUnmount() {
+	beforeDestroy() {
 		if (this.seenTimer !== undefined) {
 			logger.info('Navigating away before seenTimer delay, will not mark message as seen/read')
 			clearTimeout(this.seenTimer)


### PR DESCRIPTION
Vue 2.7 only invokes the Options API hook beforeDestroy; the Vue 3 name beforeUnmount is silently ignored. The premature rename (https://github.com/nextcloud/mail/pull/12590) meant cleanup code in these components never ran, leaking window listeners and event bus subscriptions. Most visibly, the composer's beforeunload handler survived after sending or discarding a message and blocked navigation with a bogus confirmation popup.

The hooks must be renamed again when the app actually switches to Vue 3.

Fixes #13031

Assisted-by: Claude:claude-fable-5

## How to test

1. Open the app
2. Send an email
3. Press F5

main: unload handler prevents reload
here: reload possible

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
