### PR TITLE
refactor(imap): revert getSource -> getRawMessage rename

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -231,7 +231,7 @@ return [
 			'verb' => 'GET'
 		],
 		[
-			'name' => 'messages#getRawMessage',
+			'name' => 'messages#getSource',
 			'url' => '/api/messages/{id}/source',
 			'verb' => 'GET'
 		],

--- a/lib/Controller/MessageApiController.php
+++ b/lib/Controller/MessageApiController.php
@@ -338,7 +338,7 @@ class MessageApiController extends OCSController {
 		}
 
 		try {
-			$source = $this->mailManager->getRawMessage(
+			$source = $this->mailManager->getSource(
 				$account,
 				$mailbox,
 				$message

--- a/lib/Controller/MessagesController.php
+++ b/lib/Controller/MessagesController.php
@@ -507,7 +507,7 @@ class MessagesController extends Controller {
 	 * @throws ServiceException
 	 */
 	#[TrapError]
-	public function getRawMessage(int $id): JSONResponse {
+	public function getSource(int $id): JSONResponse {
 		if ($this->userId === null) {
 			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
 		}
@@ -521,7 +521,7 @@ class MessagesController extends Controller {
 		}
 
 		$response = new JSONResponse([
-			'source' => $this->mailManager->getRawMessage(
+			'source' => $this->mailManager->getSource(
 				$account,
 				$mailbox,
 				$message
@@ -559,7 +559,7 @@ class MessagesController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$source = $this->mailManager->getRawMessage(
+		$source = $this->mailManager->getSource(
 			$account,
 			$mailbox,
 			$message
@@ -611,7 +611,7 @@ class MessagesController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$source = $this->mailManager->getRawMessage(
+		$source = $this->mailManager->getSource(
 			$account,
 			$mailbox,
 			$message

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -182,7 +182,7 @@ class MailManager {
 	 * @throws ClientException
 	 * @throws ServiceException
 	 */
-	public function getRawMessage(Account $account, Mailbox $mailbox, Message $message): ?string {
+	public function getSource(Account $account, Mailbox $mailbox, Message $message): ?string {
 		$raw = $this->protocolFactory
 			->messageConnector($account)
 			->fetchMessageRaw($account, $mailbox, $message);

--- a/tests/Integration/MailboxSynchronizationTest.php
+++ b/tests/Integration/MailboxSynchronizationTest.php
@@ -282,7 +282,7 @@ class MailboxSynchronizationTest extends TestCase {
 
 		// Receive unsolicited vanished uid
 		$message = $dbMessageMapper->findByUids($inbox, [$uid2])[0];
-		$mailManager->getRawMessage(
+		$mailManager->getSource(
 			new Account($this->account),
 			$inbox,
 			$message,

--- a/tests/Unit/Controller/MessagesControllerTest.php
+++ b/tests/Unit/Controller/MessagesControllerTest.php
@@ -1167,7 +1167,7 @@ class MessagesControllerTest extends TestCase {
 			->will($this->returnValue($this->account));
 		$source = file_get_contents(__DIR__ . '/../../data/mail-message-123.txt');
 		$this->mailManager->expects($this->exactly(1))
-			->method('getRawMessage')
+			->method('getSource')
 			->with($this->account, $mailbox, $message)
 			->willReturn($source);
 
@@ -1211,7 +1211,7 @@ class MessagesControllerTest extends TestCase {
 			->will($this->returnValue($this->account));
 		$source = file_get_contents(__DIR__ . '/../../data/mail-message-123.txt');
 		$this->mailManager->expects($this->exactly(1))
-			->method('getRawMessage')
+			->method('getSource')
 			->with($this->account, $mailbox, $message)
 			->willReturn($source);
 		$folderNode = $this->createStub(Folder::class);


### PR DESCRIPTION
Slimming down https://github.com/nextcloud/mail/pull/12800.

The rename touched the OCS route id (mail.messages.getSource -> ...getRawMessage) with no behavior change and no stated reason, unrelated to the JMAP protocol work. Restore the original name to drop this from the JMAP diff; the OCS route id and controller/service method name are back to what main already has.

Assisted-by: ClaudeCode:claude-opus-4-8

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
