### PR TITLE
fix: interactions in actions menu for mailboxes

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -111,7 +111,7 @@
 				</template>
 			</ActionButton>
 			<ActionButton
-				v-if="!editing && !account.isUnified && hasDelimiter && mailbox.specialRole !== 'flagged' && hasSubmailboxActionAcl"
+				v-if="subfolderLabel && !account.isUnified && hasDelimiter && mailbox.specialRole !== 'flagged' && hasSubmailboxActionAcl"
 				@click="openCreateMailbox">
 				<template #icon>
 					<IconAdd :size="20" />
@@ -119,13 +119,19 @@
 				{{ t('mail', 'Add subfolder') }}
 			</ActionButton>
 			<ActionInput
-				v-if="editing"
+				v-if="subfolderInput"
 				:value.sync="createMailboxName"
 				@submit.prevent.stop="createMailbox">
 				<template #icon>
 					<IconAdd :size="20" />
 				</template>
 			</ActionInput>
+			<ActionText v-if="subfolderSaving">
+				<template #icon>
+					<IconLoading :size="20" />
+				</template>
+				{{ t('mail', 'Saving') }}
+			</ActionText>
 			<ActionButton
 				v-if="renameLabel && !hasSubMailboxes && !account.isUnified && hasRenameAcl"
 				@click.prevent.stop="openRenameInput">
@@ -144,7 +150,7 @@
 						:size="20" />
 				</template>
 			</ActionInput>
-			<ActionText v-if="showSaving">
+			<ActionText v-if="renameSaving">
 				<template #icon>
 					<IconLoading :size="20" />
 				</template>
@@ -353,15 +359,17 @@ export default {
 			mailboxStats: undefined,
 			loadingMarkAsRead: false,
 			clearingCache: false,
-			showSaving: false,
 			changeSubscription: false,
 			changingSyncInBackground: false,
-			editing: false,
+			subfolderLabel: true,
+			subfolderInput: false,
+			subfolderSaving: false,
 			showSubMailboxes: false,
 			wasExpandedBeforeDrag: false,
 			menuOpen: false,
 			renameLabel: true,
 			renameInput: false,
+			renameSaving: false,
 			mailboxName: this.mailbox.displayName,
 			showMoveModal: false,
 			hasDelimiter: !!this.mailbox.delimiter,
@@ -543,6 +551,16 @@ export default {
 		onMenuToggle(open) {
 			if (open) {
 				this.fetchMailboxStats()
+			} else {
+				if (!this.renameSaving) {
+					this.renameLabel = true
+					this.renameInput = false
+				}
+
+				if (!this.subfolderSaving) {
+					this.subfolderLabel = true
+					this.subfolderInput = false
+				}
 			}
 		},
 
@@ -566,11 +584,12 @@ export default {
 		},
 
 		async createMailbox(e) {
-			this.editing = true
+			this.subfolderInput = false
+			this.subfolderSaving = true
 			const name = this.createMailboxName
 			const withPrefix = this.mailbox.name + this.mailbox.delimiter + name
 			logger.info(`creating mailbox ${withPrefix} as submailbox of ${this.mailbox.databaseId}`)
-			this.menuOpen = false
+
 			try {
 				await this.mainStore.createMailbox({
 					account: this.account,
@@ -580,16 +599,20 @@ export default {
 				logger.error(`could not create mailbox ${withPrefix}`, { error })
 				throw error
 			} finally {
-				this.editing = false
-				this.showSaving = false
+				this.menuOpen = false
+				this.subfolderLabel = true
+				this.subfolderSaving = false
 			}
+
 			logger.info(`mailbox ${withPrefix} created`)
 			this.showSubMailboxes = true
 		},
 
 		openCreateMailbox() {
-			this.editing = true
-			this.showSaving = false
+			this.subfolderLabel = false
+			this.createMailboxName = ''
+			this.subfolderInput = true
+			this.subfolderSaving = false
 		},
 
 		markAsRead() {
@@ -712,7 +735,7 @@ export default {
 
 		async renameMailbox() {
 			this.renameInput = false
-			this.showSaving = true
+			this.renameSaving = true
 
 			try {
 				let newName = this.mailboxName
@@ -724,21 +747,21 @@ export default {
 					mailbox: this.mailbox,
 					newName,
 				})
-				this.renameLabel = true
-				this.renameInput = false
 			} catch (error) {
 				showInfo(t('mail', 'An error occurred, unable to rename the mailbox.'))
 				logger.error('could not rename mailbox', { error })
 			} finally {
-				this.showSaving = false
+				this.renameSaving = false
+				this.renameLabel = true
 			}
 		},
 
 		openRenameInput() {
 			// Hide label and show input
 			this.renameLabel = false
+			this.mailboxName = this.mailbox.displayName
 			this.renameInput = true
-			this.showSaving = false
+			this.renameSaving = false
 		},
 
 		onOpenMoveModal() {


### PR DESCRIPTION
Here I've fixed the interaction with the "Rename" option (mentioned in #9107) but also with "Add subfolder" (having the same problem). Both inputs are reverted to the static label when the menu is closed.

I've also added a "Saving" animation for "Add subfolder", equivalent to the one already existing for "Rename".

Fixes #9107 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mailbox subfolder creation and rename flows with more reliable, clearly displayed loading states.
  * Prevented duplicate actions by disabling interactions while subfolder creation or renaming is in progress.
  * Ensured the navigation menu and related input/controls reset correctly when closing the menu, without interrupting active save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->