### PR TITLE
fix: buttons alignment and minor graphic fixes in signature editor

### DIFF
--- a/css/mail.scss
+++ b/css/mail.scss
@@ -28,6 +28,13 @@
 	height: 100%;
 }
 
+.mail-button-row {
+	display: flex;
+	flex-direction: row;
+	gap: var(--default-grid-baseline);
+	margin-top: var(--default-grid-baseline);
+}
+
 .folders .ui-droppable-active {
 	background-color: rgb(240, 240, 240);
 }

--- a/src/components/AliasSettings.vue
+++ b/src/components/AliasSettings.vue
@@ -51,7 +51,7 @@
 			</li>
 		</ul>
 
-		<div v-if="!account.provisioningId" class="aliases-controls">
+		<div v-if="!account.provisioningId" class="mail-button-row">
 			<NcButton
 				v-if="!showForm"
 				variant="primary"
@@ -76,7 +76,6 @@
 			<NcButton
 				v-if="showForm"
 				variant="tertiary-no-background"
-				class="button-text"
 				:aria-label="t('mail', 'Cancel')"
 				@click="resetCreate">
 				{{ t("mail", "Cancel") }}
@@ -184,38 +183,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.primary {
-	padding-inline-start: 26px;
-	background-position: 6px;
-	color: var(--color-main-background);
-
-	&:after {
-		inset-inline-start: 14px;
-	}
-}
-
-.button-text {
-	background-color: transparent;
-	border: none;
-	color: var(--color-text-maxcontrast);
-	font-weight: normal;
-
-	&:hover,
-	&:focus {
-		color: var(--color-main-text);
-	}
-}
-
-.aliases-controls {
-	display: flex;
-}
-
 input {
 	width: 195px;
-}
-
-.button-vue:deep() {
-	display: inline-block !important;
-	margin-top: 4px !important;
 }
 </style>

--- a/src/components/SignatureSettings.vue
+++ b/src/components/SignatureSettings.vue
@@ -4,17 +4,10 @@
 -->
 
 <template>
-	<div class="section">
-		<div>
-			<input
-				id="signature-above-quote-toggle"
-				v-model="signatureAboveQuote"
-				type="checkbox"
-				class="checkbox">
-			<label for="signature-above-quote-toggle">
-				{{ t("mail", "Place signature above quoted text") }}
-			</label>
-		</div>
+	<div>
+		<NcCheckboxRadioSwitch v-model="signatureAboveQuote">
+			{{ t("mail", "Place signature above quoted text") }}
+		</NcCheckboxRadioSwitch>
 		<NcSelect
 			v-if="identities.length > 1"
 			:allow-empty="false"
@@ -44,30 +37,32 @@
 			<!-- TRANSLATORS: "writing mode", "rich text" and "plain text" are labels of the Writing mode setting -->
 			<p>{{ t('mail', 'This signature contains images. New messages will use rich text, even though your writing mode is set to plain text.') }}</p>
 		</NcNoteCard>
-		<NcButton
-			variant="primary"
-			:disabled="loading"
-			:aria-label="t('mail', 'Save signature')"
-			@click="saveSignature">
-			<template #icon>
-				<NcLoadingIcon v-if="loading" :size="20" fill-color="white" />
-				<IconCheck v-else :size="20" />
-			</template>
-			{{ t('mail', 'Save signature') }}
-		</NcButton>
-		<NcButton
-			v-if="signature"
-			:aria-label="t('mail', 'Delete')"
-			variant="tertiary-no-background"
-			class="button-text"
-			@click="deleteSignature">
-			{{ t('mail', 'Delete') }}
-		</NcButton>
+
+		<div class="mail-button-row">
+			<NcButton
+				variant="primary"
+				:disabled="loading"
+				:aria-label="t('mail', 'Save signature')"
+				@click="saveSignature">
+				<template #icon>
+					<NcLoadingIcon v-if="loading" :size="20" fill-color="white" />
+					<IconCheck v-else :size="20" />
+				</template>
+				{{ t('mail', 'Save signature') }}
+			</NcButton>
+			<NcButton
+				v-if="signature"
+				:aria-label="t('mail', 'Delete')"
+				variant="tertiary-no-background"
+				@click="deleteSignature">
+				{{ t('mail', 'Delete') }}
+			</NcButton>
+		</div>
 	</div>
 </template>
 
 <script>
-import { NcButton, NcLoadingIcon, NcNoteCard, NcSelect } from '@nextcloud/vue'
+import { NcButton, NcCheckboxRadioSwitch, NcLoadingIcon, NcNoteCard, NcSelect } from '@nextcloud/vue'
 import mitt from 'mitt'
 import { mapStores } from 'pinia'
 import IconCheck from 'vue-material-design-icons/Check.vue'
@@ -84,6 +79,7 @@ export default {
 		NcNoteCard,
 		NcSelect,
 		NcButton,
+		NcCheckboxRadioSwitch,
 		NcLoadingIcon,
 		IconCheck,
 	},
@@ -189,7 +185,7 @@ export default {
 		},
 
 		async deleteSignature() {
-			this.signature = null
+			this.signature = ''
 			await this.saveSignature()
 		},
 
@@ -254,42 +250,9 @@ export default {
 	}
 }
 
-.primary {
-  padding-inline-start: 26px;
-  background-position: 6px;
-  color: var(--color-main-background);
-
-  &:after {
-    inset-inline-start: 14px;
-  }
-}
-
-.button-text {
-  background-color: transparent;
-  border: none;
-  color: var(--color-text-maxcontrast);
-  font-weight: normal;
-
-  &:hover,
-  &:focus {
-    color: var(--color-main-text);
-  }
-}
-
-.section {
-  display: block;
-  padding: 0;
-  margin-bottom: 23px;
-}
-
 .ck-balloon-panel {
 	 z-index: 10000 !important;
  }
-
-.button-vue:deep() {
-	display: inline-block !important;
-	margin-top: 4px !important;
-}
 
 /* it's a bit hard to make it work without this max-width in the modal because it overlaps with the sidebar of the modal */
 :deep(.ck.ck-toolbar-dropdown>.ck-dropdown__panel) {


### PR DESCRIPTION
Some minor fixes to Signature editor, including:

- replacement of a raw checkbox with a `NcCheckboxRadioSwitch`
- suppression of some redundant and broken CSS. In particular: the `.section` class was an override of global `.section` [from core CSS](https://github.com/nextcloud/server/blob/51568eaba7415471ab750ff418b4760178ec0522/core/css/apps.scss#L929) intended to override some padding; I've just removed the `.section` div to obtain an almost identical result (1px less `margin-bottom` in new version)
- boxing buttons in a `display: flex` node to align them. This has been inspired by the existing - and working - implementation in `AliasSettings`; to avoid to duplicate everything, I've placed the new `.row-box` class in global Mail SCSS, in the aim to reuse it somewhere else
- fixed an unreported bug: clicking "Delete", the contents of the textbox didn't emptied (no feedback of the actual deletion of the signature for the user)

<img width="1762" height="624" alt="sample" src="https://github.com/user-attachments/assets/c5f7e724-a4cd-49c9-9e63-d0121ebe3afd" />

Fixes #13461 