### PR TITLE
Feat(provisioning): add occ commands

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -90,6 +90,11 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 		<command>OCA\Mail\Command\InspectMailbox</command>
 		<command>OCA\Mail\Command\ListMailboxes</command>
 		<command>OCA\Mail\Command\PredictImportance</command>
+		<command>OCA\Mail\Command\CreateProvisioning</command>
+		<command>OCA\Mail\Command\DeleteProvisioning</command>
+		<command>OCA\Mail\Command\ListProvisionings</command>
+		<command>OCA\Mail\Command\ProvisionAccounts</command>
+		<command>OCA\Mail\Command\UpdateProvisioning</command>
 		<command>OCA\Mail\Command\TestAccount</command>
 		<command>OCA\Mail\Command\SyncAccount</command>
 		<command>OCA\Mail\Command\Thread</command>

--- a/lib/Command/CreateProvisioning.php
+++ b/lib/Command/CreateProvisioning.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use InvalidArgumentException;
+use OCA\Mail\Exception\ValidationException;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CreateProvisioning extends Command {
+	use ProvisioningOptions;
+
+	public function __construct(
+		private readonly ProvisioningManager $provisioningManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:provisioning:create');
+		$this->setDescription('Create a mail account provisioning configuration');
+		$this->setHelp(sprintf(
+			<<<'EOT'
+				A provisioning configuration creates and maintains the mail account of every
+				user whose email address matches its domain. Pass * as the domain to match all
+				users.
+
+				All options are required, except the Sieve, master password and LDAP alias ones.
+
+				%s
+
+				New accounts are provisioned when a user opens Mail. Run
+				<info>mail:provisioning:apply</info> to provision all users right away.
+				EOT,
+			$this->templatesHelp(),
+		));
+		$this->addUsage(
+			"--provisioning-domain='*' --email-template='%USERID%@example.com'"
+			. " --imap-user='%USERID%' --imap-host=imap.example.com --imap-port=993 --imap-ssl-mode=ssl"
+			. " --smtp-user='%USERID%' --smtp-host=smtp.example.com --smtp-port=587 --smtp-ssl-mode=tls"
+		);
+		$this->addProvisioningOptions();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		try {
+			$data = $this->buildProvisioningData($input, $output);
+		} catch (InvalidArgumentException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return self::INVALID;
+		}
+
+		try {
+			$provisioning = $this->provisioningManager->newProvisioning($data);
+		} catch (ValidationException $e) {
+			$output->writeln('<error>Invalid or missing values: ' . implode(', ', array_keys($e->getFields())) . '</error>');
+			return self::INVALID;
+		}
+
+		$output->writeln("<info>Provisioning configuration {$provisioning->getId()} created</info>");
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/DeleteProvisioning.php
+++ b/lib/Command/DeleteProvisioning.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class DeleteProvisioning extends Command {
+	public const ARGUMENT_ID = 'id';
+	public const OPTION_FORCE = 'force';
+
+	public function __construct(
+		private readonly ProvisioningManager $provisioningManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:provisioning:delete');
+		$this->setDescription('Delete a mail account provisioning configuration and all accounts provisioned with it');
+		$this->setHelp(
+			<<<'EOT'
+				Deleting a configuration also deletes every mail account that was provisioned
+				with it, including the locally cached messages. Mail accounts users created
+				themselves are not affected.
+
+				Run <info>mail:provisioning:list</info> to look up the id of a configuration.
+				EOT
+		);
+		$this->addUsage('42 --force');
+		$this->addArgument(self::ARGUMENT_ID, InputArgument::REQUIRED, 'Id of the provisioning configuration');
+		$this->addOption(self::OPTION_FORCE, 'f', InputOption::VALUE_NONE, 'Delete without asking for confirmation');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$id = filter_var($input->getArgument(self::ARGUMENT_ID), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+		if ($id === false) {
+			$output->writeln('<error>Provisioning configuration id must be a positive integer</error>');
+			return self::INVALID;
+		}
+
+		$provisioning = $this->provisioningManager->getConfigById($id);
+		if ($provisioning === null) {
+			$output->writeln("<error>Provisioning configuration $id does not exist</error>");
+			return self::FAILURE;
+		}
+
+		if (!$input->getOption(self::OPTION_FORCE)) {
+			$question = new ConfirmationQuestion(
+				"Delete configuration $id and all mail accounts provisioned with it? [y/N] ",
+				false,
+			);
+			if (!$this->getHelper('question')->ask($input, $output, $question)) {
+				$output->writeln('Aborted');
+				return self::SUCCESS;
+			}
+		}
+
+		$this->provisioningManager->deprovision($provisioning);
+
+		$output->writeln("<info>Provisioning configuration $id deleted</info>");
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/ListProvisionings.php
+++ b/lib/Command/ListProvisionings.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ListProvisionings extends Command {
+	public const OPTION_JSON = 'json';
+
+	public function __construct(
+		private readonly ProvisioningManager $provisioningManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:provisioning:list');
+		$this->setDescription('List the mail account provisioning configurations');
+		$this->setHelp(
+			<<<'EOT'
+				The table shows a summary of every configuration and the ids needed by
+				<info>mail:provisioning:update</info> and <info>mail:provisioning:delete</info>.
+				Pass <info>--json</info> to print all values. The master password is never printed.
+				EOT
+		);
+		$this->addOption(self::OPTION_JSON, null, InputOption::VALUE_NONE, 'Print all values as JSON');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$provisionings = $this->provisioningManager->getConfigs();
+
+		if ($input->getOption(self::OPTION_JSON)) {
+			$output->writeln(json_encode($provisionings, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+
+			return self::SUCCESS;
+		}
+
+		$table = new Table($output);
+		$table->setHeaders(['Id', 'Domain', 'Email', 'IMAP', 'SMTP', 'Sieve', 'Master password']);
+		foreach ($provisionings as $provisioning) {
+			$table->addRow([
+				$provisioning->getId(),
+				$provisioning->getProvisioningDomain(),
+				$provisioning->getEmailTemplate(),
+				$provisioning->getImapUser() . '@' . $provisioning->getImapHost() . ':' . $provisioning->getImapPort(),
+				$provisioning->getSmtpUser() . '@' . $provisioning->getSmtpHost() . ':' . $provisioning->getSmtpPort(),
+				$provisioning->getSieveEnabled() === true ? $provisioning->getSieveHost() . ':' . $provisioning->getSievePort() : 'no',
+				$provisioning->getMasterPasswordEnabled() === true ? 'yes' : 'no',
+			]);
+		}
+		$table->render();
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/ProvisionAccounts.php
+++ b/lib/Command/ProvisionAccounts.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ProvisionAccounts extends Command {
+	public function __construct(
+		private readonly ProvisioningManager $provisioningManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:provisioning:apply');
+		$this->setDescription('Apply the provisioning configurations to all users');
+		$this->setHelp(
+			<<<'EOT'
+				Walks through all users and creates or updates the mail account of everyone
+				matching a provisioning configuration, instead of waiting for each user to open
+				Mail. Users who lost access to Mail lose their provisioned account. Existing
+				accounts are kept when their owner no longer matches any configuration.
+
+				This takes no options. Configurations are managed with
+				<info>mail:provisioning:create</info> and <info>mail:provisioning:update</info>.
+
+				The IMAP, SMTP and Sieve password can only be stored while the user is logged
+				in, so provisioned accounts start syncing once their owner opens Mail.
+				EOT
+		);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$count = $this->provisioningManager->provision();
+
+		$output->writeln("<info>Provisioned $count accounts</info>");
+
+		return self::SUCCESS;
+	}
+}

--- a/lib/Command/ProvisioningOptions.php
+++ b/lib/Command/ProvisioningOptions.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use InvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StreamableInputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * Shared option definitions of the provisioning configuration commands.
+ *
+ * @psalm-type ProvisioningData = array<string, mixed>
+ */
+trait ProvisioningOptions {
+	private const SSL_MODES = ['none', 'ssl', 'tls'];
+
+	private const OPTION_MASTER_PASSWORD = 'master-password';
+	private const OPTION_NO_MASTER_PASSWORD = 'no-master-password';
+	private const OPTION_NO_SIEVE = 'no-sieve';
+	private const OPTION_NO_LDAP_ALIASES = 'no-ldap-aliases';
+
+	/** Option name => [data key, description] */
+	private const FIELDS = [
+		'provisioning-domain' => ['provisioningDomain', 'Email domain to provision, or * for all users'],
+		'email-template' => ['emailTemplate', 'Account email, supports %USERID%, %EMAIL% and %LDAP:attribute%'],
+		'imap-user' => ['imapUser', 'IMAP login, supports the same placeholders as the email template'],
+		'imap-host' => ['imapHost', 'IMAP host'],
+		'imap-port' => ['imapPort', 'IMAP port'],
+		'imap-ssl-mode' => ['imapSslMode', 'IMAP encryption: none, ssl or tls'],
+		'smtp-user' => ['smtpUser', 'SMTP login, supports the same placeholders as the email template'],
+		'smtp-host' => ['smtpHost', 'SMTP host'],
+		'smtp-port' => ['smtpPort', 'SMTP port'],
+		'smtp-ssl-mode' => ['smtpSslMode', 'SMTP encryption: none, ssl or tls'],
+		'sieve-user' => ['sieveUser', 'Sieve login, supports the same placeholders as the email template'],
+		'sieve-host' => ['sieveHost', 'Sieve host, enables Sieve when set'],
+		'sieve-port' => ['sievePort', 'Sieve port, required when Sieve is enabled'],
+		'sieve-ssl-mode' => ['sieveSslMode', 'Sieve encryption: none, ssl or tls'],
+		'master-user' => ['masterUser', 'Master user suffix appended to the login, e.g. *masteruser'],
+		'ldap-aliases-attribute' => ['ldapAliasesAttribute', 'LDAP attribute to read aliases from, enables alias provisioning when set'],
+	];
+
+	private function templatesHelp(): string {
+		return <<<'EOT'
+			The account email address and the IMAP, SMTP and Sieve logins are templates. They
+			may contain %USERID%, %EMAIL% and %LDAP:attribute%, which are replaced with the
+			values of each provisioned user.
+
+			Unless a master password is set, the login password of the user is used for IMAP,
+			SMTP and Sieve. It is stored when the user opens Mail and updated whenever it
+			changes, so an admin never has to know it.
+			EOT;
+	}
+
+	private function addProvisioningOptions(): void {
+		foreach (self::FIELDS as $option => [, $description]) {
+			$this->addOption($option, null, InputOption::VALUE_REQUIRED, $description);
+		}
+
+		$this->addOption(
+			self::OPTION_MASTER_PASSWORD,
+			null,
+			InputOption::VALUE_OPTIONAL,
+			'Master password used for all accounts instead of the login password. Pass without a value to read it from stdin',
+		);
+		$this->addOption(self::OPTION_NO_MASTER_PASSWORD, null, InputOption::VALUE_NONE, 'Use the login password of each user');
+		$this->addOption(self::OPTION_NO_SIEVE, null, InputOption::VALUE_NONE, 'Disable Sieve');
+		$this->addOption(self::OPTION_NO_LDAP_ALIASES, null, InputOption::VALUE_NONE, 'Disable alias provisioning from LDAP');
+	}
+
+	/**
+	 * @param array<string, mixed> $defaults values of the configuration being edited, empty when creating a new one
+	 * @return array<string, mixed>
+	 * @throws InvalidArgumentException
+	 */
+	private function buildProvisioningData(InputInterface $input, OutputInterface $output, array $defaults = []): array {
+		$data = $defaults;
+		foreach (self::FIELDS as $option => [$key]) {
+			$value = $input->getOption($option);
+			if ($value !== null) {
+				$data[$key] = $value;
+			}
+		}
+
+		$data['sievePort'] = isset($data['sievePort']) && $data['sievePort'] !== '' ? $data['sievePort'] : null;
+		foreach (['imapPort', 'smtpPort', 'sievePort'] as $key) {
+			if (isset($data[$key])) {
+				$port = filter_var($data[$key], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => 65535]]);
+				if ($port === false) {
+					throw new InvalidArgumentException($key . ' must be an integer between 1 and 65535');
+				}
+				$data[$key] = $port;
+			}
+		}
+
+		foreach (['imapSslMode', 'smtpSslMode', 'sieveSslMode'] as $key) {
+			$sslMode = $data[$key] ?? '';
+			if ($sslMode !== '' && !in_array($sslMode, self::SSL_MODES, true)) {
+				throw new InvalidArgumentException($key . ' must be one of ' . implode(', ', self::SSL_MODES));
+			}
+		}
+
+		$data['sieveEnabled'] = $this->resolveToggle(
+			$input->getOption(self::OPTION_NO_SIEVE),
+			$input->getOption('sieve-host'),
+			$defaults['sieveEnabled'] ?? false,
+		);
+		if ($data['sieveEnabled'] && $data['sievePort'] === null) {
+			throw new InvalidArgumentException('sievePort is required when Sieve is enabled');
+		}
+		$data['ldapAliasesProvisioning'] = $this->resolveToggle(
+			$input->getOption(self::OPTION_NO_LDAP_ALIASES),
+			$input->getOption('ldap-aliases-attribute'),
+			$defaults['ldapAliasesProvisioning'] ?? false,
+		);
+
+		if ($input->getOption(self::OPTION_NO_MASTER_PASSWORD)) {
+			$data['masterPasswordEnabled'] = false;
+			$data['masterPassword'] = '';
+			$data['masterUser'] = '';
+		} elseif ($input->hasParameterOption('--' . self::OPTION_MASTER_PASSWORD)) {
+			$masterPassword = $input->getOption(self::OPTION_MASTER_PASSWORD);
+			$data['masterPasswordEnabled'] = true;
+			$data['masterPassword'] = $masterPassword ?? $this->askMasterPassword($input, $output);
+		}
+
+		return $data;
+	}
+
+	/**
+	 * A feature is switched on by passing the value it depends on and off by its
+	 * negating flag. Without either the stored state wins.
+	 */
+	private function resolveToggle(bool $disable, ?string $value, bool $default): bool {
+		if ($disable) {
+			return false;
+		}
+		if ($value !== null) {
+			return $value !== '';
+		}
+
+		return $default;
+	}
+
+	private function askMasterPassword(InputInterface $input, OutputInterface $output): string {
+		if (!$input->isInteractive()) {
+			$stream = $input instanceof StreamableInputInterface ? $input->getStream() : null;
+			$password = fgets($stream ?? STDIN);
+			if ($password === false) {
+				throw new InvalidArgumentException('Could not read master password from stdin');
+			}
+
+			return rtrim($password, "\r\n");
+		}
+
+		$question = new Question('Master password: ');
+		$question->setHidden(true);
+		$question->setHiddenFallback(false);
+		$question->setTrimmable(false);
+
+		return rtrim((string)$this->getHelper('question')->ask($input, $output, $question), "\r\n");
+	}
+}

--- a/lib/Command/UpdateProvisioning.php
+++ b/lib/Command/UpdateProvisioning.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Command;
+
+use InvalidArgumentException;
+use OCA\Mail\Exception\ValidationException;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class UpdateProvisioning extends Command {
+	use ProvisioningOptions;
+
+	public const ARGUMENT_ID = 'id';
+
+	public function __construct(
+		private readonly ProvisioningManager $provisioningManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this->setName('mail:provisioning:update');
+		$this->setDescription('Update a mail account provisioning configuration');
+		$this->setHelp(sprintf(
+			<<<'EOT'
+				Only the values passed as options are changed, everything else keeps the value
+				it has. Sieve, the master password and LDAP alias provisioning are switched
+				off with <info>--no-sieve</info>, <info>--no-master-password</info> and <info>--no-ldap-aliases</info>.
+
+				%s
+
+				Run <info>mail:provisioning:list</info> to look up the id of a configuration.
+				EOT,
+			$this->templatesHelp(),
+		));
+		$this->addUsage('42 --imap-host=imap.example.com --imap-port=993 --imap-ssl-mode=ssl');
+		$this->addArgument(self::ARGUMENT_ID, InputArgument::REQUIRED, 'Id of the provisioning configuration');
+		$this->addProvisioningOptions();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$id = filter_var($input->getArgument(self::ARGUMENT_ID), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+		if ($id === false) {
+			$output->writeln('<error>Provisioning configuration id must be a positive integer</error>');
+			return self::INVALID;
+		}
+
+		$provisioning = $this->provisioningManager->getConfigById($id);
+		if ($provisioning === null) {
+			$output->writeln("<error>Provisioning configuration $id does not exist</error>");
+			return self::FAILURE;
+		}
+
+		try {
+			$data = $this->buildProvisioningData($input, $output, $provisioning->jsonSerialize());
+		} catch (InvalidArgumentException $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return self::INVALID;
+		}
+
+		try {
+			$this->provisioningManager->updateProvisioning($data);
+		} catch (ValidationException $e) {
+			$output->writeln('<error>Invalid or missing values: ' . implode(', ', array_keys($e->getFields())) . '</error>');
+			return self::INVALID;
+		}
+
+		$output->writeln("<info>Provisioning configuration $id updated</info>");
+
+		return self::SUCCESS;
+	}
+}

--- a/tests/Unit/Command/CreateProvisioningTest.php
+++ b/tests/Unit/Command/CreateProvisioningTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\CreateProvisioning;
+use OCA\Mail\Db\Provisioning;
+use OCA\Mail\Exception\ValidationException;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CreateProvisioningTest extends TestCase {
+	private ProvisioningManager&MockObject $provisioningManager;
+	private CommandTester $tester;
+
+	private array $options = [
+		'--provisioning-domain' => '*',
+		'--email-template' => '%USERID%@example.com',
+		'--imap-user' => '%USERID%',
+		'--imap-host' => 'imap.example.com',
+		'--imap-port' => '993',
+		'--imap-ssl-mode' => 'ssl',
+		'--smtp-user' => '%USERID%',
+		'--smtp-host' => 'smtp.example.com',
+		'--smtp-port' => '587',
+		'--smtp-ssl-mode' => 'tls',
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->provisioningManager = $this->createMock(ProvisioningManager::class);
+		$command = new CreateProvisioning($this->provisioningManager);
+		$command->setHelperSet(new HelperSet([new QuestionHelper()]));
+		$this->tester = new CommandTester($command);
+	}
+
+	public function testCreate(): void {
+		$provisioning = new Provisioning();
+		$provisioning->setId(3);
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with([
+				'provisioningDomain' => '*',
+				'emailTemplate' => '%USERID%@example.com',
+				'imapUser' => '%USERID%',
+				'imapHost' => 'imap.example.com',
+				'imapPort' => 993,
+				'imapSslMode' => 'ssl',
+				'smtpUser' => '%USERID%',
+				'smtpHost' => 'smtp.example.com',
+				'smtpPort' => 587,
+				'smtpSslMode' => 'tls',
+				'sievePort' => null,
+				'sieveEnabled' => false,
+				'ldapAliasesProvisioning' => false,
+			])
+			->willReturn($provisioning);
+
+		$status = $this->tester->execute($this->options);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringContainsString('3', $this->tester->getDisplay());
+	}
+
+	public function testCreateWithSieveAndLdapAliases(): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static function (array $data): bool {
+				return $data['sieveEnabled'] === true
+					&& $data['sieveHost'] === 'sieve.example.com'
+					&& $data['sievePort'] === 4190
+					&& $data['ldapAliasesProvisioning'] === true
+					&& $data['ldapAliasesAttribute'] === 'proxyAddresses';
+			}))
+			->willReturn(new Provisioning());
+
+		$status = $this->tester->execute(array_merge($this->options, [
+			'--sieve-host' => 'sieve.example.com',
+			'--sieve-port' => '4190',
+			'--sieve-ssl-mode' => 'tls',
+			'--ldap-aliases-attribute' => 'proxyAddresses',
+		]));
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testCreateWithMasterPassword(): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static function (array $data): bool {
+				return $data['masterPasswordEnabled'] === true
+					&& $data['masterPassword'] === 'sesame'
+					&& $data['masterUser'] === '*masteruser';
+			}))
+			->willReturn(new Provisioning());
+
+		$status = $this->tester->execute(array_merge($this->options, [
+			'--master-password' => 'sesame',
+			'--master-user' => '*masteruser',
+		]));
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testCreateWithoutMasterPassword(): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static function (array $data): bool {
+				return !isset($data['masterPasswordEnabled']);
+			}))
+			->willReturn(new Provisioning());
+
+		$status = $this->tester->execute($this->options);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	/** @dataProvider passwordInputs */
+	public function testReadsMasterPassword(bool $interactive, string $input, string $expected): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['masterPasswordEnabled'] === true
+				&& $data['masterPassword'] === $expected))
+			->willReturn(new Provisioning());
+
+		$this->tester->setInputs([$input]);
+		$status = $this->tester->execute($this->options + ['--master-password' => null], ['interactive' => $interactive]);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringNotContainsString($expected, $this->tester->getDisplay());
+	}
+
+	public static function passwordInputs(): array {
+		return [
+			'interactive' => [true, 'sesame', 'sesame'],
+			'interactive whitespace' => [true, ' sesame ', ' sesame '],
+			'interactive tabs' => [true, "\tsesame\t", "\tsesame\t"],
+			'non-interactive' => [false, 'sesame', 'sesame'],
+			'non-interactive whitespace' => [false, ' sesame ', ' sesame '],
+			'non-interactive CRLF' => [false, " sesame \r", ' sesame '],
+		];
+	}
+
+	public function testRejectsMissingPasswordInput(): void {
+		$this->provisioningManager->expects(self::never())
+			->method('newProvisioning');
+
+		$status = $this->tester->execute($this->options + ['--master-password' => null], ['interactive' => false]);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('Could not read master password', $this->tester->getDisplay());
+	}
+
+	/** @dataProvider invalidPorts */
+	public function testRejectsInvalidPorts(string $option, string $port): void {
+		$this->provisioningManager->expects(self::never())
+			->method('newProvisioning');
+
+		$status = $this->tester->execute(array_merge($this->options, [$option => $port]));
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('must be an integer between 1 and 65535', $this->tester->getDisplay());
+	}
+
+	public static function invalidPorts(): array {
+		$cases = [];
+		foreach (['--imap-port', '--smtp-port', '--sieve-port'] as $option) {
+			foreach (['0', '-1', '65536', '993typo', '1.5', '1e3', '99999999999999999999'] as $port) {
+				$cases[$option . '=' . $port] = [$option, $port];
+			}
+		}
+		return $cases;
+	}
+
+	/** @dataProvider validPortBoundaries */
+	public function testAcceptsPortBoundaries(int $port): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['imapPort'] === $port
+				&& $data['smtpPort'] === $port && $data['sievePort'] === $port))
+			->willReturn(new Provisioning());
+
+		$status = $this->tester->execute(array_merge($this->options, [
+			'--imap-port' => (string)$port,
+			'--smtp-port' => (string)$port,
+			'--sieve-port' => (string)$port,
+			'--sieve-host' => 'sieve.example.com',
+		]));
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public static function validPortBoundaries(): array {
+		return [[1], [65535]];
+	}
+
+	public function testRequiresPortWhenEnablingSieve(): void {
+		$this->provisioningManager->expects(self::never())
+			->method('newProvisioning');
+
+		$status = $this->tester->execute($this->options + ['--sieve-host' => 'sieve.example.com']);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('sievePort is required', $this->tester->getDisplay());
+	}
+
+	public function testAllowsMissingPortWhenSieveIsDisabled(): void {
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['sieveEnabled'] === false && $data['sievePort'] === null))
+			->willReturn(new Provisioning());
+
+		$status = $this->tester->execute($this->options + [
+			'--sieve-host' => 'sieve.example.com',
+			'--sieve-port' => '',
+			'--no-sieve' => true,
+		]);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testRejectsUnknownSslMode(): void {
+		$this->provisioningManager->expects(self::never())
+			->method('newProvisioning');
+
+		$status = $this->tester->execute(array_merge($this->options, ['--imap-ssl-mode' => 'starttls']));
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('imapSslMode', $this->tester->getDisplay());
+	}
+
+	public function testReportsInvalidFields(): void {
+		$exception = new ValidationException();
+		$exception->setField('imapHost', false);
+		$this->provisioningManager->expects(self::once())
+			->method('newProvisioning')
+			->willThrowException($exception);
+
+		$status = $this->tester->execute($this->options);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('imapHost', $this->tester->getDisplay());
+	}
+}

--- a/tests/Unit/Command/DeleteProvisioningTest.php
+++ b/tests/Unit/Command/DeleteProvisioningTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\DeleteProvisioning;
+use OCA\Mail\Db\Provisioning;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DeleteProvisioningTest extends TestCase {
+	private ProvisioningManager&MockObject $provisioningManager;
+	private DeleteProvisioning $command;
+	private CommandTester $tester;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->provisioningManager = $this->createMock(ProvisioningManager::class);
+		$this->command = new DeleteProvisioning($this->provisioningManager);
+		$this->command->setHelperSet(new HelperSet([new QuestionHelper()]));
+		$this->tester = new CommandTester($this->command);
+	}
+
+	public function testDeleteConfirmed(): void {
+		$provisioning = new Provisioning();
+		$provisioning->setId(3);
+		$this->provisioningManager->method('getConfigById')
+			->with(3)
+			->willReturn($provisioning);
+		$this->provisioningManager->expects(self::once())
+			->method('deprovision')
+			->with($provisioning);
+
+		$this->tester->setInputs(['y']);
+		$status = $this->tester->execute(['id' => '3']);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testDeleteDeclined(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn(new Provisioning());
+		$this->provisioningManager->expects(self::never())
+			->method('deprovision');
+
+		$this->tester->setInputs(['n']);
+		$status = $this->tester->execute(['id' => '3']);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringContainsString('Aborted', $this->tester->getDisplay());
+	}
+
+	public function testDeleteForced(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn(new Provisioning());
+		$this->provisioningManager->expects(self::once())
+			->method('deprovision');
+
+		$status = $this->tester->execute(['id' => '3', '--force' => true]);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testUnknownId(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn(null);
+		$this->provisioningManager->expects(self::never())
+			->method('deprovision');
+
+		$status = $this->tester->execute(['id' => '3']);
+
+		self::assertSame(Command::FAILURE, $status);
+	}
+
+	/** @dataProvider invalidIds */
+	public function testRejectsInvalidIdBeforeDeleting(string $id): void {
+		$this->provisioningManager->expects(self::never())
+			->method('getConfigById');
+		$this->provisioningManager->expects(self::never())
+			->method('deprovision');
+
+		$status = $this->tester->execute(['id' => $id, '--force' => true]);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('positive integer', $this->tester->getDisplay());
+	}
+
+	public static function invalidIds(): array {
+		return [[''], ['0'], ['-1'], ['3typo'], ['3.5'], ['3e1'], ['99999999999999999999']];
+	}
+}

--- a/tests/Unit/Command/ListProvisioningsTest.php
+++ b/tests/Unit/Command/ListProvisioningsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\ListProvisionings;
+use OCA\Mail\Db\Provisioning;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ListProvisioningsTest extends TestCase {
+	private ProvisioningManager&MockObject $provisioningManager;
+	private CommandTester $tester;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->provisioningManager = $this->createMock(ProvisioningManager::class);
+		$this->tester = new CommandTester(new ListProvisionings($this->provisioningManager));
+	}
+
+	private function config(): Provisioning {
+		$provisioning = new Provisioning();
+		$provisioning->setId(3);
+		$provisioning->setProvisioningDomain('example.com');
+		$provisioning->setEmailTemplate('%USERID%@example.com');
+		$provisioning->setImapUser('%USERID%');
+		$provisioning->setImapHost('imap.example.com');
+		$provisioning->setImapPort(993);
+		$provisioning->setImapSslMode('ssl');
+		$provisioning->setSmtpUser('%USERID%');
+		$provisioning->setSmtpHost('smtp.example.com');
+		$provisioning->setSmtpPort(587);
+		$provisioning->setSmtpSslMode('tls');
+		$provisioning->setSieveEnabled(false);
+		$provisioning->enableMasterPassword('sesame', '*masteruser');
+
+		return $provisioning;
+	}
+
+	public function testListEmpty(): void {
+		$this->provisioningManager->method('getConfigs')
+			->willReturn([]);
+
+		$status = $this->tester->execute([]);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testList(): void {
+		$this->provisioningManager->method('getConfigs')
+			->willReturn([$this->config()]);
+
+		$status = $this->tester->execute([]);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringContainsString('imap.example.com', $this->tester->getDisplay());
+	}
+
+	public function testListJsonHidesMasterPassword(): void {
+		$this->provisioningManager->method('getConfigs')
+			->willReturn([$this->config()]);
+
+		$status = $this->tester->execute(['--json' => true]);
+
+		self::assertSame(Command::SUCCESS, $status);
+		$decoded = json_decode($this->tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+		self::assertSame('example.com', $decoded[0]['provisioningDomain']);
+		self::assertSame(Provisioning::MASTER_PASSWORD_PLACEHOLDER, $decoded[0]['masterPassword']);
+	}
+}

--- a/tests/Unit/Command/ProvisionAccountsTest.php
+++ b/tests/Unit/Command/ProvisionAccountsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\ProvisionAccounts;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ProvisionAccountsTest extends TestCase {
+	private ProvisioningManager&MockObject $provisioningManager;
+	private CommandTester $tester;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->provisioningManager = $this->createMock(ProvisioningManager::class);
+		$this->tester = new CommandTester(new ProvisionAccounts($this->provisioningManager));
+	}
+
+	public function testProvision(): void {
+		$this->provisioningManager->expects(self::once())
+			->method('provision')
+			->willReturn(42);
+
+		$status = $this->tester->execute([]);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringContainsString('42', $this->tester->getDisplay());
+	}
+}

--- a/tests/Unit/Command/UpdateProvisioningTest.php
+++ b/tests/Unit/Command/UpdateProvisioningTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Mail\Tests\Unit\Command;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Mail\Command\UpdateProvisioning;
+use OCA\Mail\Db\Provisioning;
+use OCA\Mail\Exception\ValidationException;
+use OCA\Mail\Service\Provisioning\Manager as ProvisioningManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateProvisioningTest extends TestCase {
+	private ProvisioningManager&MockObject $provisioningManager;
+	private CommandTester $tester;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->provisioningManager = $this->createMock(ProvisioningManager::class);
+		$command = new UpdateProvisioning($this->provisioningManager);
+		$command->setHelperSet(new HelperSet([new QuestionHelper()]));
+		$this->tester = new CommandTester($command);
+	}
+
+	private function existingConfig(): Provisioning {
+		$provisioning = new Provisioning();
+		$provisioning->setId(3);
+		$provisioning->setProvisioningDomain('example.com');
+		$provisioning->setEmailTemplate('%USERID%@example.com');
+		$provisioning->setImapUser('%USERID%');
+		$provisioning->setImapHost('imap.example.com');
+		$provisioning->setImapPort(993);
+		$provisioning->setImapSslMode('ssl');
+		$provisioning->setSmtpUser('%USERID%');
+		$provisioning->setSmtpHost('smtp.example.com');
+		$provisioning->setSmtpPort(587);
+		$provisioning->setSmtpSslMode('tls');
+		$provisioning->setSieveEnabled(false);
+		$provisioning->enableMasterPassword('sesame', '*masteruser');
+
+		return $provisioning;
+	}
+
+	public function testKeepsUntouchedValues(): void {
+		$this->provisioningManager->method('getConfigById')
+			->with(3)
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static function (array $data): bool {
+				return $data['id'] === 3
+					&& $data['imapHost'] === 'imap.example.net'
+					&& $data['smtpHost'] === 'smtp.example.com'
+					&& $data['emailTemplate'] === '%USERID%@example.com'
+					&& $data['masterPasswordEnabled'] === true
+					&& $data['masterPassword'] === Provisioning::MASTER_PASSWORD_PLACEHOLDER;
+			}));
+
+		$status = $this->tester->execute([
+			'id' => '3',
+			'--imap-host' => 'imap.example.net',
+		]);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testDisablesMasterPassword(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static function (array $data): bool {
+				return $data['masterPasswordEnabled'] === false
+					&& $data['masterPassword'] === ''
+					&& $data['masterUser'] === '';
+			}));
+
+		$status = $this->tester->execute([
+			'id' => '3',
+			'--no-master-password' => true,
+		]);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testKeepsSieveDisabledWithoutSieveOptions(): void {
+		$config = $this->existingConfig();
+		$config->setSieveHost('sieve.example.com');
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($config);
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['sieveEnabled'] === false));
+
+		$status = $this->tester->execute(['id' => '3']);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testUnknownId(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn(null);
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => '3']);
+
+		self::assertSame(Command::FAILURE, $status);
+	}
+
+	public function testReportsInvalidFields(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$exception = new ValidationException();
+		$exception->setField('emailTemplate', false);
+		$this->provisioningManager->method('updateProvisioning')
+			->willThrowException($exception);
+
+		$status = $this->tester->execute([
+			'id' => '3',
+			'--email-template' => '',
+		]);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('emailTemplate', $this->tester->getDisplay());
+	}
+
+	/** @dataProvider invalidIds */
+	public function testRejectsInvalidIdBeforeUpdating(string $id): void {
+		$this->provisioningManager->expects(self::never())
+			->method('getConfigById');
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => $id, '--imap-host' => 'imap.example.net']);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('positive integer', $this->tester->getDisplay());
+	}
+
+	public static function invalidIds(): array {
+		return [[''], ['0'], ['-1'], ['3typo'], ['3.5'], ['3e1'], ['99999999999999999999']];
+	}
+
+	/** @dataProvider passwordInputModes */
+	public function testUpdatesMasterPasswordFromInput(bool $interactive): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['masterPasswordEnabled'] === true
+				&& $data['masterPassword'] === ' new password ' && $data['masterUser'] === '*masteruser'));
+
+		$this->tester->setInputs([' new password ']);
+		$status = $this->tester->execute(['id' => '3', '--master-password' => null], ['interactive' => $interactive]);
+
+		self::assertSame(Command::SUCCESS, $status);
+		self::assertStringNotContainsString('new password', $this->tester->getDisplay());
+	}
+
+	public static function passwordInputModes(): array {
+		return [[true], [false]];
+	}
+
+	public function testRejectsMissingPasswordInput(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => '3', '--master-password' => null], ['interactive' => false]);
+
+		self::assertSame(Command::INVALID, $status);
+	}
+
+	/** @dataProvider invalidPorts */
+	public function testRejectsInvalidPorts(string $option, string $port): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => '3', $option => $port]);
+
+		self::assertSame(Command::INVALID, $status);
+	}
+
+	public static function invalidPorts(): array {
+		return [['--imap-port', ''], ['--smtp-port', '587typo'], ['--sieve-port', '65536']];
+	}
+
+	public function testRequiresPortWhenEnablingSieve(): void {
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($this->existingConfig());
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => '3', '--sieve-host' => 'sieve.example.com']);
+
+		self::assertSame(Command::INVALID, $status);
+		self::assertStringContainsString('sievePort is required', $this->tester->getDisplay());
+	}
+
+	public function testKeepsExistingPortWhenEnablingSieve(): void {
+		$config = $this->existingConfig();
+		$config->setSievePort(4190);
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($config);
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['sieveEnabled'] === true && $data['sievePort'] === 4190));
+
+		$status = $this->tester->execute(['id' => '3', '--sieve-host' => 'sieve.example.com']);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+
+	public function testCannotClearPortWhileSieveIsEnabled(): void {
+		$config = $this->existingConfig();
+		$config->setSieveEnabled(true);
+		$config->setSievePort(4190);
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($config);
+		$this->provisioningManager->expects(self::never())
+			->method('updateProvisioning');
+
+		$status = $this->tester->execute(['id' => '3', '--sieve-port' => '']);
+
+		self::assertSame(Command::INVALID, $status);
+	}
+
+	public function testCanDisableSieveAndClearItsPort(): void {
+		$config = $this->existingConfig();
+		$config->setSieveEnabled(true);
+		$config->setSievePort(4190);
+		$this->provisioningManager->method('getConfigById')
+			->willReturn($config);
+		$this->provisioningManager->expects(self::once())
+			->method('updateProvisioning')
+			->with(self::callback(static fn (array $data): bool => $data['sieveEnabled'] === false && $data['sievePort'] === null));
+
+		$status = $this->tester->execute(['id' => '3', '--no-sieve' => true, '--sieve-port' => '']);
+
+		self::assertSame(Command::SUCCESS, $status);
+	}
+}


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-opus-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added console commands to create, update, list, delete, and apply mail account provisioning configurations.
  * Provisioning listings support table and JSON output.
  * Deletion supports confirmation prompts and a force option.
  * Added validation and interactive or standard-input handling for provisioning settings and passwords.
* **Tests**
  * Added comprehensive coverage for provisioning workflows, validation, error handling, and output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->