### PR TITLE
refactor: drop exact from envelope and envelopeskeleton

### DIFF
--- a/src/components/Envelope.vue
+++ b/src/components/Envelope.vue
@@ -16,7 +16,6 @@
 		class="list-item-style envelope"
 		:class="{ seen: data.flags.seen, draft, selected: selected }"
 		:to="link"
-		:exact="true"
 		:data-envelope-id="data.databaseId"
 		:name="addresses"
 		:details="formatted()"

--- a/src/components/EnvelopeSkeleton.vue
+++ b/src/components/EnvelopeSkeleton.vue
@@ -9,8 +9,7 @@
 		:is="to ? 'router-link' : 'NcVNodes'"
 		v-slot="{ href: routerLinkHref, navigate, isActive }"
 		:custom="to ? true : null"
-		:to="to"
-		:exact="to ? exact : null">
+		:to="to">
 		<li
 			class="list-item__wrapper"
 			:class="{ 'list-item__wrapper--active': isActive || active }">
@@ -156,15 +155,6 @@ export default {
 		name: {
 			type: String,
 			required: true,
-		},
-
-		/**
-		 * Pass in `true` if you want the matching behavior to
-		 * be non-inclusive: https://router.vuejs.org/api/#exact
-		 */
-		exact: {
-			type: Boolean,
-			default: false,
 		},
 
 		/**


### PR DESCRIPTION
ref: #13622 

Vue Router 4 matches routes exactly by default, making the `exact`             
  prop a no-op. Dropped the binding in Envelope.vue and the prop                 
  declaration + template binding in EnvelopeSkeleton.vue.              

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated envelope list navigation so items remain active when viewing related nested routes.
  - Removed exact route matching from envelope skeleton links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->