### PR TITLE
feat: mailbox icon in thread view

### DIFF
--- a/src/components/Thread.vue
+++ b/src/components/Thread.vue
@@ -24,7 +24,6 @@
 				ref="envelopeRefs"
 				:key="env.databaseId"
 				:envelope="env"
-				:mailbox-id="$route.params.mailboxId"
 				:thread-subject="threadSubject"
 				:expanded="expandedThreads.includes(env.databaseId)"
 				:full-height="thread.length === 1"

--- a/src/components/ThreadEnvelope.vue
+++ b/src/components/ThreadEnvelope.vue
@@ -65,6 +65,15 @@
 				@keydown.space.prevent="$emit('toggle-expand', $event)">
 				<div class="envelope__header__left__sender-subject-tags">
 					<div class="sender" :class="{ 'sender--expanded': expanded }">
+						<NcChip
+							:title="mailboxName(mailbox)"
+							variant="tertiary"
+							no-close="true">
+							<MailboxIcon
+								:account="account"
+								:mailbox="mailbox" />
+						</NcChip>
+
 						{{ envelope.from && envelope.from[0] ? envelope.from[0].label : '' }}
 					</div>
 					<NcButton
@@ -393,6 +402,7 @@ import { NcActionButton, NcButton } from '@nextcloud/vue'
 import { mapStores } from 'pinia'
 import NcActions from '@nextcloud/vue/components/NcActions'
 import NcActionText from '@nextcloud/vue/components/NcActionText'
+import NcChip from '@nextcloud/vue/components/NcChip'
 import ArchiveIcon from 'vue-material-design-icons/ArchiveArrowDownOutline.vue'
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronUpIcon from 'vue-material-design-icons/ChevronUp.vue'
@@ -411,6 +421,7 @@ import ConfirmModal from './ConfirmationModal.vue'
 import Error from './Error.vue'
 import EventModal from './EventModal.vue'
 import JunkIcon from './icons/JunkIcon.vue'
+import MailboxIcon from './icons/MailboxIcon.vue'
 import MailFilterFromEnvelope from './mailFilter/MailFilterFromEnvelope.vue'
 import MenuEnvelope from './MenuEnvelope.vue'
 import Message from './Message.vue'
@@ -426,6 +437,7 @@ import importantSvg from '../../img/important.svg'
 import { isPgpText } from '../crypto/pgp.js'
 import { matchError } from '../errors/match.js'
 import NoTrashMailboxConfiguredError from '../errors/NoTrashMailboxConfiguredError.js'
+import { translate as translateMailboxName } from '../i18n/MailboxTranslator.js'
 import logger from '../logger.js'
 import { buildRecipients as buildReplyRecipients } from '../ReplyBuilder.js'
 import { smartReply } from '../service/AiIntergrationsService.js'
@@ -459,8 +471,10 @@ export default {
 		RecipientBubble,
 		NcActionButton,
 		NcButton,
+		NcChip,
 		Error,
 		IconFavorite,
+		MailboxIcon,
 		JunkIcon,
 		MessageLoadingSkeleton,
 		MenuEnvelope,
@@ -487,16 +501,6 @@ export default {
 		envelope: {
 			required: true,
 			type: Object,
-		},
-
-		mailboxId: {
-			required: false,
-			type: [
-				String,
-				Number,
-			],
-
-			default: undefined,
 		},
 
 		expanded: {
@@ -702,7 +706,7 @@ export default {
 		},
 
 		mailbox() {
-			return this.mainStore.getMailbox(this.mailboxId)
+			return this.mainStore.getMailbox(this.envelope.mailboxId)
 		},
 
 		archiveMailbox() {
@@ -1071,6 +1075,10 @@ export default {
 			})
 		},
 
+		mailboxName() {
+			return translateMailboxName(this.mailbox)
+		},
+
 		async unsubscribeViaOneClick() {
 			try {
 				this.unsubscribing = true
@@ -1213,7 +1221,9 @@ export default {
 
 <style lang="scss" scoped>
 	.sender {
+		display: flex;
 		margin-inline-start: calc(var(--default-grid-baseline) * 3);
+		gap: var(--default-grid-baseline);
 
 		&--expanded {
 			color: var(--color-text-maxcontrast);
@@ -1410,7 +1420,7 @@ export default {
 		}
 
 		.subline {
-			margin-inline-start: 8px;
+			margin-inline-start: calc(var(--default-grid-baseline) * 3);
 			color: var(--color-text-maxcontrast);
 			cursor: default;
 			overflow: hidden;


### PR DESCRIPTION
A proposal for #9535: in the thread view, I've added the icon of the parent mailbox for each message (and a tooltip with the full name of the mailbox itself).

<img width="305" height="360" alt="Screenshot From 2026-08-13 19-37-10" src="https://github.com/user-attachments/assets/dece0671-1d55-4618-9b71-fa3272b49cfb" />

Evaluating this feature, I've been concerned of adding the full name of the mailbox as it would eventually squeezes even more the envelope's header (especially on mobile). An icon is mostly decorative, slightly informative, and the tooltip provides the full information in unobtrusive way (in particular for non-special mailboxes not having their own recognizable icon).

Here I've also fixed a minor alignment issue with the sender line and message's preview line, and I've removed the `mailboxId` parameter for `ThreadEnvelope` (I've not really understood his utility, as the same information is carried by `envelope` and indeed the `mailboxId` binded to the local route in `Thread` impacts in the functionalities enabled for every child envelope).

Fixes #9535 