### PR TITLE
fix: force user identifier when saving tags

### DIFF
--- a/lib/Db/TagMapper.php
+++ b/lib/Db/TagMapper.php
@@ -80,6 +80,7 @@ class TagMapper extends QBMapper {
 		try {
 			$tag = $this->getTagByImapLabel($tag->getImapLabel(), $userId);
 		} catch (DoesNotExistException $e) {
+			$tag->setUserId($userId);
 			$tag = $this->insert($tag);
 		}
 


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/mail/pull/12800/changes#r3715493623
- Added logic to force user identifier to be set on tags