### PR TITLE
fix: disabling shortcut for links when not editing html

### DIFF
--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -619,6 +619,11 @@ export default {
 					editor.execute('heading', { value: 'heading3' })
 					cancel()
 				})
+			} else {
+				const linkCommand = editor.commands.get('link')
+				if (linkCommand) {
+					linkCommand.forceDisabled('linking')
+				}
 			}
 
 			this.bus.on('append-to-body-at-cursor', this.appendToBodyAtCursor)


### PR DESCRIPTION
Even when formatting options of `TextEditor` are disabled, the keyboard shortcut to add links (Ctrl+K) is enabled. But, for some reason I've not entirely understood, the floating modal to insert the link is totally unusable and cannot be edited.

This PR [disables](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_command-Command.html#function-forceDisabled) the "link" command and, consequently, [the opening of the sub-modal](https://github.com/ckeditor/ckeditor5/blob/070381b0f2800ac5881cd5a36c0c5982b8d19a67/packages/ckeditor5-link/src/linkui.ts#L815). The user who wants to add a link have to explicitely enable rich formatting (or "accidentally" enable it, for example using a mention, which is unaffected by this change).

Fixes #7641 

Please note that this do not explicitely targets similar issue related to the sometimes breaking link sub-modal, as #9605 and #10977.