### PR TITLE
chore: import to mittRaw and autosize to entry point

### DIFF
--- a/src/components/AppSettingsMenu.vue
+++ b/src/components/AppSettingsMenu.vue
@@ -308,6 +308,7 @@ import {
 } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapState, mapStores } from 'pinia'
+import { markRaw } from 'vue'
 import IconArrow from 'vue-material-design-icons/ArrowRight.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
@@ -390,7 +391,7 @@ export default {
 			selectedAccount: null,
 			mailvelopeIsAvailable: false,
 			trapElements: [],
-			bus: mitt(),
+			bus: markRaw(mitt()),
 			textBlockDialogOpen: false,
 			localTextBlock: {
 				title: '',

--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -513,8 +513,7 @@ import trimStart from 'lodash/fp/trimCharsStart.js'
 import uniqBy from 'lodash/fp/uniqBy.js'
 import mitt from 'mitt'
 import { mapState, mapStores } from 'pinia'
-import Vue from 'vue'
-import Autosize from 'vue-autosize'
+import { markRaw } from 'vue'
 import { NcReferencePickerModal } from '@nextcloud/vue/components/NcRichText'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import IconFolder from 'vue-material-design-icons/FolderOutline.vue'
@@ -548,8 +547,6 @@ import textBlockSvg from './../../img/text_snippet.svg'
 const debouncedSearch = debouncePromise(findRecipient, 500)
 
 const NO_ALIAS_SET = -1
-
-Vue.use(Autosize)
 
 export default {
 	name: 'Composer',
@@ -739,7 +736,7 @@ export default {
 			selectTo: this.to,
 			selectCc: this.cc,
 			selectBcc: this.bcc,
-			bus: mitt(),
+			bus: markRaw(mitt()),
 			encrypt: false,
 			mailvelope: {
 				available: false,

--- a/src/components/ComposerAttachments.vue
+++ b/src/components/ComposerAttachments.vue
@@ -75,6 +75,12 @@ const mimes = [
 
 export default {
 	name: 'ComposerAttachments',
+
+	model: {
+		prop: 'modelValue',
+		event: 'update:modelValue',
+	},
+
 	components: {
 		FilePicker,
 		ComposerAttachment,
@@ -83,7 +89,7 @@ export default {
 	},
 
 	props: {
-		value: {
+		modelValue: {
 			type: Array,
 			required: true,
 		},
@@ -184,7 +190,7 @@ export default {
 		this.bus.on('on-add-cloud-attachment', this.openAttachementPicker)
 		this.bus.on('on-add-message-as-attachment', this.onAddMessageAsAttachment)
 		this.bus.on('on-add-local-files', this.addLocalFiles)
-		this.value.map((attachment) => {
+		this.modelValue.map((attachment) => {
 			this.attachments.push({
 				id: attachment.id,
 				fileName: attachment.fileName,
@@ -215,11 +221,11 @@ export default {
 		},
 
 		emitNewAttachments(attachments) {
-			this.$emit('input', this.value.concat(attachments))
+			this.$emit('update:modelValue', this.modelValue.concat(attachments))
 		},
 
 		totalSizeOfUpload() {
-			return Object.values(this.value).reduce((acc, upload) => {
+			return Object.values(this.modelValue).reduce((acc, upload) => {
 				if (!upload.type === 'local') {
 					// Ignore link shares
 					return acc
@@ -430,8 +436,8 @@ export default {
 			this.attachments = this.attachments.filter((a) => a !== attachment)
 
 			this.$emit(
-				'input',
-				this.value.filter((a) => {
+				'update:modelValue',
+				this.modelValue.filter((a) => {
 					if (val.type === 'cloud') {
 						return a.fileName !== val.fileName
 					} else {

--- a/src/components/MailboxThread.vue
+++ b/src/components/MailboxThread.vue
@@ -204,6 +204,7 @@ import { NcAppContent as AppContent, NcAppContentList as AppContentList, NcButto
 import addressParser from 'address-rfc2822'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
+import { markRaw } from 'vue'
 import IconInfo from 'vue-material-design-icons/InformationOutline.vue'
 import Mailbox from './Mailbox.vue'
 import NoMessageSelected from './NoMessageSelected.vue'
@@ -266,7 +267,7 @@ export default {
 			importantInfo: t('mail', 'Messages will automatically be marked as important using AI. The system learns from which messages you interact with or mark as important. In the beginning you might have to manually change the importance to teach it, but it will improve over time'),
 			favoritesInfo: t('mail', 'Messages that you marked as favorite will be shown at the top of folders. You can disable this behavior in the app settings'),
 			followupInfo: t('mail', 'AI identifies messages sent by you that likely require a reply but did not receive one after a couple of days and shows them here'),
-			bus: mitt(),
+			bus: markRaw(mitt()),
 			searchQuery: undefined,
 			shortkeys: {
 				del: ['del'],

--- a/src/components/OutOfOfficeForm.vue
+++ b/src/components/OutOfOfficeForm.vue
@@ -124,6 +124,7 @@ import { generateUrl } from '@nextcloud/router'
 import { NcButton as ButtonVue, NcDateTimePicker as DatetimePicker } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
+import { markRaw } from 'vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import TextEditor from './TextEditor.vue'
@@ -171,7 +172,7 @@ export default {
 			errorMessage: '',
 			hasPersonalAbsenceSettings: nextcloudVersion >= 28 && enableSystemOutOfOffice,
 			personalAbsenceSettingsUrl: generateUrl('/settings/user/availability'),
-			textEditorDummyBus: mitt(),
+			textEditorDummyBus: markRaw(mitt()),
 		}
 	},
 

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -63,6 +63,7 @@
 import { NcButton as ButtonVue, NcLoadingIcon as IconLoading, NcSelect } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
+import { markRaw } from 'vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import TextEditor from './TextEditor.vue'
 import logger from '../logger.js'
@@ -89,7 +90,7 @@ export default {
 	data() {
 		return {
 			loading: false,
-			bus: mitt(),
+			bus: markRaw(mitt()),
 			identity: null,
 			signature: '',
 			signatureAboveQuote: this.account.signatureAboveQuote,

--- a/src/components/textBlocks/ListItem.vue
+++ b/src/components/textBlocks/ListItem.vue
@@ -118,6 +118,7 @@ import { NcActionButton, NcAvatar, NcButton, NcDialog, NcInputField, NcListItem,
 import debounce from 'lodash/fp/debounce.js'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
+import { markRaw } from 'vue'
 import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import IconCheck from 'vue-material-design-icons/Check.vue'
 import IconClose from 'vue-material-design-icons/Close.vue'
@@ -176,7 +177,7 @@ export default {
 			saveLoading: false,
 			share: null,
 			suggestions: [],
-			bus: mitt(),
+			bus: markRaw(mitt()),
 		}
 	},
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { generateFilePath } from '@nextcloud/router'
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import vToolTip from 'v-tooltip'
 import Vue from 'vue'
+import Autosize from 'vue-autosize'
 import VueShortKey from 'vue-shortkey'
 import App from './App.vue'
 import Nextcloud from './mixins/Nextcloud.js'
@@ -26,6 +27,7 @@ const pinia = createPinia()
 
 Vue.mixin(Nextcloud)
 
+Vue.use(Autosize)
 Vue.use(VueShortKey, { prevent: ['input', 'div', 'textarea'] })
 Vue.use(vToolTip)
 


### PR DESCRIPTION
part of: https://github.com/nextcloud/groupware/issues/64

Change: bus: mitt() → bus: markRaw(mitt()), adds import { markRaw } rom 'vue' 
Change: value prop + input event → modelValue prop +   update:modelValue event + model: option for Vue 2.7 compat   
Change: Vue.use(Autosize) moved out of component into entry point
  
## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
