### PR TITLE
chore: minor graphic adjustments to quick actions modal

### DIFF
--- a/src/components/quickActions/Action.vue
+++ b/src/components/quickActions/Action.vue
@@ -5,7 +5,7 @@
 <template>
 	<div class="action">
 		<div class="action__info">
-			<DragIcon class="action__info__drag" :size="16" />
+			<DragIcon :class="'action__info__drag' + (!draggable ? ' undraggable' : '')" :size="16" />
 			<Icon class="action__info__icon" :action="action.name" />
 			<p v-if="!needsSelection">
 				{{ actionTitle }}
@@ -18,7 +18,11 @@
 				:model-value="selectedOption"
 				@update:modelValue="update" />
 		</div>
-		<NcButton :aria-label="t('mail', 'delete')" variant="tertiary-no-background" @click="$emit('delete')">
+		<NcButton
+			:aria-label="t('mail', 'delete')"
+			variant="tertiary-no-background"
+			class="delete-button"
+			@click="$emit('delete')">
 			<template #icon>
 				<CloseIcon :size="20" />
 			</template>
@@ -52,6 +56,11 @@ export default {
 
 		account: {
 			type: Object,
+			required: true,
+		},
+
+		draggable: {
+			type: Boolean,
 			required: true,
 		},
 	},
@@ -134,13 +143,23 @@ export default {
 	align-items: center;
 	&__info{
 		display: flex;
+		flex-grow: 1;
 		&__icon{
 			margin-inline-end : 3px
 		}
 		&__drag{
 			margin-inline-end : 6px;
 			cursor: grab;
+
+			&.undraggable {
+				opacity: .2;
+				cursor: revert;
+			}
 		}
+	}
+
+	.delete-button {
+		margin-inline-start : 6px;
 	}
 }
 </style>

--- a/src/components/quickActions/Settings.vue
+++ b/src/components/quickActions/Settings.vue
@@ -43,6 +43,7 @@
 						<Action
 							:action="item"
 							:account="account"
+							:draggable="item.name !== 'deleteThread' && item.name !== 'moveThread'"
 							@update="(payload) => updateAction(payload, item)"
 							@delete="deleteAction(item)" />
 					</Draggable>
@@ -370,9 +371,10 @@ export default {
 <style lang="scss" scoped>
 
 .modal-content{
-	padding: 30px;
+	padding: 0 30px 30px 30px;
+
 	&__action{
-		padding: 9px;
+		padding: 6px 0;
 	}
 	&__save {
 		position: absolute;
@@ -382,9 +384,16 @@ export default {
 }
 
 :deep(.v-select){
-	display: flex;
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	flex-grow: 1;
     align-items: center;
     justify-content: space-between;
+	margin: 0;
+
+	.select__label {
+		margin: 0;
+	}
 }
 
 .modal-name{


### PR DESCRIPTION
Here a totally unrequested adjustment of the design of Quick Action edit modal.

Changes are purely aesthetic, no functionality has been changed.

Notable changes:
- margins and spacing
- the d'n'd handle for unsortable actions (Move Thread and Delete Thread) is grayed out, to indicate to the user that those cannot be moved (I tried to drag one of those actions, it didn't worked, I believed I broke something, only reading at the code I found that those cannot be moved and it is normal...)

Working on this I found the bug #13308 which is NOT here targeted.

Those adjustments are subjective and have not been approved by a real designer! Feel free to reject this!

<img width="1721" height="846" alt="sample" src="https://github.com/user-attachments/assets/9a8ce51b-71a5-4e70-a0e4-d871b369ac58" />