### PR TITLE
fix: allow scripts in message iframe sandbox so the body resizes

### DIFF
--- a/src/components/MessageHTMLBody.vue
+++ b/src/components/MessageHTMLBody.vue
@@ -37,7 +37,8 @@
 			</NcActions>
 		</div>
 		<div id="message-container" :class="{ scroll: !fullHeight }">
-			<!-- allow-same-origin: parent JS accesses contentDocument directly (image unblocking, resize, print).
+			<!-- allow-scripts: the server-injected iframe-resizer child must run to size the frame to its content.
+			     allow-same-origin: parent JS accesses contentDocument directly (image unblocking, resize, print).
 			     allow-popups + allow-popups-to-escape-sandbox: email links must open as normal tabs, not sandboxed ones. -->
 			<iframe
 				ref="iframe"
@@ -45,7 +46,7 @@
 				:title="t('mail', 'Message frame')"
 				:src="url"
 				seamless
-				sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+				sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
 				@load="onMessageFrameLoad" />
 		</div>
 	</div>

--- a/src/tests/unit/components/MessageHTMLBody.vue.spec.js
+++ b/src/tests/unit/components/MessageHTMLBody.vue.spec.js
@@ -39,6 +39,17 @@ describe('MessageHTMLBody', () => {
 		...modifiers,
 	})
 
+	describe('iframe sandbox', () => {
+		it('allows scripts so the injected resizer can size the frame', () => {
+			const view = mountBody()
+
+			const sandbox = view.vm.$refs.iframe.getAttribute('sandbox').split(' ')
+
+			expect(sandbox).toContain('allow-scripts')
+			expect(sandbox).toContain('allow-same-origin')
+		})
+	})
+
 	describe('print shortcut', () => {
 		it('takes the shortcut from inside the frame, where the app window cannot see it', () => {
 			const view = mountBody()


### PR DESCRIPTION
PR #13088 sandboxed the message-body iframe without allow-scripts, which stopped the server-injected iframe-resizer child from running. Without it the parent never learns the content height and the body collapses to a minimal size. The frame is same-origin and its content is server-sanitized under a self+nonce CSP, so re-enabling scripts only runs the app's own trusted resizer while the sandbox still blocks forms, modals and top-navigation.

Fixes #13527

Assisted-by: Claude:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
