### PR TITLE
ci(test): skip PHP unit/integration tests on non-backend PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,13 +6,43 @@ on: pull_request
 permissions:
   contents: read
 
+concurrency:
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   E2E_NODE_VERSION: "20"
   STALWART_PWD: "secretpassword"
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.changes.outputs.backend }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            backend:
+              - '.github/workflows/**'
+              - 'appinfo/**'
+              - 'lib/**'
+              - 'templates/**'
+              - 'tests/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - 'composer.json'
+              - 'composer.lock'
+
   unit-tests:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.backend != 'false'
     strategy:
       matrix:
         php-versions: ['8.5']
@@ -66,6 +96,8 @@ jobs:
 
   integration-tests:
       runs-on: ubuntu-latest
+      needs: changes
+      if: needs.changes.outputs.backend != 'false'
       strategy:
           matrix:
               php-versions: ['8.4']


### PR DESCRIPTION
Gate the PHP unit and integration matrices behind a dorny/paths-filter "backend" check so frontend-only, CSS-only, and doc-only PRs no longer trigger the ~55-minute integration matrix. Frontend unit and e2e tests still run on every PR since either stack can break them. Also add a concurrency group so superseded runs are cancelled.

The test-summary status check already tolerates skipped jobs, so the required branch-protection context is unaffected.

Assisted-by: Claude:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
