### PR TITLE
ci(test): run e2e tests only when back- or frontend changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,14 @@ jobs:
               - 'tests/**'
               - 'vendor/**'
               - 'vendor-bin/**'
+              - 'composer/**'
               - 'composer.json'
               - 'composer.lock'
+              - '.patches/**'
+              - 'patches.json'
+              - 'patches.lock.json'
+              - 'resources/**'
+              - 'img/**'
             frontend:
               - '.github/workflows/**'
               - 'src/**'
@@ -49,6 +55,8 @@ jobs:
               - 'babel.config.js'
               - 'webpack.*.js'
               - 'playwright.config.js'
+              - 'css/**'
+              - 'img/**'
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,6 +303,8 @@ jobs:
 
   matrix:
     runs-on: ubuntu-latest-low
+    needs: changes
+    if: needs.changes.outputs.backend != 'false' || needs.changes.outputs.frontend != 'false'
     outputs:
       php-min: ${{ steps.versions.outputs.php-min }}
       branches-min: ${{ steps.versions.outputs.branches-min }}
@@ -316,7 +318,8 @@ jobs:
   frontend-e2e-tests:
     runs-on: ubuntu-latest
     name: Front-end E2E tests
-    needs: matrix
+    needs: [changes, matrix]
+    if: needs.changes.outputs.backend != 'false' || needs.changes.outputs.frontend != 'false'
     steps:
       - name: Set up Nextcloud env
         uses: nextcloud/setup-server-action@34b73d5b0e3633f83a52227d00cc2a6c41d01d9a # v1.0.0


### PR DESCRIPTION
Follow-up to #13584. The e2e suite builds the frontend and exercises it against the PHP backend, so gate it on the union of the backend and frontend path filters: it runs whenever either stack changes and is skipped only for PRs that touch neither (docs, l10n, images). The matrix helper job, which exists solely to feed e2e, is gated on the same condition.

Assisted-by: Claude:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
