### PR TITLE
feat: move imip tracking into a dedicated table

### DIFF
--- a/lib/Db/ImipData.php
+++ b/lib/Db/ImipData.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setImipMessageId(int $messageId)
+ * @method int getImipMessageId()
+ * @method void setError(bool $error)
+ * @method bool getError()
+ * @method void setProcessedAt(?int $processedAt)
+ * @method int|null getProcessedAt()
+ */
+class ImipData extends Entity {
+	/** @var int */
+	protected int $imipMessageId;
+
+	/** @var bool */
+	protected bool $error;
+
+	/** @var int|null */
+	protected ?int $processedAt = null;
+
+	public function __construct() {
+		$this->addType('imipMessageId', 'integer');
+		$this->addType('error', 'boolean');
+		$this->addType('processedAt', 'integer');
+	}
+}

--- a/lib/Db/ImipData.php
+++ b/lib/Db/ImipData.php
@@ -21,13 +21,13 @@ use OCP\AppFramework\Db\Entity;
  */
 class ImipData extends Entity {
 	/** @var int */
-	protected int $imipMessageId;
+	protected $imipMessageId;
 
 	/** @var bool */
-	protected bool $error;
+	protected $error;
 
 	/** @var int|null */
-	protected ?int $processedAt = null;
+	protected $processedAt;
 
 	public function __construct() {
 		$this->addType('imipMessageId', 'integer');

--- a/lib/Db/ImipData.php
+++ b/lib/Db/ImipData.php
@@ -12,16 +12,13 @@ namespace OCA\Mail\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method void setImipMessageId(int $messageId)
- * @method int getImipMessageId()
  * @method void setError(bool $error)
  * @method bool getError()
  * @method void setProcessedAt(?int $processedAt)
  * @method int|null getProcessedAt()
+ * @method string|null getErrorMessage()
  */
 class ImipData extends Entity {
-	/** @var int */
-	protected $imipMessageId;
 
 	/** @var bool */
 	protected $error;
@@ -29,9 +26,12 @@ class ImipData extends Entity {
 	/** @var int|null */
 	protected $processedAt;
 
+	/** @var string */
+	protected $errorMessage;
+
 	public function __construct() {
-		$this->addType('imipMessageId', 'integer');
 		$this->addType('error', 'boolean');
 		$this->addType('processedAt', 'integer');
+		$this->addType('errorMessage', 'string');
 	}
 }

--- a/lib/Db/ImipDataMapper.php
+++ b/lib/Db/ImipDataMapper.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Throwable;
+
+/**
+ * @template-extends QBMapper<ImipData>
+ */
+class ImipDataMapper extends QBMapper {
+
+	/**
+	 * @param IDBConnection $db
+	 */
+	public function __construct(
+		IDBConnection $db,
+		private ITimeFactory $timeFactory,
+	) {
+		parent::__construct($db, 'mail_messages_imip');
+	}
+
+	public function findByMessageId(int $messageId): ?ImipData {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('imip_message_id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+			);
+
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function markAsImipMessage(int $messageId): void {
+		if ($this->findByMessageId($messageId) !== null) {
+			return;
+		}
+
+		$imipData = new ImipData();
+		$imipData->setImipMessageId($messageId);
+		$imipData->setError(false);
+		$imipData->setProcessedAt(null);
+		$this->insert($imipData);
+	}
+
+	/**
+	 * @throws Exception
+	 */
+	public function markProcessed(int $messageId, bool $error): void {
+		$qb = $this->db->getQueryBuilder();
+		$update = $qb->update($this->getTableName())
+			->set('error', $qb->createNamedParameter($error, IQueryBuilder::PARAM_BOOL))
+			->set('processed_at', $qb->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
+			->where(
+				$qb->expr()->eq('imip_message_id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+			);
+
+		$update->executeStatement();
+
+	}
+
+	/**
+	 * @throws Exception
+	 * @throws Throwable
+	 */
+	public function markProcessedBulk(Message ...$messages): array {
+		$this->db->beginTransaction();
+
+		try {
+			foreach ($messages as $message) {
+				if (empty($message->getUpdatedFields())) {
+					continue;
+				}
+
+				$this->markProcessed($message->getId(), $message->isImipError());
+			}
+
+			$this->db->commit();
+		} catch (Throwable $e) {
+			$this->db->rollBack();
+
+			throw $e;
+		}
+
+		return $messages;
+	}
+
+}

--- a/lib/Db/ImipDataMapper.php
+++ b/lib/Db/ImipDataMapper.php
@@ -37,7 +37,7 @@ class ImipDataMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->eq('imip_message_id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+				$qb->expr()->eq('id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 			);
 
 		try {
@@ -47,16 +47,31 @@ class ImipDataMapper extends QBMapper {
 		}
 	}
 
+	private function hasImipData(int $id): bool {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($qb->func()->count('*'))
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
+			);
+
+		$result = $qb->executeQuery();
+		$count = (int)$result->fetchOne();
+		$result->closeCursor();
+
+		return $count > 0;
+	}
+
 	/**
 	 * @throws Exception
 	 */
 	public function markAsImipMessage(int $messageId): void {
-		if ($this->findByMessageId($messageId) !== null) {
+		if ($this->hasImipData($messageId)) {
 			return;
 		}
 
 		$imipData = new ImipData();
-		$imipData->setImipMessageId($messageId);
+		$imipData->setId($messageId);
 		$imipData->setError(false);
 		$imipData->setProcessedAt(null);
 		$this->insert($imipData);
@@ -71,7 +86,7 @@ class ImipDataMapper extends QBMapper {
 			->set('error', $qb->createNamedParameter($error, IQueryBuilder::PARAM_BOOL))
 			->set('processed_at', $qb->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
 			->where(
-				$qb->expr()->eq('imip_message_id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
+				$qb->expr()->eq('id', $qb->createNamedParameter($messageId, IQueryBuilder::PARAM_INT))
 			);
 
 		$update->executeStatement();

--- a/lib/Db/MessageMapper.php
+++ b/lib/Db/MessageMapper.php
@@ -585,7 +585,6 @@ class MessageMapper extends QBMapper {
 				->set('preview_text', $query->createParameter('preview_text'))
 				->set('structure_analyzed', $query->createNamedParameter(true, IQueryBuilder::PARAM_BOOL))
 				->set('updated_at', $query->createNamedParameter($this->timeFactory->getTime(), IQueryBuilder::PARAM_INT))
-				->set('imip_message', $query->createParameter('imip_message'))
 				->set('encrypted', $query->createParameter('encrypted'))
 				->set('mentions_me', $query->createParameter('mentions_me'))
 				->where($query->expr()->andX(
@@ -616,7 +615,6 @@ class MessageMapper extends QBMapper {
 					$previewText,
 					$previewText === null ? IQueryBuilder::PARAM_NULL : IQueryBuilder::PARAM_STR
 				);
-				$query->setParameter('imip_message', $message->isImipMessage(), IQueryBuilder::PARAM_BOOL);
 				$query->setParameter('encrypted', $message->isEncrypted(), IQueryBuilder::PARAM_BOOL);
 				$query->setParameter('mentions_me', $message->getMentionsMe(), IQueryBuilder::PARAM_BOOL);
 
@@ -1564,15 +1562,15 @@ class MessageMapper extends QBMapper {
 		$time = $this->timeFactory->getTime() - 60 * 60 * 24 * 14;
 		$qb = $this->db->getQueryBuilder();
 
-		$select = $qb->select('*')
-			->from($this->getTableName())
+		$select = $qb->select('m.*')
+			->from($this->getTableName(), 'm')
+			->join('m', 'mail_messages_imip', 'i', $qb->expr()->eq('i.imip_message_id', 'm.id'))
 			->where(
-				$qb->expr()->eq('imip_message', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
-				$qb->expr()->eq('imip_processed', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
-				$qb->expr()->eq('imip_error', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
-				$qb->expr()->eq('flag_junk', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
-				$qb->expr()->gt('sent_at', $qb->createNamedParameter($time, IQueryBuilder::PARAM_INT)),
-			)->orderBy('sent_at', 'ASC'); // make sure we don't process newer messages first
+				$qb->expr()->eq('i.error', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
+				$qb->expr()->isNull('i.processed_at'),
+				$qb->expr()->eq('m.flag_junk', $qb->createNamedParameter(false, IQueryBuilder::PARAM_BOOL), IQueryBuilder::PARAM_BOOL),
+				$qb->expr()->gt('m.sent_at', $qb->createNamedParameter($time, IQueryBuilder::PARAM_INT)),
+			)->orderBy('m.sent_at', 'ASC'); // make sure we don't process newer messages first
 
 		return $this->findEntities($select);
 	}

--- a/lib/IMAP/PreviewEnhancer.php
+++ b/lib/IMAP/PreviewEnhancer.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\IMAP;
 
 use Horde_Imap_Client_Exception;
 use OCA\Mail\Account;
+use OCA\Mail\Db\ImipDataMapper;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMapper;
@@ -18,6 +19,7 @@ use OCA\Mail\IMAP\MessageMapper as ImapMapper;
 use OCA\Mail\Service\Attachment\AttachmentService;
 use OCA\Mail\Service\Avatar\Avatar;
 use OCA\Mail\Service\AvatarService;
+use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
 use function array_key_exists;
 use function array_map;
@@ -40,6 +42,9 @@ class PreviewEnhancer {
 	/** @var AvatarService */
 	private $avatarService;
 
+	/** @var ImipDataMapper */
+	private $imipDataMapper;
+
 	public function __construct(
 		IMAPClientFactory $clientFactory,
 		ImapMapper $imapMapper,
@@ -47,12 +52,14 @@ class PreviewEnhancer {
 		LoggerInterface $logger,
 		AvatarService $avatarService,
 		private AttachmentService $attachmentService,
+		ImipDataMapper $imipDataMapper,
 	) {
 		$this->clientFactory = $clientFactory;
 		$this->imapMapper = $imapMapper;
 		$this->mapper = $dbMapper;
 		$this->logger = $logger;
 		$this->avatarService = $avatarService;
+		$this->imipDataMapper = $imipDataMapper;
 	}
 
 	/**
@@ -116,6 +123,22 @@ class PreviewEnhancer {
 			$client->logout();
 		}
 
+		foreach ($messages as $message) {
+			if (!array_key_exists($message->getUid(), $data)) {
+				continue;
+			}
+
+			if ($data[$message->getUid()]->isImipMessage()) {
+				try {
+					$this->imipDataMapper->markAsImipMessage($message->getId());
+				} catch (Exception $e) {
+					$this->logger->warning('Could not mark message as imip: ' . $e->getMessage(), [
+						'exception' => $e,
+					]);
+				}
+			}
+		}
+
 		return $this->mapper->updatePreviewDataBulk(...array_map(static function (Message $message) use ($data) {
 			if (!array_key_exists($message->getUid(), $data)) {
 				// Nothing to do
@@ -126,7 +149,6 @@ class PreviewEnhancer {
 			$message->setFlagAttachments($structureData->hasAttachments());
 			$message->setPreviewText($structureData->getPreviewText());
 			$message->setStructureAnalyzed(true);
-			$message->setImipMessage($structureData->isImipMessage());
 			$message->setEncrypted($structureData->isEncrypted());
 			$message->setMentionsMe($structureData->getMentionsMe());
 

--- a/lib/Migration/Version5201Date20260720120000.php
+++ b/lib/Migration/Version5201Date20260720120000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version5201Date20260720120000 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('mail_messages_imip')) {
+			$table = $schema->createTable('mail_messages_imip');
+			$table->addColumn('id', Types::INTEGER, [
+				'autoincrement' => true,
+				'notnull' => true,
+			]);
+			$table->addColumn('imip_message_id', Types::BIGINT, [
+				'notnull' => true,
+			]);
+			$table->addColumn('error', Types::BOOLEAN, [
+				'notnull' => true,
+				'default' => false,
+			]);
+			$table->addColumn('processed_at', Types::INTEGER, [
+				'notnull' => false,
+				'default' => null,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['imip_message_id'], 'mail_msg_imip_msg_uniq');
+			$table->addIndex(['error', 'processed_at'], 'mail_msg_imip_unproc_idx');
+
+			if ($schema->hasTable('mail_messages')) {
+				$table->addForeignKeyConstraint(
+					$schema->getTable('mail_messages'),
+					['imip_message_id'],
+					['id'],
+					[
+						'onDelete' => 'CASCADE',
+					]
+				);
+			}
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version5201Date20260720120000.php
+++ b/lib/Migration/Version5201Date20260720120000.php
@@ -42,6 +42,10 @@ class Version5201Date20260720120000 extends SimpleMigrationStep {
 				'notnull' => false,
 				'default' => null,
 			]);
+			$table->addColumn('error_message', Types::STRING, [
+				'notnull' => true,
+				'default' => '',
+			]);
 			$table->setPrimaryKey(['id']);
 			$table->addIndex(['error', 'processed_at'], 'mail_msg_imip_unproc_idx');
 

--- a/lib/Migration/Version5201Date20260720120000.php
+++ b/lib/Migration/Version5201Date20260720120000.php
@@ -30,11 +30,8 @@ class Version5201Date20260720120000 extends SimpleMigrationStep {
 
 		if (!$schema->hasTable('mail_messages_imip')) {
 			$table = $schema->createTable('mail_messages_imip');
-			$table->addColumn('id', Types::INTEGER, [
-				'autoincrement' => true,
-				'notnull' => true,
-			]);
-			$table->addColumn('imip_message_id', Types::BIGINT, [
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => false,
 				'notnull' => true,
 			]);
 			$table->addColumn('error', Types::BOOLEAN, [
@@ -46,13 +43,12 @@ class Version5201Date20260720120000 extends SimpleMigrationStep {
 				'default' => null,
 			]);
 			$table->setPrimaryKey(['id']);
-			$table->addUniqueIndex(['imip_message_id'], 'mail_msg_imip_msg_uniq');
 			$table->addIndex(['error', 'processed_at'], 'mail_msg_imip_unproc_idx');
 
 			if ($schema->hasTable('mail_messages')) {
 				$table->addForeignKeyConstraint(
 					$schema->getTable('mail_messages'),
-					['imip_message_id'],
+					['id'],
 					['id'],
 					[
 						'onDelete' => 'CASCADE',

--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service;
 
 use OCA\Mail\Account;
+use OCA\Mail\Db\ImipDataMapper;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
 use OCA\Mail\Db\Message;
@@ -32,6 +33,7 @@ class IMipService {
 	private MailManager $mailManager;
 	private MessageMapper $messageMapper;
 	private ServerVersion $serverVersion;
+	private ImipDataMapper $imipDataMapper;
 
 	public function __construct(
 		AccountService $accountService,
@@ -41,6 +43,7 @@ class IMipService {
 		MailManager $mailManager,
 		MessageMapper $messageMapper,
 		ServerVersion $serverVersion,
+		ImipDataMapper $imipDataMapper,
 	) {
 		$this->accountService = $accountService;
 		$this->calendarManager = $manager;
@@ -49,6 +52,7 @@ class IMipService {
 		$this->mailManager = $mailManager;
 		$this->messageMapper = $messageMapper;
 		$this->serverVersion = $serverVersion;
+		$this->imipDataMapper = $imipDataMapper;
 	}
 
 	public function process(): void {
@@ -108,7 +112,8 @@ class IMipService {
 					$message->setImipProcessed(true);
 					return $message;
 				}, $filteredMessages); // Silently drop from passing to DAV and mark as processed, so we won't run into these messages again.
-				$this->messageMapper->updateImipData(...$processedMessages);
+				$this->imipDataMapper->markProcessedBulk(...$processedMessages);
+
 				continue;
 			}
 
@@ -184,7 +189,7 @@ class IMipService {
 					$message->setImipError(true);
 				}
 			}
-			$this->messageMapper->updateImipData(...$filteredMessages);
+			$this->imipDataMapper->markProcessedBulk(...$filteredMessages);
 		}
 	}
 }

--- a/tests/Integration/Db/ImipDataMapperTest.php
+++ b/tests/Integration/Db/ImipDataMapperTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Mail\Tests\Integration\Db;
+
+use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
+use OCA\Mail\Db\ImipDataMapper;
+use OCA\Mail\Db\Message;
+use OCA\Mail\Tests\Integration\TestCase;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+class ImipDataMapperTest extends TestCase {
+	use DatabaseTransaction;
+
+	/** @var ImipDataMapper */
+	private $mapper;
+	/** @var IDBConnection */
+	private $db;
+	/** @var ITimeFactory */
+	private $time;
+
+	private int $timestamp = 1234567890;
+
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->db = \OCP\Server::get(\OCP\IDBConnection::class);
+		$this->time = $this->createMock(ITimeFactory::class);
+		$this->time->method('getTime')->willReturnCallback(fn () => $this->timestamp);
+		$this->mapper = new ImipDataMapper($this->db, $this->time);
+	}
+
+	private function insertMessage(int $uid, int $mailbox_id): int {
+		$qb = $this->db->getQueryBuilder();
+		$insert = $qb->insert('mail_messages')
+			->values([
+				'uid' => $qb->createNamedParameter($uid, IQueryBuilder::PARAM_INT),
+				'message_id' => $qb->createNamedParameter('<abc' . $uid . $mailbox_id . '@123.com>'),
+				'mailbox_id' => $qb->createNamedParameter($mailbox_id, IQueryBuilder::PARAM_INT),
+				'subject' => $qb->createNamedParameter('TEST'),
+				'sent_at' => $qb->createNamedParameter($this->time->getTime(), IQueryBuilder::PARAM_INT),
+				'in_reply_to' => $qb->createNamedParameter('<>')
+			]);
+		$insert->executeStatement();
+
+		return $qb->getLastInsertId();
+	}
+
+	public function testMarkAsImipMessage(): void {
+		$messageId = $this->insertMessage(100, 1);
+
+		$this->mapper->markAsImipMessage($messageId);
+
+		$row = $this->mapper->findByMessageId($messageId);
+		$this->assertNotNull($row);
+		$this->assertSame($messageId, $row->getImipMessageId());
+		$this->assertFalse($row->getError());
+		$this->assertNull($row->getProcessedAt());
+	}
+
+	public function testMarkProcessed(): void {
+		$messageId = $this->insertMessage(101, 1);
+		$this->mapper->markAsImipMessage($messageId);
+
+		$this->mapper->markProcessed($messageId, true);
+
+		$row = $this->mapper->findByMessageId($messageId);
+		$this->assertNotNull($row);
+		$this->assertTrue($row->getError());
+		$this->assertSame($this->timestamp, $row->getProcessedAt());
+	}
+
+	public function testMarkProcessedBulk(): void {
+		$messageId1 = $this->insertMessage(102, 1);
+		$messageId2 = $this->insertMessage(103, 1);
+
+		$this->mapper->markAsImipMessage($messageId1);
+		$this->mapper->markAsImipMessage($messageId2);
+
+		$message1 = new Message();
+		$message1->setId($messageId1);
+		$message1->setImipError(true);
+
+		$message2 = new Message();
+		$message2->setId($messageId2);
+		$message2->resetUpdatedFields();
+
+		$this->mapper->markProcessedBulk($message1, $message2);
+
+		$row1 = $this->mapper->findByMessageId($messageId1);
+		$this->assertNotNull($row1->getProcessedAt(), 'Message with an updated field should be marked processed');
+
+		$row2 = $this->mapper->findByMessageId($messageId2);
+		$this->assertNull($row2->getProcessedAt(), 'Message with no updated fields should not be marked processed');
+	}
+
+
+}

--- a/tests/Integration/Db/ImipDataMapperTest.php
+++ b/tests/Integration/Db/ImipDataMapperTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\Mail\Tests\Integration\Db;
@@ -54,16 +54,31 @@ class ImipDataMapperTest extends TestCase {
 		return $qb->getLastInsertId();
 	}
 
+	private function findImipRow(int $id): ?array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('mail_messages_imip')
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
+			);
+
+		$result = $qb->executeQuery();
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return $row === false ? null : $row;
+	}
+
 	public function testMarkAsImipMessage(): void {
 		$messageId = $this->insertMessage(100, 1);
 
 		$this->mapper->markAsImipMessage($messageId);
 
-		$row = $this->mapper->findByMessageId($messageId);
+		$row = $this->findImipRow($messageId);
 		$this->assertNotNull($row);
-		$this->assertSame($messageId, $row->getImipMessageId());
-		$this->assertFalse($row->getError());
-		$this->assertNull($row->getProcessedAt());
+		$this->assertSame($messageId, (int)$row['id']);
+		$this->assertFalse((bool)$row['error']);
+		$this->assertNull($row['processed_at']);
 	}
 
 	public function testMarkProcessed(): void {
@@ -72,10 +87,10 @@ class ImipDataMapperTest extends TestCase {
 
 		$this->mapper->markProcessed($messageId, true);
 
-		$row = $this->mapper->findByMessageId($messageId);
+		$row = $this->findImipRow($messageId);
 		$this->assertNotNull($row);
-		$this->assertTrue($row->getError());
-		$this->assertSame($this->timestamp, $row->getProcessedAt());
+		$this->assertTrue((bool)$row['error']);
+		$this->assertSame($this->timestamp, (int)$row['processed_at']);
 	}
 
 	public function testMarkProcessedBulk(): void {
@@ -95,11 +110,11 @@ class ImipDataMapperTest extends TestCase {
 
 		$this->mapper->markProcessedBulk($message1, $message2);
 
-		$row1 = $this->mapper->findByMessageId($messageId1);
-		$this->assertNotNull($row1->getProcessedAt(), 'Message with an updated field should be marked processed');
+		$row1 = $this->findImipRow($messageId1);
+		$this->assertNotNull($row1['processed_at'], 'Message with an updated field should be marked processed');
 
-		$row2 = $this->mapper->findByMessageId($messageId2);
-		$this->assertNull($row2->getProcessedAt(), 'Message with no updated fields should not be marked processed');
+		$row2 = $this->findImipRow($messageId2);
+		$this->assertNull($row2['processed_at'], 'Message with no updated fields should not be marked processed');
 	}
 
 

--- a/tests/Unit/IMAP/PreviewEnhancerTest.php
+++ b/tests/Unit/IMAP/PreviewEnhancerTest.php
@@ -13,6 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Address;
 use OCA\Mail\AddressList;
+use OCA\Mail\Db\ImipDataMapper;
 use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper as DbMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
@@ -41,6 +42,8 @@ class PreviewEnhancerTest extends TestCase {
 	private $previewEnhancer;
 	/** @var AttachmentService|MockObject */
 	private $attachmentService;
+	/** @var ImipDataMapper */
+	private $imipDataMapper;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -51,6 +54,7 @@ class PreviewEnhancerTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->avatarService = $this->createMock(AvatarService::class);
 		$this->attachmentService = $this->createMock(AttachmentService::class);
+		$this->imipDataMapper = $this->createMock(ImipDataMapper::class);
 
 		$this->previewEnhancer = new PreviewEnhancer(
 			$this->imapClientFactory,
@@ -58,7 +62,8 @@ class PreviewEnhancerTest extends TestCase {
 			$this->dbMapper,
 			$this->logger,
 			$this->avatarService,
-			$this->attachmentService
+			$this->attachmentService,
+			$this->imipDataMapper
 		);
 	}
 

--- a/tests/Unit/Service/IMipServiceTest.php
+++ b/tests/Unit/Service/IMipServiceTest.php
@@ -13,6 +13,7 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
 use OCA\Mail\Address;
 use OCA\Mail\AddressList;
+use OCA\Mail\Db\ImipDataMapper;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MailboxMapper;
@@ -53,6 +54,9 @@ class IMipServiceTest extends TestCase {
 
 	private OCPServerVersion $OCPServerVersion;
 
+	/** @var ImipDataMapper|MockObject */
+	private ImipDataMapper $imipDataMapper;
+
 	protected function setUp(): void {
 		parent::setUp();
 
@@ -64,6 +68,7 @@ class IMipServiceTest extends TestCase {
 		$this->messageMapper = $this->createMock(MessageMapper::class);
 		$this->serverVersion = $this->createMock(ServerVersion::class);
 		$this->OCPServerVersion = new OCPServerVersion();
+		$this->imipDataMapper = $this->createMock(ImipDataMapper::class);
 
 		$this->service = new IMipService(
 			$this->accountService,
@@ -72,7 +77,8 @@ class IMipServiceTest extends TestCase {
 			$this->mailboxMapper,
 			$this->mailManager,
 			$this->messageMapper,
-			$this->serverVersion
+			$this->serverVersion,
+			$this->imipDataMapper
 		);
 	}
 


### PR DESCRIPTION
Moves iMIP tracking (`imip_message`, `imip_processed`, `imip_error`) from `mail_messages` to a new `mail_messages_imip` table, linked to `mail_messages.id` with a cascading foreign key.

Fixes #12668

