### PR TITLE
refactor(components): rename Vue 2 lifecycle hooks to Vue 3 names

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1123,7 +1123,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('mailvelope', this.onMailvelopeLoaded)
 	},
 

--- a/src/components/DisplayContactDetails.vue
+++ b/src/components/DisplayContactDetails.vue
@@ -35,7 +35,7 @@ export default {
 		}
 	},
 
-	async beforeDestroy() {
+	async beforeUnmount() {
 		if (this.vm) {
 			this.vm.$destroy()
 		}

--- a/src/components/EnvelopeList.vue
+++ b/src/components/EnvelopeList.vue
@@ -383,7 +383,7 @@ export default {
 		dragEventBus.on('envelopes-dropped', this.unselectAll)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		dragEventBus.off('envelopes-dropped', this.unselectAll)
 	},
 

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -59,7 +59,7 @@ export default {
 		}, 3500)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		clearTimeout(this.slowTimer)
 	},
 }

--- a/src/components/Mailbox.vue
+++ b/src/components/Mailbox.vue
@@ -219,7 +219,7 @@ export default {
 		this.mainStore.setHasFetchedInitialEnvelopesMutation(true)
 	},
 
-	destroyed() {
+	unmounted() {
 		this.bus.off('load-more', this.onScroll)
 		this.bus.off('delete', this.onDelete)
 		this.bus.off('archive', this.onArchive)

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -473,7 +473,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		clearTimeout(this.startMailboxTimer)
 	},
 

--- a/src/components/MessageAttachment.vue
+++ b/src/components/MessageAttachment.vue
@@ -206,7 +206,7 @@ export default {
 		document.addEventListener('click', this.handleClickOutside)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		document.removeEventListener('click', this.handleClickOutside)
 	},
 

--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -131,7 +131,7 @@ export default {
 		}
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		scout.off('beforeprint', this.onBeforePrint)
 		scout.off('afterprint', this.onAfterPrint)
 		this.$refs.iframe.iFrameResizer.close()

--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -526,7 +526,7 @@ export default {
 		dragEventBus.on('envelopes-moved', this.onEnvelopesMoved)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		dragEventBus.off('drag-start', this.onDragStart)
 		dragEventBus.off('drag-end', this.onDragEnd)
 		dragEventBus.off('envelopes-moved', this.onEnvelopesMoved)

--- a/src/components/NewMessageModal.vue
+++ b/src/components/NewMessageModal.vue
@@ -271,7 +271,7 @@ export default {
 		window.addEventListener('resize', this.checkScreenSize)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('beforeunload', this.onBeforeUnload)
 		window.removeEventListener('resize', this.checkScreenSize)
 	},

--- a/src/components/Outbox.vue
+++ b/src/components/Outbox.vue
@@ -90,7 +90,7 @@ export default {
 		await this.fetchMessages()
 	},
 
-	destroyed() {
+	unmounted() {
 		clearInterval(this.refreshInterval)
 	},
 

--- a/src/components/TextEditor.vue
+++ b/src/components/TextEditor.vue
@@ -272,7 +272,7 @@ export default {
 		this.loadEditorTranslations(getLanguage())
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		this.unregisterSourceEditingInputListener()
 
 		if (this.editorInstance?.plugins.has('SourceEditing') && this.sourceEditingModeHandler) {

--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -175,7 +175,7 @@ export default {
 		window.addEventListener('keydown', this.handleKeyDown)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('keydown', this.handleKeyDown)
 	},
 

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -803,7 +803,7 @@ export default {
 		}, 100)
 	},
 
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.seenTimer !== undefined) {
 			logger.info('Navigating away before seenTimer delay, will not mark message as seen/read')
 			clearTimeout(this.seenTimer)


### PR DESCRIPTION
part of https://github.com/nextcloud/groupware/issues/64

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
