### PR TITLE
fix(html): strip conditional markup from html mail bodies

### DIFF
--- a/lib/Service/Html.php
+++ b/lib/Service/Html.php
@@ -193,6 +193,11 @@ class Html {
 
 		$purifier = new HTMLPurifier($config);
 
+		// Downlevel-revealed conditionals are not comments, so no HTMLPurifier comment
+		// setting covers them and some libxml versions leave them as visible text.
+		// Keep the original on a PCRE error; purify(null) would silently return an empty body.
+		$mailBody = preg_replace('/<!\[\s*(?:end)?if\b[^\]]*\]\s*>/i', '', $mailBody) ?? $mailBody;
+
 		$result = $purifier->purify($mailBody);
 		// eat xml parse errors within HTMLPurifier
 		libxml_clear_errors();

--- a/tests/Unit/Service/HtmlTest.php
+++ b/tests/Unit/Service/HtmlTest.php
@@ -158,6 +158,70 @@ class HtmlTest extends TestCase {
 		$this->assertStringContainsString('data-cid="image001@example.com"', $result);
 	}
 
+	/**
+	 * Non-Outlook renderers ignore the <![if !mso]> markers and show the content
+	 * between them. Some libxml versions leave the markers in as visible text.
+	 */
+	public function testSanitizeHtmlMailBodyStripsDownlevelRevealedConditionals(): void {
+		$urlGenerator = $this->createStub(IURLGenerator::class);
+		$request = $this->createStub(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
+		$mailBody = <<<'HTML'
+			<!DOCTYPE html>
+			<html>
+			<head><meta charset="utf-8"><title>MSO conditional rendering test</title></head>
+			<body style="font-family: Arial, sans-serif;">
+			<p>Hello,</p>
+			<p>There is a new announcement from EXAMPLE ORGANISATION.</p>
+			<![if !mso]>
+			<p><span>EXAMPLE INFORMATION SHEET</span></p>
+			<![endif]>
+			<!--[if mso]>
+			<p>Alternative content for Microsoft Outlook.</p>
+			<![endif]-->
+			<![if !mso]>
+			<a href="https://example.com/announcement">Review announcement</a>
+			<![endif]>
+			</body>
+			</html>
+			HTML;
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$result = $html->sanitizeHtmlMailBody(42, $mailBody, []);
+
+		self::assertStringNotContainsString('[if !mso]', $result);
+		self::assertStringNotContainsString('[endif]', $result);
+		self::assertStringContainsString('EXAMPLE INFORMATION SHEET', $result);
+		self::assertStringContainsString('Review announcement', $result);
+		self::assertStringNotContainsString('Alternative content', $result);
+	}
+
+	/**
+	 * @dataProvider downlevelRevealedConditionalProvider
+	 */
+	public function testSanitizeHtmlMailBodyStripsConditionalVariants(string $conditional): void {
+		$urlGenerator = $this->createStub(IURLGenerator::class);
+		$request = $this->createStub(IRequest::class);
+		$hmacGenerator = $this->createStub(ProxyHmacGenerator::class);
+
+		$html = new Html($urlGenerator, $request, $hmacGenerator);
+		$result = $html->sanitizeHtmlMailBody(42, "$conditional<p>Kept</p>", []);
+
+		self::assertDoesNotMatchRegularExpression('/<!\[\s*(?:end)?if\b/i', $result);
+		self::assertStringNotContainsString('&lt;!', $result);
+		self::assertStringContainsString('<p>Kept</p>', $result);
+	}
+
+	public function downlevelRevealedConditionalProvider(): array {
+		return [
+			'revealed if' => ['<![if !mso]>'],
+			'revealed endif' => ['<![endif]>'],
+			'uppercase' => ['<![IF !MSO]>'],
+			'padded brackets' => ['<![ endif ]>'],
+			'version gate' => ['<![if gte mso 9]>'],
+		];
+	}
+
 	public function testSanitizeStyleSheet() {
 		$blockedUrl = '/apps/mail/img/blocked-image.png';
 		$urlGenerator = self::createMock(IURLGenerator::class);


### PR DESCRIPTION
Fix https://github.com/nextcloud/mail/issues/13383 https://github.com/nextcloud/mail/issues/9913

Senders wrap content in downlevel-revealed conditionals to hide it from Outlook:

`<![if !mso]>Shown everywhere except Outlook<![endif]>`

Those markers are not comments. Every non-Outlook renderer is supposed to ignore them and show the content between them, but the parser only drops them on older libxml: 2.9.10 removes them, 2.9.14 keeps them as text, so they show up in the rendered message as literal "<![if !mso]>" markers.

Strip them before purifying so a message renders the same everywhere.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
