### PR TITLE
perf(db): index the iMIP invitation scan

### DIFF
--- a/lib/Listener/OptionalIndicesListener.php
+++ b/lib/Listener/OptionalIndicesListener.php
@@ -61,6 +61,12 @@ class OptionalIndicesListener implements IEventListener {
 		);
 
 		$event->addMissingIndex(
+			'mail_messages',
+			'mail_msg_imip_idx',
+			['imip_message', 'sent_at'],
+		);
+
+		$event->addMissingIndex(
 			'mail_classifiers',
 			'mail_class_creat_idx',
 			['created_at']

--- a/lib/Migration/Version1130Date20220412111833.php
+++ b/lib/Migration/Version1130Date20220412111833.php
@@ -176,6 +176,9 @@ class Version1130Date20220412111833 extends SimpleMigrationStep {
 		// mail_msg_mb_del_snt_idx was added later and may not exist until optional indices are created
 		$messagesTable->addIndex(['mailbox_id', 'flag_deleted', 'sent_at'], 'mail_msg_mb_del_snt_idx');
 
+		// mail_msg_imip_idx was added later and may not exist until optional indices are created
+		$messagesTable->addIndex(['imip_message', 'sent_at'], 'mail_msg_imip_idx');
+
 		return $schema;
 	}
 

--- a/tests/Unit/Listener/OptionalIndicesListenerTest.php
+++ b/tests/Unit/Listener/OptionalIndicesListenerTest.php
@@ -52,5 +52,6 @@ class OptionalIndicesListenerTest extends TestCase {
 
 		$indexNames = array_column($event->getMissingIndices(), 'indexName');
 		self::assertContains('mail_msg_mb_del_snt_idx', $indexNames);
+		self::assertContains('mail_msg_imip_idx', $indexNames);
 	}
 }


### PR DESCRIPTION
IMipService's cron (every ~300s) ran findIMipMessagesAscending, which filtered mail_messages on imip_message plus three flags with a sent_at window and ORDER BY sent_at. No index matched, so every run full-scanned the whole table (~944k rows) and filesorted, usually to return nothing. It was Nr 2 by rows examined on a 903-account instance, 100% full scans.

Add mail_msg_imip_idx (imip_message, sent_at): the rare imip_message value makes the leading column selective (1.45% of rows) and sent_at removes the filesort. The mutable flags (imip_processed, imip_error, flag_junk) are left out on purpose to avoid index churn; imip_message flips at most once. Registered via AddMissingIndicesEvent for existing installs and added to the 2022 message-index migration for new ones.

Assisted-by: Claude:claude-opus-4-8

<img width="1326" height="997" alt="Bildschirmfoto vom 2026-09-02 14-59-55" src="https://github.com/user-attachments/assets/5885837f-9513-4981-b8a1-041d3e7e8c56" />

^ applying the index on that instance shows how full table scans and sorts turn into simple index range scans.

Query time went from 300ms to 3ms.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
