### PR TITLE
When hovering summary, show full summary instead of only AI notice

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -173,8 +173,12 @@
 				<div
 					v-if="!compactMode && (data.encrypted || data.previewText)"
 					class="envelope__preview-text"
-					:title="data.summary ? t('mail', 'This summary was AI generated') : null">
-					<NcAssistantIcon v-if="data.summary" :size="15" class="envelope__preview-text__icon" />
+					:title="data.summary ? data.summary.trim() : null">
+					<NcAssistantIcon
+						v-if="data.summary"
+						:size="15"
+						class="envelope__preview-text__icon"
+						:title="t('mail', 'This summary was AI-generated')" />
 					{{ isEncrypted ? t('mail', 'Encrypted message') : data.summary ? data.summary.trim() : data.previewText.trim() }}
 				</div>
 			</div>

--- a/src/components/ThreadSummary.vue
+++ b/src/components/ThreadSummary.vue
@@ -37,7 +37,7 @@
 				</p>
 			</div>
 			<div class="summary__notice">
-				{{ t('mail', 'This summary is AI generated and may contain mistakes.') }}
+				{{ t('mail', 'This summary is AI-generated and may contain mistakes.') }}
 			</div>
 		</div>
 	</NcAssistantContent>


### PR DESCRIPTION
When hovering the AI summary `envelope__preview-text` (that is often ellipsized), it shows "This summary was AI generated" as text. Usually when hovering text that is ellipsized, the whole text is shown.

This changes it to:
- On hovering the ellipsized summary, the full summary is shown
- The "This summary was AI generated" is shown specifically when hovering the `envelope__preview-text__icon _assistantIcon`

Also changed "AI assisted" to more grammatically correct "AI-assisted".


## Before

[Screencast From 2026-07-20 14-30-04.webm](https://github.com/user-attachments/assets/e018600b-b455-43c8-9267-f38a7b7ac8fb)

## After

[Screencast From 2026-07-20 14-28-43.webm](https://github.com/user-attachments/assets/799fdb2b-c924-40ec-8dee-dfb514a428ef)




## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
