### PR TITLE
perf(jobs): run preview pre-warm daily, time-insensitive

### DIFF
--- a/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
+++ b/lib/BackgroundJob/PreviewEnhancementProcessingJob.php
@@ -35,8 +35,9 @@ class PreviewEnhancementProcessingJob extends TimedJob {
 		$this->userManager = $userManager;
 		$this->jobList = $jobList;
 
-		$this->setInterval(3600);
-		$this->setTimeSensitivity(self::TIME_SENSITIVE);
+		// Background pre-warm only; previews are computed on demand on mailbox open, so run rarely and defer under load
+		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/tests/Unit/BackgroundJob/PreviewEnhancementProcessingJobTest.php
+++ b/tests/Unit/BackgroundJob/PreviewEnhancementProcessingJobTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\BackgroundJob;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\BackgroundJob\PreviewEnhancementProcessingJob;
+use OCA\Mail\Service\AccountService;
+use OCA\Mail\Service\PreprocessingService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class PreviewEnhancementProcessingJobTest extends TestCase {
+
+	private ITimeFactory&MockObject $time;
+	private IUserManager&MockObject $userManager;
+	private AccountService&MockObject $accountService;
+	private PreprocessingService&MockObject $preprocessingService;
+	private LoggerInterface&MockObject $logger;
+	private IJobList&MockObject $jobList;
+	private PreviewEnhancementProcessingJob $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->time = $this->createMock(ITimeFactory::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->accountService = $this->createMock(AccountService::class);
+		$this->preprocessingService = $this->createMock(PreprocessingService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->jobList = $this->createMock(IJobList::class);
+
+		$this->job = new PreviewEnhancementProcessingJob(
+			$this->time,
+			$this->userManager,
+			$this->accountService,
+			$this->preprocessingService,
+			$this->logger,
+			$this->jobList,
+		);
+	}
+
+	public function testRunsDailyAndDeferrableUnderLoad(): void {
+		self::assertSame(24 * 3600, $this->job->getInterval());
+		self::assertFalse($this->job->isTimeSensitive());
+	}
+}


### PR DESCRIPTION
PreviewEnhancementProcessingJob fired hourly per account. It can't be scaled per activity — run()-time setInterval() isn't persisted, so the constructor interval governs pickup — and previews are already computed on demand when a mailbox is opened, so the background job only backfills. Run it once a day and mark it time-insensitive so it can be deferred under load.

Assisted-by: ClaudeCode:claude-opus-4-8

**Critical implication**: this means that imip invitations might be processed delayed by up to a date. The mechanic is that the preview processing job find out if an email is an invitation. It will flag it. The imip job that runs every 5min will then pick it up. If the flagging is delayed so is the actual processing.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
