### PR TITLE
fix: bubbling events from html message iframe

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -154,6 +154,19 @@ export default {
 			if (this.isSenderTrusted) {
 				this.displayIframe()
 			}
+
+			// Events occurring into the iframe are forced to bubble to the
+			// document, to be intercepted by other functions
+			const propagateEvents = ['click', 'keydown', 'keyup']
+			propagateEvents.forEach((eventType) => {
+				iframeDoc.addEventListener(eventType, (e) => {
+					const cloned = new e.constructor(e.type, e)
+					this.$refs.iframe.dispatchEvent(cloned)
+					if (cloned.defaultPrevented) {
+						e.preventDefault()
+					}
+				})
+			})
 		},
 
 		onBeforePrint() {


### PR DESCRIPTION
Issue: events occurring into the iframe rendering contents of an HTML message are absorbed by the iframe itself, and cannot be intercepted by the application. This breaks many frontend's behaviours once the user interact with the iframe itself (e.g. keyboard shortcuts do not work anymore once the user clicks on the message contents, and action menus do not close when incidentally clicking over the iframe).

With this change, some type of events are intercepted and replicated to the local DOM to be properly handled.
In details:
- `keyup` and `keydown` are consumed by `vue-shortkey` to handle keyboard shortcuts
- `click` is consumed by by `NcActions` to evaluate closing action menus (this specific change was already submitted in #13296 but reverted to isolate and better evaluate this whole proposal)

Security implications: my understanding is that Mail strips Javascript from HTML of incoming messages. Which is, indeed, a sane practice applied by most web email clients. So, the risk of JS forged events escaping from the iframe is mitigated at his very root. A confirmation for this would be appreciated.

Fixes #6804 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction handling for content displayed in embedded frames.
  * Clicks and keyboard actions within embedded content are now properly detected by the surrounding application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->