### PR TITLE
fix(sieve): terminate installed scripts with CRLF

### DIFF
--- a/lib/Service/MailFilter/FilterBuilder.php
+++ b/lib/Service/MailFilter/FilterBuilder.php
@@ -16,6 +16,7 @@ use OCA\Mail\Sieve\SieveUtils;
 class FilterBuilder {
 	private const SEPARATOR = '### Nextcloud Mail: Filters ### DON\'T EDIT ###';
 	private const DATA_MARKER = '# FILTER: ';
+	/** @deprecated use SieveUtils::NEWLINE */
 	private const SIEVE_NEWLINE = "\r\n";
 
 	public function __construct(

--- a/lib/Service/SieveService.php
+++ b/lib/Service/SieveService.php
@@ -14,6 +14,7 @@ use OCA\Mail\Exception\ClientException;
 use OCA\Mail\Exception\CouldNotConnectException;
 use OCA\Mail\Sieve\NamedSieveScript;
 use OCA\Mail\Sieve\SieveClientFactory;
+use OCA\Mail\Sieve\SieveUtils;
 
 class SieveService {
 	public function __construct(
@@ -39,7 +40,7 @@ class SieveService {
 
 		// Sieve appends the script with a carriage return and line feed (\r\n) each time it's saved.
 		// Strip those line feeds to avoid the accumulation of unnecessary white space.
-		$script = rtrim($script, "\r\n");
+		$script = rtrim($script, SieveUtils::NEWLINE);
 
 		return new NamedSieveScript($scriptName, $script);
 	}
@@ -53,7 +54,12 @@ class SieveService {
 		$sieve = $this->getClient($userId, $accountId);
 
 		$scriptName = $sieve->getActive() ?? 'nextcloud';
-		$sieve->installScript($scriptName, $script, true);
+		$sieve->installScript($scriptName, $this->enforceTrailingNewline($script), true);
+	}
+
+	private function enforceTrailingNewline(string $script): string {
+		// RFC 5228 terminates every line with CRLF.
+		return rtrim($script, SieveUtils::NEWLINE) . SieveUtils::NEWLINE;
 	}
 
 	/**

--- a/lib/Sieve/SieveUtils.php
+++ b/lib/Sieve/SieveUtils.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace OCA\Mail\Sieve;
 
 class SieveUtils {
+	public const NEWLINE = "\r\n";
+
 	/**
 	 * Escape a string for use in a Sieve script
 	 *

--- a/tests/Unit/Service/SieveServiceTest.php
+++ b/tests/Unit/Service/SieveServiceTest.php
@@ -180,7 +180,7 @@ class SieveServiceTest extends TestCase {
 			->willReturn('nextcloud');
 		$client->expects(self::once())
 			->method('installScript')
-			->with('nextcloud', '# foo bar', true);
+			->with('nextcloud', "# foo bar\r\n", true);
 
 		$this->accountService->expects(self::once())
 			->method('find')
@@ -210,7 +210,7 @@ class SieveServiceTest extends TestCase {
 			->willReturn(null);
 		$client->expects(self::once())
 			->method('installScript')
-			->with('nextcloud', '# foo bar', true);
+			->with('nextcloud', "# foo bar\r\n", true);
 
 		$this->accountService->expects(self::once())
 			->method('find')
@@ -222,6 +222,36 @@ class SieveServiceTest extends TestCase {
 			->willReturn($client);
 
 		$this->sieveService->updateActiveScript('1', 2, '# foo bar');
+	}
+
+	public function testUpdateActiveScriptCollapsesTrailingNewlines(): void {
+		$mailAccount = new MailAccount();
+		$mailAccount->setSieveEnabled(true);
+		$mailAccount->setSieveHost('localhost');
+		$mailAccount->setSievePort(4190);
+		$mailAccount->setSieveUser('user');
+		$mailAccount->setSievePassword('password');
+		$mailAccount->setSieveSslMode('');
+		$account = new Account($mailAccount);
+
+		$client = $this->createMock(\Horde\ManageSieve::class);
+		$client->expects(self::once())
+			->method('getActive')
+			->willReturn('nextcloud');
+		$client->expects(self::once())
+			->method('installScript')
+			->with('nextcloud', "# foo bar\r\n", true);
+
+		$this->accountService->expects(self::once())
+			->method('find')
+			->with('1', 2)
+			->willReturn($account);
+		$this->sieveClientFactory->expects(self::once())
+			->method('getClient')
+			->with($account)
+			->willReturn($client);
+
+		$this->sieveService->updateActiveScript('1', 2, "# foo bar\r\n\r\n\r\n");
 	}
 
 	public function testUpdateActiveScriptNoSieve(): void {


### PR DESCRIPTION
## Summary

RFC 5228 ends every line, comments included, with CRLF.

Assisted-by: ClaudeCode:claude-opus-5

## Testing

Manual. 

I had in mind logging the response from the sieve server for debugging, but the response string is not exposed (c.f https://github.com/nextcloud-libraries/horde-managesieve/blob/86c558472ccb991faad69e1bff8ac7bb55ec41fe/lib/Horde/ManageSieve.php#L1000 and the callers).

On main $response contains something like: 

```OK (WARNINGS) nextcloud: line 18: warning: no newline (CRLF) at end of hash comment at end of file.```

This branch:

```OK "PUTSCRIPT completed."```


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
