### PR TITLE
fix: Correct hasLocks() expiry check

### DIFF
--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -131,13 +131,13 @@ class Mailbox extends Entity implements JsonSerializable {
 	}
 
 	public function hasLocks(int $now): bool {
-		if ($this->getSyncNewLock() !== null || $this->getSyncNewLock() > ($now - self::LOCK_TIMEOUT)) {
+		if ($this->getSyncNewLock() !== null && $this->getSyncNewLock() > ($now - self::LOCK_TIMEOUT)) {
 			return true;
 		}
-		if ($this->getSyncChangedLock() !== null || $this->getSyncChangedLock() > ($now - self::LOCK_TIMEOUT)) {
+		if ($this->getSyncChangedLock() !== null && $this->getSyncChangedLock() > ($now - self::LOCK_TIMEOUT)) {
 			return true;
 		}
-		if ($this->getSyncVanishedLock() !== null || $this->getSyncVanishedLock() > ($now - self::LOCK_TIMEOUT)) {
+		if ($this->getSyncVanishedLock() !== null && $this->getSyncVanishedLock() > ($now - self::LOCK_TIMEOUT)) {
 			return true;
 		}
 		return false;

--- a/tests/Unit/Db/MailboxTest.php
+++ b/tests/Unit/Db/MailboxTest.php
@@ -60,4 +60,16 @@ class MailboxTest extends TestCase {
 		$this->assertArrayHasKey('cacheBuster', $json);
 		$this->assertEquals($expectedCacheBuster, $json['cacheBuster']);
 	}
+
+	public function testHasLocksIgnoresExpiredLock(): void {
+		$this->mailbox->setSyncNewLock(1000);
+
+		$this->assertFalse($this->mailbox->hasLocks(1000 + Mailbox::LOCK_TIMEOUT + 1));
+	}
+
+	public function testHasLocksRespectsFreshLock(): void {
+		$this->mailbox->setSyncNewLock(1000);
+
+		$this->assertTrue($this->mailbox->hasLocks(1000 + Mailbox::LOCK_TIMEOUT - 1));
+	}
 }


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/mail/pull/13208

hasLocks() used `||` where it should be `&&` between "lock is set" and "lock is still within LOCK_TIMEOUT", so any non-null lock was treated as active forever instead of expiring after 5 minutes. Whenever a lock field is set, the first term alone already makes the condition true, so the timeout comparison can never actually flip the result.

Assisted-by: Claude:claude-sonnet-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
