### PR TITLE
perf(internal-address): prefix userId in the idx

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -34,7 +34,7 @@ The rating depends on the installed text processing backend. See [the rating ove
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 	]]></description>
-	<version>5.12.0-beta.2</version>
+	<version>5.12.0-beta.3</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/ChristophWurst">Christoph Wurst</author>
 	<author homepage="https://github.com/GretaD">GretaD</author>

--- a/lib/Migration/Version5120Date20260901000000.php
+++ b/lib/Migration/Version5120Date20260901000000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * @psalm-api
+ */
+class Version5120Date20260901000000 extends SimpleMigrationStep {
+	private const OLD_INDEX = 'mail_internal_address_uniq';
+	private const NEW_INDEX = 'mail_int_addr_uid_addr_uidx';
+
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('mail_internal_address')) {
+			return null;
+		}
+
+		$table = $schema->getTable('mail_internal_address');
+		if ($table->hasIndex(self::NEW_INDEX)) {
+			return null;
+		}
+
+		$table->addUniqueIndex(['user_id', 'address'], self::NEW_INDEX);
+		if ($table->hasIndex(self::OLD_INDEX)) {
+			$table->dropIndex(self::OLD_INDEX);
+		}
+
+		return $schema;
+	}
+}

--- a/tests/Integration/Db/InternalAddressMapperTest.php
+++ b/tests/Integration/Db/InternalAddressMapperTest.php
@@ -12,6 +12,7 @@ namespace OCA\Mail\Tests\Integration\Db;
 use ChristophWurst\Nextcloud\Testing\DatabaseTransaction;
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use ChristophWurst\Nextcloud\Testing\TestUser;
+use OCA\Mail\Db\InternalAddress;
 use OCA\Mail\Db\InternalAddressMapper;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -203,8 +204,8 @@ class InternalAddressMapperTest extends TestCase {
 
 		$results = $this->mapper->findAll($uid);
 
-		$this->assertCount(2, $results);
-		$this->assertEquals($results[0]->getAddress(), 'hamza@next.cloud');
-		$this->assertEquals($results[1]->getAddress(), 'christoph@next.cloud');
+		$addresses = array_map(static fn (InternalAddress $a) => $a->getAddress(), $results);
+		sort($addresses);
+		$this->assertEquals(['christoph@next.cloud', 'hamza@next.cloud'], $addresses);
 	}
 }


### PR DESCRIPTION
Prefix uid from mail_internal_address_uniq to avoid full table scans from 
```
SELECT
  *
FROM
  `oc_mail_internal_address`
WHERE
  `user_id` = ?
```


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
