### PR TITLE
fix: keep delegatee signatures separate from account owner's

### DIFF
--- a/lib/Controller/AccountsController.php
+++ b/lib/Controller/AccountsController.php
@@ -304,7 +304,11 @@ class AccountsController extends Controller {
 	#[TrapError]
 	public function updateSignature(int $id, ?string $signature = null): JSONResponse {
 		$effectiveUserId = $this->delegationService->resolveAccountUserId($id, $this->userId);
-		$this->accountService->updateSignature($id, $effectiveUserId, $signature);
+		if ($this->userId === $effectiveUserId) {
+			$this->accountService->updateSignature($id, $effectiveUserId, $signature);
+		} else {
+			$this->delegationService->updateSignatureForDelegatedUser($id, $this->userId, $signature);
+		}
 		$this->delegationService->logDelegatedAction($this->userId, $effectiveUserId, "$this->userId updated signature for account <$id> on behalf of $effectiveUserId");
 		return new JSONResponse();
 	}

--- a/lib/Db/Delegation.php
+++ b/lib/Db/Delegation.php
@@ -18,16 +18,20 @@ use ReturnTypeWillChange;
  * @method void setAccountId(int $accountId)
  * @method string getUserId()
  * @method void setUserId(string $userId)
+ * @method void setSignature(string|null $string)
+ * @method string getSignature()
  */
 class Delegation extends Entity implements JsonSerializable {
 	protected $accountId;
 	protected $userId;
+	protected $signature;
 
 	private ?string $displayName = null;
 
 	public function __construct() {
 		$this->addType('userId', 'string');
 		$this->addType('accountId', 'integer');
+		$this->addType('signature', 'string');
 	}
 
 	public function getDisplayName(): ?string {
@@ -46,6 +50,7 @@ class Delegation extends Entity implements JsonSerializable {
 			'accountId' => $this->getAccountId(),
 			'userId' => $this->getUserId(),
 			'displayName' => $this->displayName ?? $this->getUserId(),
+			'signature' => $this->getSignature(),
 		];
 	}
 }

--- a/lib/Migration/Version5201Date20260909105301.php
+++ b/lib/Migration/Version5201Date20260909105301.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+class Version5201Date20260909105301 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('mail_delegations');
+
+		if (!$table->hasColumn('signature')) {
+			$table->addColumn('signature', Types::TEXT, [
+				'notnull' => false,
+			]);
+		}
+
+		return $schema;
+	}
+
+}

--- a/lib/Service/DelegationService.php
+++ b/lib/Service/DelegationService.php
@@ -226,4 +226,10 @@ class DelegationService {
 			$this->logger->warning('Failed to send delegation notification to {userId}', ['userId' => $userId,'exception' => $e]);
 		}
 	}
+
+	public function updateSignatureForDelegatedUser(int $accountId, string $userId, ?string $signature): void {
+		$delegation = $this->delegationMapper->find($accountId, $userId);
+		$delegation->setSignature($signature);
+		$this->delegationMapper->update($delegation);
+	}
 }


### PR DESCRIPTION
editing your signature as a delegate no longer overwrites the account owner's signature
fixes #13050

