### PR TITLE
fix(navigation): show the unified inbox icon

### DIFF
--- a/src/components/NavigationMailbox.vue
+++ b/src/components/NavigationMailbox.vue
@@ -209,7 +209,7 @@ import { translate as translateMailboxName } from '../i18n/MailboxTranslator.js'
 import logger from '../logger.js'
 import { getMailboxStatus, repairMailbox } from '../service/MailboxService.js'
 import { clearCache } from '../service/MessageService.js'
-import { PRIORITY_INBOX_ID, UNIFIED_INBOX_ID } from '../store/constants.js'
+import { PRIORITY_INBOX_ID } from '../store/constants.js'
 import useMainStore from '../store/mainStore.js'
 import { mailboxHasRights } from '../util/acl.js'
 
@@ -277,7 +277,6 @@ export default {
 			mailboxName: this.mailbox.displayName,
 			showMoveModal: false,
 			hasDelimiter: !!this.mailbox.delimiter,
-			UNIFIED_INBOX_ID,
 			createMailboxName: '',
 			repairing: false,
 		}

--- a/src/components/icons/MailboxIcon.vue
+++ b/src/components/icons/MailboxIcon.vue
@@ -143,6 +143,12 @@ export default {
 			required: false,
 		},
 	},
+
+	data() {
+		return {
+			UNIFIED_INBOX_ID,
+		}
+	},
 }
 
 </script>


### PR DESCRIPTION
Oversight from https://github.com/nextcloud/mail/pull/13468

UNIFIED_INBOX_ID was imported but never exposed to the template, so the comparison always failed and the unified inbox rendered a generic folder icon.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
