### PR TITLE
fix(dav): use the default webdav client instead of patching axios

### DIFF
--- a/src/dav/client.js
+++ b/src/dav/client.js
@@ -4,18 +4,8 @@
  */
 
 import { getCurrentUser } from '@nextcloud/auth'
-import axios from '@nextcloud/axios'
+import { getClient as getDavClient } from '@nextcloud/files/dav'
 import { generateRemoteUrl } from '@nextcloud/router'
 import memoize from 'lodash/fp/memoize.js'
-import * as webdav from 'webdav'
 
-export const getClient = memoize((service) => {
-	// Add this so the server knows it is an request from the browser
-	axios.defaults.headers['X-Requested-With'] = 'XMLHttpRequest'
-
-	// force our axios
-	const patcher = webdav.getPatcher()
-	patcher.patch('request', axios)
-
-	return webdav.createClient(generateRemoteUrl(`dav/${service}/${getCurrentUser().uid}`))
-})
+export const getClient = memoize((service) => getDavClient(generateRemoteUrl(`dav/${service}/${getCurrentUser().uid}`)))


### PR DESCRIPTION
# Summary

Add attachment from files and Import to calendar are broken on main. 

webdav 5 is built on fetch, but our client patched webdav's request hook with axios, which stems from webdav 4. Every operation that reads a response body then fails with "response.text is not a function", e.g. adding a file from Files as an attachment or listing the user's calendars.

Use the client from @nextcloud/files/dav, which patches webdav's fetch hook and keeps the request token up to date.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
