### PR TITLE
feat: passing full reference to mailbox in BeforeMessageDeletedEvent

### DIFF
--- a/lib/Events/BeforeMessageDeletedEvent.php
+++ b/lib/Events/BeforeMessageDeletedEvent.php
@@ -10,26 +10,28 @@ declare(strict_types=1);
 namespace OCA\Mail\Events;
 
 use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
 use OCP\EventDispatcher\Event;
 
 class BeforeMessageDeletedEvent extends Event {
-	private string $folderId;
-
 	public function __construct(
 		private Account $account,
-		string $mailbox,
+		private Mailbox $mailbox,
 		private int $uid,
 	) {
 		parent::__construct();
-		$this->folderId = $mailbox;
 	}
 
 	public function getAccount(): Account {
 		return $this->account;
 	}
 
+	public function getMailbox(): Mailbox {
+		return $this->mailbox;
+	}
+
 	public function getFolderId(): string {
-		return $this->folderId;
+		return $this->mailbox->getName();
 	}
 
 	public function getUid(): int {

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -298,7 +298,7 @@ class MailManager implements IMailManager {
 		Horde_Imap_Client_Socket $client,
 	): void {
 		$this->eventDispatcher->dispatchTyped(
-			new BeforeMessageDeletedEvent($account, $mailbox->getName(), $messageUid)
+			new BeforeMessageDeletedEvent($account, $mailbox, $messageUid)
 		);
 
 		try {

--- a/tests/Unit/Events/BeforeMessageDeletedEventTest.php
+++ b/tests/Unit/Events/BeforeMessageDeletedEventTest.php
@@ -11,18 +11,24 @@ namespace OCA\Mail\Tests\Unit\Events;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCA\Mail\Account;
+use OCA\Mail\Db\Mailbox;
 use OCA\Mail\Events\BeforeMessageDeletedEvent;
 
 class BeforeMessageDeletedEventTest extends TestCase {
 	public function testConstructorAndGetters(): void {
 		$account = $this->createStub(Account::class);
-		$folderId = 'INBOX';
+
+		$mailbox = new Mailbox();
+		$mailbox->setId(42);
+		$mailbox->setName('INBOX');
+
 		$uid = 123;
 
-		$event = new BeforeMessageDeletedEvent($account, $folderId, $uid);
+		$event = new BeforeMessageDeletedEvent($account, $mailbox, $uid);
 
 		$this->assertSame($account, $event->getAccount());
-		$this->assertSame($folderId, $event->getFolderId());
+		$this->assertSame($mailbox, $event->getMailbox());
+		$this->assertSame('INBOX', $event->getFolderId());
 		$this->assertSame($uid, $event->getUid());
 	}
 }


### PR DESCRIPTION
Right now the `BeforeMessageDeletedEvent` delivers only the name of the parent mailbox, which is a bit limiting when handling the event.

This change attachs the whole `Mailbox`, as already happens in `MessageDeletedEvent`.