### PR TITLE
perf(db): index mailbox list sort and recipient lookup

### DIFF
--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -55,6 +55,12 @@ class OptionalIndicesListener implements IEventListener {
 		);
 
 		$event->addMissingIndex(
+			'mail_messages',
+			'mail_msg_mb_del_snt_idx',
+			['mailbox_id', 'flag_deleted', 'sent_at'],
+		);
+
+		$event->addMissingIndex(
 			'mail_classifiers',
 			'mail_class_creat_idx',
 			['created_at']

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -173,6 +173,9 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 			$messagesTable->addIndex(['mailbox_id', 'thread_root_id', 'sent_at'], 'mail_msg_thrd_root_snt_idx', [], ['lengths' => [null, 64, null]]);
 		}
 
+		// mail_msg_mb_del_snt_idx was added later and may not exist until optional indices are created
+		$messagesTable->addIndex(['mailbox_id', 'flag_deleted', 'sent_at'], 'mail_msg_mb_del_snt_idx');
+
 		return $schema;
 	}
 

--- a/tests/Unit/Listener/OptionalIndicesListenerTest.php
+++ b/tests/Unit/Listener/OptionalIndicesListenerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use OCA\Mail\Listener\OptionalIndicesListener;
+use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class OptionalIndicesListenerTest extends TestCase {
+
+	private IConfig&MockObject $config;
+	private IDBConnection&MockObject $connection;
+	private OptionalIndicesListener $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->connection = $this->createMock(IDBConnection::class);
+
+		$this->listener = new OptionalIndicesListener($this->config, $this->connection);
+	}
+
+	public function testHandleIgnoresUnrelatedEvents(): void {
+		$this->config->expects(self::never())->method('getSystemValue');
+		$event = $this->createMock(Event::class);
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandleRegistersOptionalIndices(): void {
+		$this->config->method('getSystemValue')
+			->with('version', '0.0.0')
+			->willReturn('34.0.0');
+		$this->connection->method('getDatabasePlatform')
+			->willReturn($this->createMock(AbstractPlatform::class));
+		$event = new AddMissingIndicesEvent();
+
+		$this->listener->handle($event);
+
+		$indexNames = array_column($event->getMissingIndices(), 'indexName');
+		self::assertContains('mail_msg_mb_del_snt_idx', $indexNames);
+	}
+}


### PR DESCRIPTION
The mailbox list query (mailbox_id + flag_deleted, ORDER BY sent_at) had no covering index and fell back to a filesort; the standalone sent_at index was dropped in 2022 and never restored. ~~mail_recipients.local_message_id had a foreign key but no backing index, so lookups and deletes scanned the whole table on Postgres and SQLite.~~

> **Edit:** the recipient index was dropped from this PR — `mail_recipients.local_message_id` is already covered by Doctrine's implicit foreign-key index (`IDX_715DB7E31594979`, added automatically alongside `FK_715DB7E31594979`), so a dedicated index would have been a redundant duplicate.

Register it via AddMissingIndicesEvent so existing installations add it out-of-band through occ db:add-missing-indices, and add it to the creating migration so new installations get it up front.

Assisted-by: ClaudeCode:claude-opus-4-8

## How to test

```sql
EXPLAIN SELECT m.id, m.sent_at FROM oc_mail_messages m
        WHERE m.mailbox_id = 9658 AND m.flag_deleted = 0
        ORDER BY m.sent_at DESC LIMIT 20;

EXPLAIN SELECT m.id, m.sent_at
        FROM oc_mail_messages m
        WHERE m.mailbox_id = 8464          
          AND m.flag_deleted = 0
          AND m.sent_at < 1429201770           
        ORDER BY m.sent_at DESC
        LIMIT 20;
```

^ replace IDs with something existent of your local db.

Before:
1. `1|SIMPLE|m|ref|mail_messages_mb_id_uid_uidx,mail_msg_thrd_root_snt_idx,mail_msg_by_remote_id_idx|mail_messages_mb_id_uid_uidx|4|const|1|Using where; Using filesort`
2. `1|SIMPLE|m|ref|mail_messages_mb_id_uid_uidx,mail_msg_thrd_root_snt_idx,mail_msg_by_remote_id_idx|mail_messages_mb_id_uid_uidx|4|const|525|Using where; Using filesort`
After
1. `1|SIMPLE|m|ref|mail_messages_mb_id_uid_uidx,mail_msg_thrd_root_snt_idx,mail_msg_by_remote_id_idx,mail_msg_mb_del_snt_idx|mail_msg_mb_del_snt_idx|6|const,const|1|Using where; Using index`
2. `1|SIMPLE|m|range|mail_messages_mb_id_uid_uidx,mail_msg_thrd_root_snt_idx,mail_msg_by_remote_id_idx,mail_msg_mb_del_snt_idx|mail_msg_mb_del_snt_idx|10||51|Using where; Using index`

-> no more  filesort

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
