### PR TITLE
fix(ui): archive shortcut in unified mailboxes

### DIFF
--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -434,10 +434,14 @@ export default {
 					}
 
 					break
-				case 'arch':
+				case 'arch': {
 					logger.debug('archiving via shortcut')
 
-					if (this.account.archiveMailboxId === null) {
+					// In unified mailboxes this.account is the unified account which
+					// has no archive mailbox, so resolve the envelope's actual account
+					const account = this.mainStore.getAccount(env.accountId)
+
+					if (account.archiveMailboxId === null) {
 						showWarning(t('mail', 'To archive a message please configure an archive folder in account settings'))
 						return
 					}
@@ -447,7 +451,7 @@ export default {
 						return
 					}
 
-					if (env.mailboxId === this.account.archiveMailboxId) {
+					if (env.mailboxId === account.archiveMailboxId) {
 						logger.debug('message is already in archive folder')
 						return
 					}
@@ -457,7 +461,7 @@ export default {
 					try {
 						await this.mainStore.moveThread({
 							envelope: env,
-							destMailboxId: this.account.archiveMailboxId,
+							destMailboxId: account.archiveMailboxId,
 						})
 					} catch (error) {
 						logger.error('could not archive envelope', {
@@ -468,6 +472,7 @@ export default {
 						showError(t('mail', 'Could not archive message'))
 					}
 					break
+				}
 				case 'flag':
 					logger.debug('flagging envelope via shortkey', { env })
 					this.mainStore.toggleEnvelopeFlagged(env).catch((error) => logger.error('could not flag envelope via shortkey', {


### PR DESCRIPTION
I noticed that in the unified inbox ("All inboxes"), when I wanted to archive a message with the A key, I got an error, because the unified account itself has no archive folder, so I couldn't archive these mails from the unified inbox. Archiving the same message via the three-dot menu works, it is only the keyboard shortcut that fails.

This fix does the following: instead of looking at the unified account's archive folder, it looks at which account the email belongs to and uses that account's archive folder. That way the mail ends up in the correct archive from now on.

(I'm not a native English speaker — I wrote this in German and used AI only to translate it.)



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
