### PR TITLE
fix: avatars in dashboard widgets

### DIFF
--- a/lib/Dashboard/MailWidget.php
+++ b/lib/Dashboard/MailWidget.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Dashboard;
 
+use OCA\Mail\Address;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\Contracts\IAvatarService;
 use OCA\Mail\Contracts\IMailSearch;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Exception\ClientException;
@@ -40,6 +42,7 @@ abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOpt
 		IL10N $l10n,
 		IURLGenerator $urlGenerator,
 		IUserManager $userManager,
+		private IAvatarService $avatarService,
 		protected AccountService $accountService,
 		protected IMailSearch $mailSearch,
 		IInitialState $initialState,
@@ -128,6 +131,37 @@ abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOpt
 		return array_values(array_filter($mailboxIdsToExclude));
 	}
 
+	protected function getAvatar(string $userId, ?Address $from): string {
+		if ($from) {
+			$email = $from->getEmail();
+			if ($email) {
+				$avatar = $this->avatarService->getAvatar($email, $userId);
+				if ($avatar) {
+					if ($avatar->isExternal()) {
+						return $this->urlGenerator->getAbsoluteURL(
+							$this->urlGenerator->linkToRoute('mail.avatars.image', [
+								'email' => $email,
+							])
+						);
+					}
+
+					return $avatar->getUrl();
+				}
+			}
+		}
+
+		return $this->urlGenerator->getAbsoluteURL(
+			$this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', [
+				'guestName' => $from
+					? ($from->getLabel()
+						? str_replace('/', '-', $from->getLabel())
+						: $from->getEmail())
+					: '',
+				'size' => 44,
+			])
+		);
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -137,7 +171,7 @@ abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOpt
 		$emails = $this->getEmails($userId, $intSince, $limit);
 
 		/** @var list<WidgetItem> */
-		return array_map(function (Message $email) {
+		return array_map(function (Message $email) use ($userId) {
 			$firstFrom = $email->getFrom()->first();
 			return new WidgetItem(
 				$firstFrom ? $firstFrom->getLabel() : '',
@@ -145,16 +179,7 @@ abstract class MailWidget implements IAPIWidget, IAPIWidgetV2, IIconWidget, IOpt
 				$this->urlGenerator->getAbsoluteURL(
 					$this->urlGenerator->linkToRoute('mail.page.thread', ['mailboxId' => $email->getMailboxId(), 'id' => $email->getId()])
 				),
-				$this->urlGenerator->getAbsoluteURL(
-					$this->urlGenerator->linkToRoute('core.GuestAvatar.getAvatar', [
-						'guestName' => $firstFrom
-							? ($firstFrom->getLabel()
-								? str_replace('/', '-', $firstFrom->getLabel())
-								: $firstFrom->getEmail())
-							: '',
-						'size' => 44,
-					])
-				),
+				$this->getAvatar($userId, $firstFrom),
 				(string)$email->getSentAt()
 			);
 		}, $emails);

--- a/tests/Unit/Dashboard/ImportantMailWidgetTest.php
+++ b/tests/Unit/Dashboard/ImportantMailWidgetTest.php
@@ -11,10 +11,13 @@ namespace Unit\Dashboard;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
+use OCA\Mail\AddressList;
+use OCA\Mail\Contracts\IAvatarService;
 use OCA\Mail\Dashboard\ImportantMailWidget;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Avatar\Avatar;
 use OCA\Mail\Service\Search\GlobalSearchQuery;
 use OCA\Mail\Service\Search\MailSearch;
 use OCA\Mail\Service\Search\SearchQuery as MailSearchQuery;
@@ -30,6 +33,7 @@ class ImportantMailWidgetTest extends TestCase {
 	private IL10N&MockObject $l10n;
 	private IURLGenerator&MockObject $urlGenerator;
 	private IUserManager&MockObject $userManager;
+	private IAvatarService&MockObject $avatarService;
 	private AccountService&MockObject $accountService;
 	private MailSearch&MockObject $mailSearch;
 	private IInitialState&MockObject $initialState;
@@ -41,6 +45,7 @@ class ImportantMailWidgetTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->avatarService = $this->createMock(IAvatarService::class);
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->mailSearch = $this->createMock(MailSearch::class);
 		$this->initialState = $this->createMock(IInitialState::class);
@@ -49,6 +54,7 @@ class ImportantMailWidgetTest extends TestCase {
 			$this->l10n,
 			$this->urlGenerator,
 			$this->userManager,
+			$this->avatarService,
 			$this->accountService,
 			$this->mailSearch,
 			$this->initialState,
@@ -84,6 +90,46 @@ class ImportantMailWidgetTest extends TestCase {
 		$items = $this->widget->getItems('bob', null, 7);
 
 		$this->assertCount(2, $items);
+	}
+
+	public function testGetItemsWithAvatars(): void {
+		$user = $this->createStub(IUser::class);
+		$this->userManager->expects($this->once())
+			->method('get')
+			->willReturn($user);
+
+		$message1 = new Message();
+		$message1->setSubject('Important');
+		$message1->setMailboxId(1);
+		$message1->setFrom(AddressList::fromRow([
+			'label' => 'John Doe',
+			'email' => 'john@doe.com',
+		]));
+
+		$this->mailSearch->expects($this->once())
+			->method('findMessagesGlobally')
+			->with($user, $this->callback(function (GlobalSearchQuery $query) {
+				self::assertCount(1, $query->getFlags());
+				self::assertNull($query->getStart());
+				return true;
+			}))
+			->willReturn([$message1]);
+
+		$mailAccount = new MailAccount();
+		$account = new Account($mailAccount);
+		$this->accountService->expects($this->once())
+			->method('findByUserId')
+			->willReturn([$account]);
+
+		$avatar = new Avatar('https://example.com/avatar.png', 'image/png', false);
+		$this->avatarService->expects($this->once())
+			->method('getAvatar')
+			->with('john@doe.com', 'bob')
+			->willReturn($avatar);
+
+		$items = $this->widget->getItems('bob', null, 7);
+
+		$this->assertCount(1, $items);
 	}
 
 	public function testGetItemsWithSince(): void {


### PR DESCRIPTION
Fixes #11634 

Warning: those changes do not address apparent issues caused by the avatars' cache: just changing an image may not provide immediate results until the cache is expired and recalculated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mail dashboard items now display sender avatars when available.
  * External avatars are supported with appropriate URL handling.
  * A fallback guest avatar is shown when no sender avatar is available.

* **Tests**
  * Added coverage for avatar retrieval and display in important mail items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->