### PR TITLE
fix: resolve strict type issues flagged by Psalm 6

### DIFF
--- a/lib/Db/Delegation.php
+++ b/lib/Db/Delegation.php
@@ -38,6 +38,7 @@ class Delegation extends Entity implements JsonSerializable {
 		$this->displayName = $displayName;
 	}
 
+	#[\Override]
 	#[ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [

--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -151,7 +151,7 @@ class MessageMapper {
 		// Here we assume somewhat equally distributed UIDs
 		// +1 is added to fetch all messages with the rare case of strictly
 		// continuous UIDs and fractions
-		$estimatedPageSize = (int)((float)($totalRange / $total) * $maxResults) + 1;
+		$estimatedPageSize = (int)((float)($totalRange / $total) * (float)$maxResults) + 1;
 		// Determine min UID to fetch, but don't exceed the known maximum
 		$lower = max(
 			$min,
@@ -178,7 +178,7 @@ class MessageMapper {
 		while ($actualPageSize > $maxResults) {
 			$logger->debug("Range for findAll matches too many messages: min=$min max=$max total=$total estimatedPageSize=$estimatedPageSize actualPageSize=$actualPageSize");
 
-			$estimatedPageSize = (int)($estimatedPageSize / 2.0);
+			$estimatedPageSize = (int)((float)$estimatedPageSize / 2.0);
 
 			$upper = min(
 				$max,

--- a/lib/JMAP/JmapClientAdapter.php
+++ b/lib/JMAP/JmapClientAdapter.php
@@ -39,6 +39,7 @@ class JmapClientAdapter implements ClientInterface {
 	) {
 	}
 
+	#[\Override]
 	public function sendRequest(RequestInterface $request): ResponseInterface {
 		// convert PSR-7 request to native transport client request
 		$options = $this->defaultOptions;

--- a/lib/JMAP/JmapClientFactory.php
+++ b/lib/JMAP/JmapClientFactory.php
@@ -41,7 +41,7 @@ class JmapClientFactory {
 
 		$host = $mailAccount->getInboundHost();
 		if ($host === null || $host === '') {
-			throw new ServiceException('JMAP host is not configured for account ' . $account->getId());
+			throw new ServiceException('JMAP host is not configured for account ' . (string)$account->getId());
 		}
 
 		$port = $mailAccount->getInboundPort();
@@ -51,14 +51,14 @@ class JmapClientFactory {
 		$encryptedPassword = $mailAccount->getInboundPassword();
 
 		if ($encryptedPassword === null) {
-			throw new ServiceException('No password set for JMAP account ' . $account->getId());
+			throw new ServiceException('No password set for JMAP account ' . (string)$account->getId());
 		}
 
 		try {
 			$password = $this->crypto->decrypt($encryptedPassword);
 		} catch (\Exception $e) {
 			throw new ServiceException(
-				'Could not decrypt password for JMAP account ' . $account->getId() . ': ' . $e->getMessage(),
+				'Could not decrypt password for JMAP account ' . (string)$account->getId() . ': ' . $e->getMessage(),
 				0,
 				$e,
 			);
@@ -80,7 +80,7 @@ class JmapClientFactory {
 
 		$client = new JmapClient('', null, $adapter, $requestFactory, $streamFactory);
 		$client->configureTransportMode($secure ? 'https' : 'http');
-		$client->setHost($host . ':' . $port);
+		$client->setHost($host . ':' . (string)$port);
 		if ($path !== '/.well-known/jmap') {
 			$client->setDiscoveryPath($path);
 		}

--- a/lib/Support/PerformanceLoggerTask.php
+++ b/lib/Support/PerformanceLoggerTask.php
@@ -46,8 +46,8 @@ class PerformanceLoggerTask {
 			$this->logger->debug(
 				sprintf(
 					$message . ' %d/%dMB memory used',
-					round(memory_get_usage() / 1024.0 / 1024.0),
-					round(memory_get_peak_usage() / 1024.0 / 1024.0)
+					round((float)memory_get_usage() / 1024.0 / 1024.0),
+					round((float)memory_get_peak_usage() / 1024.0 / 1024.0)
 				)
 			);
 		} else {


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/mail/pull/11224

Psalm 6 enables stricter checks that surface a few pre-existing type issues in code that Psalm 5 accepted. These are behaviour-preserving and can land on main ahead of the Psalm 6 upgrade (#11224):

- strictBinaryOperands: add explicit (float) casts where int and float operands are mixed (MessageMapper, PerformanceLoggerTask) and (string) casts when concatenating ints (JmapClientFactory)
- MissingOverrideAttribute: add #[\Override] to jsonSerialize() in Delegation and sendRequest() in JmapClientAdapter

Assisted-by: Claude:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
