### PR TITLE
fix: configurable timeout for connectivity tester

### DIFF
--- a/lib/Service/AutoConfig/ConnectivityTester.php
+++ b/lib/Service/AutoConfig/ConnectivityTester.php
@@ -10,16 +10,14 @@ declare(strict_types=1);
 
 namespace OCA\Mail\Service\AutoConfig;
 
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
 class ConnectivityTester {
-	public const CONNECTION_TIMEOUT = 5;
-
-	/** @var LoggerInterface */
-	protected $logger;
-
-	public function __construct(LoggerInterface $logger) {
-		$this->logger = $logger;
+	public function __construct(
+		protected IConfig $config,
+		protected LoggerInterface $logger,
+	) {
 	}
 
 	/**
@@ -30,7 +28,8 @@ class ConnectivityTester {
 	 */
 	public function canConnect(string $url, int $port): bool {
 		$this->logger->debug("attempting to connect to <$url> on port <$port>");
-		$fp = @fsockopen($url, $port, $error, $errorstr, self::CONNECTION_TIMEOUT);
+		$timeout = (float)$this->config->getSystemValue('app.mail.imap.timeout', 5);
+		$fp = @fsockopen($url, $port, $error, $errorstr, $timeout);
 		if (is_resource($fp)) {
 			fclose($fp);
 			$this->logger->debug("connection to <$url> on port <$port> established");


### PR DESCRIPTION
Small change in `ConnectivityTester` to use a user-configurable value as timeout interval, instead of an hard-wired constant.

I've arbitrarily choose `app.mail.imap.timeout` instead of other existing configuration: it is not meant to be semantically correct, but to give a chance to user intervention.

Fixes #7872 (in particular [this comment](https://github.com/nextcloud/mail/issues/7872#issuecomment-1404924657)).
