### PR TITLE
occ commands for mailboxes

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -87,6 +87,8 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\DeleteAccount</command>
 		<command>OCA\Mail\Command\ExportAccount</command>
 		<command>OCA\Mail\Command\ExportAccountThreads</command>
+		<command>OCA\Mail\Command\InspectMailbox</command>
+		<command>OCA\Mail\Command\ListMailboxes</command>
 		<command>OCA\Mail\Command\PredictImportance</command>
 		<command>OCA\Mail\Command\TestAccount</command>
 		<command>OCA\Mail\Command\SyncAccount</command>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -79,6 +79,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	<commands>
 		<command>OCA\Mail\Command\AddMissingTags</command>
 		<command>OCA\Mail\Command\CleanUp</command>
+		<command>OCA\Mail\Command\ClearMailboxCache</command>
 		<command>OCA\Mail\Command\CreateImapAccount</command>
 		<command>OCA\Mail\Command\CreateJmapAccount</command>
 		<command>OCA\Mail\Command\CreateTagMigrationJobEntry</command>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -94,6 +94,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\TrainAccount</command>
 		<command>OCA\Mail\Command\UpdateImapAccount</command>
 		<command>OCA\Mail\Command\UpdateJmapAccount</command>
+		<command>OCA\Mail\Command\UnlockMailbox</command>
 		<command>OCA\Mail\Command\UpdateSystemAutoresponders</command>
 		<command>OCA\Mail\Command\RunMetaEstimator</command>
 	</commands>

--- a/lib/Command/ClearMailboxCache.php
+++ b/lib/Command/ClearMailboxCache.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Sync\SyncService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ClearMailboxCache extends Command {
+	public const ARGUMENT_MAILBOX_ID = 'mailbox-id';
+
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		private AccountService $accountService,
+		private SyncService $syncService,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:mailbox:clear-cache');
+		$this->setDescription('Clear the cached messages of a mailbox. The mailbox will be resynced from IMAP on its next regular sync');
+		$this->addArgument(self::ARGUMENT_MAILBOX_ID, InputArgument::REQUIRED, 'Id of the mailbox to clear');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$mailboxId = (int)$input->getArgument(self::ARGUMENT_MAILBOX_ID);
+
+		try {
+			$mailbox = $this->mailboxMapper->findById($mailboxId);
+			$account = $this->accountService->findById($mailbox->getAccountId());
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Mailbox $mailboxId does not exist</error>");
+
+			return self::FAILURE;
+		}
+
+		try {
+			$this->syncService->clearCache($account, $mailbox);
+		} catch (ServiceException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+
+			return self::FAILURE;
+		}
+
+		$output->writeln('<info>Cache cleared</info>');
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/InspectMailbox.php
+++ b/lib/Command/InspectMailbox.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Cache\HordeSyncTokenParser;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InspectMailbox extends Command {
+	public const ARGUMENT_MAILBOX_ID = 'mailbox-id';
+
+	public function __construct(
+		private readonly MailboxMapper $mailboxMapper,
+		private readonly ITimeFactory $timeFactory,
+		private readonly HordeSyncTokenParser $syncTokenParser,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:mailbox:info');
+		$this->setDescription('Show information about a mailbox');
+		$this->addArgument(self::ARGUMENT_MAILBOX_ID, InputArgument::REQUIRED, 'Id of the mailbox');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$mailboxId = (int)$input->getArgument(self::ARGUMENT_MAILBOX_ID);
+
+		try {
+			$mailbox = $this->mailboxMapper->findById($mailboxId);
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Mailbox $mailboxId does not exist</error>");
+
+			return self::FAILURE;
+		}
+
+		$now = $this->timeFactory->getTime();
+
+		$table = new Table($output);
+		$table->setHeaders(['Property', 'Value']);
+		$table->addRows([
+			['Id', $mailbox->getId()],
+			['Account Id', $mailbox->getAccountId()],
+			['Name', $mailbox->getName() ?? '-'],
+			['Delimiter', $mailbox->getDelimiter() ?? '-'],
+			['Attributes', $mailbox->getAttributes() ?? '-'],
+			['Special Use', $mailbox->getSpecialUse() ?? '-'],
+			['Selectable', $this->formatNullableBool($mailbox->getSelectable())],
+			['Messages', $mailbox->getMessages()],
+			['Unseen', $mailbox->getUnseen()],
+			['Sync In Background', $this->formatSyncInBackground($mailbox)],
+			['Shared', $this->formatNullableBool($mailbox->isShared())],
+			['User ACLs', $mailbox->getMyAcls() ?? '-'],
+			// @todo remove for stable5.10 backport
+			['Remote Id', $mailbox->getRemoteId() ?? '-'],
+			// @todo remove for stable5.10 backport
+			['Remote Parent Id', $mailbox->getRemoteParentId() ?? '-'],
+			// @todo remove for stable5.10 backport
+			['State', $mailbox->getState() ?? '-'],
+			new TableSeparator(),
+			['Token New', $this->formatToken($mailbox->getSyncNewToken())],
+			['Token Changed', $this->formatToken($mailbox->getSyncChangedToken())],
+			['Token Vanished', $this->formatToken($mailbox->getSyncVanishedToken())],
+			new TableSeparator(),
+			['Lock New', $this->formatLock($mailbox->getSyncNewLock(), $mailbox->hasNewLock($now))],
+			['Lock Changed', $this->formatLock($mailbox->getSyncChangedLock(), $mailbox->hasChangedLock($now))],
+			['Lock Vanished', $this->formatLock($mailbox->getSyncVanishedLock(), $mailbox->hasVanishedLock($now))],
+		]);
+		$table->render();
+
+		return self::SUCCESS;
+	}
+
+	private function formatSyncInBackground(Mailbox $mailbox): string {
+		if ($mailbox->isInbox()) {
+			return 'yes';
+		}
+		return $this->formatNullableBool($mailbox->getSyncInBackground());
+	}
+
+	private function formatNullableBool(?bool $value): string {
+		if ($value === null) {
+			return '-';
+		}
+		return $value ? 'yes' : 'no';
+	}
+
+	private function formatLock(?int $lock, bool $active): string {
+		if ($lock === null) {
+			return '-';
+		}
+		return date('Y-m-d H:i:s', $lock) . ($active ? ' (active)' : ' (stale)');
+	}
+
+	private function formatToken(?string $token): string {
+		if ($token === null) {
+			return '-';
+		}
+		$parsed = $this->syncTokenParser->parseSyncToken($token);
+		return sprintf(
+			'uid=%s, validity=%s, modseq=%s',
+			$parsed->getNextUid() ?? '-',
+			$parsed->getUidValidity() ?? '-',
+			$parsed->getHighestModSeq() ?? '-',
+		);
+	}
+}

--- a/lib/Command/ListMailboxes.php
+++ b/lib/Command/ListMailboxes.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListMailboxes extends Command {
+	public const ARGUMENT_ACCOUNT_ID = 'account-id';
+
+	public function __construct(
+		private readonly AccountService $accountService,
+		private readonly MailboxMapper $mailboxMapper,
+		private readonly ITimeFactory $timeFactory,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:mailbox:list');
+		$this->setDescription('List the mailboxes of an account');
+		$this->addArgument(self::ARGUMENT_ACCOUNT_ID, InputArgument::REQUIRED, 'Id of the account');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$accountId = (int)$input->getArgument(self::ARGUMENT_ACCOUNT_ID);
+
+		try {
+			$account = $this->accountService->findById($accountId);
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Account $accountId does not exist</error>");
+
+			return self::FAILURE;
+		}
+
+		$mailboxes = $this->mailboxMapper->findAll($account);
+		usort($mailboxes, static fn (Mailbox $a, Mailbox $b) => [$a->getName(), $a->getId()] <=> [$b->getName(), $b->getId()]);
+		$now = $this->timeFactory->getTime();
+
+		$table = new Table($output);
+		$table->setHeaders(['Id', 'Name', 'Special Use', 'Messages', 'Unseen', 'Shared', 'Lock']);
+		foreach ($mailboxes as $mailbox) {
+			$table->addRow([
+				$mailbox->getId(),
+				$mailbox->getName(),
+				$mailbox->getSpecialUse(),
+				$mailbox->getMessages(),
+				$mailbox->getUnseen(),
+				$mailbox->isShared() ? 'yes' : 'no',
+				$mailbox->hasLocks($now) ? 'yes' : 'no',
+			]);
+		}
+		$table->render();
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/UnlockMailbox.php
+++ b/lib/Command/UnlockMailbox.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Db\MailboxMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UnlockMailbox extends Command {
+	public const ARGUMENT_MAILBOX_ID = 'mailbox-id';
+	public const OPTION_FORCE = 'force';
+
+	public function __construct(
+		private MailboxMapper $mailboxMapper,
+		private ITimeFactory $timeFactory,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:mailbox:unlock');
+		$this->setDescription('Release the sync locks of a mailbox');
+		$this->addArgument(self::ARGUMENT_MAILBOX_ID, InputArgument::REQUIRED, 'Id of the mailbox to unlock');
+		$this->addOption(self::OPTION_FORCE, 'f', InputOption::VALUE_NONE, 'Unlock even if the mailbox is still actively locked');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$mailboxId = (int)$input->getArgument(self::ARGUMENT_MAILBOX_ID);
+		$force = (bool)$input->getOption(self::OPTION_FORCE);
+
+		try {
+			$mailbox = $this->mailboxMapper->findById($mailboxId);
+		} catch (DoesNotExistException $e) {
+			$output->writeln("<error>Mailbox $mailboxId does not exist</error>");
+
+			return self::FAILURE;
+		}
+
+		if ($mailbox->getSyncNewLock() === null && $mailbox->getSyncChangedLock() === null && $mailbox->getSyncVanishedLock() === null) {
+			$output->writeln('<info>Mailbox not locked</info>');
+
+			return self::SUCCESS;
+		}
+
+		if (!$force && $mailbox->hasLocks($this->timeFactory->getTime())) {
+			$output->writeln("<error>Mailbox $mailboxId is still actively locked, a sync might be in progress. Use --force to unlock anyway</error>");
+
+			return self::FAILURE;
+		}
+
+		$this->mailboxMapper->unlockFromNewSync($mailbox);
+		$this->mailboxMapper->unlockFromChangedSync($mailbox);
+		$this->mailboxMapper->unlockFromVanishedSync($mailbox);
+
+		$output->writeln('<info>Mailbox unlocked</info>');
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Db/Mailbox.php
+++ b/lib/Db/Mailbox.php
@@ -130,17 +130,26 @@ class Mailbox extends Entity implements JsonSerializable {
 			&& $this->getSyncVanishedToken() !== null;
 	}
 
+	private function isLockActive(?int $lock, int $now): bool {
+		return $lock !== null && $lock > ($now - self::LOCK_TIMEOUT);
+	}
+
+	public function hasNewLock(int $now): bool {
+		return $this->isLockActive($this->getSyncNewLock(), $now);
+	}
+
+	public function hasChangedLock(int $now): bool {
+		return $this->isLockActive($this->getSyncChangedLock(), $now);
+	}
+
+	public function hasVanishedLock(int $now): bool {
+		return $this->isLockActive($this->getSyncVanishedLock(), $now);
+	}
+
 	public function hasLocks(int $now): bool {
-		if ($this->getSyncNewLock() !== null && $this->getSyncNewLock() > ($now - self::LOCK_TIMEOUT)) {
-			return true;
-		}
-		if ($this->getSyncChangedLock() !== null && $this->getSyncChangedLock() > ($now - self::LOCK_TIMEOUT)) {
-			return true;
-		}
-		if ($this->getSyncVanishedLock() !== null && $this->getSyncVanishedLock() > ($now - self::LOCK_TIMEOUT)) {
-			return true;
-		}
-		return false;
+		return $this->hasNewLock($now)
+			|| $this->hasChangedLock($now)
+			|| $this->hasVanishedLock($now);
 	}
 
 	/**

--- a/tests/Unit/Command/ClearMailboxCacheTest.php
+++ b/tests/Unit/Command/ClearMailboxCacheTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Command\ClearMailboxCache;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\Sync\SyncService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ClearMailboxCacheTest extends TestCase {
+	private MailboxMapper|\PHPUnit\Framework\MockObject\MockObject $mailboxMapper;
+	private AccountService|\PHPUnit\Framework\MockObject\MockObject $accountService;
+	private SyncService|\PHPUnit\Framework\MockObject\MockObject $syncService;
+	private ClearMailboxCache $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->syncService = $this->createMock(SyncService::class);
+
+		$this->command = new ClearMailboxCache(
+			$this->mailboxMapper,
+			$this->accountService,
+			$this->syncService,
+		);
+	}
+
+	public function testName(): void {
+		$this->assertSame('mail:mailbox:clear-cache', $this->command->getName());
+	}
+
+	public function testClearsCache(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+		$mailbox->setAccountId(1);
+		$account = new Account($this->createMock(\OCA\Mail\Db\MailAccount::class));
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->accountService->method('findById')
+			->with(1)
+			->willReturn($account);
+		$this->syncService->expects($this->once())
+			->method('clearCache')
+			->with($account, $mailbox);
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testFailsWhenMailboxDoesNotExist(): void {
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willThrowException(new DoesNotExistException('not found'));
+		$this->syncService->expects($this->never())
+			->method('clearCache');
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+
+	public function testFailsWhenClearingCacheThrows(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+		$mailbox->setAccountId(1);
+		$account = new Account($this->createMock(\OCA\Mail\Db\MailAccount::class));
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->accountService->method('findById')
+			->with(1)
+			->willReturn($account);
+		$this->syncService->method('clearCache')
+			->willThrowException($this->createMock(ServiceException::class));
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+}

--- a/tests/Unit/Command/InspectMailboxTest.php
+++ b/tests/Unit/Command/InspectMailboxTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Cache\HordeSyncTokenParser;
+use OCA\Mail\Command\InspectMailbox;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class InspectMailboxTest extends TestCase {
+	private MailboxMapper|\PHPUnit\Framework\MockObject\MockObject $mailboxMapper;
+	private ITimeFactory|\PHPUnit\Framework\MockObject\MockObject $timeFactory;
+	private InspectMailbox $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$this->command = new InspectMailbox(
+			$this->mailboxMapper,
+			$this->timeFactory,
+			new HordeSyncTokenParser(),
+		);
+	}
+
+	public function testName(): void {
+		$this->assertSame('mail:mailbox:info', $this->command->getName());
+	}
+
+	public function testShowsMailboxDetails(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(1);
+		$mailbox->setAccountId(2);
+		$mailbox->setName('INBOX');
+		$mailbox->setSpecialUse('["inbox"]');
+		$mailbox->setMessages(5);
+		$mailbox->setUnseen(2);
+		$mailbox->setSyncInBackground(true);
+		$mailbox->setShared(false);
+		$mailbox->setSyncNewLock(999);
+		$mailbox->setSyncNewToken(base64_encode('U100,V200,H300'));
+		$mailbox->setAttributes('["\\\\HasNoChildren"]');
+		$mailbox->setDelimiter('.');
+		$mailbox->setSelectable(true);
+
+		$this->mailboxMapper->method('findById')
+			->with(1)
+			->willReturn($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '1']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$display = $tester->getDisplay();
+		$this->assertStringContainsString('INBOX', $display);
+		$this->assertStringNotContainsString('Name hash', $display);
+		$this->assertStringContainsString('Delimiter', $display);
+		$this->assertStringContainsString('Selectable', $display);
+		$this->assertStringContainsString('Lock New', $display);
+		$this->assertStringContainsString(date('Y-m-d H:i:s', 999) . ' (active)', $display);
+		$this->assertStringContainsString('Lock Changed', $display);
+		$this->assertStringContainsString('Token New', $display);
+		$this->assertStringContainsString('uid=100, validity=200, modseq=300', $display);
+	}
+
+	public function testShowsStaleLock(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(1);
+		$mailbox->setAccountId(2);
+		$mailbox->setName('INBOX');
+		$mailbox->setSyncNewLock(1);
+
+		$this->mailboxMapper->method('findById')
+			->with(1)
+			->willReturn($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(['mailbox-id' => '1']);
+
+		$this->assertStringContainsString(date('Y-m-d H:i:s', 1) . ' (stale)', $tester->getDisplay());
+	}
+
+	public function testShowsSyncInBackgroundYesForInboxRegardlessOfFlag(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(1);
+		$mailbox->setAccountId(2);
+		$mailbox->setName('INBOX');
+		$mailbox->setSyncInBackground(false);
+
+		$this->mailboxMapper->method('findById')
+			->with(1)
+			->willReturn($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(['mailbox-id' => '1']);
+
+		$display = $tester->getDisplay();
+		$this->assertMatchesRegularExpression('/Sync In Background\s*\|\s*yes/', $display);
+	}
+
+	public function testShowsSyncInBackgroundDashForNonInboxWithoutFlag(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(1);
+		$mailbox->setAccountId(2);
+		$mailbox->setName('Archive');
+
+		$this->mailboxMapper->method('findById')
+			->with(1)
+			->willReturn($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(['mailbox-id' => '1']);
+
+		$display = $tester->getDisplay();
+		$this->assertMatchesRegularExpression('/Sync In Background\s*\|\s*-/', $display);
+	}
+
+	public function testFailsWhenMailboxDoesNotExist(): void {
+		$this->mailboxMapper->method('findById')
+			->with(1)
+			->willThrowException(new DoesNotExistException('not found'));
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '1']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+}

--- a/tests/Unit/Command/ListMailboxesTest.php
+++ b/tests/Unit/Command/ListMailboxesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Account;
+use OCA\Mail\Command\ListMailboxes;
+use OCA\Mail\Db\MailAccount;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCA\Mail\Service\AccountService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListMailboxesTest extends TestCase {
+	private AccountService|\PHPUnit\Framework\MockObject\MockObject $accountService;
+	private MailboxMapper|\PHPUnit\Framework\MockObject\MockObject $mailboxMapper;
+	private ITimeFactory|\PHPUnit\Framework\MockObject\MockObject $timeFactory;
+	private ListMailboxes $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$this->command = new ListMailboxes(
+			$this->accountService,
+			$this->mailboxMapper,
+			$this->timeFactory,
+		);
+	}
+
+	private function mockAccount(): Account {
+		$account = new Account($this->createMock(MailAccount::class));
+
+		$this->accountService->method('findById')
+			->with(42)
+			->willReturn($account);
+
+		return $account;
+	}
+
+	public function testName(): void {
+		$this->assertSame('mail:mailbox:list', $this->command->getName());
+	}
+
+	public function testListsMailboxes(): void {
+		$account = $this->mockAccount();
+		$inbox = new Mailbox();
+		$inbox->setId(1);
+		$inbox->setName('INBOX');
+		$inbox->setSpecialUse('["inbox"]');
+		$inbox->setMessages(5);
+		$inbox->setUnseen(2);
+		$inbox->setShared(false);
+		$inbox->setSyncNewLock(999);
+		$inbox->setSyncVanishedLock(999);
+
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([$inbox]);
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['account-id' => '42']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$display = $tester->getDisplay();
+		$this->assertStringContainsString('INBOX', $display);
+		$this->assertStringNotContainsString('Sync in background', $display);
+		$this->assertStringContainsString('Shared', $display);
+		$this->assertStringContainsString('Lock', $display);
+	}
+
+	public function testShowsNoLockWhenUnlocked(): void {
+		$account = $this->mockAccount();
+		$inbox = new Mailbox();
+		$inbox->setId(1);
+		$inbox->setName('INBOX');
+		$inbox->setSpecialUse('["inbox"]');
+		$inbox->setMessages(5);
+		$inbox->setUnseen(2);
+
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([$inbox]);
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(['account-id' => '42']);
+
+		$this->assertStringContainsString('-', $tester->getDisplay());
+	}
+
+	public function testOrdersMailboxesByNameThenId(): void {
+		$account = $this->mockAccount();
+		$work2 = new Mailbox();
+		$work2->setId(2);
+		$work2->setName('Work');
+		$work2->setSpecialUse('work-mailbox-two');
+		$sent = new Mailbox();
+		$sent->setId(3);
+		$sent->setName('Sent');
+		$sent->setSpecialUse('sent-mailbox');
+		$work1 = new Mailbox();
+		$work1->setId(1);
+		$work1->setName('Work');
+		$work1->setSpecialUse('work-mailbox-one');
+
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([$work2, $sent, $work1]);
+
+		$tester = new CommandTester($this->command);
+		$tester->execute(['account-id' => '42']);
+
+		$display = $tester->getDisplay();
+		$sentPos = strpos($display, 'sent-mailbox');
+		$work1Pos = strpos($display, 'work-mailbox-one');
+		$work2Pos = strpos($display, 'work-mailbox-two');
+		$this->assertLessThan($work1Pos, $sentPos);
+		$this->assertLessThan($work2Pos, $work1Pos);
+	}
+
+	public function testFailsWhenAccountDoesNotExist(): void {
+		$this->accountService->method('findById')
+			->with(42)
+			->willThrowException(new DoesNotExistException('not found'));
+		$this->mailboxMapper->expects($this->never())
+			->method('findAll');
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['account-id' => '42']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+}

--- a/tests/Unit/Command/UnlockMailboxTest.php
+++ b/tests/Unit/Command/UnlockMailboxTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\UnlockMailbox;
+use OCA\Mail\Db\Mailbox;
+use OCA\Mail\Db\MailboxMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UnlockMailboxTest extends TestCase {
+	private MailboxMapper|\PHPUnit\Framework\MockObject\MockObject $mailboxMapper;
+	private ITimeFactory|\PHPUnit\Framework\MockObject\MockObject $timeFactory;
+	private UnlockMailbox $command;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$this->command = new UnlockMailbox(
+			$this->mailboxMapper,
+			$this->timeFactory,
+		);
+	}
+
+	public function testName(): void {
+		$this->assertSame('mail:mailbox:unlock', $this->command->getName());
+	}
+
+	public function testUnlocksAMailboxWithOnlyStaleLocks(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+		$mailbox->setSyncNewLock(1);
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromNewSync')->with($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromChangedSync')->with($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromVanishedSync')->with($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testReportsNotLockedForAnAlreadyUnlockedMailbox(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->mailboxMapper->expects($this->never())->method('unlockFromNewSync');
+		$this->mailboxMapper->expects($this->never())->method('unlockFromChangedSync');
+		$this->mailboxMapper->expects($this->never())->method('unlockFromVanishedSync');
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+		$this->assertStringContainsString('Mailbox not locked', $tester->getDisplay());
+	}
+
+	public function testRefusesToUnlockAnActivelyLockedMailbox(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+		$mailbox->setSyncNewLock(999);
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->mailboxMapper->expects($this->never())->method('unlockFromNewSync');
+		$this->mailboxMapper->expects($this->never())->method('unlockFromChangedSync');
+		$this->mailboxMapper->expects($this->never())->method('unlockFromVanishedSync');
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+
+	public function testForceUnlocksAnActivelyLockedMailbox(): void {
+		$mailbox = new Mailbox();
+		$mailbox->setId(10);
+		$mailbox->setSyncNewLock(999);
+
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willReturn($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromNewSync')->with($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromChangedSync')->with($mailbox);
+		$this->mailboxMapper->expects($this->once())->method('unlockFromVanishedSync')->with($mailbox);
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10', '--force' => true]);
+
+		$this->assertSame(Command::SUCCESS, $exitCode);
+	}
+
+	public function testFailsWhenMailboxDoesNotExist(): void {
+		$this->mailboxMapper->method('findById')
+			->with(10)
+			->willThrowException(new DoesNotExistException('not found'));
+
+		$tester = new CommandTester($this->command);
+		$exitCode = $tester->execute(['mailbox-id' => '10']);
+
+		$this->assertSame(Command::FAILURE, $exitCode);
+	}
+}


### PR DESCRIPTION
| Command | Description |
|--------|--------|
| `mail:mailbox:list` | to list the mailboxes for an account |
| `mail:mailbox:info` | show details about a mailbox |
| `mail:mailbox:cache-clear` | reset the local cache for a mailbox |
| `mail:mailbox:unlock` | remove the lock | 

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
