### PR TITLE
perf(db): load local-message children via PK join

### DIFF
--- a/lib/Db/LocalAttachmentMapper.php
+++ b/lib/Db/LocalAttachmentMapper.php
@@ -48,10 +48,11 @@ class LocalAttachmentMapper extends QBMapper {
 			return [];
 		}
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('*')
-			->from($this->getTableName())
+		$qb->select('a.*')
+			->from($this->getTableName(), 'a')
+			->innerJoin('a', 'mail_local_messages', 'lm', $qb->expr()->eq('lm.id', 'a.local_message_id'))
 			->where(
-				$qb->expr()->in('local_message_id', $qb->createNamedParameter($localMessageIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
+				$qb->expr()->in('lm.id', $qb->createNamedParameter($localMessageIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
 			);
 		return $this->findEntities($qb);
 	}

--- a/lib/Db/RecipientMapper.php
+++ b/lib/Db/RecipientMapper.php
@@ -44,10 +44,11 @@ class RecipientMapper extends QBMapper {
 			return [];
 		}
 		$qb = $this->db->getQueryBuilder();
-		$query = $qb->select('*')
-			->from($this->getTableName())
+		$query = $qb->select('r.*')
+			->from($this->getTableName(), 'r')
+			->innerJoin('r', 'mail_local_messages', 'lm', $qb->expr()->eq('lm.id', 'r.local_message_id'))
 			->where(
-				$qb->expr()->in('local_message_id', $qb->createNamedParameter($localMessageIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
+				$qb->expr()->in('lm.id', $qb->createNamedParameter($localMessageIds, IQueryBuilder::PARAM_INT_ARRAY), IQueryBuilder::PARAM_INT_ARRAY)
 			);
 
 		return $this->findEntities($query);

--- a/tests/Integration/Db/RecipientMapperTest.php
+++ b/tests/Integration/Db/RecipientMapperTest.php
@@ -115,6 +115,36 @@ class RecipientMapperTest extends TestCase {
 		$this->assertEmpty($result);
 	}
 
+	public function testFindAllRecipientsForMultipleMessages(): void {
+		$secondMessage = new LocalMessage();
+		$secondMessage->setType(LocalMessage::TYPE_OUTGOING);
+		$secondMessage->setAccountId(1);
+		$secondMessage->setAliasId(2);
+		$secondMessage->setSendAt(123);
+		$secondMessage->setSubject('subject');
+		$secondMessage->setBodyHtml('message');
+		$secondMessage->setHtml(true);
+		$secondMessage->setInReplyToMessageId('efgh');
+		$secondMessage = $this->localMessageMapper->insert($secondMessage);
+
+		$recipient = new Recipient();
+		$recipient->setLocalMessageId($secondMessage->getId());
+		$recipient->setEmail('sebastian@stardewvalley.com');
+		$recipient->setType(Recipient::TYPE_TO);
+		$recipient->setLabel('Sebastian');
+		$this->mapper->insert($recipient);
+
+		$result = $this->mapper->findByLocalMessageIds([$this->message->getId(), $secondMessage->getId()]);
+
+		$this->assertCount(3, $result);
+		$byMessage = [];
+		foreach ($result as $r) {
+			$byMessage[$r->getLocalMessageId()][] = $r;
+		}
+		$this->assertCount(2, $byMessage[$this->message->getId()]);
+		$this->assertCount(1, $byMessage[$secondMessage->getId()]);
+	}
+
 	/**
 	 * @depends testFindAllRecipientsEmpty
 	 */


### PR DESCRIPTION
findByLocalMessageIds filtered mail_recipients / mail_attachments by local_message_id IN (...). That column is NULL for nearly all rows, so its index statistics estimate ~1099 rows per value; a large IN list (a user's whole outbox+drafts, loaded on every Mail page open) pushes the estimate past the full-scan threshold and the optimizer scans the whole ~2M-row recipients table. It was the top query by rows examined on a 903-account instance, 85% full scans.

Join mail_local_messages and put the IN on its primary key instead, so the child table is reached by a ref lookup on the existing FK index at any list size. Same result set (ids originate from mail_local_messages; the FK cascades on delete), so no behavior change.

Assisted-by: Claude:claude-opus-4-8

EXPLAIN of the new query:

```
+------+-------------+-------+------+---------------------------+---------------------+---------+---------+------+-------------------------------------------------+
| id | select_type | table | type | possible_keys | key | key_len | ref | rows | Extra |
+------+-------------+-------+------+---------------------------+---------------------+---------+---------+------+-------------------------------------------------+
| 1 | SIMPLE | a | ref | PRIMARY,mail_userid_index | mail_userid_index | 258 | const | 1 | Using where; Using index |
| 1 | SIMPLE | m | ALL | PRIMARY | NULL | NULL | NULL | 1017 | Using where; Using join buffer (flat, BNL join) |
| 1 | SIMPLE | r | ref | IDX_715DB7E31594979 | IDX_715DB7E31594979 | 5 | oc.m.id | 1099 | |
+------+-------------+-------+------+---------------------------+---------------------+---------+---------+------+-------------------------------------------------+
3 rows in set (0.000 sec
```

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
