### PR TITLE
fix(mailbox): Flag shared mailboxes as shared

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -39,6 +39,11 @@ use function str_starts_with;
 class MailboxSync {
 	use TTransactional;
 
+	private const NON_PERSONAL_NAMESPACE_TYPES = [
+		Horde_Imap_Client_Data_Namespace::NS_OTHER,
+		Horde_Imap_Client_Data_Namespace::NS_SHARED,
+	];
+
 	/** @var ITimeFactory */
 	private $timeFactory;
 
@@ -239,7 +244,7 @@ class MailboxSync {
 	private function isMailboxShared(?Horde_Imap_Client_Namespace_List $namespaces, Mailbox $mailbox): bool {
 		foreach (($namespaces ?? []) as $namespace) {
 			/** @var Horde_Imap_Client_Data_Namespace $namespace */
-			if ($namespace->type === Horde_Imap_Client_Data_Namespace::NS_OTHER && str_starts_with($mailbox->getName(), $namespace->name)) {
+			if (in_array($namespace->type, self::NON_PERSONAL_NAMESPACE_TYPES, true) && str_starts_with($mailbox->getName(), $namespace->name)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
For https://github.com/ChristophWurst/docker-imap-devel/pull/21

--- 
RFC-2342 IMAP4 Namespace [^1]

1 Personal Namespace
2 Other Users' Namespace
3 Shared Namespace

Before this change only mailboxes with type 2 (Other User's Namespace) were flagged as shared.

Now also mailboxes with type 3 (Shared Namespace) are flagged.

[^1]: https://datatracker.ietf.org/doc/html/rfc2342


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
