### PR TITLE
test(settings): fix flaky timeout in large-signature test

### DIFF
--- a/src/tests/unit/components/SignatureSettings.vue.spec.js
+++ b/src/tests/unit/components/SignatureSettings.vue.spec.js
@@ -18,7 +18,7 @@ describe('SignatureSettings', () => {
 			propsData: {
 				account: {
 					aliases: [],
-					signature: String('<p>Lorem ipsum</p>').repeat(120000),
+					signature: '<p>Lorem ipsum</p><img src="data:image/png;base64,' + 'A'.repeat(2 * 1024 * 1024) + '">',
 				},
 			},
 		})


### PR DESCRIPTION
Attempts to fix the flaky CI seen in https://github.com/nextcloud/mail/pull/13366 and other recent PRs.

The fixture reached 2 MB via 120000 <p> elements, so mounting SignatureSettings ran DOMParser over them twice (~4.8s) and tripped vitest's 5s timeout on loaded CI runners. Use a 2 MB embedded image instead - the realistic reason a signature exceeds 2 MB - which keeps the >2 MB HTML case but parses in ~0.2s.

Assisted-by: Claude:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
