### PR TITLE
fix(smtp): respect configured SMTP user for XOAUTH2 authentication

### DIFF
--- a/lib/SMTP/SmtpClientFactory.php
+++ b/lib/SMTP/SmtpClientFactory.php
@@ -75,8 +75,18 @@ class SmtpClientFactory {
 			}
 
 			$params['password'] = $decryptedAccessToken; // Not used, but Horde wants this
+			// The SASL XOAUTH2 user is the identity we authenticate as. It usually
+			// matches the account's email address, but some providers require a
+			// different one. Microsoft 365, for example, rejects shared mailboxes as
+			// SMTP AUTH identity while accepting them for IMAP. Respecting the
+			// configured SMTP user allows authenticating as the personal mailbox and
+			// sending on behalf of the shared one.
+			$xoauth2User = $mailAccount->getOutboundUser();
+			if (empty($xoauth2User)) {
+				$xoauth2User = $account->getEmail();
+			}
 			$params['xoauth2_token'] = new Horde_Smtp_Password_Xoauth2(
-				$account->getEmail(),
+				$xoauth2User,
 				$decryptedAccessToken,
 			);
 		}

--- a/tests/Unit/SMTP/SmtpClientFactoryTest.php
+++ b/tests/Unit/SMTP/SmtpClientFactoryTest.php
@@ -11,6 +11,7 @@ namespace OCA\Mail\Tests\Unit\Smtp;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use Horde_Mail_Transport_Smtphorde;
+use Horde_Smtp_Password_Xoauth2;
 use OCA\Mail\Account;
 use OCA\Mail\Db\MailAccount;
 use OCA\Mail\SMTP\SmtpClientFactory;
@@ -18,6 +19,7 @@ use OCA\Mail\Support\HostNameFactory;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionProperty;
 
 class SmtpClientFactoryTest extends TestCase {
 	/** @var IConfig|MockObject */
@@ -91,5 +93,81 @@ class SmtpClientFactoryTest extends TestCase {
 		$this->assertNotNull($transport);
 		$this->assertInstanceOf(Horde_Mail_Transport_Smtphorde::class, $transport);
 		$this->assertEquals($expected, $transport);
+	}
+
+	public function testSmtpTransportWithXOAuth2UsesConfiguredSmtpUser(): void {
+		$mailAccount = new MailAccount([
+			'emailAddress' => 'shared@domain.tld',
+			'smtpHost' => 'smtp.domain.tld',
+			'smtpPort' => 25,
+			'smtpSslMode' => 'none',
+			'smtpUser' => 'user@domain.tld',
+		]);
+		$mailAccount->setAuthMethod('xoauth2');
+		$mailAccount->setOauthAccessToken('enctoken');
+		$account = new Account($mailAccount);
+		$this->mockConfig();
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->with('enctoken')
+			->willReturn('token123');
+		$this->hostNameFactory->expects($this->once())
+			->method('getHostName')
+			->willReturn('cloud.example.com');
+
+		$transport = $this->factory->create($account);
+
+		$this->assertEquals(
+			new Horde_Smtp_Password_Xoauth2('user@domain.tld', 'token123'),
+			$this->getXOAuth2Token($transport),
+		);
+	}
+
+	public function testSmtpTransportWithXOAuth2FallsBackToEmailAddress(): void {
+		$mailAccount = new MailAccount([
+			'emailAddress' => 'user@domain.tld',
+			'smtpHost' => 'smtp.domain.tld',
+			'smtpPort' => 25,
+			'smtpSslMode' => 'none',
+			'smtpUser' => '',
+		]);
+		$mailAccount->setAuthMethod('xoauth2');
+		$mailAccount->setOauthAccessToken('enctoken');
+		$account = new Account($mailAccount);
+		$this->mockConfig();
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->with('enctoken')
+			->willReturn('token123');
+		$this->hostNameFactory->expects($this->once())
+			->method('getHostName')
+			->willReturn('cloud.example.com');
+
+		$transport = $this->factory->create($account);
+
+		$this->assertEquals(
+			new Horde_Smtp_Password_Xoauth2('user@domain.tld', 'token123'),
+			$this->getXOAuth2Token($transport),
+		);
+	}
+
+	private function mockConfig(): void {
+		$this->config->expects($this->any())
+			->method('getSystemValue')
+			->willReturnMap([
+				['app.mail.transport', 'smtp', 'smtp'],
+				['app.mail.smtp.timeout', 20, 2],
+			]);
+		$this->config->expects($this->any())
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['app.mail.verify-tls-peer', true, true],
+				['app.mail.debug', false, false],
+			]);
+	}
+
+	private function getXOAuth2Token(Horde_Mail_Transport_Smtphorde $transport): Horde_Smtp_Password_Xoauth2 {
+		$reflection = new ReflectionProperty($transport, '_params');
+		return $reflection->getValue($transport)['xoauth2_token'];
 	}
 }


### PR DESCRIPTION
Fixes #13667

## Summary

For `xoauth2` accounts the SASL XOAUTH2 identity used for SMTP was hardcoded to
`$account->getEmail()`, so the configured SMTP user had no effect. This makes it
impossible to authenticate as one mailbox and send as another — which is exactly what
Microsoft 365 requires for shared mailboxes.

This PR uses `getOutboundUser()` when set and falls back to the account's email address
otherwise.

## Why

Exchange Online accepts a shared mailbox as the XOAUTH2 identity for IMAP but rejects it
for SMTP AUTH with `535 5.7.3 Authentication unsuccessful`, because a shared mailbox has
no sign-in credentials of its own. A Microsoft engineer confirms this in
[this Q&A thread](https://learn.microsoft.com/en-us/answers/questions/162233/shared-mailbox-oauth-access):
"we cannot use shared mailbox for SMTP AUTH client submission."

The supported pattern is to authenticate as the delegate's own mailbox and let Exchange
Send As handle the sender address. Thunderbird works this way, which is why users report
that Thunderbird can send from a shared mailbox while Mail cannot.

## Why only SMTP

`IMAPClientFactory` deliberately keeps using the account email: for IMAP the shared
mailbox address *is* the correct identity, and Microsoft documents that substitution.
That path works today and is untouched.

## Backwards compatibility

No behaviour change for existing accounts:

- `AccountForm.vue` requires `smtpUser` in the OAuth flow as well (only the password
  fields are gated behind `!useOauth`) and pre-fills it with the email address.
- Autoconfig fills it from `smtpConfig.username`; provisioning computes it via
  `buildSmtpUser()`.
- The submit payload deliberately keeps `smtpUser` for OAuth accounts.

So for accounts created through the UI both values are already identical, and the
fallback covers CLI/provisioning cases where the column may be empty.

## Precedent

#12442 (Dovecot master user) introduced the same concept — an SMTP auth identity distinct
from the account address — across the IMAP, SMTP and Sieve factories.

## Tests

`tests/Unit/SMTP/SmtpClientFactoryTest.php` had no xoauth2 coverage at all. This PR adds
two cases:

- SMTP user set and different from the email address → used as XOAUTH2 identity
- SMTP user empty → falls back to the email address

Verified locally against a Nextcloud instance (PHP 8.5):

```
OK (3 tests, 11 assertions)
```

Reverting the production change makes the new test fail with exactly the reported
symptom, confirming the tests are meaningful:

```
-    'username' => 'user@domain.tld'
+    'username' => 'shared@domain.tld'
```

## End-to-end verification against a real Microsoft 365 tenant

Verified with an actual Exchange Online shared mailbox (`shared@example.org`), with Full Access and
Send As granted to the personal account (`user@example.org`), configured exactly as users do today:
the shared mailbox added as its own account, authorised with the personal user's OAuth
token.

| Step | XOAUTH2 identity | Result |
|---|---|---|
| IMAP (read) | `shared@example.org` | OK — 11 mailboxes listed |
| SMTP, before fix (`smtp_user` = account address) | `shared@example.org` | **Server denied authentication** |
| SMTP, after fix (`smtp_user` = `user@example.org`) | `user@example.org` | **Login OK** |
| Actually sending `From: shared@example.org` | `user@example.org` | **Message delivered** |
| Counter-test: revert `smtp_user` to `shared@example.org` | `shared@example.org` | Denied again |

So the same account, token and mailbox only differ in the SMTP auth identity, and that is
what decides between rejection and delivery. Sending as the shared mailbox works through
Exchange Send As once the identity is decoupled — which is what this PR enables.

The sent message is stored in the shared mailbox's own Sent Items folder (verified over
IMAP), so it is visible to everyone with access to that mailbox. That is a meaningful
difference from the alias-based workaround, where the copy ends up in the sender's
personal Sent folder and colleagues sharing the mailbox never see the replies.

## Context

Reported during the SURF Works pilot, which offers Nextcloud to Dutch research and
education institutions where functional/shared mailboxes are common.

## Checklist

- [x] Code is properly formatted (php-cs-fixer clean)
- [x] Unit tests added and passing
- [x] Backwards compatible
- [x] Conventional commit message with DCO sign-off
