### PR TITLE
ci(codecov): carry forward coverage for skipped test flags

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,12 @@ coverage:
         target: auto
         flags:
           - integrationtests
+flag_management:
+  individual_flags:
+    - name: unittests
+      carryforward: true
+    - name: integrationtests
+      carryforward: true
 ignore:
   - "tests"
   - "lib/Vendor"


### PR DESCRIPTION
Since the test jobs are gated on path filters, PRs that touch only the frontend (or neither stack) skip the backend unit/integration jobs, so no unittests/integrationtests coverage is uploaded. Codecov then never posts the required project/unit and project/integration statuses and the PR is stuck waiting for them (e.g. #13492).

Enable carryforward for both flags so Codecov reuses the parent commit's coverage when a flag is not uploaded, letting the statuses resolve instead of hanging.

Assisted-by: Claude:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
