### PR TITLE
fix(composer): keep signature images by switching to rich text

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -21,17 +21,17 @@
 			:name="t('mail', 'Alias to S/MIME certificate mapping')">
 			<CertificateSettings :account="account" />
 		</AppSettingsSection>
-		<AppSettingsSection id="signature" :name="t('mail', 'Signature')">
-			<p class="settings-hint">
-				{{ t('mail', 'A signature is added to the text of new messages and replies.') }}
-			</p>
-			<SignatureSettings :account="account" />
-		</AppSettingsSection>
 		<AppSettingsSection id="writing-mode" :name="t('mail', 'Writing mode')">
 			<p class="settings-hint">
 				{{ t('mail', 'Preferred writing mode for new messages and replies.') }}
 			</p>
 			<EditorSettings :account="account" />
+		</AppSettingsSection>
+		<AppSettingsSection id="signature" :name="t('mail', 'Signature')">
+			<p class="settings-hint">
+				{{ t('mail', 'A signature is added to the text of new messages and replies.') }}
+			</p>
+			<SignatureSettings :account="account" />
 		</AppSettingsSection>
 		<AppSettingsSection id="default-folders" :name=" t('mail', 'Default folders')">
 			<p class="settings-hint">

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -542,7 +542,7 @@ import { EDITOR_MODE_HTML, EDITOR_MODE_TEXT } from '../store/constants.js'
 import useMainStore from '../store/mainStore.js'
 import { parseEmailList } from '../util/emailAddress.js'
 import { formatDateTime } from '../util/formatDateTime.js'
-import { detect, html, toHtml, toPlain } from '../util/text.js'
+import { containsImage, detect, html, toHtml, toPlain } from '../util/text.js'
 import textBlockSvg from './../../img/text_snippet.svg'
 
 const debouncedSearch = debouncePromise(findRecipient, 500)
@@ -1206,7 +1206,10 @@ export default {
 			}
 			// Only overwrite editormode if body is empty
 			if (previous === NO_ALIAS_SET && (!this.body || this.body.value === '')) {
-				this.editorMode = this.selectedAlias.editorMode
+				// Pick the mode before the editor exists so insertSignature doesn't have to re-create it
+				this.editorMode = containsImage(toHtml(detect(this.selectedAlias.signature)).value)
+					? EDITOR_MODE_HTML
+					: this.selectedAlias.editorMode
 			}
 		},
 
@@ -1295,6 +1298,22 @@ export default {
 		},
 
 		insertSignature() {
+			const signature = toHtml(detect(this.selectedAlias.signature)).value
+
+			/**
+			 * Plain text can't carry the images of a signature, they would be
+			 * dropped when the body is converted on submit. Switch to rich text
+			 * instead of losing them.
+			 *
+			 * As editorMode is the key for the TextEditor component the change
+			 * destroys the current instance and the signature is inserted via
+			 * the onEditorReady event of the new instance.
+			 */
+			if (this.editorPlainText && containsImage(signature)) {
+				this.editorMode = EDITOR_MODE_HTML
+				return
+			}
+
 			let trigger
 
 			if (this.changeSignature) {
@@ -1306,7 +1325,7 @@ export default {
 			this.$refs.editor.editorExecute(
 				'insertSignature',
 				trigger,
-				toHtml(detect(this.selectedAlias.signature)).value,
+				signature,
 				this.selectedAlias.signatureAboveQuote,
 			)
 

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -27,16 +27,23 @@
 			@option:selected="changeIdentity" />
 		<!-- Added wrapper to give the signature editor a clear input-style border -->
 		<div class="signature-editor-wrapper">
+			<!-- Plugins are picked when the editor is created, so re-create it whenever html changes -->
 			<TextEditor
+				:key="allowHtml"
 				v-model="signature"
-				:html="true"
+				:html="allowHtml"
 				:placeholder="t('mail', 'Signature …')"
 				:bus="bus"
 				class="signature-editor-wrapper__editor" />
 		</div>
-		<p v-if="isLargeSignature" class="warning-large-signature">
-			{{ t('mail', 'Your signature is larger than 2 MB. This may affect the performance of your editor.') }}
-		</p>
+		<NcNoteCard v-if="isLargeSignature" type="warning">
+			<!-- TRANSLATORS: "It is added to every message" refers to the signature, not to the image -->
+			<p>{{ t('mail', 'This signature is larger than 2 MB, usually because an image is embedded in it. It is added to every message you send and may slow down the editor.') }}</p>
+		</NcNoteCard>
+		<NcNoteCard v-if="overridesPlainText" type="warning">
+			<!-- TRANSLATORS: "writing mode", "rich text" and "plain text" are labels of the Writing mode setting -->
+			<p>{{ t('mail', 'This signature contains images. New messages will use rich text, even though your writing mode is set to plain text.') }}</p>
+		</NcNoteCard>
 		<ButtonVue
 			type="primary"
 			:disabled="loading"
@@ -60,19 +67,21 @@
 </template>
 
 <script>
-import { NcButton as ButtonVue, NcLoadingIcon as IconLoading, NcSelect } from '@nextcloud/vue'
+import { NcButton as ButtonVue, NcLoadingIcon as IconLoading, NcNoteCard, NcSelect } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import TextEditor from './TextEditor.vue'
 import logger from '../logger.js'
+import { EDITOR_MODE_HTML } from '../store/constants.js'
 import useMainStore from '../store/mainStore.js'
-import { detect, toHtml } from '../util/text.js'
+import { containsImage, detect, toHtml } from '../util/text.js'
 
 export default {
 	name: 'SignatureSettings',
 	components: {
 		TextEditor,
+		NcNoteCard,
 		NcSelect,
 		ButtonVue,
 		IconLoading,
@@ -92,6 +101,9 @@ export default {
 			bus: mitt(),
 			identity: null,
 			signature: '',
+			// Snapshot from the loaded signature: deleting the image while editing must
+			// not swap the editor under the cursor
+			signatureEnforcesHtml: false,
 			signatureAboveQuote: this.account.signatureAboveQuote,
 		}
 	},
@@ -114,6 +126,30 @@ export default {
 			})
 
 			return identities
+		},
+
+		/**
+		 * Plain text accounts get the plain text editor so they can't add images to
+		 * their signature in the first place. Signatures that already contain one
+		 * keep the rich text editor, otherwise the image would be stripped on load
+		 * and silently lost on save.
+		 *
+		 * @return {boolean}
+		 */
+		allowHtml() {
+			return this.account.editorMode === EDITOR_MODE_HTML || this.signatureEnforcesHtml
+		},
+
+		/**
+		 * Unlike allowHtml this follows the current content so the warning disappears
+		 * as soon as the image is gone.
+		 *
+		 * @return {boolean}
+		 */
+		overridesPlainText() {
+			return this.account.editorMode !== EDITOR_MODE_HTML
+				&& !!this.signature
+				&& containsImage(this.signature)
 		},
 
 		isLargeSignature() {
@@ -149,6 +185,7 @@ export default {
 			this.signature = identity.signature
 				? toHtml(detect(identity.signature)).value
 				: ''
+			this.signatureEnforcesHtml = containsImage(this.signature)
 		},
 
 		async deleteSignature() {
@@ -252,10 +289,6 @@ export default {
 .button-vue:deep() {
 	display: inline-block !important;
 	margin-top: 4px !important;
-}
-
-.warning-large-signature {
-	color: darkorange;
 }
 
 /* it's a bit hard to make it work without this max-width in the modal because it overlaps with the sidebar of the modal */

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -131,12 +131,12 @@ export default {
 			Mention,
 			Link,
 			FindAndReplace,
-			GeneralHtmlSupport,
 		]
 		const toolbar = ['undo', 'redo']
 
 		if (this.html) {
 			plugins.push(...[
+				GeneralHtmlSupport,
 				Heading,
 				Alignment,
 				Bold,

--- a/src/tests/unit/components/Composer.vue.spec.js
+++ b/src/tests/unit/components/Composer.vue.spec.js
@@ -514,4 +514,94 @@ describe('Composer', () => {
 
 		expect(insertSignature).toHaveBeenCalled()
 	})
+	it('starts in rich text when the signature contains an image', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+						connectionStatus: true,
+						signature: '<p>Regards<img src="cid:logo"></p>',
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+
+		expect(view.vm.editorMode).toEqual('richtext')
+	})
+
+	it('switches to rich text when the signature contains an image', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+		const editorExecute = vi.fn()
+		view.vm.$refs.editor = { editorExecute }
+		view.vm.selectedAlias = {
+			id: 123,
+			signature: '<p>Regards<img src="cid:logo"></p>',
+			signatureAboveQuote: false,
+		}
+
+		view.vm.insertSignature()
+
+		expect(view.vm.editorMode).toEqual('richtext')
+		expect(editorExecute).not.toHaveBeenCalled()
+	})
+
+	it('keeps plain text when the signature contains no image', () => {
+		const view = shallowMount(Composer, {
+			propsData: {
+				isFirstOpen: true,
+				accounts: [
+					{
+						id: 123,
+						editorMode: 'plaintext',
+						isUnified: false,
+						aliases: [],
+					},
+				],
+			},
+			mocks: {
+				$route,
+			},
+			store,
+			localVue,
+		})
+		const editorExecute = vi.fn()
+		view.vm.$refs.editor = { editorExecute }
+		view.vm.selectedAlias = {
+			id: 123,
+			signature: '<p>Regards</p>',
+			signatureAboveQuote: false,
+		}
+
+		view.vm.insertSignature()
+
+		expect(view.vm.editorMode).toEqual('plaintext')
+		expect(editorExecute).toHaveBeenCalled()
+	})
 })

--- a/src/tests/unit/components/SignatureSettings.vue.spec.js
+++ b/src/tests/unit/components/SignatureSettings.vue.spec.js
@@ -25,4 +25,81 @@ describe('SignatureSettings', () => {
 
 		expect(wrapper.vm.isLargeSignature).toBeTruthy()
 	})
+
+	it.each([
+		['richtext', '<p>Lorem ipsum</p>', true],
+		['plaintext', '<p>Lorem ipsum</p>', false],
+		['plaintext', '<p>Lorem <img src="cid:logo"> ipsum</p>', true],
+	])('uses the %s writing mode for %s', (editorMode, signature, html) => {
+		const wrapper = shallowMount(SignatureSettings, {
+			localVue,
+			propsData: {
+				account: {
+					aliases: [],
+					editorMode,
+					signature,
+				},
+			},
+		})
+
+		expect(wrapper.findComponent({ name: 'TextEditor' }).props('html')).toBe(html)
+	})
+
+	it.each([
+		['richtext', '<p>Lorem <img src="cid:logo"> ipsum</p>', false],
+		['plaintext', '<p>Lorem ipsum</p>', false],
+		['plaintext', '<p>Lorem <img src="cid:logo"> ipsum</p>', true],
+	])('warns about the overridden %s mode for %s', (editorMode, signature, warns) => {
+		const wrapper = shallowMount(SignatureSettings, {
+			localVue,
+			propsData: {
+				account: {
+					aliases: [],
+					editorMode,
+					signature,
+				},
+			},
+		})
+
+		expect(wrapper.vm.overridesPlainText).toBe(warns)
+	})
+
+	it.each([
+		['the image is deleted', '<p>Lorem ipsum</p>'],
+		['the signature is deleted', null],
+	])('drops the warning once %s', async (_, signature) => {
+		const wrapper = shallowMount(SignatureSettings, {
+			localVue,
+			propsData: {
+				account: {
+					aliases: [],
+					editorMode: 'plaintext',
+					signature: '<p>Lorem <img src="cid:logo"> ipsum</p>',
+				},
+			},
+		})
+
+		wrapper.vm.signature = signature
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.vm.overridesPlainText).toBe(false)
+	})
+
+	it('keeps the editor when the image is deleted while editing', async () => {
+		const wrapper = shallowMount(SignatureSettings, {
+			localVue,
+			propsData: {
+				account: {
+					aliases: [],
+					editorMode: 'plaintext',
+					signature: '<p>Lorem <img src="cid:logo"> ipsum</p>',
+				},
+			},
+		})
+
+		wrapper.vm.signature = '<p>Lorem ipsum</p>'
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.findComponent({ name: 'TextEditor' }).props('html')).toBe(true)
+	})
 })

--- a/src/tests/unit/components/TextEditor.spec.js
+++ b/src/tests/unit/components/TextEditor.spec.js
@@ -4,7 +4,7 @@
  */
 
 import { createLocalVue, shallowMount } from '@vue/test-utils'
-import { Paragraph } from 'ckeditor5'
+import { GeneralHtmlSupport, Paragraph } from 'ckeditor5'
 import mitt from 'mitt'
 import { vi } from 'vitest'
 import TextEditor from '../../../components/TextEditor.vue'
@@ -25,6 +25,35 @@ describe('TextEditor', () => {
 				bus: mitt(),
 			},
 		})
+	})
+
+	it('does not support additional html elements in plain text mode', async () => {
+		const wrapper = shallowMount(TextEditor, {
+			localVue,
+			propsData: {
+				value: 'bonjour',
+				bus: mitt(),
+			},
+		})
+
+		expect(wrapper.vm.config.plugins).not.toContain(GeneralHtmlSupport)
+	})
+
+	it('supports additional html elements in html mode', async () => {
+		const wrapper = shallowMount(TextEditor, {
+			localVue,
+			provide: {
+				addToFocusTrap: vi.fn(),
+			},
+			propsData: {
+				value: 'bonjour',
+				html: true,
+				bus: mitt(),
+			},
+		})
+
+		expect(wrapper.vm.config.plugins).toContain(GeneralHtmlSupport)
+		expect(wrapper.vm.config.htmlSupport.allow.some((rule) => rule.name === 'img')).toBe(true)
 	})
 
 	it('throw when editor not ready', async () => {

--- a/src/tests/unit/util/text.spec.js
+++ b/src/tests/unit/util/text.spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { detect, html, plain, toPlain } from '../../../util/text.js'
+import { containsImage, detect, html, plain, toPlain } from '../../../util/text.js'
 
 describe('text', () => {
 	describe('toPlain', () => {
@@ -169,6 +169,24 @@ describe('text', () => {
 > >`)
 
 			const actual = toPlain(source)
+
+			expect(actual).toEqual(expected)
+		})
+	})
+
+	describe('containsImage', () => {
+		it.each([
+			['<p>hello <img src="cid:1" alt="logo"> world</p>', true],
+			['<IMG SRC="cid:1"/>', true],
+			['<img\n\tsrc="cid:1">', true],
+			['<p>hello world</p>', false],
+			['<p>&lt;img src="cid:1"&gt;</p>', false],
+			['<p><image-of-the-day /></p>', false],
+			['<!-- <img src="cid:1"> -->', false],
+			['<p title="<img >">hello</p>', false],
+			['', false],
+		])('detects images in %j', (value, expected) => {
+			const actual = containsImage(value)
 
 			expect(actual).toEqual(expected)
 		})

--- a/src/util/text.js
+++ b/src/util/text.js
@@ -69,6 +69,19 @@ export function detect(str) {
 }
 
 /**
+ * Check whether an HTML string contains an inline image.
+ *
+ * Plain text can't carry images: toPlain() skips <img> entirely. Callers use
+ * this to detect content that would be lost before converting it.
+ *
+ * @param {string} value HTML string
+ * @return {boolean}
+ */
+export function containsImage(value) {
+	return new DOMParser().parseFromString(value, 'text/html').querySelector('img') !== null
+}
+
+/**
  * @function
  * @param {string} format
  * @param {Text} text


### PR DESCRIPTION
## Summary

GeneralHtmlSupport was loaded in both editor modes, so plain text mode kept <img> elements that toPlain() then dropped without notice on submit. Load it only in html mode and switch the editor mode when a signature contains an image.

We documented the weird ux about signature (with html elements) and using plain text at https://github.com/nextcloud/mail/issues/10617, but never improved the current state.

Adding the GeneralHtmlSupport plugin made it worse, because before the image (was unsupported) and removed by ckeditor (=> not visible in the editor). With GeneralHtmlSupport it's supported and the image is not removed. However the actual sending process will still drop it.

That PR's brings back the old behavior, by loading html only for rich text, with the small addition that we'd automatically switch to rich text. Also the signature editor is now using the editor mode from the account and shows a warning if you signature enforces html. 

<img width="803" height="265" alt="image" src="https://github.com/user-attachments/assets/0f8ccca3-1e13-40fa-ad41-29befe1e4f9b" />


## Steps to reproduce

- Pick editor mode plain text
- Add an image to the signature
- Open composer
- See the image in the signature
- Send message 
- Image missing



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
