### PR TITLE
fix: the hint that theres no "to" reciepient

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1876,6 +1876,7 @@ export default {
 .composer-fields {
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	align-items: flex-start;
 	padding: 0 calc(var(--default-grid-baseline) * 2);
 	min-height: calc(var(--default-clickable-area) + calc(var(--default-grid-baseline) * 2));
@@ -1947,6 +1948,8 @@ export default {
 	}
 
 	&__helper-text {
+		flex-basis: 100%;
+		padding-inline-start: calc(var(--default-grid-baseline) * 12);
 		margin-top: calc(var(--default-grid-baseline) * 0.5);
 		margin-bottom: calc(var(--default-grid-baseline) * 0.5);
 		color: var(--color-text-maxcontrast);


### PR DESCRIPTION
fixes the overlapping of the hint with the "to" field

<img width="634" height="311" alt="Screenshot from 2026-08-13 17-31-13" src="https://github.com/user-attachments/assets/4d81a10f-be5c-456e-ab88-ac15317a127c" />

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
