### PR TITLE
fix: correct spelling errors in error messages and comments

### DIFF
--- a/lib/Command/UpdateImapAccount.php
+++ b/lib/Command/UpdateImapAccount.php
@@ -157,7 +157,7 @@ final class UpdateImapAccount extends Command {
 
 		$this->mapper->save($mailAccount);
 
-		$output->writeln('<info>Account ' . $mailAccount->getEmail() . " with ID  $accountId  succesfully updated </info>");
+		$output->writeln('<info>Account ' . $mailAccount->getEmail() . " with ID  $accountId  successfully updated </info>");
 		return self::SUCCESS;
 	}
 }

--- a/lib/Command/UpdateJmapAccount.php
+++ b/lib/Command/UpdateJmapAccount.php
@@ -105,7 +105,7 @@ final class UpdateJmapAccount extends Command {
 
 		$this->mapper->save($mailAccount);
 
-		$output->writeln('<info>JMAP account ' . $mailAccount->getEmail() . " with ID $accountId succesfully updated </info>");
+		$output->writeln('<info>JMAP account ' . $mailAccount->getEmail() . " with ID $accountId successfully updated </info>");
 		return self::SUCCESS;
 	}
 }

--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -217,7 +217,7 @@ class MessageApiController extends OCSController {
 			LocalMessage::STATUS_NO_SENT_MAILBOX => new DataResponse('Configuration error: Cannot send message without sent mailbox.', Http::STATUS_FORBIDDEN),
 			LocalMessage::STATUS_SMPT_SEND_FAIL => new DataResponse('SMTP error: could not send message. Message sending will be retried. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR),
 			LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL => new DataResponse('Email was sent but could not be copied to sent mailbox. Copying will be retried. Please check the logs.', Http::STATUS_ACCEPTED),
-			default => new DataResponse('An error occured. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR),
+			default => new DataResponse('An error occurred. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR),
 		};
 	}
 

--- a/lib/Service/Provisioning/Manager.php
+++ b/lib/Service/Provisioning/Manager.php
@@ -339,7 +339,7 @@ class Manager {
 			// The password is empty (and not null) when using WebAuthn passwordless login.
 			// Maybe research other providers as well.
 			// Ref \OCA\Mail\Controller\PageController::index()
-			//     -> inital state for password-is-unavailable
+			//     -> initial state for password-is-unavailable
 			if ($provisioning->getMasterPasswordEnabled() === true && $provisioning->getMasterPassword() !== null) {
 				$password = $provisioning->getMasterPassword();
 				$this->logger->debug('Password set to master password for ' . $user->getUID());

--- a/lib/Service/Sync/ImapToDbSynchronizer.php
+++ b/lib/Service/Sync/ImapToDbSynchronizer.php
@@ -238,7 +238,7 @@ class ImapToDbSynchronizer {
 					$logger->debug("Running initial sync for {$mailbox->getId()} after cache reset");
 					$this->runInitialSync($client, $account, $mailbox, $logger);
 				} catch (MailboxDoesNotSupportModSequencesException $e) {
-					$logger->warning("Mailbox does not support mod-sequences error occured. Wiping cache and performing full sync for {$mailbox->getId()}", [
+					$logger->warning("Mailbox does not support mod-sequences error occurred. Wiping cache and performing full sync for {$mailbox->getId()}", [
 						'exception' => $e,
 					]);
 					$this->resetCache($account, $mailbox);

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -356,7 +356,7 @@ export default {
 						total: filesFromCloud[i].size,
 						sizeString: this.formatBytes(filesFromCloud[i].size),
 						hasPreview: filesFromCloud[i]['has-preview'],
-						// dont know, may be it will be conflict if cloud & local has equal IDs?
+						// don't know, may be it will be conflict if cloud & local has equal IDs?
 						id: filesFromCloud[i].fileid,
 						uploaded: 0,
 					}

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -319,7 +319,7 @@ export default {
 		 * @param {boolean=} opts.showToast Show a toast after saving
 		 * @return {Promise<number>} Draft id promise
 		 */
-		// TODO: when there's no draft is saved, Cloing wont move ie case 2 doesn't work
+		// TODO: when there's no draft is saved, Cloning won't move ie case 2 doesn't work
 		onDraft(data, { showToast = false } = {}) {
 			if (!this.composerMessage) {
 				logger.info('Ignoring draft because there is no message anymore', { data })

--- a/src/util/CrashReport.js
+++ b/src/util/CrashReport.js
@@ -39,7 +39,7 @@ function flattenTrace(trace) {
 
 export function getReportUrl(error) {
 	logger.error('crash report', { error })
-	let message = error.message || 'An unkown error occurred.'
+	let message = error.message || 'An unknown error occurred.'
 	if (!message.endsWith('.')) {
 		message += '.'
 	}

--- a/tests/Unit/Command/UpdateImapAccountTest.php
+++ b/tests/Unit/Command/UpdateImapAccountTest.php
@@ -96,7 +96,7 @@ class UpdateImapAccountTest extends TestCase {
 			->method('writeln')
 			->withConsecutive(
 				['<info>Found account with email: old@example.com</info>'],
-				['<info>Account updated@example.com with ID  42  succesfully updated </info>'],
+				['<info>Account updated@example.com with ID  42  successfully updated </info>'],
 			);
 
 		$this->crypto->expects($this->exactly(2))

--- a/tests/Unit/Controller/MessageApiControllerTest.php
+++ b/tests/Unit/Controller/MessageApiControllerTest.php
@@ -482,7 +482,7 @@ class MessageApiControllerTest extends TestCase {
 			[LocalMessage::STATUS_NO_SENT_MAILBOX, new DataResponse('Configuration error: Cannot send message without sent mailbox.', Http::STATUS_FORBIDDEN), 'john attempted sending a message on behalf of john but no sent mailbox is configured'],
 			[LocalMessage::STATUS_SMPT_SEND_FAIL, new DataResponse('SMTP error: could not send message. Message sending will be retried. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR), 'john attempted sending a message on behalf of john but SMTP sending failed'],
 			[LocalMessage::STATUS_IMAP_SENT_MAILBOX_FAIL, new DataResponse('Email was sent but could not be copied to sent mailbox. Copying will be retried. Please check the logs.', Http::STATUS_ACCEPTED), 'john sent a message on behalf of john but copying to sent mailbox failed'],
-			[LocalMessage::STATUS_TOO_MANY_RECIPIENTS, new DataResponse('An error occured. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR), 'john attempted sending a message on behalf of john but an unknown error occurred'],
+			[LocalMessage::STATUS_TOO_MANY_RECIPIENTS, new DataResponse('An error occurred. Please check the logs.', Http::STATUS_INTERNAL_SERVER_ERROR), 'john attempted sending a message on behalf of john but an unknown error occurred'],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Fixes 11 spelling errors in source code error messages and comments across 10 files.

## Changes

| # | File | Correction |
|---|---|---|
| 1 | `lib/Controller/MessageApiController.php` | `occured` → `occurred` |
| 2 | `tests/Unit/Controller/MessageApiControllerTest.php` | `occured` → `occurred` |
| 3 | `lib/Service/Sync/ImapToDbSynchronizer.php` | `occured` → `occurred` |
| 4 | `src/util/CrashReport.js` | `unkown` → `unknown` |
| 5 | `lib/Service/Provisioning/Manager.php` | `inital` → `initial` |
| 6 | `lib/Command/UpdateImapAccount.php` | `succesfully` → `successfully` |
| 7 | `lib/Command/UpdateJmapAccount.php` | `succesfully` → `successfully` |
| 8 | `tests/Unit/Command/UpdateImapAccountTest.php` | `succesfully` → `successfully` |
| 9 | `src/components/ComposerAttachments.vue` | `dont` → `don't` |
| 10 | `src/components/NewMessageModal.vue` | `wont` → `won't` |
| 11 | `src/components/NewMessageModal.vue` | `Cloing` → `Cloning` |

All changes are limited to comments and error message strings — no functional impact.

## AI Assistance

This contribution was made with the help of DeepSeek V4 Pro.

Assisted-by: DeepSeek:V4-Pro