### PR TITLE
fix: the draft resets when you click outside

### DIFF
--- a/src/components/Composer.vue
+++ b/src/components/Composer.vue
@@ -1059,10 +1059,6 @@ export default {
 	},
 
 	watch: {
-		'$route.params.threadId': function() {
-			this.reset()
-		},
-
 		allRecipients() {
 			this.checkRecipientsKeys()
 		},


### PR DESCRIPTION

This pr fixes the issue that when you start typing in the composer, and then you open a mail, or click somewhere outside the floating composer, the draft is removed/cleared. 

Removing leftover code from when we used the modal composer.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
