### PR TITLE
feat(composer): reflect the selection in the image picker button

### DIFF
--- a/src/ckeditor/image/FilesImagePlugin.ts
+++ b/src/ckeditor/image/FilesImagePlugin.ts
@@ -57,8 +57,17 @@ export default class FilesImagePlugin extends Plugin {
 			const nodes = await getFilePickerBuilder(t('mail', 'Choose an image'))
 				.setMimeTypeFilter(MIME_TYPES)
 				.setMultiSelect(false)
-				// TRANSLATORS: button of the file picker to insert the selected image
-				.addButton({ label: t('mail', 'Insert'), type: 'primary', callback: () => {} })
+				.setCanPick((node) => (node.size ?? 0) <= SIZE_LIMIT)
+				.setButtonFactory((selection) => [{
+					label: selection.length === 0
+						// TRANSLATORS: call to action of the file picker while nothing is selected
+						? t('mail', 'Select an image')
+						// TRANSLATORS: button of the file picker to insert the selected image, {name} is a file name
+						: t('mail', 'Insert {name}', { name: selection[0].basename }, { escape: false, sanitize: false }),
+					disabled: selection.length === 0,
+					variant: 'primary',
+					callback: (nodes) => logger.debug('picked an image from Files', { nodes }),
+				}])
 				.build()
 				.pickNodes()
 			node = nodes[0]


### PR DESCRIPTION
## Summary

Follow up for https://github.com/nextcloud/mail/pull/13477

 The change was a fixup! commit that got lost when the branch was rebased before merging :see_no_evil: 

Main:

<img width="987" height="925" alt="image" src="https://github.com/user-attachments/assets/99741910-f7d3-40c4-b4ea-8ec0525f415e" />

Here:

<img width="987" height="925" alt="image" src="https://github.com/user-attachments/assets/6e590c12-fe0e-4998-b0e3-79ca2ef06773" />

1) The name of the selected file is shown
2) The insert button is disabled without a selection

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
