### PR TITLE
test(imap): Add tests covering MailboxSync client reuse and fallback

### DIFF
--- a/tests/Unit/IMAP/MailboxSyncTest.php
+++ b/tests/Unit/IMAP/MailboxSyncTest.php
@@ -254,6 +254,62 @@ class MailboxSyncTest extends TestCase {
 		$this->assertFalse($inbox->isShared());
 	}
 
+	public function testSyncWithClient(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(0);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$personal = new Horde_Imap_Client_Data_Namespace();
+		$personal->name = '';
+		$personal->type = Horde_Imap_Client_Data_Namespace::NS_PERSONAL;
+		$client->method('getNamespaces')
+			->willReturn(new Horde_Imap_Client_Namespace_List([$personal]));
+		$this->folderMapper->method('getFolders')
+			->with($account, $client)
+			->willReturn([]);
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([]);
+
+		$this->imapClientFactory->expects($this->never())
+			->method('getClient');
+		$client->expects($this->never())
+			->method('logout');
+
+		$this->sync->sync($account, new NullLogger(), false, $client);
+	}
+
+	public function testSyncWithoutClient(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setLastMailboxSync(0);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$this->timeFactory->method('getTime')->willReturn(100000);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$personal = new Horde_Imap_Client_Data_Namespace();
+		$personal->name = '';
+		$personal->type = Horde_Imap_Client_Data_Namespace::NS_PERSONAL;
+		$client->method('getNamespaces')
+			->willReturn(new Horde_Imap_Client_Namespace_List([$personal]));
+		$this->folderMapper->method('getFolders')
+			->with($account, $client)
+			->willReturn([]);
+		$this->mailboxMapper->method('findAll')
+			->with($account)
+			->willReturn([]);
+
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+		$client->expects($this->once())
+			->method('logout');
+
+		$this->sync->sync($account, new NullLogger(), false);
+	}
+
 	public function testSyncStats(): void {
 		$client = $this->createStub(Horde_Imap_Client_Socket::class);
 		$stats = new MailboxStats(42, 10, null);


### PR DESCRIPTION
- Add `testSyncWithClient` for the provided client branch. When a client is provided, `sync()` should not call `IMAPClientFactory::getClient()` and must not call `logout()` on the passed-in connection

 - Add `testSyncWithoutClient` for the factory-created client branch verifying `getClient` and `logout` are called 
 
Closes https://github.com/nextcloud/mail/issues/12593



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
