### PR TITLE
fix(html): prevent invalid UTF-8 from blanking mail body

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -59,6 +59,14 @@ class Html {
 	 * @return string
 	 */
 	public function convertLinks(string $data): string {
+		if (!mb_check_encoding($data, 'UTF-8')) {
+			// Some senders (e.g. Lotus Notes/Domino) declare a message as UTF-8 while
+			// actually sending a different charset. UrlLinker's escapeHtml() calls
+			// htmlspecialchars() without ENT_SUBSTITUTE/ENT_IGNORE, which returns an
+			// empty string for the whole input on the first invalid byte it hits.
+			$data = mb_convert_encoding($data, 'UTF-8', 'UTF-8');
+		}
+
 		$linker = new UrlLinker([
 			'allowFtpAddresses' => true,
 			'allowUpperCaseUrlSchemes' => false,

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -58,6 +58,46 @@ class HtmlTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider invalidUtf8Provider
+	 */
+	public function testLinkDetectionRepairsInvalidUtf8(string $text, string $expectedSubstring): void {
+		$urlGenerator = Server::get(IURLGenerator::class);
+		$request = Server::get(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$withLinks = $html->convertLinks($text);
+
+		self::assertNotSame('', $withLinks);
+		self::assertStringContainsString($expectedSubstring, $withLinks);
+	}
+
+	public function invalidUtf8Provider(): array {
+		return [
+			'stray latin-1 byte' => ["Hello team,\r\n\r\nSee you n\xFCxt week.\r\n", 'Hello team,'],
+			// The two 3-byte sequences below are a UTF-16 surrogate pair (high D83D,
+			// low DE09) that got UTF-8-encoded one half at a time instead of combined
+			// into one 4-byte sequence - a CESU-8 encoding bug seen from some senders.
+			'cesu-8 surrogate pair' => ["Hello team,\r\n\r\nSee you soon \xED\xA0\xBD\xED\xB8\x89\r\n", 'Hello team,'],
+			'invalid bytes at the very start' => ["\xFF\xFEHello team,\r\n", 'Hello team,'],
+			'only invalid bytes' => ["\xFF\xFE\xFD", '?'],
+		];
+	}
+
+	public function testLinkDetectionLeavesValidMultibyteTextUnchanged(): void {
+		$urlGenerator = Server::get(IURLGenerator::class);
+		$request = Server::get(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$text = "Hello team, \u{1F609}\r\n\r\nÜmlaut test: äöüß";
+		$withLinks = $html->convertLinks($text);
+
+		self::assertStringContainsString('äöüß', $withLinks);
+		self::assertStringContainsString("\u{1F609}", $withLinks);
+	}
+
+	/**
 	 * @dataProvider parseMailBodyProvider
 	 * @param $expected
 	 * @param $text


### PR DESCRIPTION
Html::convertLinks() passes the plain-text body to UrlLinker::escapeHtml(), which calls htmlspecialchars() without ENT_SUBSTITUTE/ENT_IGNORE. On any invalid UTF-8 byte, that call returns an empty string for the entire input, not just the bad character - so one malformed byte anywhere in a message wiped the whole visible body.

Reproduced with a real report: a Domino/Notes-originated reply contained an emoji encoded as a raw UTF-16 surrogate pair (CESU-8, each half UTF-8-encoded separately instead of combined into one 4-byte sequence), which is invalid UTF-8 and triggered the bug.

Repair the body via mb_convert_encoding() before it reaches convertLinks() when it isn't valid UTF-8, so only the malformed bytes degrade instead of the entire message.

Assisted-by: Claude:claude-sonnet-4-6

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
