### PR TITLE
fix(migration): heal legacy non-bool appconfig values

### DIFF
--- a/lib/Migration/Version5120Date20260820000000.php
+++ b/lib/Migration/Version5120Date20260820000000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCA\Mail\ConfigLexicon;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Heal appconfig keys that switched to typed BOOL storage in the config lexicon
+ * but may still hold a legacy value of a different type in the database, e.g. a
+ * string 'yes'/'no' written by `occ config:app:set` before the lexicon existed
+ * (its --type defaults to string). Reading such a value via getValueBool()
+ * raises an AppConfigTypeConflictException and takes down the whole app.
+ *
+ * @psalm-api
+ */
+class Version5120Date20260820000000 extends SimpleMigrationStep {
+	private const BOOL_KEYS = [
+		ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS,
+		ConfigLexicon::LLM_PROCESSING,
+		ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT,
+		ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT,
+	];
+
+	public function __construct(
+		private IAppConfig $appConfig,
+	) {
+	}
+
+	#[Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$values = $this->appConfig->getAllAppValues();
+		foreach (self::BOOL_KEYS as $key) {
+			if (!array_key_exists($key, $values)) {
+				continue;
+			}
+
+			$enabled = (bool)$values[$key];
+			$this->appConfig->deleteAppValue($key);
+			$this->appConfig->setAppValueBool($key, $enabled);
+		}
+	}
+}

--- a/tests/Unit/Migration/Version5120Date20260820000000Test.php
+++ b/tests/Unit/Migration/Version5120Date20260820000000Test.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Migration;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\ConfigLexicon;
+use OCA\Mail\Migration\Version5120Date20260820000000;
+use OCP\AppFramework\Services\IAppConfig;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class Version5120Date20260820000000Test extends TestCase {
+
+	private IAppConfig&MockObject $appConfig;
+	private IOutput&MockObject $output;
+	private Version5120Date20260820000000 $migration;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->output = $this->createMock(IOutput::class);
+		$this->migration = new Version5120Date20260820000000($this->appConfig);
+	}
+
+	public function testHealsPresentBoolKeys(): void {
+		$this->appConfig->method('getAllAppValues')
+			->willReturn([
+				ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS => true,
+				ConfigLexicon::LLM_PROCESSING => false,
+				ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT => false,
+				ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT => true,
+			]);
+
+		$this->appConfig->expects(self::exactly(4))
+			->method('deleteAppValue')
+			->withConsecutive(
+				[ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS],
+				[ConfigLexicon::LLM_PROCESSING],
+				[ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT],
+				[ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT],
+			);
+		$this->appConfig->expects(self::exactly(4))
+			->method('setAppValueBool')
+			->withConsecutive(
+				[ConfigLexicon::ALLOW_NEW_MAIL_ACCOUNTS, true],
+				[ConfigLexicon::LLM_PROCESSING, false],
+				[ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT, false],
+				[ConfigLexicon::INDEX_CONTEXT_CHAT_DEFAULT, true],
+			);
+
+		$this->migration->postSchemaChange($this->output, fn () => $this->createMock(ISchemaWrapper::class), []);
+	}
+
+	public function testOnlyHealsPresentKeys(): void {
+		$this->appConfig->method('getAllAppValues')
+			->willReturn([
+				ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT => false,
+				ConfigLexicon::LAYOUT_MESSAGE_VIEW => 'threaded',
+			]);
+
+		$this->appConfig->expects(self::once())
+			->method('deleteAppValue')
+			->with(ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT);
+		$this->appConfig->expects(self::once())
+			->method('setAppValueBool')
+			->with(ConfigLexicon::IMPORTANCE_CLASSIFICATION_DEFAULT, false);
+
+		$this->migration->postSchemaChange($this->output, fn () => $this->createMock(ISchemaWrapper::class), []);
+	}
+
+	public function testDoesNothingWhenNoKeysPresent(): void {
+		$this->appConfig->method('getAllAppValues')
+			->willReturn([
+				ConfigLexicon::LAYOUT_MESSAGE_VIEW => 'threaded',
+			]);
+
+		$this->appConfig->expects(self::never())
+			->method('deleteAppValue');
+		$this->appConfig->expects(self::never())
+			->method('setAppValueBool');
+
+		$this->migration->postSchemaChange($this->output, fn () => $this->createMock(ISchemaWrapper::class), []);
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/mail/issues/13537

The config lexicon declared allow_new_mail_accounts, llm_processing, importance_classification_default and index_context_chat_default as BOOL and switched reads to getValueBool(). Instances that set one of these before the lexicon existed (e.g. `occ config:app:set` defaults --type to string) have the value stored as STRING, so getValueBool() throws AppConfigTypeConflictException and the whole app fails to load.

Kind-of regression of https://github.com/nextcloud/mail/pull/13342.

Rewrite any present legacy value with the correct BOOL type on upgrade, reading through getAllAppValues() which tolerates the old type.

Assisted-by: Claude:claude-opus-4-8

## How to test

1. Check out main
2. ``php occ config:app:set mail importance_classification_default --value no``
3. ``php occ config:app:set mail importance_classification_default --value no --type string``
4. Open `/apps/mail`

This will cause a hard error. Check out this branch and upgrade. The error will be resolved.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
