### PR TITLE
refactor(config): add config lexicon for app config keys

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace OCA\Mail\AppInfo;
 
 use Horde_Translation;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\ContextChat\ContextChatProvider;
 use OCA\Mail\Contracts\IAttachmentService;
 use OCA\Mail\Contracts\IAvatarService;
@@ -171,6 +172,8 @@ final class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(MailConnectionPerformance::class);
 
 		$context->registerUserMigrator(MailAccountMigrator::class);
+
+		$context->registerConfigLexicon(ConfigLexicon::class);
 
 		// bypass Horde Translation system
 		Horde_Translation::setHandler('Horde_Imap_Client', new HordeTranslationHandler());

--- a/lib/ConfigLexicon.php
+++ b/lib/ConfigLexicon.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail;
+
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\ILexicon;
+use OCP\Config\Lexicon\Strictness;
+use OCP\Config\ValueType;
+
+/**
+ * Config lexicon for the Mail app.
+ *
+ * Central declaration of all app config keys: their type, default value and a
+ * short definition surfaced by `occ config:app:*`. Please keep this file in
+ * sync whenever a config key is added, changed or removed.
+ *
+ * {@see ILexicon}
+ */
+class ConfigLexicon implements ILexicon {
+	public const ALLOW_NEW_MAIL_ACCOUNTS = 'allow_new_mail_accounts';
+	public const LLM_PROCESSING = 'llm_processing';
+	public const LAYOUT_MESSAGE_VIEW = 'layout_message_view';
+	public const IMPORTANCE_CLASSIFICATION_DEFAULT = 'importance_classification_default';
+	public const INDEX_CONTEXT_CHAT_DEFAULT = 'index_context_chat_default';
+	public const GOOGLE_OAUTH_CLIENT_ID = 'google_oauth_client_id';
+	public const GOOGLE_OAUTH_CLIENT_SECRET = 'google_oauth_client_secret';
+	public const MICROSOFT_OAUTH_CLIENT_ID = 'microsoft_oauth_client_id';
+	public const MICROSOFT_OAUTH_CLIENT_SECRET = 'microsoft_oauth_client_secret';
+	public const MICROSOFT_OAUTH_TENANT_ID = 'microsoft_oauth_tenant_id';
+	public const ANTISPAM_REPORTING_SPAM = 'antispam_reporting_spam';
+	public const ANTISPAM_REPORTING_HAM = 'antispam_reporting_ham';
+
+	#[\Override]
+	public function getStrictness(): Strictness {
+		return Strictness::IGNORE;
+	}
+
+	#[\Override]
+	public function getAppConfigs(): array {
+		return [
+			new Entry(
+				self::ALLOW_NEW_MAIL_ACCOUNTS,
+				ValueType::BOOL,
+				defaultRaw: true,
+				definition: 'Whether users are allowed to set up new mail accounts themselves',
+			),
+			new Entry(
+				self::LLM_PROCESSING,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Whether large language model processing (e.g. thread summaries) is enabled',
+			),
+			new Entry(
+				self::LAYOUT_MESSAGE_VIEW,
+				ValueType::STRING,
+				defaultRaw: 'threaded',
+				definition: 'Default message list layout for users that did not choose one themselves',
+			),
+			new Entry(
+				self::IMPORTANCE_CLASSIFICATION_DEFAULT,
+				ValueType::BOOL,
+				defaultRaw: true,
+				definition: 'Whether importance classification is enabled by default for users that did not toggle the preference',
+			),
+			new Entry(
+				self::INDEX_CONTEXT_CHAT_DEFAULT,
+				ValueType::BOOL,
+				defaultRaw: false,
+				definition: 'Whether mails are indexed for Context Chat by default for users that did not toggle the preference',
+			),
+			new Entry(
+				self::GOOGLE_OAUTH_CLIENT_ID,
+				ValueType::STRING,
+				definition: 'OAuth client ID used to connect Google (Gmail) accounts',
+			),
+			new Entry(
+				self::GOOGLE_OAUTH_CLIENT_SECRET,
+				ValueType::STRING,
+				definition: 'OAuth client secret used to connect Google (Gmail) accounts',
+				note: 'Stored encrypted by the app before being written',
+			),
+			new Entry(
+				self::MICROSOFT_OAUTH_CLIENT_ID,
+				ValueType::STRING,
+				definition: 'OAuth client ID used to connect Microsoft (Outlook) accounts',
+			),
+			new Entry(
+				self::MICROSOFT_OAUTH_CLIENT_SECRET,
+				ValueType::STRING,
+				definition: 'OAuth client secret used to connect Microsoft (Outlook) accounts',
+				note: 'Stored encrypted by the app before being written',
+			),
+			new Entry(
+				self::MICROSOFT_OAUTH_TENANT_ID,
+				ValueType::STRING,
+				defaultRaw: 'common',
+				definition: 'Microsoft OAuth tenant ID used to connect Microsoft (Outlook) accounts',
+			),
+			new Entry(
+				self::ANTISPAM_REPORTING_SPAM,
+				ValueType::STRING,
+				definition: 'Email address spam reports are forwarded to',
+			),
+			new Entry(
+				self::ANTISPAM_REPORTING_HAM,
+				ValueType::STRING,
+				definition: 'Email address ham (not spam) reports are forwarded to',
+			),
+		];
+	}
+
+	#[\Override]
+	public function getUserConfigs(): array {
+		return [];
+	}
+}

--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -13,6 +13,7 @@ namespace OCA\Mail\Controller;
 use Horde_Imap_Client;
 use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\Mailbox;
@@ -33,6 +34,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -62,6 +64,7 @@ class AccountsController extends Controller {
 		private MailboxSync $mailboxSync,
 		private ITimeFactory $timeFactory,
 		private DelegationService $delegationService,
+		private IAppConfig $appConfig,
 	) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;
@@ -334,7 +337,7 @@ class AccountsController extends Controller {
 		?string $smtpPassword = null,
 		string $authMethod = 'password',
 		?bool $classificationEnabled = null): JSONResponse {
-		if ($this->config->getAppValue(Application::APP_ID, 'allow_new_mail_accounts', 'yes') === 'no') {
+		if (!$this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, true)) {
 			$this->logger->info('Creating account disabled by admin.');
 			return MailJsonResponse::error('Could not create account');
 		}

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Controller;
 
 use OCA\Contacts\Event\LoadContactsOcaApiEvent;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Db\SmimeCertificate;
@@ -38,6 +39,7 @@ use OCP\Authentication\Exceptions\PasswordUnavailableException;
 use OCP\Authentication\LoginCredentials\IStore as ICredentialStore;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -89,6 +91,7 @@ class PageController extends Controller {
 		private IAppManager $appManager,
 		private ContextChatSettingsService $contextChatSettingsService,
 		private ClassificationSettingsService $classificationSettingsService,
+		private IAppConfig $appConfig,
 	) {
 		parent::__construct($appName, $request);
 
@@ -228,7 +231,7 @@ class PageController extends Controller {
 			'app-version' => $this->config->getAppValue('mail', 'installed_version'),
 			'external-avatars' => $this->preferences->getPreference($this->userId, 'external-avatars', 'true'),
 			'layout-mode' => $this->preferences->getPreference($this->userId, 'layout-mode', 'vertical-split'),
-			'layout-message-view' => $this->preferences->getPreference($this->userId, 'layout-message-view', $this->config->getAppValue('mail', 'layout_message_view', 'threaded')),
+			'layout-message-view' => $this->preferences->getPreference($this->userId, 'layout-message-view', $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::LAYOUT_MESSAGE_VIEW, 'threaded')),
 			'reply-mode' => $this->preferences->getPreference($this->userId, 'reply-mode', 'top'),
 			'collect-data' => $this->preferences->getPreference($this->userId, 'collect-data', 'true'),
 			'search-priority-body' => $this->preferences->getPreference($this->userId, 'search-priority-body', 'false'),
@@ -259,7 +262,7 @@ class PageController extends Controller {
 			'quick-actions',
 			$this->quickActionsService->findAll($this->userId),
 		);
-		$googleOauthclientId = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_id');
+		$googleOauthclientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID);
 		if (!empty($googleOauthclientId)) {
 			$this->initialStateService->provideInitialState(
 				'google-oauth-url',
@@ -275,8 +278,8 @@ class PageController extends Controller {
 				]),
 			);
 		}
-		$microsoftOauthClientId = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_id');
-		$microsoftOauthTenantId = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_tenant_id', 'common');
+		$microsoftOauthClientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID);
+		$microsoftOauthTenantId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID, 'common');
 		if (!empty($microsoftOauthClientId) && !empty($microsoftOauthTenantId)) {
 			$this->initialStateService->provideInitialState(
 				'microsoft-oauth-url',
@@ -306,7 +309,7 @@ class PageController extends Controller {
 
 		$this->initialStateService->provideInitialState(
 			'allow-new-accounts',
-			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
+			$this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, true)
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Controller;
 
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Exception\ValidationException;
 use OCA\Mail\Http\JsonResponse as HttpJsonResponse;
 use OCA\Mail\Service\AntiSpamService;
@@ -18,25 +19,22 @@ use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use Psr\Container\ContainerInterface;
 use function array_merge;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class SettingsController extends Controller {
-	private IConfig $config;
-
 	public function __construct(
 		IRequest $request,
 		private ProvisioningManager $provisioningManager,
 		private AntiSpamService $antiSpamService,
-		IConfig $config,
+		private IAppConfig $appConfig,
 		private ContainerInterface $container,
 		private ClassificationSettingsService $classificationSettingsService,
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->config = $config;
 	}
 
 	public function index(): JSONResponse {
@@ -104,15 +102,15 @@ class SettingsController extends Controller {
 	}
 
 	public function setAllowNewMailAccounts(bool $allowed): void {
-		$this->config->setAppValue('mail', 'allow_new_mail_accounts', $allowed ? 'yes' : 'no');
+		$this->appConfig->setValueBool(Application::APP_ID, ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, $allowed);
 	}
 
 	public function setEnabledLlmProcessing(bool $enabled): JSONResponse {
-		$this->config->setAppValue('mail', 'llm_processing', $enabled ? 'yes' : 'no');
+		$this->appConfig->setValueBool(Application::APP_ID, ConfigLexicon::LLM_PROCESSING, $enabled);
 		return new JSONResponse([]);
 	}
 	public function setLayoutMessageView(string $value): JSONResponse {
-		$this->config->setAppValue('mail', 'layout_message_view', $value);
+		$this->appConfig->setValueString(Application::APP_ID, ConfigLexicon::LAYOUT_MESSAGE_VIEW, $value);
 		return new JSONResponse([]);
 	}
 	public function setImportanceClassificationEnabledByDefault(bool $enabledByDefault): JSONResponse {

--- a/lib/Integration/GoogleIntegration.php
+++ b/lib/Integration/GoogleIntegration.php
@@ -12,9 +12,10 @@ namespace OCA\Mail\Integration;
 use Exception;
 use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IURLGenerator;
 use OCP\Security\ICrypto;
 use Psr\Log\LoggerInterface;
@@ -23,14 +24,14 @@ use function json_encode;
 
 class GoogleIntegration {
 	private ITimeFactory $timeFactory;
-	private IConfig $config;
+	private IAppConfig $appConfig;
 	private ICrypto $crypto;
 	private IClientService $clientService;
 	private IURLGenerator $urlGenerator;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		IConfig $config,
+		IAppConfig $appConfig,
 		ICrypto $crypto,
 		IClientService $clientService,
 		IURLGenerator $urlGenerator,
@@ -39,36 +40,36 @@ class GoogleIntegration {
 		$this->timeFactory = $timeFactory;
 		$this->clientService = $clientService;
 		$this->crypto = $crypto;
-		$this->config = $config;
+		$this->appConfig = $appConfig;
 		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function configure(string $clientId, string $clientSecret): void {
-		$this->config->setAppValue(
+		$this->appConfig->setValueString(
 			Application::APP_ID,
-			'google_oauth_client_id',
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID,
 			$clientId
 		);
-		$this->config->setAppValue(
+		$this->appConfig->setValueString(
 			Application::APP_ID,
-			'google_oauth_client_secret',
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_SECRET,
 			$this->crypto->encrypt($clientSecret),
 		);
 	}
 
 	public function unlink(): void {
-		$this->config->deleteAppValue(
+		$this->appConfig->deleteKey(
 			Application::APP_ID,
-			'google_oauth_client_id',
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID,
 		);
-		$this->config->deleteAppValue(
+		$this->appConfig->deleteKey(
 			Application::APP_ID,
-			'google_oauth_client_secret',
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_SECRET,
 		);
 	}
 
 	public function getClientId(): ?string {
-		$value = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_id');
+		$value = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID);
 		if ($value === '') {
 			return null;
 		}
@@ -82,8 +83,8 @@ class GoogleIntegration {
 
 	public function finishConnect(Account $account,
 		string $code): Account {
-		$clientId = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_id');
-		$encryptedClientSecret = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_secret');
+		$clientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID);
+		$encryptedClientSecret = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_SECRET);
 		if (empty($clientId) || empty($encryptedClientSecret)) {
 			// This is highly unexpected
 			$this->logger->critical('Can not finish Google account linking due to missing client secrets');
@@ -131,8 +132,8 @@ class GoogleIntegration {
 			return $account;
 		}
 
-		$clientId = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_id');
-		$encryptedClientSecret = $this->config->getAppValue(Application::APP_ID, 'google_oauth_client_secret');
+		$clientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID);
+		$encryptedClientSecret = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_SECRET);
 		if (empty($clientId) || empty($encryptedClientSecret)) {
 			// Nothing to do here
 			return $account;

--- a/lib/Integration/MicrosoftIntegration.php
+++ b/lib/Integration/MicrosoftIntegration.php
@@ -12,9 +12,10 @@ namespace OCA\Mail\Integration;
 use Exception;
 use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Http\Client\IClientService;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IURLGenerator;
 use OCP\Security\ICrypto;
 use Psr\Log\LoggerInterface;
@@ -22,14 +23,14 @@ use function json_decode;
 
 class MicrosoftIntegration {
 	private ITimeFactory $timeFactory;
-	private IConfig $config;
+	private IAppConfig $appConfig;
 	private ICrypto $crypto;
 	private IClientService $clientService;
 	private IURLGenerator $urlGenerator;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		IConfig $config,
+		IAppConfig $appConfig,
 		ICrypto $crypto,
 		IClientService $clientService,
 		IURLGenerator $urlGenerator,
@@ -38,51 +39,51 @@ class MicrosoftIntegration {
 		$this->timeFactory = $timeFactory;
 		$this->clientService = $clientService;
 		$this->crypto = $crypto;
-		$this->config = $config;
+		$this->appConfig = $appConfig;
 		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function configure(?string $tenantId, string $clientId, string $clientSecret): void {
 		if ($tenantId !== null) {
-			$this->config->setAppValue(
+			$this->appConfig->setValueString(
 				Application::APP_ID,
-				'microsoft_oauth_tenant_id',
+				ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID,
 				$tenantId
 			);
 		}
-		$this->config->setAppValue(
+		$this->appConfig->setValueString(
 			Application::APP_ID,
-			'microsoft_oauth_client_id',
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID,
 			$clientId
 		);
-		$this->config->setAppValue(
+		$this->appConfig->setValueString(
 			Application::APP_ID,
-			'microsoft_oauth_client_secret',
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_SECRET,
 			$this->crypto->encrypt($clientSecret),
 		);
 	}
 
 	public function unlink(): void {
-		$this->config->deleteAppValue(
+		$this->appConfig->deleteKey(
 			Application::APP_ID,
-			'microsoft_oauth_tenant_id',
+			ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID,
 		);
-		$this->config->deleteAppValue(
+		$this->appConfig->deleteKey(
 			Application::APP_ID,
-			'microsoft_oauth_client_id',
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID,
 		);
-		$this->config->deleteAppValue(
+		$this->appConfig->deleteKey(
 			Application::APP_ID,
-			'microsoft_oauth_client_secret',
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_SECRET,
 		);
 	}
 
 	public function getTenantId(): ?string {
-		return $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_tenant_id', 'common');
+		return $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID, 'common');
 	}
 
 	public function getClientId(): ?string {
-		$value = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_id');
+		$value = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID);
 		if ($value === '') {
 			return null;
 		}
@@ -97,8 +98,8 @@ class MicrosoftIntegration {
 	public function finishConnect(Account $account,
 		string $code): Account {
 		$tenantId = $this->getTenantId();
-		$clientId = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_id');
-		$encryptedClientSecret = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_secret');
+		$clientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID);
+		$encryptedClientSecret = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_SECRET);
 		if (empty($tenantId) || empty($clientId) || empty($encryptedClientSecret)) {
 			// This is highly unexpected
 			$this->logger->critical('Can not finish Microsoft account linking due to missing client secrets');
@@ -145,9 +146,9 @@ class MicrosoftIntegration {
 			return $account;
 		}
 
-		$tenantId = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_tenant_id');
-		$clientId = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_id');
-		$encryptedClientSecret = $this->config->getAppValue(Application::APP_ID, 'microsoft_oauth_client_secret');
+		$tenantId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID);
+		$clientId = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID);
+		$encryptedClientSecret = $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_SECRET);
 		if (empty($tenantId) || empty($clientId) || empty($encryptedClientSecret)) {
 			// Nothing to do here
 			return $account;

--- a/lib/Listener/NewMessagesSummarizeListener.php
+++ b/lib/Listener/NewMessagesSummarizeListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Listener;
 
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Events\NewMessagesSynchronized;
 use OCA\Mail\Exception\ServiceException;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
@@ -31,7 +32,7 @@ class NewMessagesSummarizeListener implements IEventListener {
 
 	#[\Override]
 	public function handle(Event $event): void {
-		if ($this->appConfig->getAppValueBool('llm_processing', false) === false) {
+		if ($this->appConfig->getAppValueBool(ConfigLexicon::LLM_PROCESSING, false) === false) {
 			return;
 		}
 		if (!($event instanceof NewMessagesSynchronized)) {

--- a/lib/Service/AiIntegrations/AiIntegrationsService.php
+++ b/lib/Service/AiIntegrations/AiIntegrationsService.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Service\AiIntegrations;
 use JsonException;
 use OCA\Mail\Account;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\Message;
@@ -390,7 +391,7 @@ class AiIntegrationsService {
 	 * Whether the llm_processing admin setting is enabled globally on this instance.
 	 */
 	public function isLlmProcessingEnabled(): bool {
-		return $this->appConfig->getValueString(Application::APP_ID, 'llm_processing', 'no') === 'yes';
+		return $this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::LLM_PROCESSING, false);
 	}
 
 	/**

--- a/lib/Service/AntiSpamService.php
+++ b/lib/Service/AntiSpamService.php
@@ -15,6 +15,8 @@ use Horde_Mime_Mail;
 use OCA\Mail\Account;
 use OCA\Mail\Address;
 use OCA\Mail\AddressList;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Exception\ClientException;
@@ -29,7 +31,6 @@ use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 
 class AntiSpamService {
-	private const NAME = 'antispam_reporting';
 	private const MESSAGE_TYPE = 'message/rfc822';
 
 	public function __construct(
@@ -44,11 +45,11 @@ class AntiSpamService {
 	}
 
 	public function getSpamEmail(): string {
-		return $this->appConfig->getValueString('mail', self::NAME . '_spam');
+		return $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM);
 	}
 
 	public function getHamEmail(): string {
-		return $this->appConfig->getValueString('mail', self::NAME . '_ham');
+		return $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_HAM);
 	}
 
 	public function getSpamSubject(): string {
@@ -60,16 +61,16 @@ class AntiSpamService {
 	}
 
 	public function setSpamEmail(string $email): void {
-		$this->appConfig->setValueString('mail', self::NAME . '_spam', $email);
+		$this->appConfig->setValueString(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM, $email);
 	}
 
 	public function setHamEmail(string $email): void {
-		$this->appConfig->setValueString('mail', self::NAME . '_ham', $email);
+		$this->appConfig->setValueString(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_HAM, $email);
 	}
 
 	public function deleteConfig(): void {
-		$this->appConfig->deleteKey('mail', self::NAME . '_spam');
-		$this->appConfig->deleteKey('mail', self::NAME . '_ham');
+		$this->appConfig->deleteKey(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM);
+		$this->appConfig->deleteKey(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_HAM);
 	}
 
 	/**

--- a/lib/Service/Classification/ClassificationSettingsService.php
+++ b/lib/Service/Classification/ClassificationSettingsService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\Classification;
 
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCP\IAppConfig;
 
@@ -25,11 +26,11 @@ class ClassificationSettingsService {
 	 * preference themselves.
 	 */
 	public function isClassificationEnabledByDefault(): bool {
-		return $this->appConfig->getValueString(
+		return $this->appConfig->getValueBool(
 			Application::APP_ID,
-			'importance_classification_default',
-			'yes'
-		) === 'yes';
+			ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT,
+			true,
+		);
 	}
 
 	/**
@@ -37,10 +38,10 @@ class ClassificationSettingsService {
 	 * the preference themselves.
 	 */
 	public function setClassificationEnabledByDefault(bool $enabledByDefault): void {
-		$this->appConfig->setValueString(
+		$this->appConfig->setValueBool(
 			Application::APP_ID,
-			'importance_classification_default',
-			$enabledByDefault ? 'yes' : 'no',
+			ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT,
+			$enabledByDefault,
 		);
 	}
 }

--- a/lib/Service/ContextChat/ContextChatSettingsService.php
+++ b/lib/Service/ContextChat/ContextChatSettingsService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Service\ContextChat;
 
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCP\IAppConfig;
 
@@ -24,15 +25,15 @@ class ContextChatSettingsService {
 	 * Whether the classification by importance is enabled for a given user.
 	 */
 	public function isIndexingEnabled(string $userId): bool {
-		$appConfig = $this->appConfig->getValueString(
+		$enabledByDefault = $this->appConfig->getValueBool(
 			Application::APP_ID,
-			'index_context_chat_default',
-			'no',
+			ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT,
+			false,
 		);
 		$preference = $this->preferences->getPreference(
 			$userId,
 			'index-context-chat',
-			$appConfig !== 'no' ? 'true' : 'false',
+			$enabledByDefault ? 'true' : 'false',
 		);
 		return $preference === 'true';
 	}
@@ -42,11 +43,11 @@ class ContextChatSettingsService {
 	 * preference themselves.
 	 */
 	public function isIndexingEnabledByDefault(): bool {
-		return $this->appConfig->getValueString(
+		return $this->appConfig->getValueBool(
 			Application::APP_ID,
-			'index_context_chat_default',
-			'no'
-		) !== 'no';
+			ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT,
+			false,
+		);
 	}
 
 	/**
@@ -54,10 +55,10 @@ class ContextChatSettingsService {
 	 * the preference themselves.
 	 */
 	public function setIndexingEnabledByDefault(bool $enabledByDefault): void {
-		$this->appConfig->setValueString(
+		$this->appConfig->setValueBool(
 			Application::APP_ID,
-			'index_context_chat_default',
-			$enabledByDefault ? 'yes' : 'no',
+			ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT,
+			$enabledByDefault,
 		);
 	}
 }

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Settings;
 
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Integration\GoogleIntegration;
 use OCA\Mail\Integration\MicrosoftIntegration;
 use OCA\Mail\Service\AiIntegrations\AiIntegrationsService;
@@ -19,7 +20,7 @@ use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Settings\ISettings;
 use OCP\TaskProcessing\TaskTypes\TextToText;
 use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
@@ -31,7 +32,7 @@ class AdminSettings implements ISettings {
 		private AntiSpamService $antiSpamService,
 		private GoogleIntegration $googleIntegration,
 		private MicrosoftIntegration $microsoftIntegration,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private AiIntegrationsService $aiIntegrationsService,
 		private Defaults $themingDefaults,
 		private ClassificationSettingsService $classificationSettingsService,
@@ -55,12 +56,12 @@ class AdminSettings implements ISettings {
 
 		$this->initialStateService->provideInitialState(
 			'allow_new_mail_accounts',
-			$this->config->getAppValue('mail', 'allow_new_mail_accounts', 'yes') === 'yes'
+			$this->appConfig->getValueBool(Application::APP_ID, ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, true)
 		);
 
 		$this->initialStateService->provideInitialState(
 			'layout_message_view',
-			$this->config->getAppValue('mail', 'layout_message_view', 'threaded')
+			$this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::LAYOUT_MESSAGE_VIEW, 'threaded')
 		);
 
 		$this->initialStateService->provideInitialState(

--- a/tests/Unit/ConfigLexiconTest.php
+++ b/tests/Unit/ConfigLexiconTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\ConfigLexicon;
+use OCP\Config\Lexicon\Entry;
+use OCP\Config\Lexicon\Preset;
+use OCP\Config\Lexicon\Strictness;
+use OCP\Config\ValueType;
+
+class ConfigLexiconTest extends TestCase {
+
+	private ConfigLexicon $lexicon;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->lexicon = new ConfigLexicon();
+	}
+
+	public function testGetStrictness(): void {
+		self::assertSame(Strictness::IGNORE, $this->lexicon->getStrictness());
+	}
+
+	public function testGetUserConfigsIsEmpty(): void {
+		self::assertSame([], $this->lexicon->getUserConfigs());
+	}
+
+	/**
+	 * @return array<string, array{ValueType, string|null}>
+	 */
+	public function appConfigProvider(): array {
+		return [
+			ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS => [ValueType::BOOL, '1'],
+			ConfigLexicon::LLM_PROCESSING => [ValueType::BOOL, '0'],
+			ConfigLexicon::LAYOUT_MESSAGE_VIEW => [ValueType::STRING, 'threaded'],
+			ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT => [ValueType::BOOL, '1'],
+			ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT => [ValueType::BOOL, '0'],
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID => [ValueType::STRING, null],
+			ConfigLexicon::GOOGLE_OAUTH_CLIENT_SECRET => [ValueType::STRING, null],
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID => [ValueType::STRING, null],
+			ConfigLexicon::MICROSOFT_OAUTH_CLIENT_SECRET => [ValueType::STRING, null],
+			ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID => [ValueType::STRING, 'common'],
+			ConfigLexicon::ANTISPAM_REPORTING_SPAM => [ValueType::STRING, null],
+			ConfigLexicon::ANTISPAM_REPORTING_HAM => [ValueType::STRING, null],
+		];
+	}
+
+	public function testAppConfigKeysMatchProvider(): void {
+		$declaredKeys = array_map(
+			static fn (Entry $entry): string => $entry->getKey(),
+			$this->lexicon->getAppConfigs(),
+		);
+
+		sort($declaredKeys);
+		$expectedKeys = array_keys($this->appConfigProvider());
+		sort($expectedKeys);
+
+		self::assertSame($expectedKeys, $declaredKeys);
+	}
+
+	public function testAppConfigTypesAndDefaults(): void {
+		$expected = $this->appConfigProvider();
+
+		foreach ($this->lexicon->getAppConfigs() as $entry) {
+			$key = $entry->getKey();
+			self::assertArrayHasKey($key, $expected, "Unexpected config key $key");
+			[$type, $default] = $expected[$key];
+			self::assertSame($type, $entry->getValueType(), "Wrong type for $key");
+			self::assertSame($default, $entry->getDefault(Preset::NONE), "Wrong default for $key");
+		}
+	}
+}

--- a/tests/Unit/Controller/AccountsControllerTest.php
+++ b/tests/Unit/Controller/AccountsControllerTest.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -88,6 +89,9 @@ class AccountsControllerTest extends TestCase {
 	/** @var IConfig|(IConfig&MockObject)|MockObject */
 	private IConfig|MockObject $config;
 
+	/** @var IAppConfig|MockObject */
+	private IAppConfig|MockObject $appConfig;
+
 	/** @var DelegationService|MockObject */
 	private $delegationService;
 	/** @var IRemoteHostValidator|MockObject */
@@ -109,6 +113,7 @@ class AccountsControllerTest extends TestCase {
 		$this->syncService = $this->createMock(SyncService::class);
 		$this->mailboxSync = $this->createMock(mailboxSync::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->hostValidator = $this->createMock(IRemoteHostValidator::class);
 		$this->hostValidator->method('isValid')->willReturn(true);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
@@ -133,6 +138,7 @@ class AccountsControllerTest extends TestCase {
 			$this->mailboxSync,
 			$this->timeFactory,
 			$this->delegationService,
+			$this->appConfig,
 		);
 		$this->account = $this->createMock(Account::class);
 		$this->accountId = 123;
@@ -244,9 +250,9 @@ class AccountsControllerTest extends TestCase {
 	}
 
 	public function testCreateManualSuccess(): void {
-		$this->config->expects(self::once())
-			->method('getAppValue')
-			->willReturn('yes');
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->willReturn(true);
 		$email = 'user@domain.tld';
 		$accountName = 'Mail';
 		$imapHost = 'localhost';
@@ -285,9 +291,9 @@ class AccountsControllerTest extends TestCase {
 		$smtpSslMode = 'none';
 		$smtpUser = 'user@domain.tld';
 		$smtpPassword = 'mypassword';
-		$this->config->expects(self::once())
-			->method('getAppValue')
-			->willReturn('no');
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->willReturn(false);
 		$this->logger->expects(self::once())
 			->method('info');
 		$this->setupService->expects(self::never())
@@ -300,6 +306,9 @@ class AccountsControllerTest extends TestCase {
 	}
 
 	public function testCreateManualFailure(): void {
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->willReturn(true);
 		$email = 'user@domain.tld';
 		$accountName = 'Mail';
 		$imapHost = 'localhost';

--- a/tests/Unit/Controller/PageControllerTest.php
+++ b/tests/Unit/Controller/PageControllerTest.php
@@ -12,6 +12,8 @@ namespace OCA\Mail\Tests\Unit\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Controller\PageController;
 use OCA\Mail\Db\Mailbox;
@@ -34,6 +36,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\Authentication\LoginCredentials\ICredentials;
 use OCP\Authentication\LoginCredentials\IStore as ICredentialStore;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -60,6 +63,9 @@ class PageControllerTest extends TestCase {
 
 	/** @var IConfig|MockObject */
 	private $config;
+
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
 
 	/** @var AccountService|MockObject */
 	private $accountService;
@@ -124,6 +130,7 @@ class PageControllerTest extends TestCase {
 		$this->request = $this->createMock(IRequest::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->accountService = $this->createMock(AccountService::class);
 		$this->aiIntegrationsService = $this->createMock(AiIntegrationsService::class);
 		$this->aliasesService = $this->createMock(AliasesService::class);
@@ -172,7 +179,8 @@ class PageControllerTest extends TestCase {
 			$this->quickActionsService,
 			$this->appManager,
 			$this->contextChatSettingsService,
-			$this->classificationSettingsService
+			$this->classificationSettingsService,
+			$this->appConfig
 		);
 	}
 
@@ -275,26 +283,32 @@ class PageControllerTest extends TestCase {
 				['version', '0.0.0', '26.0.0'],
 				['app.mail.attachment-size-limit', 0, 123],
 			]);
-		$this->config->expects($this->exactly(7))
+		$this->config->expects($this->exactly(2))
 			->method('getAppValue')
 			->withConsecutive(
-				[ 'mail', 'installed_version' ],
-				['mail', 'layout_message_view' ],
-				['mail', 'google_oauth_client_id' ],
-				['mail', 'microsoft_oauth_client_id' ],
-				['mail', 'microsoft_oauth_tenant_id' ],
-				['core', 'backgroundjobs_mode', 'ajax' ],
-				['mail', 'allow_new_mail_accounts', 'yes'],
+				['mail', 'installed_version'],
+				['core', 'backgroundjobs_mode', 'ajax'],
 			)->willReturnOnConsecutiveCalls(
-				$this->returnValue('1.2.3'),
-				$this->returnValue('threaded'),
-				$this->returnValue(''),
-				$this->returnValue(''),
-				$this->returnValue(''),
-				$this->returnValue('cron'),
-				$this->returnValue('yes'),
-				$this->returnValue('no')
+				'1.2.3',
+				'cron',
 			);
+		$this->appConfig->expects($this->exactly(4))
+			->method('getValueString')
+			->withConsecutive(
+				[Application::APP_ID, ConfigLexicon::LAYOUT_MESSAGE_VIEW, 'threaded'],
+				[Application::APP_ID, ConfigLexicon::GOOGLE_OAUTH_CLIENT_ID],
+				[Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_CLIENT_ID],
+				[Application::APP_ID, ConfigLexicon::MICROSOFT_OAUTH_TENANT_ID, 'common'],
+			)->willReturnOnConsecutiveCalls(
+				'threaded',
+				'',
+				'',
+				'',
+			);
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, true)
+			->willReturn(true);
 		$this->aiIntegrationsService->expects(self::exactly(4))
 			->method('isLlmProcessingEnabled')
 			->willReturn(false);

--- a/tests/Unit/Service/AiIntegrationsServiceTest.php
+++ b/tests/Unit/Service/AiIntegrationsServiceTest.php
@@ -14,6 +14,8 @@ use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Address;
 use OCA\Mail\AddressList;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IMailManager;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
@@ -256,18 +258,18 @@ class AiIntegrationsServiceTest extends TestCase {
 
 	public function isLlmProcessingEnabledDataProvider(): array {
 		return [
-			['no', false],
-			['yes', true],
+			[false, false],
+			[true, true],
 		];
 	}
 
 	/**
 	 * @dataProvider isLlmProcessingEnabledDataProvider
 	 */
-	public function testIsLlmProcessingEnabled(string $appConfigValue, bool $expected) {
+	public function testIsLlmProcessingEnabled(bool $appConfigValue, bool $expected) {
 		$this->appConfig->expects(self::once())
-			->method('getValueString')
-			->with('mail', 'llm_processing', 'no')
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::LLM_PROCESSING, false)
 			->willReturn($appConfigValue);
 
 		$this->assertEquals($expected, $this->aiIntegrationsService->isLlmProcessingEnabled());

--- a/tests/Unit/Service/AntiSpamServiceTest.php
+++ b/tests/Unit/Service/AntiSpamServiceTest.php
@@ -9,6 +9,8 @@ namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IMailTransmission;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\Db\Mailbox;
@@ -69,7 +71,7 @@ class AntiSpamServiceTest extends TestCase {
 
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
-			->with('mail', 'antispam_reporting_spam')
+			->with(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM)
 			->willReturn('');
 		$this->dbMessageMapper->expects(self::never())
 			->method('getIdForUid');
@@ -86,7 +88,7 @@ class AntiSpamServiceTest extends TestCase {
 
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
-			->with('mail', 'antispam_reporting_spam')
+			->with(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM)
 			->willReturn('test@test.com');
 		$this->dbMessageMapper->expects(self::once())
 			->method('getIdForUid')
@@ -106,7 +108,7 @@ class AntiSpamServiceTest extends TestCase {
 
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
-			->with('mail', 'antispam_reporting_spam')
+			->with(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM)
 			->willReturn('test@test.com');
 		$messageData = NewMessageData::fromRequest(
 			$event->getAccount(),
@@ -149,7 +151,7 @@ class AntiSpamServiceTest extends TestCase {
 
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
-			->with('mail', 'antispam_reporting_spam')
+			->with(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM)
 			->willReturn('test@test.com');
 		$messageData = NewMessageData::fromRequest(
 			$event->getAccount(),
@@ -215,7 +217,7 @@ class AntiSpamServiceTest extends TestCase {
 
 		$this->appConfig->expects(self::once())
 			->method('getValueString')
-			->with('mail', 'antispam_reporting_spam')
+			->with(Application::APP_ID, ConfigLexicon::ANTISPAM_REPORTING_SPAM)
 			->willReturn('test@test.com');
 		$messageData = NewMessageData::fromRequest(
 			$event->getAccount(),

--- a/tests/Unit/Service/Classification/ClassificationSettingsServiceTest.php
+++ b/tests/Unit/Service/Classification/ClassificationSettingsServiceTest.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Tests\Unit\Service\Classification;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
 use OCA\Mail\Contracts\IUserPreferences;
 use OCA\Mail\Service\Classification\ClassificationSettingsService;
 use OCP\IAppConfig;
@@ -35,9 +36,9 @@ class ClassificationSettingsServiceTest extends TestCase {
 
 	public function testIsClassificationEnabledByDefault(): void {
 		$this->appConfig->expects(self::once())
-			->method('getValueString')
-			->with(Application::APP_ID, 'importance_classification_default', 'yes')
-			->willReturn('yes');
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT, true)
+			->willReturn(true);
 
 		$result = $this->service->isClassificationEnabledByDefault();
 
@@ -46,8 +47,8 @@ class ClassificationSettingsServiceTest extends TestCase {
 
 	public function testSetClassificationEnabledByDefaultTrue(): void {
 		$this->appConfig->expects(self::once())
-			->method('setValueString')
-			->with(Application::APP_ID, 'importance_classification_default', 'yes');
+			->method('setValueBool')
+			->with(Application::APP_ID, ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT, true);
 
 		$this->service->setClassificationEnabledByDefault(true);
 	}

--- a/tests/Unit/Service/ContextChat/ContextChatSettingsServiceTest.php
+++ b/tests/Unit/Service/ContextChat/ContextChatSettingsServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Service\ContextChat;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\AppInfo\Application;
+use OCA\Mail\ConfigLexicon;
+use OCA\Mail\Contracts\IUserPreferences;
+use OCA\Mail\Service\ContextChat\ContextChatSettingsService;
+use OCP\IAppConfig;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ContextChatSettingsServiceTest extends TestCase {
+
+	private IUserPreferences&MockObject $preferences;
+	private IAppConfig&MockObject $appConfig;
+	private ContextChatSettingsService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->preferences = $this->createMock(IUserPreferences::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->service = new ContextChatSettingsService(
+			$this->preferences,
+			$this->appConfig,
+		);
+	}
+
+	public function testIsIndexingEnabledByDefault(): void {
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT, false)
+			->willReturn(true);
+
+		self::assertTrue($this->service->isIndexingEnabledByDefault());
+	}
+
+	public function testSetIndexingEnabledByDefault(): void {
+		$this->appConfig->expects(self::once())
+			->method('setValueBool')
+			->with(Application::APP_ID, ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT, true);
+
+		$this->service->setIndexingEnabledByDefault(true);
+	}
+
+	public function testIsIndexingEnabledFallsBackToDefault(): void {
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT, false)
+			->willReturn(true);
+		$this->preferences->expects(self::once())
+			->method('getPreference')
+			->with('user123', 'index-context-chat', 'true')
+			->willReturn('true');
+
+		self::assertTrue($this->service->isIndexingEnabled('user123'));
+	}
+
+	public function testIsIndexingEnabledRespectsUserOptOut(): void {
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with(Application::APP_ID, ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT, false)
+			->willReturn(false);
+		$this->preferences->expects(self::once())
+			->method('getPreference')
+			->with('user123', 'index-context-chat', 'false')
+			->willReturn('false');
+
+		self::assertFalse($this->service->isIndexingEnabled('user123'));
+	}
+}


### PR DESCRIPTION
Declare the Mail app's appconfig keys in a ConfigLexicon with their type, default and definition, and route call sites through key constants and the typed IAppConfig API instead of scattered string literals and mixed accessors.

Scope is appconfig values only. User preferences (stored via IUserPreferences with hyphenated keys) remain out of scope and unchanged.

Assisted-by: Claude:claude-opus-4-8

Ref https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/config/lexicon.html

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
