### PR TITLE
fix: recursive iteration of malboxes

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -2435,12 +2435,16 @@ export default function mainStoreActions() {
 		getMailboxes(accountId) {
 			return this.accountsUnmapped[accountId].mailboxes.map((id) => this.mailboxes[id])
 		},
-		* getRecursiveMailboxIterator(accountId) {
-			for (const mailbox of this.getMailboxes(accountId)) {
+		* getRecursiveMailboxIterator(accountId, parentMailboxId = null) {
+			const mailboxes = parentMailboxId ? this.getSubMailboxes(parentMailboxId) : this.getMailboxes(accountId)
+			for (const mailbox of mailboxes) {
 				yield mailbox
 
-				for (const subMailboxId of mailbox.mailboxes) {
-					yield this.getMailbox(subMailboxId)
+				if (mailbox.mailboxes) {
+					for (const subMailboxId of mailbox.mailboxes) {
+						yield this.getMailbox(subMailboxId)
+						yield* this.getRecursiveMailboxIterator(accountId, subMailboxId)
+					}
 				}
 			}
 		},
@@ -2449,11 +2453,14 @@ export default function mainStoreActions() {
 			return mailbox.mailboxes.map((id) => this.mailboxes[id])
 		},
 		getParentMailbox(id) {
-			for (const mailbox of this.getMailboxes(this.getMailbox(id).accountId)) {
+			const accountId = this.getMailbox(id).accountId
+
+			for (const mailbox of this.getRecursiveMailboxIterator(accountId)) {
 				if (mailbox.mailboxes.includes(id)) {
 					return mailbox
 				}
 			}
+
 			return undefined
 		},
 		getUnifiedMailbox(specialRole) {


### PR DESCRIPTION
Follow-up #13357 

Fixing `getRecursiveMailboxIterator()` to really unfold all mailboxes and sub mailboxes recursively.

Fun fact: testing this, I've found that also `getParentMailbox()` was limited to the first level of depth. I've not found any relevant open issue related to this behavior.