### PR TITLE
refactor(imap): revert getMessagesByMessageId -> getByMessageId rename

### DIFF
--- a/lib/BackgroundJob/FollowUpClassifierJob.php
+++ b/lib/BackgroundJob/FollowUpClassifierJob.php
@@ -55,7 +55,7 @@ class FollowUpClassifierJob extends QueuedJob {
 			return;
 		}
 
-		$messages = $this->mailManager->getMessagesByMessageId($account, $messageId);
+		$messages = $this->mailManager->getByMessageId($account, $messageId);
 		$messages = array_filter(
 			$messages,
 			static fn (Message $message) => $message->getMailboxId() === $mailboxId,

--- a/lib/Service/MailManager.php
+++ b/lib/Service/MailManager.php
@@ -199,7 +199,7 @@ class MailManager {
 	/**
 	 * @return Message[]
 	 */
-	public function getMessagesByMessageId(Account $account, string $messageId): array {
+	public function getByMessageId(Account $account, string $messageId): array {
 		return $this->dbMessageMapper->findByMessageId($account, $messageId);
 	}
 
@@ -591,7 +591,7 @@ class MailManager {
 
 		foreach ($accounts as $account) {
 			try {
-				$messages = array_merge(... array_map(fn ($messageTag) => $this->getMessagesByMessageId($account, $messageTag->getImapMessageId()), array_values($messageTags)));
+				$messages = array_merge(... array_map(fn ($messageTag) => $this->getByMessageId($account, $messageTag->getImapMessageId()), array_values($messageTags)));
 			} catch (DoesNotExistException $e) {
 				throw new ClientException('Messages not found', 0, $e);
 			}

--- a/tests/Unit/Job/FollowUpClassifierJobTest.php
+++ b/tests/Unit/Job/FollowUpClassifierJobTest.php
@@ -99,7 +99,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::once())
@@ -142,7 +142,7 @@ class FollowUpClassifierJobTest extends TestCase {
 		$this->accountService->expects(self::never())
 			->method('find');
 		$this->mailManager->expects(self::never())
-			->method('getMessagesByMessageId');
+			->method('getByMessageId');
 		$this->threadMapper->expects(self::never())
 			->method('findNewerMessageIdsInThread');
 		$this->aiService->expects(self::never())
@@ -182,7 +182,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::never())
@@ -232,7 +232,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::once())
@@ -286,7 +286,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::once())
@@ -340,7 +340,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::once())
@@ -391,7 +391,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager->expects(self::once())
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn($messages);
 		$this->threadMapper->expects(self::once())
@@ -436,7 +436,7 @@ class FollowUpClassifierJobTest extends TestCase {
 			->with('user', 100)
 			->willReturn($account);
 		$this->mailManager
-			->method('getMessagesByMessageId')
+			->method('getByMessageId')
 			->with($account, '<message1@foo.bar>')
 			->willReturn([$message]);
 		$this->threadMapper


### PR DESCRIPTION
Slimming down github.com/nextcloud/mail/pull/12800.

Pure rename with no behavior or signature change, unrelated to the JMAP protocol work (flagged in review as noise). Restores the name main already uses.

Assisted-by: ClaudeCode:claude-opus-4-8



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
