### PR TITLE
fix(tags): add accessible name to tag modal

### DIFF
--- a/src/components/TagModal.vue
+++ b/src/components/TagModal.vue
@@ -10,9 +10,13 @@
 		:envelopes="envelopes"
 		:account-id="envelopes[0].accountId"
 		@close="closeDeleteModal" />
-	<Modal v-else size="large" @close="onClose">
+	<Modal
+		v-else
+		size="large"
+		label-id="tag-modal-heading"
+		@close="onClose">
 		<div class="modal-content">
-			<h2 class="tag-title">
+			<h2 id="tag-modal-heading" class="tag-title">
 				{{ t('mail', 'Add default tags') }}
 			</h2>
 			<TagItem


### PR DESCRIPTION
NcModal requires a name or labelId for accessibility; without it Vue warns and screen readers get no dialog label;

```
[Vue warn]: [NcModal] You need either set the name or set a `labelId` for accessibility.

found in

---> <NcModal>
       <TagModal> at src/components/TagModal.vue
         <RouterLink>
           <EnvelopeSkeleton> at src/components/EnvelopeSkeleton.vue
             <Envelope> at src/components/Envelope.vue
               <TransitionGroup>
                 <EnvelopeList> at src/components/EnvelopeList.vue
                   <Mailbox> at src/components/Mailbox.vue
                     <NcAppContentList>
                       <Pane>
                         <Splitpanes>
                           <NcAppContent>
                             <MailboxThread> at src/components/MailboxThread.vue
                               <NcContent>
                                 <Home> at src/views/Home.vue
                                   <App> at src/App.vue
                                     <Root>
```

Assisted-by: Claude:claude-opus-4-8

Discovered while testing https://github.com/nextcloud/mail/pull/13257.

## How to test

1. Open the three dot menu of a thread envelope
2. Click *Edit tags*

main: console Vue warning
here: :sparkles: 

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
