### PR TITLE
fix: updating state of message when stopping it

### DIFF
--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -619,7 +619,7 @@ export default function mainStoreActions() {
 				if (type === 'outbox' && data.id && data.sendAt) {
 					originalSendAt = data.sendAt
 					const outboxStore = useOutboxStore()
-					await outboxStore.stopMessage({ message: { ...data } })
+					data = await outboxStore.stopMessage({ message: { ...data } })
 				}
 
 				this.startComposerSessionMutation({


### PR DESCRIPTION
Here I apply the laziest possible solution to fix the issue: use the state of the message already kept updated by outboxStore.

Fixes #6384 