### PR TITLE
fix: handle empty replyTo array properly

### DIFF
--- a/src/ReplyBuilder.js
+++ b/src/ReplyBuilder.js
@@ -62,7 +62,7 @@ export function buildRecipients(envelope, ownAddress, replyTo) {
 
 	// The Reply-To header has higher precedence than the From header.
 	// This reuses Horde's handling of the reply_to field directly.
-	const from = replyTo !== undefined ? replyTo : envelope.from
+	const from = replyTo?.length > 0 ? replyTo : envelope.from
 
 	// Locate why we received this envelope
 	// Can be in 'to', 'cc' or unknown

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -527,7 +527,7 @@ export default function mainStoreActions() {
 						// Reply-To points to the list address, not the original sender.
 						// For regular emails, honor Reply-To if the sender set one.
 						const isMailingList = !!(original.unsubscribeUrl || original.unsubscribeMailto)
-						let to = (!isMailingList && original.replyTo !== undefined)
+						let to = (!isMailingList && original.replyTo?.length > 0)
 							? original.replyTo
 							: reply.data.from
 						// Replying to a message we sent ourselves: follow up with the

--- a/src/tests/unit/ReplyBuilder.spec.js
+++ b/src/tests/unit/ReplyBuilder.spec.js
@@ -82,6 +82,20 @@ describe('ReplyBuilder', () => {
 		assertSameAddressList(reply.cc, [])
 	})
 
+	it('uses From when Reply-To is empty', () => {
+		const a = createAddress('a@domain.tld')
+		const b = createAddress('b@domain.tld')
+		envelope.from = [b]
+		envelope.to = [a]
+		envelope.cc = []
+
+		const reply = buildRecipients(envelope, a, [])
+
+		assertSameAddressList(reply.from, [a])
+		assertSameAddressList(reply.to, [b])
+		assertSameAddressList(reply.cc, [])
+	})
+
 	it('handles simple group reply', () => {
 		const a = createAddress('a@domain.tld')
 		const b = createAddress('b@domain.tld')

--- a/src/tests/unit/store/actions.spec.js
+++ b/src/tests/unit/store/actions.spec.js
@@ -810,6 +810,21 @@ describe('Vuex store actions', () => {
 			}))
 		})
 
+		it('uses From when Reply-To is empty', async () => {
+			MessageService.fetchMessage.mockResolvedValue(makeOriginal({ replyTo: [] }))
+
+			await store.startComposerSession({
+				reply: {
+					mode: 'reply',
+					data: makeEnvelope(),
+				},
+			})
+
+			expect(store.startComposerSessionMutation).toHaveBeenCalledWith(expect.objectContaining({
+				data: expect.objectContaining({ to: from }),
+			}))
+		})
+
 		it('uses To for own sent messages (isOwnMessage follow-up)', async () => {
 			const ownFrom = [{ email: 'me@example.com', label: 'Me' }]
 			MessageService.fetchMessage.mockResolvedValue(makeOriginal())


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/mail/pull/12871#discussion_r3718588072
- Modified logic to handle empty or undefined replyTo 