### PR TITLE
fix(composer): only warn about missing 'To' when cc/bcc are set

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1042,7 +1042,9 @@ export default {
 		},
 
 		displayMissingToWarning() {
-			return this.toFieldTouched && this.selectTo.length === 0
+			return this.toFieldTouched
+				&& this.selectTo.length === 0
+				&& (this.selectCc.length > 0 || this.selectBcc.length > 0)
 		},
 	},
 


### PR DESCRIPTION
The no-'To'-recipient hint fired whenever the auto-focused To field was blurred empty, annoying users who write the body before the recipients. Restrict it to the case it exists for: cc or bcc filled but To empty.

Assisted-by: Claude:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
