### PR TITLE
feat: rename an attachment to be saved in Files

### DIFF
--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -841,6 +841,37 @@ class MessagesController extends Controller {
 		return $zip;
 	}
 
+	private function moveAttachmentToFiles(Attachment $attachment, string $targetPath, ?string $fileName): void {
+		if ($this->userFolder === null) {
+			return;
+		}
+
+		if ($fileName === null) {
+			$fileName = '';
+		} else {
+			$fileName = trim($fileName);
+		}
+
+		if ($fileName === '') {
+			$fileName = $attachment->getName() ?? $this->l10n->t('Embedded message %s', [
+				$attachment->getId(),
+			]) . '.eml';
+		}
+
+		$fileParts = pathinfo($fileName);
+		$fileName = $fileParts['filename'];
+		$fileExtension = $fileParts['extension'] ?? '';
+		$fullPath = "$targetPath/$fileName.$fileExtension";
+		$counter = 2;
+		while ($this->userFolder->nodeExists($fullPath)) {
+			$fullPath = "$targetPath/$fileName ($counter).$fileExtension";
+			$counter++;
+		}
+
+		$newFile = $this->userFolder->newFile($fullPath);
+		$newFile->putContent($attachment->getContent());
+	}
+
 	/**
 	 * @NoAdminRequired
 	 *
@@ -858,7 +889,8 @@ class MessagesController extends Controller {
 	#[TrapError]
 	public function saveAttachment(int $id,
 		string $attachmentId,
-		string $targetPath) {
+		string $targetPath,
+		?string $fileName) {
 		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
@@ -880,40 +912,27 @@ class MessagesController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		/** @var Attachment[] $attachments */
-		$attachments = [];
 		if ($attachmentId === '0') {
 			$attachments = $this->mailManager->getMailAttachments(
 				$account,
 				$mailbox,
 				$message,
 			);
+
+			foreach ($attachments as $attachment) {
+				$this->moveAttachmentToFiles($attachment, $targetPath, null);
+			}
 		} else {
-			$attachments[] = $this->mailManager->getMailAttachment(
+			$attachment = $this->mailManager->getMailAttachment(
 				$account,
 				$mailbox,
 				$message,
 				$attachmentId,
 			);
+
+			$this->moveAttachmentToFiles($attachment, $targetPath, $fileName);
 		}
 
-		foreach ($attachments as $attachment) {
-			$fileName = $attachment->getName() ?? $this->l10n->t('Embedded message %s', [
-				$attachment->getId(),
-			]) . '.eml';
-			$fileParts = pathinfo($fileName);
-			$fileName = $fileParts['filename'];
-			$fileExtension = $fileParts['extension'] ?? '';
-			$fullPath = "$targetPath/$fileName.$fileExtension";
-			$counter = 2;
-			while ($this->userFolder->nodeExists($fullPath)) {
-				$fullPath = "$targetPath/$fileName ($counter).$fileExtension";
-				$counter++;
-			}
-
-			$newFile = $this->userFolder->newFile($fullPath);
-			$newFile->putContent($attachment->getContent());
-		}
 		return new JSONResponse();
 	}
 

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -19,6 +19,7 @@
 			</span>
 			<span class="attachment-size">{{ humanReadable(size) }}</span>
 		</div>
+
 		<FilePicker
 			v-if="isFilePickerOpen"
 			:name="t('mail', 'Choose a folder to store the attachment in')"
@@ -27,6 +28,17 @@
 			:multiselect="false"
 			:mimetype-filter="['httpd/unix-directory']"
 			@close="() => isFilePickerOpen = false" />
+
+		<NcDialog
+			:open.sync="isRenameOpen"
+			:name="t('mail', 'Rename')"
+			:buttons="renameButtons">
+			<NcInputField
+				v-model="newFileName"
+				:label="t('mail', 'Filename')"
+				required />
+		</NcDialog>
+
 		<Actions :boundaries-element="boundariesElement">
 			<template v-if="!showCalendarPopover">
 				<ActionButton
@@ -85,7 +97,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { FilePickerVue as FilePicker } from '@nextcloud/dialogs/filepicker.js'
 import { formatFileSize } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
-import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading } from '@nextcloud/vue'
+import { NcActionButton as ActionButton, NcActions as Actions, NcLoadingIcon as IconLoading, NcDialog, NcInputField } from '@nextcloud/vue'
 import IconArrow from 'vue-material-design-icons/ArrowLeft.vue'
 import IconSave from 'vue-material-design-icons/FolderOutline.vue'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
@@ -98,6 +110,8 @@ export default {
 	name: 'MessageAttachment',
 	components: {
 		FilePicker,
+		NcDialog,
+		NcInputField,
 		Actions,
 		ActionButton,
 		IconAdd,
@@ -163,13 +177,32 @@ export default {
 			showCalendarPopover: false,
 			saveAttachementButtons: [
 				{
-					label: t('mail', 'Choose'),
+					label: t('mail', 'Rename and save'),
+					callback: this.openRename,
+					type: 'secondary',
+				},
+				{
+					label: t('mail', 'Save as {filename}', {
+						filename: this.fileName,
+					}),
+
 					callback: this.saveToCloud,
 					type: 'primary',
 				},
 			],
 
+			renameButtons: [
+				{
+					label: t('mail', 'Save'),
+					callback: this.saveRename,
+					type: 'primary',
+				},
+			],
+
+			path: '',
 			isFilePickerOpen: false,
+			newFileName: this.fileName,
+			isRenameOpen: false,
 		}
 	},
 
@@ -225,13 +258,29 @@ export default {
 			return formatFileSize(size)
 		},
 
-		async saveToCloud(dest) {
-			const path = dest[0].path
+		openRename(dest) {
+			this.path = dest[0].path
+			this.newFileName = this.fileName
+			this.isRenameOpen = true
+		},
+
+		saveRename() {
+			this.isRenameOpen = false
+			this.realSave()
+		},
+
+		saveToCloud(dest) {
+			this.path = dest[0].path
+			this.newFileName = this.fileName
+			this.realSave()
+		},
+
+		async realSave() {
 			this.savingToCloud = true
 			const id = this.$route.params.threadId
 
 			try {
-				await saveAttachmentToFiles(id, this.id, path)
+				await saveAttachmentToFiles(id, this.id, this.path, this.newFileName)
 				Logger.info('saved')
 				showSuccess(t('mail', 'Attachment saved to Files'))
 			} catch (e) {

--- a/src/service/AttachmentService.js
+++ b/src/service/AttachmentService.js
@@ -6,7 +6,7 @@
 import Axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 
-export async function saveAttachmentToFiles(id, attachmentId, directory) {
+export async function saveAttachmentToFiles(id, attachmentId, directory, filename) {
 	const url = generateUrl(
 		'/apps/mail/api/messages/{id}/attachment/{attachmentId}',
 		{
@@ -17,12 +17,13 @@ export async function saveAttachmentToFiles(id, attachmentId, directory) {
 
 	return await Axios.post(url, {
 		targetPath: directory,
+		fileName: filename,
 	})
 }
 
 export async function saveAttachmentsToFiles(id, directory) {
 	// attachmentId = 0 means 'all attachments' (see MessageController.php::saveAttachement)
-	return await saveAttachmentToFiles(id, 0, directory)
+	return await saveAttachmentToFiles(id, 0, directory, null)
 }
 
 export function downloadAttachment(url) {

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -408,7 +408,71 @@ class MessagesControllerTest extends TestCase {
 		$response = $this->controller->saveAttachment(
 			$id,
 			$attachmentId,
-			$targetPath
+			$targetPath,
+			null
+		);
+
+		$this->assertEquals($expected, $response);
+	}
+
+	public function testSaveAndRenameSingleAttachment() {
+		$accountId = 17;
+		$mailboxId = 987;
+		$id = 123;
+		$uid = 321;
+		$attachmentId = '2.2';
+		$targetPath = 'Downloads';
+		$message = new \OCA\Mail\Db\Message();
+		$message->setMailboxId($mailboxId);
+		$message->setUid($uid);
+		$mailbox = new \OCA\Mail\Db\Mailbox();
+		$mailbox->setName('INBOX');
+		$mailbox->setAccountId($accountId);
+		$this->mailManager->expects($this->once())
+			->method('getMessage')
+			->with($this->userId, $id)
+			->willReturn($message);
+		$this->mailManager->expects($this->once())
+			->method('getMailbox')
+			->with($this->userId, $mailboxId)
+			->willReturn($mailbox);
+		$this->accountService->expects($this->once())
+			->method('find')
+			->with($this->equalTo($this->userId), $this->equalTo($accountId))
+			->will($this->returnValue($this->account));
+		$this->mailManager->expects($this->once())
+			->method('getMailAttachment')
+			->with($this->account, $mailbox, $message, $attachmentId)
+			->will($this->returnValue($this->attachment));
+		$folderNode = $this->createStub(Folder::class);
+		$this->userFolder->expects($this->once())
+			->method('get')
+			->with('Downloads')
+			->willReturn($folderNode);
+		$this->userFolder->expects($this->exactly(2))
+			->method('nodeExists')
+			->withConsecutive(['Downloads'], ['Downloads/foobar.jpg'])
+			->willReturnOnConsecutiveCalls(true, false);
+		$file = $this->getMockBuilder('\OCP\Files\File')
+			->disableOriginalConstructor()
+			->getMock();
+		$this->userFolder->expects($this->once())
+			->method('newFile')
+			->with('Downloads/foobar.jpg')
+			->will($this->returnValue($file));
+		$file->expects($this->once())
+			->method('putContent')
+			->with('abcdefg');
+		$this->attachment->expects($this->once())
+			->method('getContent')
+			->will($this->returnValue('abcdefg'));
+
+		$expected = new JSONResponse();
+		$response = $this->controller->saveAttachment(
+			$id,
+			$attachmentId,
+			$targetPath,
+			'foobar.jpg'
 		);
 
 		$this->assertEquals($expected, $response);
@@ -476,7 +540,8 @@ class MessagesControllerTest extends TestCase {
 		$response = $this->controller->saveAttachment(
 			$id,
 			$attachmentId,
-			$targetPath
+			$targetPath,
+			null
 		);
 
 		$this->assertEquals($expected, $response);
@@ -488,7 +553,7 @@ class MessagesControllerTest extends TestCase {
 			->with('NoSuchFolder')
 			->willReturn(false);
 
-		$response = $this->controller->saveAttachment(123, '1', 'NoSuchFolder');
+		$response = $this->controller->saveAttachment(123, '1', 'NoSuchFolder', null);
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
@@ -506,7 +571,7 @@ class MessagesControllerTest extends TestCase {
 			->with('some/file.txt')
 			->willReturn($fileNode);
 
-		$response = $this->controller->saveAttachment(123, '1', 'some/file.txt');
+		$response = $this->controller->saveAttachment(123, '1', 'some/file.txt', null);
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}


### PR DESCRIPTION
This adds an extra button to the `FilePicker` modal used to save an attachment to Files, opening a new modal which permits to overwrite the filename to be used.

[I tried to ask](https://github.com/nextcloud-libraries/nextcloud-dialogs/issues/2491) to embed this functionality (= specify a filename) directly into `FilePicker` but the request has been rejected. This is fair, as this use case doesn't seems to be widely common across Nextcloud apps: perhaps one day this will change, but right now seems an overkill to embed this directly in the shared library.

Note that the extra modal may later be used to perform other operations while saving an attachment to Files, e.g. attaching tags (#604), without depending to `FilePicker` abilities.

Fixes #1827 