### PR TITLE
fix: improved widget for mailbox selection

### DIFF
--- a/src/components/AccountDefaultsSettings.vue
+++ b/src/components/AccountDefaultsSettings.vue
@@ -4,42 +4,52 @@
 -->
 
 <template>
-	<div>
-		<p>
-			{{ t('mail', 'Drafts are saved in:') }}
-		</p>
-		<MailboxInlinePicker v-model="draftsMailbox" :account="account" :disabled="saving" />
+	<div class="default-folders">
+		<MailboxInlinePicker
+			:label="t('mail', 'Drafts are saved in:')"
+			:value="account.draftsMailboxId"
+			:account="account"
+			:disabled="saving.draftsMailboxId"
+			@update="(folderId) => updateFolder('draftsMailboxId', folderId)" />
 
-		<p>
-			{{ t('mail', 'Sent messages are saved in:') }}
-		</p>
+		<MailboxInlinePicker
+			:label="t('mail', 'Sent messages are saved in:')"
+			:value="account.sentMailboxId"
+			:account="account"
+			:disabled="saving.sentMailboxId"
+			@update="(folderId) => updateFolder('sentMailboxId', folderId)" />
 
-		<MailboxInlinePicker v-model="sentMailbox" :account="account" :disabled="saving" />
-		<p>
-			{{ t('mail', 'Deleted messages are moved in:') }}
-		</p>
+		<MailboxInlinePicker
+			:label="t('mail', 'Deleted messages are moved in:')"
+			:value="account.trashMailboxId"
+			:account="account"
+			:disabled="saving.trashMailboxId"
+			@update="(folderId) => updateFolder('trashMailboxId', folderId)" />
 
-		<MailboxInlinePicker v-model="trashMailbox" :account="account" :disabled="saving" />
-		<p>
-			{{ t('mail', 'Archived messages are moved in:') }}
-		</p>
+		<MailboxInlinePicker
+			:label="t('mail', 'Archived messages are moved in:')"
+			:value="account.archiveMailboxId"
+			:account="account"
+			:disabled="saving.archiveMailboxId"
+			@update="(folderId) => updateFolder('archiveMailboxId', folderId)" />
 
-		<MailboxInlinePicker v-model="archiveMailbox" :account="account" :disabled="saving" />
-		<p>
-			{{ t('mail', 'Snoozed messages are moved in:') }}
-		</p>
+		<MailboxInlinePicker
+			:label="t('mail', 'Snoozed messages are moved in:')"
+			:value="account.snoozeMailboxId"
+			:account="account"
+			:disabled="saving.snoozeMailboxId"
+			@update="(folderId) => updateFolder('snoozeMailboxId', folderId)" />
 
-		<MailboxInlinePicker v-model="snoozeMailbox" :account="account" :disabled="saving" />
-
-		<p>
-			{{ t('mail', 'Junk messages are saved in:') }}
-		</p>
-		<MailboxInlinePicker v-model="junkMailbox" :account="account" :disabled="saving" />
+		<MailboxInlinePicker
+			:label="t('mail', 'Junk messages are saved in:')"
+			:value="account.junkMailboxId"
+			:account="account"
+			:disabled="saving.junkMailboxId"
+			@update="(folderId) => updateFolder('junkMailboxId', folderId)" />
 	</div>
 </template>
 
 <script>
-import { mapStores } from 'pinia'
 import MailboxInlinePicker from './MailboxInlinePicker.vue'
 import logger from '../logger.js'
 import useMainStore from '../store/mainStore.js'
@@ -59,198 +69,48 @@ export default {
 
 	data() {
 		return {
-			saving: false,
+			saving: {
+				draftsMailboxId: false,
+				sentMailboxId: false,
+				trashMailboxId: false,
+				archiveMailboxId: false,
+				snoozeMailboxId: false,
+				junkMailboxId: false,
+			},
 		}
 	},
 
 	computed: {
-		...mapStores(useMainStore),
-		draftsMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.draftsMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(draftsMailboxId) {
-				logger.debug('setting drafts folder to ' + draftsMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							draftsMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set drafts folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
+		mainStore() {
+			return useMainStore()
 		},
+	},
 
-		sentMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.sentMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(sentMailboxId) {
-				logger.debug('setting sent folder to ' + sentMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							sentMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set sent folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
-		},
-
-		trashMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.trashMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(trashMailboxId) {
-				logger.debug('setting trash folder to ' + trashMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							trashMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set trash folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
-		},
-
-		archiveMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.archiveMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(archiveMailboxId) {
-				logger.debug('setting archive folder to ' + archiveMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							archiveMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set archive folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
-		},
-
-		junkMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.junkMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(junkMailboxId) {
-				logger.debug('setting junk folder to ' + junkMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							junkMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set junk folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
-		},
-
-		snoozeMailbox: {
-			get() {
-				const mb = this.mainStore.getMailbox(this.account.snoozeMailboxId)
-				if (!mb) {
-					return
-				}
-				return mb.databaseId
-			},
-
-			async set(snoozeMailboxId) {
-				logger.debug('setting snooze folder to ' + snoozeMailboxId)
-				this.saving = true
-				try {
-					await this.mainStore.patchAccount({
-						account: this.account,
-						data: {
-							snoozeMailboxId,
-						},
-					})
-				} catch (error) {
-					logger.error('could not set snooze folder', {
-						error,
-					})
-				} finally {
-					this.saving = false
-				}
-			},
+	methods: {
+		async updateFolder(type, id) {
+			this.saving[type] = true
+			try {
+				await this.mainStore.patchAccount({
+					account: this.account,
+					data: {
+						[type]: id,
+					},
+				})
+			} catch (error) {
+				logger.error('could not set default folder', {
+					error,
+				})
+			} finally {
+				this.saving[type] = false
+			}
 		},
 	},
 }
 </script>
 
-<style lang="scss" scoped>
-.button.icon-rename {
-	background-color: transparent;
-	border: none;
-	opacity: 0.3;
-
-	&:hover,
-	&:focus {
-		opacity: 1;
-	}
+<style>
+.default-folders {
+	display: flex;
+	flex-direction: column;
 }
 </style>

--- a/src/components/MailboxInlinePicker.vue
+++ b/src/components/MailboxInlinePicker.vue
@@ -3,27 +3,24 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<Treeselect
-		ref="Treeselect"
-		v-model="selected"
+	<NcSelect
+		:input-label="label"
 		:options="mailboxes"
-		:multiple="false"
-		:clearable="false"
-		:disabled="disabled" />
+		label="value"
+		:model-value="selectedOption"
+		:disabled="disabled"
+		@update:modelValue="update" />
 </template>
 
 <script>
-import Treeselect from '@riophae/vue-treeselect'
-import { mapStores } from 'pinia'
+import { NcSelect } from '@nextcloud/vue'
 import useMainStore from '../store/mainStore.js'
 import { mailboxHasRights } from '../util/acl.js'
-
-import '@riophae/vue-treeselect/dist/vue-treeselect.css'
 
 export default {
 	name: 'MailboxInlinePicker',
 	components: {
-		Treeselect,
+		NcSelect,
 	},
 
 	props: {
@@ -32,27 +29,33 @@ export default {
 			required: true,
 		},
 
-		disabled: {
-			type: Boolean,
-			default: false,
+		label: {
+			type: String,
+			default: '',
 		},
 
 		value: {
 			type: Number,
 			default: undefined,
 		},
-	},
 
-	data() {
-		return {
-			selected: this.value,
-		}
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	computed: {
-		...mapStores(useMainStore),
+		mainStore() {
+			return useMainStore()
+		},
+
 		mailboxes() {
 			return this.getMailboxes()
+		},
+
+		selectedOption() {
+			return this.mailboxes.find((option) => option.id === this.value) || null
 		},
 	},
 
@@ -66,66 +69,22 @@ export default {
 	},
 
 	methods: {
-		getMailboxes(mailboxId) {
-			let mailboxes = []
-			if (!mailboxId) {
-				mailboxes = this.mainStore.getMailboxes(this.account.accountId)
-			} else {
-				mailboxes = this.mainStore.getSubMailboxes(mailboxId)
-			}
-			mailboxes = mailboxes.filter((mailbox) => mailboxHasRights(mailbox, 'i'))
-			return mailboxes.map((mailbox) => {
-				return {
-					id: mailbox.databaseId,
-					label: mailbox.displayName,
-					children: mailbox.mailboxes.length > 0 ? this.getMailboxes(mailbox.databaseId) : '',
+		getMailboxes() {
+			const mailboxes = []
+			for (const mailbox of this.mainStore.getRecursiveMailboxIterator(this.account.accountId)) {
+				if (mailboxHasRights(mailbox, 'i')) {
+					mailboxes.push({
+						value: mailbox.name,
+						id: mailbox.databaseId,
+					})
 				}
-			})
+			}
+			return mailboxes
+		},
+
+		update(value) {
+			this.$emit('update', value ? value.id : 0)
 		},
 	},
 }
 </script>
-
-<style>
-.vue-treeselect__control {
-	padding: 0;
-	border: 0;
-	width: 250px;
-}
-
-.vue-treeselect__control-arrow-container {
-	display: none;
-}
-
-.vue-treeselect--searchable .vue-treeselect__input-container {
-	padding-inline-start: 0;
-	background-color: var(--color-main-background)
-}
-
-input.vue-treeselect__input {
-	margin: 0;
-	padding: 0;
-	border: 1px solid var(--color-border-maxcontrast) !important;
-}
-
-.vue-treeselect__menu {
-	background: var(--color-main-background);
-}
-
-.vue-treeselect--single .vue-treeselect__option--selected {
-	background: var(--color-primary-element-light);
-	border-radius: var(--border-radius-large);
-}
-
-.vue-treeselect__option.vue-treeselect__option--highlight,
-.vue-treeselect__option:hover,
-.vue-treeselect__option:focus {
-	border-radius: var(--border-radius-large);
-	}
-
-.vue-treeselect__placeholder, .vue-treeselect__single-value {
-	line-height: 34px;
-	color: var(--color-main-text);
-}
-
-</style>

--- a/src/components/mailFilter/Action.vue
+++ b/src/components/mailFilter/Action.vue
@@ -130,9 +130,6 @@ export default {
 		width: 100%;
 		&__column {
 			flex: 0 1 auto;
-			&__select {
-				margin: 0
-			}
 		}
 	}
 	&__delete {

--- a/src/components/mailFilter/ActionFileinto.vue
+++ b/src/components/mailFilter/ActionFileinto.vue
@@ -3,7 +3,11 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<MailboxInlinePicker :account="account" :value="mailbox" @input="onInput" />
+	<MailboxInlinePicker
+		ariaLabelCombobox="t('mail', 'Choose target folder')"
+		:account="account"
+		:value="mailbox"
+		@update="onInput" />
 </template>
 
 <script>
@@ -52,13 +56,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-:deep(.vue-treeselect__control) {
-	width: 100%; /* todo: fix MailboxInlinePicker.vue styling instead */
-}
-
-:deep(.vue-treeselect__input-container) {
-	padding-inline-end: 0; /* todo: fix MailboxInlinePicker.vue styling instead */
-}
-</style>


### PR DESCRIPTION
Diving into #8726 I stumbled upon `MailboxInlinePicker`, the only user of [@riophae/vue-treeselect](https://www.npmjs.com/package/@riophae/vue-treeselect), a not-so-lightweight dependency which did not received any update in the last 7 years.

So I rewrote it using the more familiar `NcSelect`, which do not permit nested navigation and selection of subfolders. Let you evaluate if this is an acceptable loss.

This PR includes:
- major rewrite of `MailboxInlinePicker`, as specified above
- major rewrite of `AccountDefaultsSettings`, to adapt to the new `MailboxInlinePicker`, remove most of the duplicated code around, and separate the flags to disable the single inputs while saving (which was the original request of #8726)
- minor review of `ActionFileinto`, also to be adapted to the new `MailboxInlinePicker`
- remove of all specific CSS style targeting `vue-treeselect`

My only concern is about the filter on `mailboxHasRights`, which has been here removed. It is not entirely clear to me what kind of check was here performed, but if it was required perhaps the same elaboration should be added also to Quick Folders selections (cfr. #13305) and similar folder/subfolder selections.

Fixes #8726

Note: if this PR is merged, I recommend to remove then the dependency from `@riophae/vue-treeselect` in `package.json`: I avoided to change that myself in order to not mess up with `package-lock.json`