### PR TITLE
feat(vue3): inverted boolean props

### DIFF
--- a/src/components/mailFilter/CreateModal.vue
+++ b/src/components/mailFilter/CreateModal.vue
@@ -5,7 +5,6 @@
 <template>
 	<NcModal
 		size="normal"
-		:close-on-click-outside="false"
 		@close="closeModal">
 		<form class="modal__content" @submit.prevent="createFilter">
 			<h2>{{ t('mail', 'Create a new mail filter') }}</h2>

--- a/src/components/mailFilter/Operator.vue
+++ b/src/components/mailFilter/Operator.vue
@@ -13,7 +13,7 @@
 			:reduce="operator => operator.value"
 			:clearable="false"
 			@input="updateOperator($event)" />
-		<NcPopover class="operator__popover" :no-focus-trap="true" popup-role="dialog">
+		<NcPopover class="operator__popover" no-focus-trap popup-role="dialog">
 			<template #trigger>
 				<NcButton variant="tertiary-no-background" :aria-label="t('mail', 'Help')">
 					<template #icon>

--- a/src/components/mailFilter/UpdateModal.vue
+++ b/src/components/mailFilter/UpdateModal.vue
@@ -5,7 +5,6 @@
 <template>
 	<NcModal
 		size="normal"
-		:close-on-click-outside="false"
 		:name="t('mail', 'New filter')"
 		@close="closeModal">
 		<form class="modal__content" @submit.prevent="updateFilter">


### PR DESCRIPTION
 `no-focus-trap` (NcPopover) no longer needs explicit `="true"` —               
  shorthand form is the preferred pattern when defaults are false.               
  `:close-on-click-outside="false"` on NcModal was redundant                     
  (the prop already defaults to false).                                          
                                                                                 
  Assisted-by: ClaudeCode:claude-sonnet-4-6                                      
                                             
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
