### PR TITLE
fix(settings): mount account-settings dialog at app root

### DIFF
--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -10,7 +10,7 @@
 		:show-navigation="true"
 		:additional-trap-elements="trapElements"
 		:name="t('mail', 'Account settings')"
-		@update:open="updateOpen">
+		@update:open="onClose">
 		<NcAppSettingsSection
 			id="alias-settings"
 			:name="t('mail', 'Aliases')">
@@ -206,7 +206,6 @@ export default {
 	data() {
 		return {
 			trapElements: [],
-			fetchActiveSieveScript: this.account.sieveEnabled,
 			loadingClassificationToggle: false,
 			systemVersion: parseInt(OC.config.version.split('.')[0], 10),
 		}
@@ -224,24 +223,26 @@ export default {
 	},
 
 	watch: {
-		open(newState, oldState) {
-			if (newState === true && this.fetchActiveSieveScript === true) {
-				logger.debug(`Load active sieve script for account ${this.account.accountId}`)
-				this.fetchActiveSieveScript = false
-				this.mainStore.fetchActiveSieveScript({
-					accountId: this.account.id,
+		scrollToSection: {
+			immediate: true,
+			handler(newState) {
+				this.$nextTick(() => {
+					this.$refs[newState]?.$el?.scrollIntoView({
+						behavior: 'smooth',
+						block: 'start',
+					})
 				})
-			}
+			},
 		},
+	},
 
-		scrollToSection(newState) {
-			this.$nextTick(() => {
-				this.$refs[newState]?.$el?.scrollIntoView({
-					behavior: 'smooth',
-					block: 'start',
-				})
+	mounted() {
+		if (this.account.sieveEnabled) {
+			logger.debug(`Load active sieve script for account ${this.account.accountId}`)
+			this.mainStore.fetchActiveSieveScript({
+				accountId: this.account.id,
 			})
-		},
+		}
 	},
 
 	methods: {
@@ -251,8 +252,8 @@ export default {
 			})
 		},
 
-		updateOpen() {
-			this.$emit('update:open')
+		onClose() {
+			this.$emit('close')
 		},
 
 		async onToggleClassification(classificationEnabled) {

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -82,6 +82,16 @@
 			</div>
 		</template>
 		<AppSettingsMenu :open.sync="showSettings" />
+
+		<!-- Must stay outside the #list slot: within NavigationAccount's vue-frag
+		     fragment the dialog gets pulled back into the clipped sidebar after
+		     NcModal relocated it to <body>. -->
+		<AccountSettings
+			v-if="settingsAccount"
+			:open="true"
+			:account="settingsAccount"
+			:scroll-to-section="settingsSection"
+			@close="onCloseAccountSettings" />
 	</NcAppNavigation>
 </template>
 
@@ -104,6 +114,7 @@ export default {
 	name: 'Navigation',
 	components: {
 		NcAppNavigation,
+		AccountSettings: () => import(/* webpackChunkName: "account-settings" */ './AccountSettings.vue'),
 		AppSettingsMenu,
 		NavigationAccount,
 		NavigationAccountExpandCollapse,
@@ -120,11 +131,17 @@ export default {
 		return {
 			refreshing: false,
 			showSettings: false,
+			settingsAccountId: null,
+			settingsSection: undefined,
 		}
 	},
 
 	computed: {
 		...mapStores(useOutboxStore, useMainStore),
+		settingsAccount() {
+			return this.settingsAccountId ? this.mainStore.getAccount(this.settingsAccountId) : null
+		},
+
 		menu() {
 			return this.mainStore.getAccounts
 				.filter((account) => account.id !== UNIFIED_ACCOUNT_ID)
@@ -164,7 +181,23 @@ export default {
 		},
 	},
 
+	watch: {
+		'mainStore.showAccountSettings': function(settings) {
+			if (settings?.accountId) {
+				this.settingsAccountId = settings.accountId
+				this.settingsSection = settings.section
+			} else {
+				this.settingsAccountId = null
+				this.settingsSection = undefined
+			}
+		},
+	},
+
 	methods: {
+		onCloseAccountSettings() {
+			this.mainStore.showSettingsForAccountMutation(null)
+		},
+
 		showMailSettings() {
 			this.showSettings = true
 		},

--- a/src/components/NavigationAccount.vue
+++ b/src/components/NavigationAccount.vue
@@ -30,7 +30,7 @@
 					</NcActionText>
 					<NcActionButton
 						:close-after-click="true"
-						@click="showAccountSettings(true)">
+						@click="showAccountSettings">
 						<template #icon>
 							<IconSettings :size="20" />
 						</template>
@@ -96,11 +96,6 @@
 				</template>
 			</template>
 		</NcAppNavigationCaption>
-		<AccountSettings
-			:open="showSettings"
-			:account="account"
-			:scroll-to-section="showSettingsSection"
-			@update:open="showAccountSettings($event)" />
 		<DelegationModal v-if="showDelegationModal" :account="account" @close="showDelegationModal = false" />
 	</Fragment>
 </template>
@@ -132,7 +127,6 @@ export default {
 		NcActionCheckbox,
 		NcActionInput,
 		NcActionText,
-		AccountSettings: () => import(/* webpackChunkName: "account-settings" */ './AccountSettings.vue'),
 		DelegationModal: () => import(/* webpackChunkName: "delegation-modal" */ './DelegationModal.vue'),
 		IconInfo,
 		IconSettings,
@@ -193,14 +187,6 @@ export default {
 
 	computed: {
 		...mapStores(useMainStore),
-		showSettings() {
-			return this.mainStore.showSettingsForAccount(this.account.id)
-		},
-
-		showSettingsSection() {
-			return this.mainStore.showSettingsSectionForAccount(this.account.id)
-		},
-
 		visible() {
 			return this.account.isUnified !== true && this.account.visible !== false
 		},
@@ -344,17 +330,8 @@ export default {
 			}
 		},
 
-		/**
-		 * Show the settings for the given account
-		 *
-		 * @param {boolean} show true to show, false to hide
-		 */
-		showAccountSettings(show) {
-			if (show) {
-				this.mainStore.showSettingsForAccountMutation(this.account.id)
-			} else {
-				this.mainStore.showSettingsForAccountMutation(null)
-			}
+		showAccountSettings() {
+			this.mainStore.showSettingsForAccountMutation(this.account.id)
 		},
 	},
 }

--- a/src/store/mainStore/actions.js
+++ b/src/store/mainStore/actions.js
@@ -2513,15 +2513,6 @@ export default function mainStoreActions() {
 		getInbox(accountId) {
 			return this.findMailboxBySpecialRole(accountId, 'inbox')
 		},
-		showSettingsForAccount(accountId) {
-			return this.showAccountSettings?.accountId === accountId
-		},
-		showSettingsSectionForAccount(accountId) {
-			if (this.showAccountSettings?.accountId !== accountId) {
-				return undefined
-			}
-			return this.showAccountSettings.section
-		},
 		getMyTextBlocks() {
 			return this.myTextBlocks
 		},


### PR DESCRIPTION
## Summary

Fix https://github.com/nextcloud/mail/issues/13109
Fix https://github.com/nextcloud/mail/issues/10977
Fix https://github.com/nextcloud/mail/issues/9605

Pulled from https://github.com/nextcloud/mail/pull/13133

Inside the navigation, vue-frag pulled the dialog back into the overflow-clipped sidebar after NcModal had relocated it to <body>. CKEditor's Rect.getVisible() then returned null, so the find-and-replace dialog and every balloon ended up off-screen.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
