### PR TITLE
feat: do not autoreply to noreply@ and no-reply@ senders

### DIFF
--- a/lib/Service/OutOfOffice/OutOfOfficeParser.php
+++ b/lib/Service/OutOfOffice/OutOfOfficeParser.php
@@ -120,7 +120,13 @@ class OutOfOfficeParser {
 			$vacationCondition = "currentdate :value \"ge\" \"iso8601\" \"$formattedStart\"";
 		}
 
-		$automaticMailCondition = 'anyof(exists "List-Id", exists "List-Unsubscribe")';
+		$skipConditions = [
+			'exists "List-Id"',
+			'exists "List-Unsubscribe"',
+			'address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]',
+		];
+
+		$automaticMailCondition = 'anyof(' . join(', ', $skipConditions) . ')';
 
 		$escapedSubject = SieveUtils::escapeString($state->getSubject());
 		$vacation = [

--- a/tests/data/mail-filter/parser3.sieve
+++ b/tests/data/mail-filter/parser3.sieve
@@ -16,7 +16,7 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/mail-filter/parser3_untouched.sieve
+++ b/tests/data/mail-filter/parser3_untouched.sieve
@@ -16,7 +16,7 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/mail-filter/parser4.sieve
+++ b/tests/data/mail-filter/parser4.sieve
@@ -26,7 +26,7 @@ if address :is :all "From" ["marketing@mail.internal"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/mail-filter/parser4_untouched.sieve
+++ b/tests/data/mail-filter/parser4_untouched.sieve
@@ -16,7 +16,7 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/mail-filter/service1.sieve
+++ b/tests/data/mail-filter/service1.sieve
@@ -16,7 +16,7 @@ if allof(
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/mail-filter/service1_new.sieve
+++ b/tests/data/mail-filter/service1_new.sieve
@@ -26,7 +26,7 @@ if address :is :all "From" ["marketing@mail.internal"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/mail-filter/service2.sieve
+++ b/tests/data/mail-filter/service2.sieve
@@ -30,7 +30,7 @@ if header :contains "Subject" ["World"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/mail-filter/service2_new.sieve
+++ b/tests/data/mail-filter/service2_new.sieve
@@ -26,7 +26,7 @@ if header :contains "Subject" ["Hello"] {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2024-10-08T22:00:00+00:00","subject":"Thanks for your message!","message":"I'm not here, please try again later.\u00a0"}
 if currentdate :value "ge" "iso8601" "2024-10-08T22:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Thanks for your message!" :addresses ["alice@mail.internal"] "I'm not here, please try again later. ";
 	}
 }

--- a/tests/data/sieve-vacation-on-no-end-date.sieve
+++ b/tests/data/sieve-vacation-on-no-end-date.sieve
@@ -13,7 +13,7 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/sieve-vacation-on-no-tz.sieve
+++ b/tests/data/sieve-vacation-on-no-tz.sieve
@@ -13,7 +13,7 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02","end":"2022-09-08","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01", currentdate :value "le" "iso8601" "2022-09-08") {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/sieve-vacation-on-special-chars-message.sieve
+++ b/tests/data/sieve-vacation-on-special-chars-message.sieve
@@ -13,7 +13,7 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation","message":"I'm on vacation.\r\n\"Hello, World!\"\r\n\\ escaped backslash"}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.
 \"Hello, World!\"
 \\ escaped backslash";

--- a/tests/data/sieve-vacation-on-special-chars-subject.sieve
+++ b/tests/data/sieve-vacation-on-special-chars-subject.sieve
@@ -13,7 +13,7 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","subject":"On vacation, \"Hello, World!\", \\ escaped backslash","message":"I'm on vacation."}
 if currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z" {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation, \"Hello, World!\", \\ escaped backslash" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/sieve-vacation-on-subject-placeholder.sieve
+++ b/tests/data/sieve-vacation-on-subject-placeholder.sieve
@@ -18,7 +18,7 @@ if header :matches "subject" "*" {
 	set "subject" "${1}";
 }
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "Re: ${subject}" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }

--- a/tests/data/sieve-vacation-on.sieve
+++ b/tests/data/sieve-vacation-on.sieve
@@ -13,7 +13,7 @@ if address "From" "marketing@company.org" {
 ### Nextcloud Mail: Vacation Responder ### DON'T EDIT ###
 # DATA: {"version":1,"enabled":true,"start":"2022-09-02T00:00:00+01:00","end":"2022-09-08T23:59:00+01:00","subject":"On vacation","message":"I'm on vacation."}
 if allof(currentdate :value "ge" "iso8601" "2022-09-01T23:00:00Z", currentdate :value "le" "iso8601" "2022-09-08T22:59:00Z") {
-	if not anyof(exists "List-Id", exists "List-Unsubscribe") {
+	if not anyof(exists "List-Id", exists "List-Unsubscribe", address :all :matches ["From", "Sender"] ["noreply@*", "no-reply@*"]) {
 		vacation :days 4 :subject "On vacation" :addresses ["Test Test <test@test.org>", "Test Alias <alias@test.org>"] "I'm on vacation.";
 	}
 }


### PR DESCRIPTION
Do not autoreply to `noreply@` and `no-reply@` senders.

Fixes #11600 

## 🤖 AI (if applicable)

- [X] The content of this PR was partly or fully generated using AI

I've asked an advice to Gemini about Sieve syntax.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic-mail detection by excluding messages sent from addresses matching `noreply@*` or `no-reply@*`.
  * Continued support for identifying list messages through `List-Id` and `List-Unsubscribe` headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->