### PR TITLE
Fix case-insensitive charset detection for ISO-2022-JP

### DIFF
--- a/lib/IMAP/Charset/Converter.php
+++ b/lib/IMAP/Charset/Converter.php
@@ -35,7 +35,7 @@ class Converter {
 		$charset = trim($charset);
 		$lowerCharset = strtolower($charset);
 
-		return self::CHARSET_MAP[$lowerCharset] ?? $charset;
+		return self::CHARSET_MAP[$lowerCharset] ?? strtoupper($charset);
 	}
 
 	/**
@@ -45,7 +45,7 @@ class Converter {
 		/** @var list<string>|null $encodings */
 		static $encodings = null;
 		if ($encodings === null) {
-			$encodings = mb_list_encodings();
+			$encodings = array_map('strtoupper', mb_list_encodings());
 		}
 
 		return $encodings;

--- a/tests/Unit/IMAP/Charset/ConverterTest.php
+++ b/tests/Unit/IMAP/Charset/ConverterTest.php
@@ -56,10 +56,18 @@ class ConverterTest extends TestCase {
 		$iso88591MimePart_noCharset = new Horde_Mime_Part();
 		$iso88591MimePart_noCharset->setContents('בה בדף לחבר ממונרכיה, בקר בגרסה ואמנות דת');
 		// Japanese
+		$iso2022jpText = '外せ園査リツハワ題';
+		$iso2022jpBytes = mb_convert_encoding($iso2022jpText, 'ISO-2022-JP', 'UTF-8');
+
 		$iso2022jpMimePart = new Horde_Mime_Part();
 		$iso2022jpMimePart->setType('text/plain');
 		$iso2022jpMimePart->setCharset('ISO-2022-JP');
-		$iso2022jpMimePart->setContents(mb_convert_encoding('外せ園査リツハワ題', 'ISO-2022-JP', 'UTF-8'));
+		$iso2022jpMimePart->setContents($iso2022jpBytes);
+
+		$iso2022jpLowerMimePart = new Horde_Mime_Part();
+		$iso2022jpLowerMimePart->setType('text/plain');
+		$iso2022jpLowerMimePart->setCharset('iso-2022-jp');
+		$iso2022jpLowerMimePart->setContents($iso2022jpBytes);
 		// Korean (Outlook) - all ks_c_5601 spellings map to UHC (CP949). Encode
 		// with iconv to avoid depending on mbstring's UHC support, and cover the
 		// case-insensitive charset spellings.
@@ -84,7 +92,8 @@ class ConverterTest extends TestCase {
 			[$utfMimePart, '😊'],
 			[$utfMimeStreamPart, '💦'],
 			[$iso88591MimePart, 'Ümlaut'],
-			[$iso2022jpMimePart, '外せ園査リツハワ題'],
+			[$iso2022jpMimePart, $iso2022jpText],
+			[$iso2022jpLowerMimePart, $iso2022jpText],
 			[$iso88591MimePart_noCharset, 'בה בדף לחבר ממונרכיה, בקר בגרסה ואמנות דת'],
 		], $koreanCases, [
 			[$windowsMimePart, 'قام زهاء أوراقهم ما,'],


### PR DESCRIPTION
## 🤖 AI (if applicable)

* [x] The content of this PR was partly or fully generated using AI

## Summary

Fixes ISO-2022-JP email conversion when the charset is provided in lowercase.

## Problem

Some emails declare their charset as `ISO-2022-JP`, but Horde can return the charset as lowercase (`iso-2022-jp`).

`Converter` previously checked the charset against `mb_list_encodings()` using a case-sensitive comparison. As a result, `iso-2022-jp` was not recognized as an mbstring encoding and the conversion fell back to `iconv()`.

On the affected Alpine/libiconv environment, `iconv()` fails to convert these ISO-2022-JP messages, resulting in garbled email content.

## Fix

Make the charset comparison case-insensitive when checking the available mbstring encodings.

The existing charset normalization and conversion logic are otherwise unchanged.

## Tests

Added a regression test covering lowercase `iso-2022-jp`.

Tested with:

* `ConverterTest`: **15 tests, 30 assertions — OK**
* Full Mail unit test suite: **1518 tests, 4378 assertions — OK**

Fixes #13472
