### PR TITLE
test: improve tests around messages deletion functionality

### DIFF
--- a/tests/Unit/Job/TrashRetentionJobTest.php
+++ b/tests/Unit/Job/TrashRetentionJobTest.php
@@ -22,7 +22,6 @@ use OCA\Mail\Db\Message;
 use OCA\Mail\Db\MessageMapper;
 use OCA\Mail\Db\MessageRetentionMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
-use OCA\Mail\Service\Sync\SyncService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -56,9 +55,6 @@ class TrashRetentionJobTest extends TestCase {
 	/** @var IMailManager|MockObject */
 	private $mailManager;
 
-	/** @var SyncService|MockObject */
-	private $syncService;
-
 	private TrashRetentionJob $job;
 
 	protected function setUp(): void {
@@ -72,7 +68,6 @@ class TrashRetentionJobTest extends TestCase {
 		$this->accountMapper = $this->createMock(MailAccountMapper::class);
 		$this->mailboxMapper = $this->createMock(MailboxMapper::class);
 		$this->mailManager = $this->createMock(IMailManager::class);
-		$this->syncService = $this->createMock(SyncService::class);
 
 		$this->job = new TrashRetentionJob(
 			$this->timeFactory,
@@ -83,7 +78,6 @@ class TrashRetentionJobTest extends TestCase {
 			$this->accountMapper,
 			$this->mailboxMapper,
 			$this->mailManager,
-			$this->syncService,
 		);
 	}
 
@@ -106,8 +100,6 @@ class TrashRetentionJobTest extends TestCase {
 			->method('findById')
 			->with(42)
 			->willReturn($trash);
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->timeFactory->expects($this->once())
 			->method('getTime')
 			->willReturn(1000000);
@@ -134,8 +126,6 @@ class TrashRetentionJobTest extends TestCase {
 		$this->accountMapper->expects($this->once())
 			->method('getAllAccounts')
 			->willReturn([$dbAccount]);
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->mailManager->expects($this->never())
 			->method('deleteMessageWithClient');
 
@@ -149,8 +139,6 @@ class TrashRetentionJobTest extends TestCase {
 		$this->accountMapper->expects($this->once())
 			->method('getAllAccounts')
 			->willReturn([$dbAccount]);
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->mailManager->expects($this->never())
 			->method('deleteMessageWithClient');
 
@@ -164,8 +152,6 @@ class TrashRetentionJobTest extends TestCase {
 		$this->accountMapper->expects($this->once())
 			->method('getAllAccounts')
 			->willReturn([$dbAccount]);
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->mailManager->expects($this->never())
 			->method('deleteMessageWithClient');
 
@@ -182,8 +168,6 @@ class TrashRetentionJobTest extends TestCase {
 			->willReturn([$dbAccount]);
 		$this->mailboxMapper->expects($this->never())
 			->method('findById');
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->mailManager->expects($this->never())
 			->method('deleteMessageWithClient');
 
@@ -202,10 +186,50 @@ class TrashRetentionJobTest extends TestCase {
 			->method('findById')
 			->with(42)
 			->willThrowException(new DoesNotExistException('Mailbox 42 does not exist'));
-		$this->syncService->expects($this->never())
-			->method('syncMailbox');
 		$this->mailManager->expects($this->never())
 			->method('deleteMessageWithClient');
+
+		$this->job->run(self::ARGUMENT);
+	}
+
+	public function testRunRetentionCleanupCalledAfterDelete() {
+		$dbAccount = new MailAccount();
+		$dbAccount->setTrashRetentionDays(60);
+		$dbAccount->setTrashMailboxId(42);
+		$dbAccount->setUserId('user');
+		$account = new Account($dbAccount);
+		$trash = new Mailbox();
+		$message1 = new Message();
+		$message1->setMailboxId(123);
+		$message1->setUid(420);
+		$message2 = new Message();
+		$message2->setMailboxId(124);
+		$message2->setUid(421);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+
+		$this->accountMapper->expects($this->once())
+			->method('getAllAccounts')
+			->willReturn([$dbAccount]);
+		$this->mailboxMapper->expects($this->once())
+			->method('findById')
+			->with(42)
+			->willReturn($trash);
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(1000000);
+		$this->messageMapper->expects($this->once())
+			->method('findMessagesKnownSinceBefore')
+			->with(42, 1000000 - 24 * 60 * 3600)
+			->willReturn([$message1, $message2]);
+		$this->clientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$this->mailManager->expects($this->exactly(2))
+			->method('deleteMessageWithClient');
+		$this->messageRetentionMapper->expects($this->exactly(2))
+			->method('deleteByMailboxIdAndUid');
+		$client->expects($this->once())
+			->method('logout');
 
 		$this->job->run(self::ARGUMENT);
 	}

--- a/tests/Unit/Service/MailManagerTest.php
+++ b/tests/Unit/Service/MailManagerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Mail\Tests\Unit\Service;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use Horde_Imap_Client_Exception;
 use Horde_Imap_Client_Socket;
 use OCA\Mail\Account;
 use OCA\Mail\Attachment;
@@ -22,8 +23,10 @@ use OCA\Mail\Db\MessageTagsMapper;
 use OCA\Mail\Db\Tag;
 use OCA\Mail\Db\TagMapper;
 use OCA\Mail\Db\ThreadMapper;
+use OCA\Mail\Events\BeforeMessageDeletedEvent;
 use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\ServiceException;
+use OCA\Mail\Exception\TrashMailboxNotSetException;
 use OCA\Mail\Folder;
 use OCA\Mail\IMAP\FolderMapper;
 use OCA\Mail\IMAP\IMAPClientFactory;
@@ -273,6 +276,117 @@ class MailManagerTest extends TestCase {
 			$account,
 			'Trash',
 			123
+		);
+	}
+
+	public function testDeleteMessageTrashMailboxIdNull(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setTrashMailboxId(null);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$mailbox = new Mailbox();
+		$mailbox->setName('INBOX');
+		$this->mailboxMapper->expects($this->once())
+			->method('find')
+			->with($account, 'INBOX')
+			->willReturn($mailbox);
+		$client = $this->createMock(Horde_Imap_Client_Socket::class);
+		$this->imapClientFactory->expects($this->once())
+			->method('getClient')
+			->willReturn($client);
+		$client->expects($this->once())
+			->method('logout');
+		$this->expectException(TrashMailboxNotSetException::class);
+
+		$this->manager->deleteMessage(
+			$account,
+			'INBOX',
+			123
+		);
+	}
+
+	public function testDeleteMessageWithClientTrashMailboxIdNull(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setTrashMailboxId(null);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$mailbox = new Mailbox();
+		$mailbox->setName('INBOX');
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(fn ($event) => $event instanceof BeforeMessageDeletedEvent));
+		$this->imapMessageMapper->expects($this->never())
+			->method('expunge');
+		$this->imapMessageMapper->expects($this->never())
+			->method('move');
+		$this->expectException(TrashMailboxNotSetException::class);
+
+		$this->manager->deleteMessageWithClient(
+			$account,
+			$mailbox,
+			123,
+			$client
+		);
+	}
+
+	public function testDeleteMessageWithClientExpungeThrowsException(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setTrashMailboxId(123);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$trash = new Mailbox();
+		$trash->setName('Trash');
+		$source = new Mailbox();
+		$source->setName('Trash');
+		$this->mailboxMapper->expects($this->once())
+			->method('findById')
+			->with(123)
+			->willReturn($trash);
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$this->imapMessageMapper->expects($this->once())
+			->method('expunge')
+			->willThrowException(new Horde_Imap_Client_Exception('expunge failed'));
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(fn ($event) => $event instanceof BeforeMessageDeletedEvent));
+		$this->expectException(Horde_Imap_Client_Exception::class);
+
+		$this->manager->deleteMessageWithClient(
+			$account,
+			$source,
+			123,
+			$client
+		);
+	}
+
+	public function testDeleteMessageWithClientMoveThrowsException(): void {
+		$account = $this->createMock(Account::class);
+		$mailAccount = new MailAccount();
+		$mailAccount->setTrashMailboxId(123);
+		$account->method('getMailAccount')->willReturn($mailAccount);
+		$trash = new Mailbox();
+		$trash->setName('Trash');
+		$inbox = new Mailbox();
+		$inbox->setName('INBOX');
+		$this->mailboxMapper->expects($this->once())
+			->method('findById')
+			->with(123)
+			->willReturn($trash);
+		$client = $this->createStub(Horde_Imap_Client_Socket::class);
+		$this->imapMessageMapper->expects($this->once())
+			->method('move')
+			->willThrowException(new Horde_Imap_Client_Exception('move failed'));
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->callback(fn ($event) => $event instanceof BeforeMessageDeletedEvent));
+		$this->expectException(Horde_Imap_Client_Exception::class);
+
+		$this->manager->deleteMessageWithClient(
+			$account,
+			$inbox,
+			123,
+			$client
 		);
 	}
 
@@ -781,6 +895,10 @@ class MailManagerTest extends TestCase {
 			->method('findById')
 			->with($trashMailbox->getId())
 			->willReturn($trashMailbox);
+		$this->imapClientFactory
+			->expects(self::exactly(2))
+			->method('getClient')
+			->willReturn($this->createStub(Horde_Imap_Client_Socket::class));
 		$this->imapMessageMapper
 			->expects(self::exactly(2))
 			->method('move');
@@ -824,9 +942,70 @@ class MailManagerTest extends TestCase {
 				['messageUid' => 200, 'mailboxName' => 'Trash'],
 				['messageUid' => 300, 'mailboxName' => 'Trash'],
 			]);
+		$this->imapClientFactory
+			->expects(self::exactly(2))
+			->method('getClient')
+			->willReturn($this->createStub(Horde_Imap_Client_Socket::class));
 		$this->imapMessageMapper
 			->expects(self::exactly(2))
 			->method('expunge');
+		$this->eventDispatcher
+			->expects(self::exactly(4))
+			->method('dispatchTyped');
+
+		$this->manager->deleteThread(
+			$account,
+			$mailbox,
+			$threadRootId
+		);
+	}
+
+	public function testDeleteThreadMessagesInDifferentMailboxes(): void {
+		$threadRootId = 'some-thread-root-id-1';
+		$mailAccount = new MailAccount();
+		$mailAccount->setId(1);
+		$mailAccount->setTrashMailboxId(80);
+		$account = new Account($mailAccount);
+		$mailbox = new Mailbox();
+		$mailbox->setId(20);
+		$mailbox->setAccountId($mailAccount->getId());
+		$mailbox->setName('INBOX');
+		$this->threadMapper
+			->expects(self::once())
+			->method('findMessageUidsAndMailboxNamesByAccountAndThreadRoot')
+			->with($mailAccount, $threadRootId, false)
+			->willReturn([
+				['messageUid' => 200, 'mailboxName' => 'INBOX'],
+				['messageUid' => 300, 'mailboxName' => 'Sent'],
+			]);
+		$inbox = new Mailbox();
+		$inbox->setId(20);
+		$inbox->setName('INBOX');
+		$sent = new Mailbox();
+		$sent->setId(40);
+		$sent->setName('Sent');
+		$this->mailboxMapper
+			->expects(self::exactly(2))
+			->method('find')
+			->willReturnMap([
+				[$account, 'INBOX', $inbox],
+				[$account, 'Sent', $sent],
+			]);
+		$trash = new Mailbox();
+		$trash->setId(80);
+		$trash->setName('Trash');
+		$this->mailboxMapper
+			->expects(self::exactly(2))
+			->method('findById')
+			->with(80)
+			->willReturn($trash);
+		$this->imapClientFactory
+			->expects(self::exactly(2))
+			->method('getClient')
+			->willReturn($this->createStub(Horde_Imap_Client_Socket::class));
+		$this->imapMessageMapper
+			->expects(self::exactly(2))
+			->method('move');
 		$this->eventDispatcher
 			->expects(self::exactly(4))
 			->method('dispatchTyped');


### PR DESCRIPTION
Improve some tests regarding messages deletion:
- Remove unused `SyncService` dependency from `TrashRetentionJobTest`. It never existed in the actual `TrashRetentionJob`
- Test that `MessageRetentionMapper::deleteByMailboxIdAndUid` is called after each message deletion in `TrashRetentionJob::run`
- Add edge cases tests for `MailManager::deleteMessage()` and `MailManager::deleteMessageWithClient()`
- Add validation for `MailManager::deleteThread()` correctly handling messages from different mailboxes in the same thread


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for message deletion, including messages across different mailboxes.
  * Added verification for trash-mailbox configuration, client logout, deletion events, and retention cleanup.
  * Added coverage for handling IMAP errors during message expunging and moving.
  * Improved validation of thread deletion and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->