### PR TITLE
fix(MoveMailboxModal): make self-move a real no-op and always reset state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 * Prefix the internal-address index with the user id
 ### Fixed
 * Quick actions for special folders
+* Prevent a stuck dialog when moving a folder onto itself
 * Show the unified inbox icon
 * Detect message language in the browser for translation
 * Skip IMAP fetch results without a UID during sync

--- a/src/components/MoveMailboxModal.vue
+++ b/src/components/MoveMailboxModal.vue
@@ -56,33 +56,36 @@ export default {
 		},
 
 		async onMove() {
+			if (this.mailbox.databaseId === this.destMailboxId) {
+				this.$emit('close')
+				return
+			}
+
 			this.moving = true
-			if (this.mailbox.id !== this.destMailboxId) {
-				try {
-					if (!this.destMailboxId) {
-						const newName = this.mailbox.displayName
-						await this.mainStore.renameMailbox({
-							account: this.account,
-							mailbox: this.mailbox,
-							newName,
-						})
-					} else {
-						const destMailbox = this.mainStore.getMailbox(this.destMailboxId)
-						const newName = destMailbox.name + this.mailbox.delimiter + this.mailbox.displayName
-						await this.mainStore.renameMailbox({
-							account: this.account,
-							mailbox: this.mailbox,
-							newName,
-						})
-					}
-				} catch (error) {
-					logger.error('could not move folder', {
-						error,
+			try {
+				if (!this.destMailboxId) {
+					const newName = this.mailbox.displayName
+					await this.mainStore.renameMailbox({
+						account: this.account,
+						mailbox: this.mailbox,
+						newName,
 					})
-				} finally {
-					this.moving = false
-					this.$emit('close')
+				} else {
+					const destMailbox = this.mainStore.getMailbox(this.destMailboxId)
+					const newName = destMailbox.name + this.mailbox.delimiter + this.mailbox.displayName
+					await this.mainStore.renameMailbox({
+						account: this.account,
+						mailbox: this.mailbox,
+						newName,
+					})
 				}
+			} catch (error) {
+				logger.error('could not move folder', {
+					error,
+				})
+			} finally {
+				this.moving = false
+				this.$emit('close')
 			}
 		},
 

--- a/src/tests/unit/components/MoveMailboxModal.vue.spec.js
+++ b/src/tests/unit/components/MoveMailboxModal.vue.spec.js
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createTestingPinia } from '@pinia/testing'
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { PiniaVuePlugin, setActivePinia } from 'pinia'
+import MoveMailboxModal from '../../../components/MoveMailboxModal.vue'
+import Nextcloud from '../../../mixins/Nextcloud.js'
+import useMainStore from '../../../store/mainStore.js'
+
+const localVue = createLocalVue()
+localVue.use(PiniaVuePlugin)
+localVue.mixin(Nextcloud)
+
+describe('MoveMailboxModal', () => {
+	let store
+
+	const mount = (mailbox) => shallowMount(MoveMailboxModal, {
+		propsData: {
+			account: { accountId: 1 },
+			mailbox,
+		},
+		localVue,
+	})
+
+	beforeEach(() => {
+		setActivePinia(createTestingPinia())
+		store = useMainStore()
+		store.renameMailbox = vi.fn().mockResolvedValue()
+	})
+
+	it('treats selecting the same mailbox as a no-op and closes', async () => {
+		store.getMailbox = vi.fn().mockReturnValue({ name: 'INBOX' })
+		const view = mount({ databaseId: 7, id: 'SU5CT1g=', displayName: 'INBOX', delimiter: '.' })
+		view.vm.destMailboxId = 7
+
+		await view.vm.onMove()
+
+		expect(store.renameMailbox).not.toHaveBeenCalled()
+		expect(view.vm.moving).toBe(false)
+		expect(view.emitted().close).toBeTruthy()
+	})
+
+	it('moves the folder when the destination differs and resets state', async () => {
+		store.getMailbox = vi.fn().mockReturnValue({ name: 'Archive' })
+		const view = mount({ databaseId: 7, id: 'SU5CT1g=', displayName: 'INBOX', delimiter: '.' })
+		view.vm.destMailboxId = 9
+
+		await view.vm.onMove()
+
+		expect(store.renameMailbox).toHaveBeenCalledWith({
+			account: { accountId: 1 },
+			mailbox: view.vm.mailbox,
+			newName: 'Archive.INBOX',
+		})
+		expect(view.vm.moving).toBe(false)
+		expect(view.emitted().close).toBeTruthy()
+	})
+
+	it('resets moving state after a failed move', async () => {
+		store.getMailbox = vi.fn().mockReturnValue({ name: 'Archive' })
+		store.renameMailbox = vi.fn().mockRejectedValue(new Error('IMAP error'))
+		const view = mount({ databaseId: 7, id: 'SU5CT1g=', displayName: 'INBOX', delimiter: '.' })
+		view.vm.destMailboxId = 9
+
+		await view.vm.onMove()
+
+		expect(view.vm.moving).toBe(false)
+		expect(view.emitted().close).toBeTruthy()
+	})
+})


### PR DESCRIPTION
## What

Closes #13534

Fixes the dead self-move guard in the move-folder modal.

## The bug

`onMove()` set `this.moving = true` and then guarded the whole operation with `this.mailbox.id !== this.destMailboxId`:

- `Mailbox::jsonSerialize` exposes `id` as `base64_encode($name)`, while `destMailboxId` is always the numeric `databaseId` (or `undefined`). The two can never be equal, so the "moving a folder into itself is a no-op" check never fired — selecting the current parent for a folder that already sits there issued a rename to its own name, and the resulting IMAP error was only logged (silent no-op for the user).
- The `moving = false` / `$emit('close')` cleanup lived inside the `finally` of that dead branch, so a corrected early exit would have left the dialog's primary button disabled forever (since #13431 made the handler's promise the one `NcDialogButton` awaits).

## Fix

- Compare `this.mailbox.databaseId` against `this.destMailboxId`.
- Return early (after emitting `close`) when they match, before setting `moving = true`.
- The `try/finally` now covers the actual move, so `moving` is always reset and the dialog always closes.

## Tests

Added `src/tests/unit/components/MoveMailboxModal.vue.spec.js` covering: same-mailbox no-op (no `renameMailbox`, `moving` reset, `close` emitted), a real move with correct new name, and state reset after a failed move.

## Validation

```
$ npx vitest --run src/tests/unit/components/MoveMailboxModal.vue.spec.js
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Genuine RED→GREEN: reverting `src/components/MoveMailboxModal.vue` to the buggy version makes the "same mailbox is a no-op" test fail (the old code calls `renameMailbox` when moving into itself); restoring the fix turns it green.

`npx eslint` on both changed files is clean. I ran the full `vitest --run` suite too — a handful of unrelated files (TranslationModal, MessageService, store/actions, filePicker, languageDetection) fail non-deterministically with jsdom timeouts on the same count on a clean `main` checkout without my change, so they are pre-existing and outside this diff.

Happy to adjust.
