### PR TITLE
fix: envelope drag and drop ghost

### DIFF
--- a/src/directives/drag-and-drop/styles/draggable-envelope.scss
+++ b/src/directives/drag-and-drop/styles/draggable-envelope.scss
@@ -8,9 +8,22 @@
 	cursor: default;
 }
 
+@keyframes ghost-appearing {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
 .draggable-envelope-ghost {
 	height: auto;
 	width: 300px;
+	position: relative;
+	z-index: 10000;
+	animation: .5s 1 normal ghost-appearing;
 
 	&--counter {
 		position: absolute;
@@ -36,7 +49,8 @@
 			width: 100%;
 			text-align: start;
 			margin-bottom: 1px;
-			background-color: #fff;
+			color: var(--color-main-text);
+			background-color: var(--color-main-background);
 			border-inline-start: 2px solid var(--color-primary-element);
 
 			&:first-child {


### PR DESCRIPTION
Fix for the the broken "ghost" element created while dragging an envelope, and colors on dark theme.

### Explanation

Commenting out [this line](https://github.com/nextcloud/mail/blob/1968041ebcbd120bfce97be65d40fe636428252b/src/directives/drag-and-drop/draggable-envelope/draggable-envelope.js#L106), the DOM node used to generate the ghost is not removed and the situation can be examinated. From here, you find that the temporary `div` is positioned in the top left corner of the screen, and appears already shredded.
Why?
Forcing his background color, it becomes evident: it is placed behind the Nextcloud headers icons!
Eventually, when the DOM element is removed in order to obtain the ghost copy, the browser keeps this exact clip, and the final result appears distorted.
What I have done is to force it above the header with a very high `z-index` value, so to generate a clean element.

<img width="423" height="655" alt="proof" src="https://github.com/user-attachments/assets/db135b47-e6de-4b3c-bbd7-2a84c116a403" />

BUT!

A previously existing issue, made even worse by this change, was the visible flash perceptible when the drag starts on the top left corner, exactly caused by the described DOM element created and destroyed with a small delay.
Here I've added also a brief animation intended to make the ghost visible with a delay, intended to reveal it just after all the creation/positioning/deletion process.

That said: the ghost on Firefox is still very transparent, but this is due browser rendering behavior and nothing can be done using just JS and CSS. A completely different approach (e.g. using a new draggable DOM item) is required for a predictable rendering on all browsers.

Fixes #12260 