### PR TITLE
fix(mailbox): Ignore namespaces without a prefix when detecting share…

### DIFF
--- a/lib/IMAP/MailboxSync.php
+++ b/lib/IMAP/MailboxSync.php
@@ -244,6 +244,10 @@ class MailboxSync {
 	private function isMailboxShared(?Horde_Imap_Client_Namespace_List $namespaces, Mailbox $mailbox): bool {
 		foreach (($namespaces ?? []) as $namespace) {
 			/** @var Horde_Imap_Client_Data_Namespace $namespace */
+			// An empty prefix would match every mailbox
+			if ($namespace->name === '') {
+				continue;
+			}
 			if (in_array($namespace->type, self::NON_PERSONAL_NAMESPACE_TYPES, true) && str_starts_with($mailbox->getName(), $namespace->name)) {
 				return true;
 			}

--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -211,6 +211,49 @@ class MailboxSyncTest extends TestCase {
 		$this->sync->sync($account, new NullLogger());
 	}
 
+	public function testSyncSharedNamespaceWithoutPrefix(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(0);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$this->imapClientFactory->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$personal = new Horde_Imap_Client_Data_Namespace();
+		$personal->name = '';
+		$personal->type = Horde_Imap_Client_Data_Namespace::NS_PERSONAL;
+		$shared = new Horde_Imap_Client_Data_Namespace();
+		$shared->name = '';
+		$shared->type = Horde_Imap_Client_Data_Namespace::NS_SHARED;
+		$client->method('getNamespaces')
+			->willReturn(new Horde_Imap_Client_Namespace_List([
+				$personal,
+				$shared,
+			]));
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getMailbox')->willReturn('INBOX');
+		$folder->method('getStatus')->willReturn(['unseen' => 10, 'messages' => 42]);
+		$this->folderMapper->method('getFolders')
+			->with($account, $client)
+			->willReturn([$folder]);
+		$inbox = new Mailbox();
+		$inbox->setId(101);
+		$inbox->setName('INBOX');
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([$inbox]);
+		$this->folderMapper->method('getFolderStatus')
+			->willReturn(new MailboxStats(1, 2));
+		$this->mailboxMapper->method('update')
+			->willReturnArgument(0);
+
+		$this->sync->sync($account, new NullLogger());
+
+		$this->assertFalse($inbox->isShared());
+	}
+
 	public function testSyncStats(): void {
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);
 		$stats = new MailboxStats(42, 10, null);


### PR DESCRIPTION
…d mailboxes

Horde returns '' for an unset namespace name, and str_starts_with() matches every mailbox against an empty prefix. A server advertising an other/shared namespace without a prefix therefore flagged the whole account as shared, which in turn stopped special mailbox auto-detection.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
