### PR TITLE
feat: ability to disable sync job by configuration

### DIFF
--- a/lib/BackgroundJob/SyncJob.php
+++ b/lib/BackgroundJob/SyncJob.php
@@ -32,6 +32,7 @@ class SyncJob extends TimedJob {
 	private IUserManager $userManager;
 	private IJobList $jobList;
 	private readonly bool $forcedSyncInterval;
+	private readonly bool $forcedSkip;
 
 	public function __construct(
 		ITimeFactory $time,
@@ -51,7 +52,14 @@ class SyncJob extends TimedJob {
 		$configuredSyncInterval = $config->getSystemValueInt('app.mail.background-sync-interval');
 		if ($configuredSyncInterval > 0) {
 			$this->forcedSyncInterval = true;
+			$this->forcedSkip = false;
 		} else {
+			if ($configuredSyncInterval === -1) {
+				$this->forcedSkip = true;
+			} else {
+				$this->forcedSkip = false;
+			}
+
 			$this->forcedSyncInterval = false;
 			$configuredSyncInterval = self::DEFAULT_SYNC_INTERVAL;
 		}
@@ -65,6 +73,10 @@ class SyncJob extends TimedJob {
 	 */
 	#[\Override]
 	protected function run($argument) {
+		if ($this->forcedSkip) {
+			return;
+		}
+
 		$accountId = (int)$argument['accountId'];
 
 		try {

--- a/tests/Unit/BackgroundJob/SyncJobTest.php
+++ b/tests/Unit/BackgroundJob/SyncJobTest.php
@@ -16,6 +16,7 @@ use OCA\Mail\Account;
 use OCA\Mail\BackgroundJob\SyncJob;
 use OCA\Mail\Db\MailAccount;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\IConfig;
 use OCP\IUser;
 
 class SyncJobTest extends TestCase {
@@ -137,5 +138,24 @@ class SyncJobTest extends TestCase {
 			'accountId' => 123,
 		]);
 		$this->job->start($this->createMock(JobList::class));
+	}
+
+	public function testDisabledJob(): void {
+		$config = $this->createMock(IConfig::class);
+
+		$config->expects(self::once())
+			->method('getSystemValueInt')
+			->with('app.mail.background-sync-interval')
+			->willReturn(-1);
+
+		$serviceMock = $this->createServiceMock(SyncJob::class, [
+			'config' => $config,
+		]);
+
+		$serviceMock->getParameter('accountService')
+			->expects(self::never())
+			->method('findById');
+
+		$serviceMock->getService()->start($this->createMock(JobList::class));
 	}
 }


### PR DESCRIPTION
Here I've added the ability to disable the syncronization job by settings `-1` as value of `app.mail.background-sync-interval`.
I've avoided to use `0` as special value to avoid breaking existing behavior (which is: when 0, fallback to the default interval).

I've not found better ways to disable the job "on demand". References I've found in other Nextcloud repositories (in [files_antivirus](https://github.com/nextcloud/files_antivirus/blob/master/lib/BackgroundJob/BackgroundScanner.php) and [bookmarks](https://github.com/nextcloud/bookmarks/blob/master/lib/BackgroundJobs/CrawlJob.php)) adopt all the same approach: just return from the `run()` method if the condition of disabling is true.

Fixes #10287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-configurable option to disable background synchronization.

* **Bug Fixes**
  * Background synchronization now exits cleanly when disabled, preventing unnecessary processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->