### PR TITLE
fix(psalm): resolve type issues ahead of the Psalm 6 upgrade

### DIFF
--- a/lib/Http/JsonResponse.php
+++ b/lib/Http/JsonResponse.php
@@ -40,7 +40,7 @@ class JsonResponse extends Base {
 	 * @param array|JsonSerializable|bool|string $data
 	 * @param Http::STATUS_* $status
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function success($data = null,
 		int $status = Http::STATUS_OK): self {
@@ -57,7 +57,7 @@ class JsonResponse extends Base {
 	 * @param array|JsonSerializable|bool|string $data
 	 * @param Http::STATUS_* $status
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function fail($data = null,
 		int $status = Http::STATUS_BAD_REQUEST): self {
@@ -85,7 +85,7 @@ class JsonResponse extends Base {
 	 * @param Http::STATUS_* $status
 	 * @param array|JsonSerializable|bool|string $data
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function error(string $message,
 		int $status = Http::STATUS_INTERNAL_SERVER_ERROR,

--- a/lib/Listener/InteractionListener.php
+++ b/lib/Listener/InteractionListener.php
@@ -55,7 +55,7 @@ class InteractionListener implements IEventListener {
 		}
 		$message = $event->getLocalMessage();
 		$emails = [];
-		foreach ($message->getRecipients() as $recipient) {
+		foreach ($message->getRecipients() ?? [] as $recipient) {
 			if (in_array($recipient->getEmail(), $emails)) {
 				continue;
 			}

--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -17,7 +17,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 
 /**
- * @template-implements IEventListener<Event|OptionalIndicesListener>
+ * @template-implements IEventListener<AddMissingIndicesEvent>
  */
 class OptionalIndicesListener implements IEventListener {
 

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -38,7 +38,7 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 		$this->connection = $connection;
 
 		$tempBaseDir = $tempManager->getTempBaseDir();
-		$this->backupPath = tempnam($tempBaseDir, 'mail_recipients_backup');
+		$this->backupPath = (string)tempnam($tempBaseDir, 'mail_recipients_backup');
 	}
 
 	/**


### PR DESCRIPTION
Extracts behaviour-preserving type fixes from the Psalm 6 bump (#11224) so the eventual version bump stays small: align JsonResponse factory return docblocks with their self return type, null-guard the recipient iteration in InteractionListener, correct the OptionalIndicesListener event template, and cast the tempnam() result in the 1130 migration.

Pure Psalm suppressions and the version/baseline changes stay with the bump PR.

Assisted-by: Claude:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
