### PR TITLE
fix(imip): log why an iMIP message was flagged as failed

### DIFF
--- a/lib/Service/IMipService.php
+++ b/lib/Service/IMipService.php
@@ -112,10 +112,23 @@ class IMipService {
 			$systemVersion = $this->serverVersion->getMajorVersion();
 
 			foreach ($filteredMessages as $message) {
-				/** @var IMAPMessage $imapMessage */
+				$logContext = [
+					'messageId' => $message->getId(),
+					'mailboxId' => $mailbox->getId(),
+				];
+
 				$imapMessage = current(array_filter($imapMessages, static fn (IMAPMessage $imapMessage) => $message->getUid() === $imapMessage->getUid()));
+				if ($imapMessage === false) {
+					// the message vanished from the mailbox, the row is removed by the next sync run
+					$this->logger->debug('iMIP message could not be processed because it is no longer available on the IMAP server', $logContext);
+					$message->setImipProcessed(true);
+					$message->setImipError(true);
+					continue;
+				}
+
 				if (empty($imapMessage->scheduling)) {
-					// No scheduling info, maybe the DB is wrong
+					// the message advertises a scheduling method we do not support, see ImapMessageFetcher
+					$this->logger->warning('iMIP message could not be processed because it does not contain a supported scheduling method', $logContext);
 					$message->setImipProcessed(true);
 					$message->setImipError(true);
 					continue;
@@ -123,6 +136,7 @@ class IMipService {
 
 				$sender = $imapMessage->getFrom()->first()?->getEmail();
 				if ($sender === null) {
+					$this->logger->warning('iMIP message could not be processed because it does not contain a sender', $logContext);
 					$message->setImipProcessed(true);
 					$message->setImipError(true);
 					continue;
@@ -130,7 +144,9 @@ class IMipService {
 
 				try {
 					// an IMAP message could contain more than one iMIP object
+					$allProcessed = true;
 					foreach ($imapMessage->scheduling as $schedulingInfo) {
+						$logContext['method'] = $schedulingInfo['method'];
 						$processed = false;
 						if ($systemVersion < 33) {
 							$principalUri = 'principals/users/' . $userId;
@@ -144,7 +160,8 @@ class IMipService {
 							}
 						} else {
 							if (!method_exists($this->calendarManager, 'handleIMip')) {
-								$this->logger->error('iMIP handling is not supported by server version installed.');
+								$this->logger->error('iMIP handling is not supported by server version installed', $logContext);
+								$allProcessed = false;
 								continue;
 							}
 							$processed = $this->calendarManager->handleIMip(
@@ -154,19 +171,23 @@ class IMipService {
 									'recipient' => $recipient,
 									'absent' => $imipCreate ? 'create' : 'ignore',
 									'absentCreateStatus' => 'tentative',
+									'mailMessageId' => $message->getId(),
 								],
 							);
 						}
 
-						$message->setImipProcessed($processed);
-						$message->setImipError(!$processed);
+						if (!$processed) {
+							$this->logger->warning('iMIP message could not be processed by the calendar app, see the preceding log entry for the reason', $logContext);
+						}
+
+						$allProcessed = $allProcessed && $processed;
 					}
+
+					$message->setImipProcessed($allProcessed);
+					$message->setImipError(!$allProcessed);
 				} catch (Throwable $e) {
-					$this->logger->error('iMIP message processing failed', [
-						'exception' => $e,
-						'messageId' => $message->getId(),
-						'mailboxId' => $mailbox->getId(),
-					]);
+					$logContext['exception'] = $e;
+					$this->logger->error('iMIP message processing failed', $logContext);
 					$message->setImipProcessed(true);
 					$message->setImipError(true);
 				}

--- a/tests/Unit/Service/IMipServiceTest.php
+++ b/tests/Unit/Service/IMipServiceTest.php
@@ -49,9 +49,11 @@ class IMipServiceTest extends TestCase {
 
 	private IMipService $service;
 
+	/** mocked to pick the code path under test */
 	private ServerVersion|MockObject $serverVersion;
 
-	private OCPServerVersion $OCPServerVersion;
+	/** the version of the server the tests run against, to skip what it does not support */
+	private OCPServerVersion $installedServerVersion;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -63,7 +65,7 @@ class IMipServiceTest extends TestCase {
 		$this->mailManager = $this->createMock(MailManager::class);
 		$this->messageMapper = $this->createMock(MessageMapper::class);
 		$this->serverVersion = $this->createMock(ServerVersion::class);
-		$this->OCPServerVersion = new OCPServerVersion();
+		$this->installedServerVersion = new OCPServerVersion();
 
 		$this->service = new IMipService(
 			$this->accountService,
@@ -205,9 +207,56 @@ class IMipServiceTest extends TestCase {
 			->method('handleIMipReply');
 		$this->calendarManager->expects(self::never())
 			->method('handleIMipCancel');
+		$this->logger->expects(self::once())
+			->method('warning')
+			->with(
+				'iMIP message could not be processed because it does not contain a supported scheduling method',
+				['messageId' => $message->getId(), 'mailboxId' => $mailbox->getId()]
+			);
 		$this->messageMapper->expects(self::once())
 			->method('updateImipData')
-			->with($message);
+			->with(self::callback(fn (Message $msg) => $msg->isImipProcessed() === true && $msg->isImipError() === true));
+
+		$this->service->process();
+	}
+
+	public function testMessageNotAvailableOnImapServer(): void {
+		$message = new Message();
+		$message->setImipMessage(true);
+		$message->setUid(1);
+		$message->setMailboxId(100);
+		$mailbox = new Mailbox();
+		$mailbox->setId(100);
+		$mailbox->setAccountId(200);
+		$account = $this->createConfiguredMock(Account::class, [
+			'getId' => 200,
+			'getEmail' => 'dimitrius@stardew-science.com'
+		]);
+
+		$this->messageMapper->expects(self::once())
+			->method('findIMipMessagesAscending')
+			->willReturn([$message]);
+		$this->mailboxMapper->expects(self::once())
+			->method('findById')
+			->willReturn($mailbox);
+		$this->accountService->expects(self::once())
+			->method('findById')
+			->willReturn($account);
+		$this->mailManager->expects(self::once())
+			->method('getImapMessagesForScheduleProcessing')
+			->with($account, $mailbox, [$message->getUid()])
+			->willReturn([]);
+		$this->logger->expects(self::never())
+			->method('warning');
+		$this->logger->expects(self::once())
+			->method('debug')
+			->with(
+				'iMIP message could not be processed because it is no longer available on the IMAP server',
+				['messageId' => $message->getId(), 'mailboxId' => $mailbox->getId()]
+			);
+		$this->messageMapper->expects(self::once())
+			->method('updateImipData')
+			->with(self::callback(fn (Message $msg) => $msg->isImipProcessed() === true && $msg->isImipError() === true));
 
 		$this->service->process();
 	}
@@ -436,7 +485,7 @@ class IMipServiceTest extends TestCase {
 	}
 
 	public function testIsRequestServerVersion33(): void {
-		if ($this->OCPServerVersion->getMajorVersion() < 33) {
+		if ($this->installedServerVersion->getMajorVersion() < 33) {
 			$this->markTestSkipped('Requires Nextcloud 33 or higher');
 		}
 
@@ -493,6 +542,7 @@ class IMipServiceTest extends TestCase {
 				'recipient' => 'vincent@stardew-valley.edu',
 				'absent' => 'ignore',
 				'absentCreateStatus' => 'tentative',
+				'mailMessageId' => $message->getId(),
 			])
 			->willReturn(true);
 		$this->messageMapper->expects(self::once())
@@ -502,7 +552,7 @@ class IMipServiceTest extends TestCase {
 	}
 
 	public function testIsReplyServerVersion33(): void {
-		if ($this->OCPServerVersion->getMajorVersion() < 33) {
+		if ($this->installedServerVersion->getMajorVersion() < 33) {
 			$this->markTestSkipped('Requires Nextcloud 33 or higher');
 		}
 
@@ -558,7 +608,8 @@ class IMipServiceTest extends TestCase {
 			->with('vincent', 'VCARD', [
 				'recipient' => 'vincent@stardew-valley.edu',
 				'absent' => 'ignore',
-				'absentCreateStatus' => 'tentative'
+				'absentCreateStatus' => 'tentative',
+				'mailMessageId' => $message->getId(),
 			])
 			->willReturn(true);
 		$this->messageMapper->expects(self::once())
@@ -568,7 +619,7 @@ class IMipServiceTest extends TestCase {
 	}
 
 	public function testIsCancelServerVersion33(): void {
-		if ($this->OCPServerVersion->getMajorVersion() < 33) {
+		if ($this->installedServerVersion->getMajorVersion() < 33) {
 			$this->markTestSkipped('Requires Nextcloud 33 or higher');
 		}
 
@@ -624,7 +675,8 @@ class IMipServiceTest extends TestCase {
 			->with('vincent', 'VCARD', [
 				'recipient' => 'vincent@stardew-valley.edu',
 				'absent' => 'ignore',
-				'absentCreateStatus' => 'tentative'
+				'absentCreateStatus' => 'tentative',
+				'mailMessageId' => $message->getId(),
 			])
 			->willReturn(true);
 		$this->messageMapper->expects(self::once())
@@ -690,6 +742,139 @@ class IMipServiceTest extends TestCase {
 		$this->messageMapper->expects(self::once())
 			->method('updateImipData')
 			->with(self::callback(fn (Message $msg) => $msg->isImipProcessed() === true && $msg->isImipError() === true));
+
+		$this->service->process();
+	}
+
+	public function testHandleImipReturnsFalse(): void {
+		if ($this->installedServerVersion->getMajorVersion() < 33) {
+			$this->markTestSkipped('Requires Nextcloud 33 or higher');
+		}
+
+		$message = new Message();
+		$message->setImipMessage(true);
+		$message->setUid(1);
+		$message->setMailboxId(100);
+		$mailbox = new Mailbox();
+		$mailbox->setId(100);
+		$mailbox->setAccountId(200);
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(200);
+		$mailAccount->setEmail('vincent@stardew-valley.edu');
+		$mailAccount->setUserId('vincent');
+		$account = new Account($mailAccount);
+		$imapMessage = $this->createMock(IMAPMessage::class);
+		$imapMessage->scheduling[] = ['method' => 'REQUEST', 'contents' => 'VCALENDAR'];
+		$addressList = $this->createMock(AddressList::class);
+		$address = $this->createMock(Address::class);
+
+		$this->messageMapper->expects(self::once())
+			->method('findIMipMessagesAscending')
+			->willReturn([$message]);
+		$this->mailboxMapper->expects(self::once())
+			->method('findById')
+			->willReturn($mailbox);
+		$this->accountService->expects(self::once())
+			->method('findById')
+			->willReturn($account);
+		$this->mailManager->expects(self::once())
+			->method('getImapMessagesForScheduleProcessing')
+			->with($account, $mailbox, [$message->getUid()])
+			->willReturn([$imapMessage]);
+		$this->serverVersion->expects(self::once())
+			->method('getMajorVersion')
+			->willReturn(33);
+		$imapMessage->expects(self::once())
+			->method('getUid')
+			->willReturn(1);
+		$imapMessage->expects(self::once())
+			->method('getFrom')
+			->willReturn($addressList);
+		$addressList->expects(self::once())
+			->method('first')
+			->willReturn($address);
+		$address->expects(self::once())
+			->method('getEmail')
+			->willReturn('pam@stardew-bus-service.com');
+		$this->calendarManager->expects(self::once())
+			->method('handleIMip')
+			->willReturn(false);
+		$this->logger->expects(self::once())
+			->method('warning')
+			->with(
+				'iMIP message could not be processed by the calendar app, see the preceding log entry for the reason',
+				[
+					'messageId' => $message->getId(),
+					'mailboxId' => $mailbox->getId(),
+					'method' => 'REQUEST',
+				]
+			);
+		$this->messageMapper->expects(self::once())
+			->method('updateImipData')
+			->with(self::callback(fn (Message $msg) => $msg->isImipProcessed() === false && $msg->isImipError() === true));
+
+		$this->service->process();
+	}
+
+	public function testOneOfSeveralSchedulingObjectsIsNotProcessed(): void {
+		if ($this->installedServerVersion->getMajorVersion() < 33) {
+			$this->markTestSkipped('Requires Nextcloud 33 or higher');
+		}
+
+		$message = new Message();
+		$message->setImipMessage(true);
+		$message->setUid(1);
+		$message->setMailboxId(100);
+		$mailbox = new Mailbox();
+		$mailbox->setId(100);
+		$mailbox->setAccountId(200);
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(200);
+		$mailAccount->setEmail('vincent@stardew-valley.edu');
+		$mailAccount->setUserId('vincent');
+		$account = new Account($mailAccount);
+		$imapMessage = $this->createMock(IMAPMessage::class);
+		$imapMessage->scheduling[] = ['method' => 'REQUEST', 'contents' => 'VCALENDAR1'];
+		$imapMessage->scheduling[] = ['method' => 'CANCEL', 'contents' => 'VCALENDAR2'];
+		$addressList = $this->createMock(AddressList::class);
+		$address = $this->createMock(Address::class);
+
+		$this->messageMapper->expects(self::once())
+			->method('findIMipMessagesAscending')
+			->willReturn([$message]);
+		$this->mailboxMapper->expects(self::once())
+			->method('findById')
+			->willReturn($mailbox);
+		$this->accountService->expects(self::once())
+			->method('findById')
+			->willReturn($account);
+		$this->mailManager->expects(self::once())
+			->method('getImapMessagesForScheduleProcessing')
+			->with($account, $mailbox, [$message->getUid()])
+			->willReturn([$imapMessage]);
+		$this->serverVersion->expects(self::once())
+			->method('getMajorVersion')
+			->willReturn(33);
+		$imapMessage->expects(self::once())
+			->method('getUid')
+			->willReturn(1);
+		$imapMessage->expects(self::once())
+			->method('getFrom')
+			->willReturn($addressList);
+		$addressList->expects(self::once())
+			->method('first')
+			->willReturn($address);
+		$address->expects(self::once())
+			->method('getEmail')
+			->willReturn('pam@stardew-bus-service.com');
+		$this->calendarManager->expects(self::exactly(2))
+			->method('handleIMip')
+			->willReturnOnConsecutiveCalls(false, true);
+		$this->logger->expects(self::once())
+			->method('warning');
+		$this->messageMapper->expects(self::once())
+			->method('updateImipData')
+			->with(self::callback(fn (Message $msg) => $msg->isImipProcessed() === false && $msg->isImipError() === true));
 
 		$this->service->process();
 	}


### PR DESCRIPTION
Every path that set imip_error was silent, so a failed invitation left no trace. Log each one with the message and mailbox id, guard the message that vanished from IMAP, and pass mailMessageId to handleIMip so the calendar app's entries can be tied back to a mail message.

A message with several iMIP parts is now flagged as failed if any part failed instead of only the last one.




## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
