### PR TITLE
chore: fixing typo of attribute name

### DIFF
--- a/src/store/outboxStore.js
+++ b/src/store/outboxStore.js
@@ -117,7 +117,7 @@ export default defineStore('outbox', {
 			this.stopMessageMutation({ message })
 			const updatedMessage = await OutboxService.updateMessage({
 				...message,
-				sentAt: undefined,
+				sendAt: null,
 			}, message.id)
 			this.updateMessageMutation({ message: updatedMessage })
 			return updatedMessage


### PR DESCRIPTION
As reported in #6493, the issue has already been fixed.

This PR is just to correct a minor typo with no impact: `sendAt` has been mistyped as `sentAt`, but at this point `sendAt` attribute has already been removed from the previous call to `stopMessageMutation()` and the `sentAt` attribute has no effect while calling the store.

I've been tempted to remove `stopMessageMutation()` at all and just save the modified value of `message`: it seems a bit redundant, but voiding `sendAt` before obtaining a response from the server in `OutboxService.updateMessage()` provides immediate feedback for the user even on slow connections.