### PR TITLE
fix(imap): use PEEK when fetching attachment/body content

### DIFF
--- a/lib/IMAP/MessageMapper.php
+++ b/lib/IMAP/MessageMapper.php
@@ -751,8 +751,12 @@ class MessageMapper {
 		// TODO: compare logic and merge with getAttachments()
 
 		$query = new Horde_Imap_Client_Fetch_Query();
-		$query->bodyPart($attachmentId);
-		$query->mimeHeader($attachmentId);
+		$query->bodyPart($attachmentId, [
+			'peek' => true,
+		]);
+		$query->mimeHeader($attachmentId, [
+			'peek' => true,
+		]);
 		$this->smimeService->addEncryptionCheckQueries($query);
 
 		$uids = new Horde_Imap_Client_Ids($messageUid);
@@ -836,7 +840,7 @@ class MessageMapper {
 	 */
 	private function buildAttachmentsPartsQuery(Horde_Mime_Part $structure, array $attachmentIds) : Horde_Imap_Client_Fetch_Query {
 		$partsQuery = new Horde_Imap_Client_Fetch_Query();
-		$partsQuery->fullText();
+		$partsQuery->fullText(['peek' => true]);
 		foreach ($structure->partIterator() as $part) {
 			/** @var Horde_Mime_Part $part */
 			if ($part->getMimeId() === '0') {


### PR DESCRIPTION
buildAttachmentsPartsQuery() and getAttachment() fetch full message text and body parts without the 'peek' option, unlike every other fetch in this file. Per RFC 3501, a non-PEEK fetch implicitly sets \Seen on the IMAP server, so viewing attachments or the HTML body (e.g. via itinerary detection) silently marks messages as read on the server without any explicit read action.

AI-assisted: Claude Code (Claude Sonnet 5)



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
