### PR TITLE
fix: use envelope databaseId when saving attachments

### DIFF
--- a/src/components/MessageAttachments.vue
+++ b/src/components/MessageAttachments.vue
@@ -167,7 +167,7 @@ export default {
 			}
 
 			this.savingToCloud = true
-			const id = this.$route.params.threadId
+			const id = this.envelope.databaseId
 
 			try {
 				await saveAttachmentsToFiles(id, path)


### PR DESCRIPTION
replaces threadId with envelope databaseId when saving attachments

fixes #13632
