### PR TITLE
fix(proxy): preserve percent-encoded image URLs in proxy link

### DIFF
--- a/lib/Service/HtmlPurify/TransformURLScheme.php
+++ b/lib/Service/HtmlPurify/TransformURLScheme.php
@@ -89,16 +89,16 @@ class TransformURLScheme extends HTMLPurifier_URIFilter {
 		$proxyUrl = $this->urlGenerator->linkToRoute('mail.proxy.proxy', [
 			'id' => $this->messageId,
 			'hmac' => $this->hmacGenerator->generate($this->messageId, $originalURL),
-			'src' => $originalURL
 		]);
 		$parsedProxyUrl = parse_url($proxyUrl);
 		/** @var array{path: string, query: string} $parsedProxyUrl */
+		$query = $parsedProxyUrl['query'] . '&src=' . rawurlencode($originalURL);
 		return new \HTMLPurifier_URI(
 			$this->request->getServerProtocol(),
 			null, $this->request->getServerHost(),
 			null,
 			$parsedProxyUrl['path'],
-			$parsedProxyUrl['query'],
+			$query,
 			null
 		);
 	}

--- a/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformURLSchemeTest.php
@@ -199,9 +199,8 @@ class TransformURLSchemeTest extends TestCase {
 			->with('mail.proxy.proxy', [
 				'id' => 42,
 				'hmac' => $hmac,
-				'src' => $originalURL,
 			])
-			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fimage.png');
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123');
 
 		$this->filter->filter($uri, $config, $context);
 
@@ -271,9 +270,8 @@ class TransformURLSchemeTest extends TestCase {
 			->with('mail.proxy.proxy', [
 				'id' => 42,
 				'hmac' => $hmac,
-				'src' => $originalURL,
 			])
-			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fpage%3Fid%3D123%26name%3Dtest');
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123');
 
 		$this->filter->filter($uri, $config, $context);
 
@@ -306,13 +304,68 @@ class TransformURLSchemeTest extends TestCase {
 			->with('mail.proxy.proxy', [
 				'id' => 42,
 				'hmac' => $hmac,
-				'src' => $originalURL,
 			])
-			->willReturn('/apps/mail/proxy?id=42&hmac=abc123&src=https%3A%2F%2Fexample.com%2Fpage%23section');
+			->willReturn('/apps/mail/proxy?id=42&hmac=abc123');
 
 		$this->filter->filter($uri, $config, $context);
 
 		$this->assertStringContainsString('%23section', $uri->query);
+	}
+
+	public function testSrcWithPercentEncodedQueryPreservedForHmac(): void {
+		$uri = new HTMLPurifier_URI(
+			'https',
+			null,
+			'cdn.example.com',
+			null,
+			'/img.jpg',
+			'sig=%2Fabc%2Bdef%3D&t=123',
+			null,
+		);
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+		$attr = 'src';
+		$context->register('CurrentAttr', $attr);
+
+		$originalURL = 'https://cdn.example.com/img.jpg?sig=%2Fabc%2Bdef%3D&t=123';
+		$hmac = 'deadbeef';
+
+		$this->hmacGenerator->expects($this->once())
+			->method('generate')
+			->with(42, $originalURL)
+			->willReturn($hmac);
+
+		$this->request->method('getServerProtocol')->willReturn('https');
+		$this->request->method('getServerHost')->willReturn('mail.example.com');
+		$this->urlGenerator->expects($this->once())
+			->method('linkToRoute')
+			->with('mail.proxy.proxy', [
+				'id' => 42,
+				'hmac' => $hmac,
+			])
+			->willReturnCallback(static function (string $route, array $args): string {
+				$query = http_build_query($args, '', '&', PHP_QUERY_RFC3986);
+				return '/index.php/apps/mail/proxy?' . strtr($query, [
+					'%2F' => '/',
+					'%252F' => '%2F',
+					'%3F' => '?',
+					'%40' => '@',
+					'%3A' => ':',
+					'%21' => '!',
+					'%3B' => ';',
+					'%2C' => ',',
+					'%2A' => '*',
+				]);
+			});
+
+		$this->filter->filter($uri, $config, $context);
+
+		parse_str($uri->query, $parsed);
+		$this->assertSame(
+			$originalURL,
+			$parsed['src'],
+			'The src reaching the server must be byte-identical to the value the HMAC was generated over',
+		);
 	}
 
 	public function testCidSchemeRewritesUriFromUrl(): void {


### PR DESCRIPTION
linkToRoute() routes the src through Symfony's UrlGenerator, whose QUERY_FRAGMENT_DECODED map rewrites %252F back to %2F. That single character diverged from the value the HMAC was signed over, so the proxy rejected signed CDN image URLs with HTTP 401. Append src to the query with our own single encoding so it round-trips intact.

Assisted-by: Claude:claude-opus-4-8

Fixes https://github.com/nextcloud/mail/issues/13493

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
