### PR TITLE
fix: mail printing with hidden images

### DIFF
--- a/lib/Service/HtmlPurify/TransformImageSrc.php
+++ b/lib/Service/HtmlPurify/TransformImageSrc.php
@@ -58,6 +58,9 @@ class TransformImageSrc extends HTMLPurifier_AttrTransform {
 		$url = $this->parser->parse($attr['src']);
 		if ($url->host === Util::getServerHostName() && $url->path === $this->urlGenerator->linkToRoute('mail.proxy.proxy')) {
 			$attr['data-original-src'] = $attr['src'];
+			if (isset($attr['style'])) {
+				$attr['data-original-style'] = $attr['style'];
+			}
 			$attr['src'] = $this->urlGenerator->imagePath('mail', 'blocked-image.png');
 			$attr = $this->setDisplayNone($attr);
 		}
@@ -65,17 +68,22 @@ class TransformImageSrc extends HTMLPurifier_AttrTransform {
 	}
 
 	/**
+	 * Hide a blocked image, keeping the rest of its style attribute.
+	 *
+	 * The declaration is appended rather than prepended, and marked important,
+	 * because an email's own style attribute commonly carries a `display` of its
+	 * own: a prepended `display: none` loses to it, and the 1x1 placeholder is
+	 * then laid out at the image's `width` attribute as a blank square the size
+	 * of the image that was blocked.
+	 *
 	 * @param array $attr
 	 * @return array
-	 *
-	 * Sets html attribute style="display: none;", keeps old style
-	 * attributes
 	 */
 	private function setDisplayNone(array $attr): array {
 		if (isset($attr['style'])) {
-			$attr['style'] = 'display: none;' . $attr['style']; // the space is important for jquery!
+			$attr['style'] = rtrim($attr['style'], "; \t\n\r") . '; display: none !important;';
 		} else {
-			$attr['style'] = 'display: none;';
+			$attr['style'] = 'display: none !important;';
 		}
 		return $attr;
 	}

--- a/lib/Service/HtmlPurify/TransformStyleURLs.php
+++ b/lib/Service/HtmlPurify/TransformStyleURLs.php
@@ -64,7 +64,12 @@ class TransformStyleURLs extends HTMLPurifier_AttrTransform {
 
 		// Replace style if required
 		if ($newStyle !== $attr['style']) {
-			$attr['data-original-style'] = $attr['style'];
+			// An img has already been through TransformImageSrc, which saves the
+			// untouched style and then hides the image. Overwriting that backup
+			// would bake the hiding into what "Show images" restores.
+			if (!isset($attr['data-original-style'])) {
+				$attr['data-original-style'] = $attr['style'];
+			}
 			$attr['style'] = $newStyle;
 		}
 

--- a/tests/Unit/Service/HtmlPurify/TransformImageSrcTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformImageSrcTest.php
@@ -15,6 +15,7 @@ use HTMLPurifier_Context;
 use HTMLPurifier_Token_Start;
 use OCA\Mail\Service\HtmlPurify\TransformImageSrc;
 use OCP\IURLGenerator;
+use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class TransformImageSrcTest extends TestCase {
@@ -126,7 +127,7 @@ class TransformImageSrcTest extends TestCase {
 
 		$result = $this->transform->transform($attr, $config, $context);
 
-		$this->assertStringContainsString('display: none;', $result['style']);
+		$this->assertStringContainsString('display: none !important;', $result['style']);
 		$this->assertStringContainsString('margin: 10px;', $result['style']);
 	}
 
@@ -144,7 +145,7 @@ class TransformImageSrcTest extends TestCase {
 
 		$result = $this->transform->transform($attr, $config, $context);
 
-		$this->assertSame('display: none;', $result['style']);
+		$this->assertSame('display: none !important;', $result['style']);
 	}
 
 	public function testOnlyHeightSmall(): void {
@@ -158,5 +159,67 @@ class TransformImageSrcTest extends TestCase {
 
 		$this->assertSame('https://example.com/pixel.png', $result['src']);
 		$this->assertFalse(isset($result['style']));
+	}
+
+	public function testTrackingPixelStyleNotBackedUp(): void {
+		$attr = ['src' => 'https://example.com/pixel.png', 'width' => '1', 'height' => '1', 'style' => 'margin: 10px;'];
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+		$token = new HTMLPurifier_Token_Start('img');
+		$context->register('CurrentToken', $token);
+
+		$this->urlGenerator->method('imagePath')->willReturn('/apps/mail/img/blocked-image.png');
+
+		$result = $this->transform->transform($attr, $config, $context);
+
+		$this->assertArrayNotHasKey('data-original-style', $result);
+	}
+
+	public function testBlockedImageHidingBeatsOwnDisplay(): void {
+		$attr = ['src' => $this->proxySrc(), 'width' => '221', 'style' => 'width:221px;display:block;'];
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+		$token = new HTMLPurifier_Token_Start('img');
+		$context->register('CurrentToken', $token);
+
+		$result = $this->transform->transform($attr, $config, $context);
+
+		$this->assertSame('width:221px;display:block; display: none !important;', $result['style']);
+	}
+
+	public function testBlockedImageBacksUpOriginalStyle(): void {
+		$attr = ['src' => $this->proxySrc(), 'style' => 'width:221px;display:block;'];
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+		$token = new HTMLPurifier_Token_Start('img');
+		$context->register('CurrentToken', $token);
+
+		$result = $this->transform->transform($attr, $config, $context);
+
+		$this->assertSame('width:221px;display:block;', $result['data-original-style']);
+	}
+
+	public function testBlockedImageWithoutStyleHasNoBackup(): void {
+		$attr = ['src' => $this->proxySrc()];
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+		$token = new HTMLPurifier_Token_Start('img');
+		$context->register('CurrentToken', $token);
+
+		$result = $this->transform->transform($attr, $config, $context);
+
+		$this->assertArrayNotHasKey('data-original-style', $result);
+		$this->assertSame('display: none !important;', $result['style']);
+	}
+
+	private function proxySrc(): string {
+		$this->urlGenerator->method('linkToRoute')
+			->with('mail.proxy.proxy')
+			->willReturn('/index.php/apps/mail/proxy');
+		$this->urlGenerator->method('imagePath')
+			->with('mail', 'blocked-image.png')
+			->willReturn('/apps/mail/img/blocked-image.png');
+
+		return 'https://' . Util::getServerHostName() . '/index.php/apps/mail/proxy?id=1&src=x';
 	}
 }

--- a/tests/Unit/Service/HtmlPurify/TransformStyleURLsTest.php
+++ b/tests/Unit/Service/HtmlPurify/TransformStyleURLsTest.php
@@ -195,4 +195,21 @@ class TransformStyleURLsTest extends TestCase {
 		$this->assertStringContainsString('/apps/mail/img/blocked-image.png', $result['style']);
 		$this->assertStringNotContainsString('http://example.com/1.png', $result['style']);
 	}
+
+	public function testExistingOriginalStyleBackupKept(): void {
+		$attr = [
+			'style' => 'background-image: url(http://example.com/image.jpg); display: none !important;',
+			'data-original-style' => 'background-image: url(http://example.com/image.jpg);',
+		];
+		$config = HTMLPurifier_Config::createDefault();
+		$context = new HTMLPurifier_Context();
+
+		$this->urlGenerator->method('imagePath')
+			->with('mail', 'blocked-image.png')
+			->willReturn('/apps/mail/img/blocked-image.png');
+
+		$result = $this->transform->transform($attr, $config, $context);
+
+		$this->assertSame('background-image: url(http://example.com/image.jpg);', $result['data-original-style']);
+	}
 }


### PR DESCRIPTION
Makes images take up no height or width when blocked

| Before | After |
| - | - |
| <img width="854" height="1118" alt="image" src="https://github.com/user-attachments/assets/ac4330da-54f6-4078-8da5-542b5d14fb05" /> | <img width="899" height="1122" alt="image" src="https://github.com/user-attachments/assets/73912919-6001-4f69-8368-06d207cd739d" /> |

For example it made this email go from 7 pages of white blanks from where images were to 2 pages

Keep in mind this also affects the rendering of emails in the mail app, however I think it is also an advantage there, less scrolling

Downside: breaks some super specific layouts, but those are rare

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
