### PR TITLE
ci(codecov): pass coverage checks when tests are skipped

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -391,6 +391,20 @@ jobs:
     env:
       CI: true
 
+  codecov-empty:
+    runs-on: ubuntu-latest-low
+    needs: changes
+    if: needs.changes.outputs.backend == 'false'
+    name: codecov-empty-upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Send empty Codecov upload so required coverage checks pass
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: empty-upload
+
   summary:
     runs-on: ubuntu-latest-low
     needs:

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,3 +15,6 @@ coverage:
 ignore:
   - "tests"
   - "lib/Vendor"
+  - "src"
+  - "css"
+  - "img"


### PR DESCRIPTION
Path-filtered test gating skips the backend unit/integration jobs on PRs that do not touch PHP, so no coverage is uploaded and Codecov's required `project/unit`/`project/integration` statuses never post — the PR gets stuck (e.g. #13492).

This runs Codecov's `empty-upload` from a dedicated job when the backend jobs are skipped, so Codecov processes the commit and marks the coverage statuses as passing. `empty-upload` only passes when every changed file is Codecov-ignored, so the non-PHP source paths (`src`, `css`, `img`) are added to the ignore list.

Replaces #13595 (carryforward doesn't help the zero-upload case).

_Drafted with AI assistance (Claude Code, Opus 4.8) — maintainer to review/reword._